### PR TITLE
Distributed DataFrame Changes

### DIFF
--- a/src/dataframe_blocks.jl
+++ b/src/dataframe_blocks.jl
@@ -263,11 +263,11 @@ function _sorted_col_vals_at_pos(dt::DDataFrame, col, numvalid, minv, maxv, pos)
         nrowslt,nrowsgt = _count_col_seps(dt, col, pivot)
 
         #println("for $(col) => $(minv):$(maxv). rowdist: $(nrowslt) - $(pos) - $(nrowsgt)")
-        if (nrowslt <= pos) && (nrowsgt <= posr)
+        if (nrowslt < pos) && (nrowsgt <= posr)
             return pivot
         elseif (nrowsgt > posr)
             minv = pivot
-        else  # (nrowslt > pos)
+        else  # (nrowslt >= pos)
             maxv = pivot
         end
     end
@@ -351,7 +351,7 @@ function getindex{T <: DataFrames.ColumnIndex}(dt::DDataFrame, col_inds::Abstrac
 end
 
 # Operations on Distributed DataFrames
-# TODO: colmedians, colstds, colvars, colffts, colnorms
+# TODO: colstds, colvars, colffts, colnorms
 
 for f in [DataFrames.elementary_functions, DataFrames.unary_operators, :copy, :deepcopy, :isfinite, :isnan]
     @eval begin
@@ -455,6 +455,24 @@ for f in (:colmins, :colmaxs, :colprods, :colsums, :colmeans)
         end
     end
 end    
+
+function colmedians(dt::DDataFrame)
+    cnames = colnames(dt)
+    ctypes = coltypes(dt)
+    qcolnames = String[]
+    for idx in 1:length(cnames)
+        ((ctypes[idx] <: Number)) && push!(qcolnames, cnames[idx])
+    end
+    mins,maxs,means,numvalids = _colranges(dt, qcolnames)
+    qcols={}
+    for idx in 1:length(qcolnames)
+        q2 = _dquantile(dt, qcolnames[idx], numvalids[idx], mins[idx], maxs[idx], 0.5)
+        push!(qcols, [q2])
+    end
+    dm = DataFrame(qcols)
+    colnames!(dm, qcolnames)
+    dm
+end
 
 for f in DataFrames.array_arithmetic_operators
     @eval begin


### PR DESCRIPTION
- Added `colmedians` for `DDataFrame`
- Fixed bug in distributed median computation being used in `describe`
- Minor change to use the `|>` operator with the new `@prepare` macro for chaining methods for block preparation. The `|>` operator is more convenient than the `.>` operator as it has a left to right associativity.
