### PR TITLE
Make dump(DataFrame) print out all variables

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -452,7 +452,7 @@ function dump(io::IOStream, x::AbstractDataFrame, n::Int, indent)
         println(io)
     end
     if n > 0
-        for col in names(x)[1:min(10,end)]
+        for col in names(x)[1:end]
             print(io, indent, "  ", col, ": ")
             dump(io, x[col], n - 1, strcat(indent, "  "))
         end


### PR DESCRIPTION
`dump(DataFrame)` printed out 10 variables but `dump` should write out 
a "thorough text representation" (not a partial one).
