### PR TITLE
Implement grouped columns - issue #36

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -76,6 +76,8 @@ done(df::AbstractDataFrame, i) = i > ncol(df)
 next(df::AbstractDataFrame, i) = (df[i], i + 1)
 numel(df::AbstractDataFrame) = ncol(df)
 isempty(df::AbstractDataFrame) = ncol(df) == 0
+# Column groups
+add_group(d::DataFrame, newgroup, names) = add_group(d.colindex, newgroup, names)
 
 function insert(df::DataFrame, index::Integer, item, name)
     @assert 0 < index <= ncol(df) + 1

--- a/src/index.jl
+++ b/src/index.jl
@@ -7,12 +7,12 @@
 abstract AbstractIndex
 
 type Index <: AbstractIndex   # an OrderedDict would be nice here...
-    lookup::Dict{ByteString,Int}      # name => names array position
+    lookup::Dict{ByteString,Indices}      # name => names array position
     names::Vector{ByteString}
 end
-Index{T<:ByteString}(x::Vector{T}) = Index(Dict{ByteString, Int}(tuple(x...), tuple([1:length(x)]...)),
+Index{T<:ByteString}(x::Vector{T}) = Index(Dict{ByteString, Indices}(tuple(x...), tuple([1:length(x)]...)),
                                            convert(Vector{ByteString}, x))
-Index() = Index(Dict{ByteString,Int}(), ByteString[])
+Index() = Index(Dict{ByteString,Indices}(), ByteString[])
 length(x::Index) = length(x.names)
 names(x::Index) = copy(x.names)
 copy(x::Index) = Index(copy(x.lookup), copy(x.names))
@@ -62,7 +62,7 @@ function del(x::Index, nm)
     del(x, idx)
 end
 
-ref{T<:ByteString}(x::Index, idx::Vector{T}) = convert(Vector{Int}, [x.lookup[i] for i in idx])
+ref{T<:ByteString}(x::Index, idx::Vector{T}) = [[x.lookup[i] for i in idx]...]
 ref{T<:ByteString}(x::Index, idx::T) = x.lookup[idx]
 
 # fall-throughs, when something other than the index type is passed
@@ -79,3 +79,6 @@ end
 SimpleIndex() = SimpleIndex(0)
 length(x::SimpleIndex) = x.length
 names(x::SimpleIndex) = nothing
+
+# Chris's idea of namespaces adapted by Harlan for column groups
+add_group(idx::Index, newgroup, names) = idx.lookup[newgroup] = [[idx.lookup[nm] for nm in names]...]


### PR DESCRIPTION
This turned out to be pretty easy given that column names are stored in a Dict. We can just add groupings in with those. Some things of note:
- This isn't a hierarchical index like pandas. Groupings can overlap. 
- Overlapping indexes will repeat columns in the output.

Examples:

``` julia
d = DataFrame(quote
    y1 = randn(10)
    y2 = randn(10)
    x1 = randn(10)
    x2 = randn(10)
    x3 = randn(10)
end)

add_group(d, "responses", ["y1", "y2"])
add_group(d, "odd_predictors", ["x1", "x3"])
add_group(d, "predictors", ["odd_predictors", "x2"])

# Usage:

julia> d[1:3,"responses"]
DataFrame  (3,2)
                  y1        y2
[1,]    -0.000745666  0.583151
[2,]        0.246578 -0.411998
[3,]       -0.506249  -1.63488

julia> d[1:3,"predictors"]
DataFrame  (3,3)
               x1        x3        x2
[1,]     0.389423   1.31454 -0.476905
[2,]     0.704261  -0.80892 -0.728721
[3,]    -0.684409 -0.371066  -0.49958

julia> d[1:3,["predictors", "y1"]]
DataFrame  (3,4)
               x1        x3        x2           y1
[1,]     0.389423   1.31454 -0.476905 -0.000745666
[2,]     0.704261  -0.80892 -0.728721     0.246578
[3,]    -0.684409 -0.371066  -0.49958    -0.506249


julia> d[1:3,["odd_predictors", "x1"]]
DataFrame  (3,3)
               x1        x3        x1
[1,]     0.389423   1.31454  0.389423
[2,]     0.704261  -0.80892  0.704261
[3,]    -0.684409 -0.371066 -0.684409
```
