### PR TITLE
permute!!() is not exported by Base

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1763,7 +1763,7 @@ function sort!(df::AbstractDataFrame, a::Algorithm, o::Ordering)
     pp = similar(p)
     for col in df.columns
         copy!(pp,p)
-        permute!!(col, pp)
+        Base.permute!!(col, pp)
     end
     df
 end


### PR DESCRIPTION
Julia's `permute!()` is defined in terms of `permute!!()`, but sometimes calling `permute!!()` (as in this code) is more efficient.  However, `permute!!()` needs to be fully qualified to use.
