### PR TITLE
Added poly term to model formulas - issue #60.

### DIFF
--- a/src/datavec.jl
+++ b/src/datavec.jl
@@ -801,3 +801,8 @@ function cut{T}(x::Vector{T}, breaks::Vector{T})
     PooledDataVec(refs, pool, KEEP, "")
 end
 cut(x::Vector, ngroups::Integer) = cut(x, quantile(x, [1 : ngroups - 1] / ngroups))
+
+function .^{T}(x::DataVec{T}, degree::Int)
+    newx = x.data.^degree
+    DataVec(newx, x.na, x.naRule, convert(eltype(newx), x.replaceVal))
+end

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -51,6 +51,10 @@ end
 unique_symbols(ex::Array{Expr,1}) = [unique_symbols(ex[1])]
 unique_symbols(ex::Symbol) = [ex]
 unique_symbols(ex::Array{Symbol,1}) = [ex[1]]
+unique_symbols(ex::Int) = []      ## Added so that numeric arguments can be passed to formula
+unique_symbols(ex::Float64) = []  ## expansion functions like poly or spline
+unique_symbols(ex::Bool) = []     ## 
+
 
 # Create a DataFrame containing only variables required by the Formula
 # Include grouped indexes present in original DataFrame that are in Formula
@@ -269,7 +273,6 @@ function expand(poolcol::PooledDataVec, colname::ByteString, df::AbstractDataFra
     DataFrame(newcol, convert(Vector{ByteString}, newcolname))
 end
 
-
 #
 # Methods for Formula expansion
 #
@@ -290,3 +293,7 @@ function *(::FormulaExpander, args::Vector{Any}, df::AbstractDataFrame)
     d = insert(d, all_interactions(expand(args, df)))
     d
 end
+
+function poly(::FormulaExpander, args::Vector{Any}, df::AbstractDataFrame)
+     poly(expand(args[1], df), args[2:end]...)
+ end

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -227,3 +227,18 @@ mf = model_frame(Formula(:(y ~ odd_predictors)), d)
 mf = model_frame(Formula(:(y ~ odd_predictors * x2)), d)
 mm = model_matrix(mf)
 @test mm.model == [ones(4) x1 x3 x2 x1.*x2 x3.*x2]
+
+test_group("poly model terms")
+mm = model_matrix(:(y ~ x2 + poly(x1, 3)), d) ## orthogonal basis
+@test dot(mm.model[:,3], mm.model[:,4]) < eps(Float64)
+@test dot(mm.model[:,4], mm.model[:,5]) < eps(Float64)
+@test dot(mm.model[:,3], mm.model[:,5]) < eps(Float64)
+mm = model_matrix(:(y ~ x2 + poly(x1, 3, false)), d) ## monomial basis
+@test mm.model[:,4] == [25., 36., 49., 64.]
+@test mm.model_colnames == ["(Intercept)", "x2", "poly(x1,1)", "poly(x1,2)", "poly(x1,3)"]
+dfloat = deepcopy(d)  ## Test with floats
+dfloat["x1"] = [5., 6., 7., 8.]
+mm = model_matrix(:(y ~ x2 + poly(x1, 3, true)), dfloat)
+@test dot(mm.model[:,3], mm.model[:,4]) < eps(Float64)
+@test dot(mm.model[:,4], mm.model[:,5]) < eps(Float64)
+@test dot(mm.model[:,3], mm.model[:,5]) < eps(Float64)


### PR DESCRIPTION
As John suggested, I implemented the `poly` term to test the waters before trying to add the spline `bs` term.  The usage is

```
d = DataFrame()
d["y"] = [1:4]
d["x1"] = [5:8]
d["x2"] = [9:12]
d["x3"] = [13:16]
d["x4"] = [17:20]
model_matrix(:(y ~ x2 + poly(x1, 3)), d)
```

Please let me know if this needs any revisions.
