### PR TITLE
fix PooledDataArray ERROR: no method sort(KeyIterator{Dict{Int64,Uint16}},)

### DIFF
--- a/src/pooleddataarray.jl
+++ b/src/pooleddataarray.jl
@@ -68,7 +68,7 @@ function PooledDataArray{T, N}(d::AbstractArray{T, N}, m::AbstractArray{Bool, N}
     end
 
     # Fill positions in poolref
-    newpool = sort(keys(poolref))
+    newpool = sort(collect(keys(poolref)))
     i = 1
     for p in newpool
         poolref[p] = i
@@ -778,7 +778,7 @@ function PooledDataVecs(v1::AbstractArray,
     end
 
     # fill positions in poolref
-    pool = sort(keys(poolref))
+    pool = sort(collect(keys(poolref)))
     i = 1
     for p in pool
         poolref[p] = i


### PR DESCRIPTION
I figured out how to fork it and do a pull request so here it is.
The ability to create a PooledDataArray stopped working on Thursday. Changing pooleddataarray.jl:71 & 781: from newpool = sort(keys(poolref)) to newpool = sort(collect(keys(poolref))) seems to fix the problem.

julia> a = PooledDataArray([1,1,2,2])
ERROR: no method sort(KeyIterator{Dict{Int64,Uint16}},)
in PooledDataArray at /Users/madmax/.julia/DataFrames/src/pooleddataarray.jl:71
in PooledDataArray at /Users/madmax/.julia/DataFrames/src/pooleddataarray.jl:134

julia> p = PooledDataArray(DataVector[9,9,8,NA,1,1])
ERROR: no method sort(KeyIterator{Dict{Int64,Uint16}},)
in PooledDataArray at /Users/madmax/.julia/DataFrames/src/pooleddataarray.jl:71
in PooledDataArray at /Users/madmax/.julia/DataFrames/src/pooleddataarray.jl:128

This is due to the Julia commit da43f62 thursday "make keys() and values() return view objects. closes #2347"
here KeyIterator is created in base/dict.jl
and in base/darray2.jl line 63 "f = sort!(keys(factor(np)), Sort.Reverse)" is replaced with "f = sort!(collect(keys(factor(np))), Sort.Reverse)"
