### PR TITLE
tracking fix: JuliaLang/julia@f38c2b8d0eff54efabc8c6a21f920aa71ddf399d

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -342,9 +342,9 @@ let out::Vector{Float64} = Array(Float64, 1)
 
         wasparsed = ccall(:jl_substrtod,
                           Int32,
-                          (Ptr{Uint8}, Int, Int, Ptr{Float64}),
+                          (Ptr{Uint8}, Csize_t, Int, Ptr{Float64}),
                           buffer,
-                          left - 1,
+                          convert(Csize_t,left - 1),
                           right - left + 1,
                           out) == 0
 


### PR DESCRIPTION
`jl_substrtod` signature changed to take offsets as `size_t`.
Offsets on large strings may otherwise go out of range.
