### PR TITLE
Added setindex! for SubDataFrames

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1016,6 +1016,8 @@ const subset = sub
 getindex(df::SubDataFrame, c) = df.parent[df.rows, c]
 getindex(df::SubDataFrame, r, c) = df.parent[df.rows[r], c]
 
+setindex!(df::SubDataFrame, v, r, c) = (df.parent[df.rows[r], c] = v)
+
 nrow(df::SubDataFrame) = length(df.rows)
 ncol(df::SubDataFrame) = ncol(df.parent)
 colnames(df::SubDataFrame) = colnames(df.parent) 


### PR DESCRIPTION
Before:

``` julia
julia> g[(g["sample_id"] .== sample_id[i]),"parental_id"] = sample_id[i-1]
ERROR: no method setindex!(SubDataFrame,ASCIIString,DataArray{Bool,1},ASCIIString)
```

After:

``` julia
g[(g["sample_id"] .== sample_id[i]),"parental_id"] = sample_id[i-1]
"TCGA-02-0003-10A"
```

This is a simple, one-liner.
