### PR TITLE
fix doc section 03 where use of super(DataVector) errors

### DIFF
--- a/doc/sections/03_design_details.md
+++ b/doc/sections/03_design_details.md
@@ -106,10 +106,10 @@ Instead, you can simply focus on the behavior of the `DataVector` type. Let's st
 	typeof(DataVector)
 	typeof(DataVector{Int64})
 
-	super(DataVector)
-	super(super(DataVector))
+	super(DataVector{Int64})
+	super(super(DataVector{Int64}))
 
-	DataVector.names
+	DataVector{Int64}.names
 
 If you want to drill down further, you can always run `dump()`:
 


### PR DESCRIPTION
this patch fixes doc section 3 error:

```
julia> super(DataVector)
ERROR: no method super(TypeConstructor,)

julia> super(super(DataVector))
ERROR: no method super(TypeConstructor,)

julia> DataVector.names
ERROR: type TypeConstructor has no field names
```
