### PR TITLE
Grouped data columns, implementing issue #36.

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -78,7 +78,9 @@ next(df::AbstractDataFrame, i) = (df[i], i + 1)
 ## numel(df::AbstractDataFrame) = ncol(df)
 isempty(df::AbstractDataFrame) = ncol(df) == 0
 # Column groups
-add_group(d::DataFrame, newgroup, names) = add_group(d.colindex, newgroup, names)
+set_group(d::DataFrame, newgroup, names) = set_group(d.colindex, newgroup, names)
+set_groups(d::DataFrame, gr::Dict{ByteString,Vector{ByteString}}) = set_groups(d.colindex, gr)
+get_groups(d::DataFrame) = get_groups(d.colindex)
 
 function insert(df::DataFrame, index::Integer, item, name)
     @assert 0 < index <= ncol(df) + 1
@@ -163,7 +165,9 @@ maxShowLength(v::Vector) = length(v) > 0 ? max([length(_string(x)) for x = v]) :
 maxShowLength(dv::AbstractDataVec) = max([length(_string(x)) for x = dv])
 function show(io, df::AbstractDataFrame)
     ## TODO use alignment() like print_matrix in show.jl.
-    println(io, "$(typeof(df))  $(size(df))")
+    print(io, "$(typeof(df))  $(size(df))")
+    gr = get_groups(df)
+    length(gr) > 0 ? println(io, "; Column groups: ", gr) : println(io)
     N = nrow(df)
     Nmx = 20   # maximum head and tail lengths
     if N <= 2Nmx
@@ -204,7 +208,9 @@ end
 # get the structure of a DF
 
 function dump(io::IOStream, x::AbstractDataFrame, n::Int, indent)
-    println(io, typeof(x), "  $(nrow(x)) observations of $(ncol(x)) variables")
+    print(io, typeof(x), "  $(nrow(x)) observations of $(ncol(x)) variables")
+    gr = get_groups(x)
+    length(gr) > 0 ? println(io, "; Column groups: ", gr) : println(io)
     if n > 0
         for col in names(x)[1:min(10,end)]
             print(io, indent, "  ", col, ": ")

--- a/src/index.jl
+++ b/src/index.jl
@@ -51,8 +51,14 @@ function del(x::Index, idx::Integer)
     for i in idx+1:length(x.names)
         x.lookup[x.names[i]] = i - 1
     end
+    gr = get_groups(x)
     del(x.lookup, x.names[idx])
     del(x.names, idx)
+    # fix groups:
+    for (k,v) in gr
+        newv = [[has(x, vv) ? vv : ASCIIString[] for vv in v]...]
+        set_group(x, k, newv)
+    end
 end
 function del(x::Index, nm)
     if !has(x.lookup, nm)
@@ -81,4 +87,24 @@ length(x::SimpleIndex) = x.length
 names(x::SimpleIndex) = nothing
 
 # Chris's idea of namespaces adapted by Harlan for column groups
-add_group(idx::Index, newgroup, names) = idx.lookup[newgroup] = [[idx.lookup[nm] for nm in names]...]
+function set_group(idx::Index, newgroup, names)
+    if !has(idx, newgroup) || isa(idx.lookup[newgroup], Array)
+        idx.lookup[newgroup] = [[idx.lookup[nm] for nm in names]...]
+    end
+end
+function set_groups(idx::Index, gr::Dict{ByteString,Vector{ByteString}})
+    for (k,v) in gr
+        if !has(idx, k) 
+            idx.lookup[k] = [[idx.lookup[nm] for nm in v]...]
+        end
+    end
+end
+function get_groups(idx::Index)
+    gr = Dict{ByteString,Vector{ByteString}}()
+    for (k,v) in idx.lookup
+        if isa(v,Array)
+            gr[k] = idx.names[v]
+        end
+    end
+    gr
+end


### PR DESCRIPTION
This turned out to be pretty easy given that column names are stored in a Dict. We can just add groupings in with those. Some things of note:
- This isn't a hierarchical index like pandas. Groupings can overlap. 
- Overlapping indexes will repeat columns in the output.

Examples:

``` julia
d = DataFrame(quote
    y1 = randn(10)
    y2 = randn(10)
    x1 = randn(10)
    x2 = randn(10)
    x3 = randn(10)
end)

add_group(d, "responses", ["y1", "y2"])
add_group(d, "odd_predictors", ["x1", "x3"])
add_group(d, "predictors", ["odd_predictors", "x2"])

# Usage:

julia> d[1:3,"responses"]
DataFrame  (3,2)
                  y1        y2
[1,]    -0.000745666  0.583151
[2,]        0.246578 -0.411998
[3,]       -0.506249  -1.63488

julia> d[1:3,"predictors"]
DataFrame  (3,3)
               x1        x3        x2
[1,]     0.389423   1.31454 -0.476905
[2,]     0.704261  -0.80892 -0.728721
[3,]    -0.684409 -0.371066  -0.49958

julia> d[1:3,["predictors", "y1"]]
DataFrame  (3,4)
               x1        x3        x2           y1
[1,]     0.389423   1.31454 -0.476905 -0.000745666
[2,]     0.704261  -0.80892 -0.728721     0.246578
[3,]    -0.684409 -0.371066  -0.49958    -0.506249


julia> d[1:3,["odd_predictors", "x1"]]
DataFrame  (3,3)
               x1        x3        x1
[1,]     0.389423   1.31454  0.389423
[2,]     0.704261  -0.80892  0.704261
[3,]    -0.684409 -0.371066 -0.684409
```
