### PR TITLE
RFC: Added constructor for DataFrame from a Vector of Associative objects

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -183,6 +183,7 @@ function DataFrame(column_types::Vector, column_names::Vector, n::Int64)
     end
   end
 
+  println(names)
   DataFrame(columns, Index(names))
 end
 
@@ -195,7 +196,7 @@ end
 
 # Initialize from a Vector of Associatives (aka list of dicts)
 function DataFrame{D<:Associative}(ds::Vector{D})
-    ks = unique([k for k in [keys(d) for d in ds]])
+    ks = [Set([[k for k in [keys(d) for d in ds]]...]...)...]
     DataFrame(ds, ks)
 end
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -106,3 +106,10 @@ df = DataFrame(eye(10, 5))
 @assert nrow(df) == 10
 @assert ncol(df) == 5
 @assert typeof(df[:, 1]) == DataVec{Float64}
+
+test_group("Other DataFrame constructors")
+df = DataFrame([{"a"=>1, "b"=>'c'}, {"a"=>3, "b"=>'d'}, {"a"=>5}])
+@assert nrow(df) == 3
+@assert ncol(df) == 2
+@assert typeof(df[:,"a"]) == DataVec{Int}
+@assert typeof(df[:,"b"]) == DataVec{Char}


### PR DESCRIPTION
(aka a list of dictionaries)

In Pandas, I frequently create data on the fly using a list of dictionaries, which I then turn into a DataFrame.  This method allows that type of DataFrame creation.  

``` julia
julia> load("DataFrames")

julia> using DataFrames

julia> aa = [{"a"=>1, "b"=>'c'}, {"a"=>3, "b"=>'d'}, {"a"=>5}]
3-element Dict{Any,Any} Array:
 {"a"=>1,"b"=>'c'}
 {"a"=>3,"b"=>'d'}
 {"a"=>5}         

julia> df = DataFrame(aa)
DataFrame  (3,2)
        a   b
[1,]    1 'c'
[2,]    3 'd'
[3,]    5  NA

julia> df["a"]
3-element Int64 Array:
 1
 3
 5

julia> df["b"]
3-element Union(NAtype,Char) Array:
 'c'  
 'd'  
    NA
```

It seems to work, but since I don't know the DataFrames.jl code base that well, I might have made some incorrect assumptions.  In particular, I assign NA values up front for missing values--is this okay?  

Feedback appreciated.

Cheers!

   Kevin
