### PR TITLE
importing Base.Sort after JuliaLang/julia#3931

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -33,6 +33,7 @@ const DEFAULT_POOLED_REF_TYPE = Uint32
 
 importall Base
 importall Stats
+import Base.Sort
 import Base.Sort.Algorithm, Base.Sort.By, Base.Sort.Forward
 import Base.Sort.Ordering, Base.Sort.Perm, Base.Sort.lt
 import Base.Sort.sort, Base.Sort.sort!, Base.Sort.sortby, Base.Sort.sortby!


### PR DESCRIPTION
`Sort` was removed from exports by JuliaLang/julia#3931
