### PR TITLE
fixes load_df when deserializing stored dataframe

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -488,7 +488,7 @@ end
 
 function load_df(filename)
     f = open(filename)
-    dd = deserialize(f)()
+    dd = deserialize(f)
     close(f)
     return dd
 end


### PR DESCRIPTION
when using load_df get this error:
ERROR: type: load_df: in apply, expected Function, got DataFrame

this fixed that error
