### PR TITLE
Pooledvec interface functions

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -377,7 +377,7 @@ function csvDataFrame(filename, o::Options)
                 colStrings[string(v)] = true # do we need a count here?
             end
         end
-        if colPoolStrings && length(keys(colStrings)) > typemax(Uint32)
+        if colPoolStrings && length(keys(colStrings)) > typemax(Uint16)
             # we've ran past the limit of pooled strings!
             colPoolStrings = false
         end
@@ -566,7 +566,7 @@ similar{T}(dv::DataVec{T}, dims) =
     DataVec(zeros(T, dims), fill(true, dims), dv.filter, dv.replace, dv.replaceVal)  
 
 similar{T}(dv::PooledDataVec{T}, dims) =
-    PooledDataVec(fill(uint32(1), dims), dv.pool, dv.filter, dv.replace, dv.replaceVal)  
+    PooledDataVec(fill(uint16(1), dims), dv.pool, dv.filter, dv.replace, dv.replaceVal)  
 
 similar(df::DataFrame, dims) = 
     DataFrame([similar(x, dims) for x in df.columns], colnames(df)) 

--- a/test/data.jl
+++ b/test/data.jl
@@ -38,7 +38,7 @@ pdvpp = PooledDataVec([1,2,2,3,2,1], [1,2,3,4])
 @test string(pdvpp) == "[1,2,2,3,2,1]"
 pdvpp = PooledDataVec(["one","two","two"], ["one","two","three"])
 @test all(values(pdvpp) .== ["one","two","two"])
-@test all(indices(pdvpp) .== uint32([1,3,3]))
+@test all(indices(pdvpp) .== uint16([1,3,3]))
 @test all(levels(pdvpp) .== ["one","three","two"])
 @test pdvpp.pool == ["one","three","two"]
 @test string(pdvpp) == "[one,two,two]"


### PR DESCRIPTION
I have been experimenting with the following:

```

julia> pdvpp = PooledDataVec(["one","two","two"], ["one","two","three"])
values: ["one", "two", "two"]
levels: ["one", "three", "two"]

julia> levels(pdvpp)
3-element ASCIIString Array:
 "one"  
 "three"
 "two"  

julia> values(pdvpp)
3-element ASCIIString Array:
 "one"
 "two"
 "two"

julia> indices(pdvpp)
3-element Uint32 Array:
 0x00000001
 0x00000003
 0x00000003

julia> int(indices(pdvpp))
3-element Int64 Array:
 1
 3
 3
```

I've found the above helper functions useful.  The interface varies a little bit, however, with R's `factor` and pandas' `Categorical`.  

I've also changed the default to Uint32 for keeping references rather than Uint16.  This makes it more useful for large categorical variables, e.g. UserID.  

I also rearranged a few things to add UTF8String support.

```
julia> pdvpp = PooledDataVec([utf8("hello")])
values: ["hello"]
levels: ["hello"]

julia> typeof(pdvpp[1])
UTF8String
```

I thought I'd use a different branch in case there's anything worth discussing.
