### PR TITLE
RFC: Only columns of strings should be made factors.

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -414,7 +414,6 @@ function builddf{T <: ByteString}(rows::Int,
         is_int::Bool = true
         is_float::Bool = true
         is_bool::Bool = true
-        is_string::Bool = true
 
         i::Int = 0
         while i < rows
@@ -490,7 +489,7 @@ function builddf{T <: ByteString}(rows::Int,
               bytestostring(buffer, left, right, nastrings, quotemark)
         end
 
-        if makefactors && is_string
+        if makefactors && !(is_int || is_float || is_bool)
             columns[j] = PooledDataArray(values, missing)
         else
             columns[j] = DataArray(values, missing)

--- a/test/data/factors/mixedvartypes.csv
+++ b/test/data/factors/mixedvartypes.csv
@@ -1,0 +1,9 @@
+y,factorvar,floatvar
+1.0,green,2.000
+0.0,blue,1.000
+0.0,blue,1.250
+1.0,green,1.500
+1.0,blue,1.400
+1.0,green,1.750
+0.0,blue,1.300
+1.0,yellow,1.450

--- a/test/io.jl
+++ b/test/io.jl
@@ -2,6 +2,8 @@ require("test.jl")
 using DataFrames
 
 let
+    test_group("Confirm that we can read various file types.")
+
     filenames = ["test/data/blanklines/blanklines.csv",
                  "test/data/compressed/movies.csv.gz",
                  "test/data/newlines/os9.csv",
@@ -28,7 +30,7 @@ let
 
     for filename in filenames
         try
-    	    df = readtable(filename)
+          df = readtable(filename)
         catch
             error(@sprintf "Failed to read %s\n" filename)
         end
@@ -44,9 +46,7 @@ let
     # TODO: Implement skipping lines at bottom
     # readtable("test/data/skiplines/skipbottom.csv", skipstartlines = 4)
 
-    #
-    # Confirm that we can read a large file
-    #
+    test_group("Confirm that we can read a large file.")
 
     df = DataFrame()
 
@@ -87,4 +87,16 @@ let
     all(df .== df1)
 
     rm(filename)
+
+
+    test_group("Properties of data frames returned by readtable method.")
+
+    # Readtable with makefactors active should only make factors from columns
+    # of strings.
+    filename = "test/data/factors/mixedvartypes.csv"
+    df = readtable(filename, makefactors = true)
+
+    @assert typeof(df["factorvar"]) == PooledDataArray{UTF8String,Uint32,1}
+    @assert typeof(df["floatvar"]) == DataArray{Float64,1}
+
 end


### PR DESCRIPTION
As I understand the spec and the outline of the the readtable method code,
only columns of data files that have all strings should be made into factors
given that the makefactors boolean in the method is active.

This logic is implemented here.
