### PR TITLE
fix dataframe delete! with multiple column numbers behavior

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1040,7 +1040,8 @@ index(df::SubDataFrame) = index(df.parent)
 # delete!(df, 1)
 # delete!(df, "old")
 function delete!(df::DataFrame, inds::Vector{Int})
-    for ind in inds
+    for i in 1:length(inds)
+        ind = inds[i] - i + 1
         if 1 <= ind <= ncol(df)
             splice!(df.columns, ind)
             delete!(df.colindex, ind)


### PR DESCRIPTION
Deleting multiple columns from a dataframe by specifying a list of indices (`delete!` method) works by progressively deleting each column. This results in the following behavior:

```
julia> d = DataFrame(rand(2, 10))
2x10 DataFrame:
               x1        x2        x3       x4        x5       x6        x7       x8       x9       x10
[1,]     0.753006  0.814508  0.825233 0.463091 0.0405086 0.666034  0.951882 0.787001 0.221712  0.389528
[2,]     0.602259  0.953115  0.811547 0.578169  0.239391 0.267321  0.409466  0.65386  0.65489  0.246472


julia> delete!(d, [1,2])   # want to delete the 1st and 2nd columns
2x8 DataFrame:
                x2       x4        x5       x6        x7       x8       x9       x10
[1,]      0.814508 0.463091 0.0405086 0.666034  0.951882 0.787001 0.221712  0.389528
[2,]      0.953115 0.578169  0.239391 0.267321  0.409466  0.65386  0.65489  0.246472
```

This seems unintuitive and was probably unintentional. Hence proposing this change with which the column numbers would refer to those prior to the `delete!` call, so that the result is:

```
julia> delete!(d, [1,2])   # want to delete the 1st and 2nd columns
2x8 DataFrame:
                x3       x4        x5       x6        x7       x8       x9       x10
[1,]      0.825233 0.463091 0.0405086 0.666034  0.951882 0.787001 0.221712  0.389528
[2,]      0.811547 0.578169  0.239391 0.267321  0.409466  0.65386  0.65489  0.246472
```
