### PR TITLE
Add clipboard(x::DataFrame) function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -101,3 +101,20 @@ function _dv_most_generic_type(vals)
     end
     return toptype
 end
+
+# Exports a delimted DataFrame instead of the Base default string representation
+function clipboard(df::DataFrame)
+  n, p = nrow(df), ncol(df)
+  column_names = join(colnames(df),'\t')*"\n"
+  c = df.columns
+  t = ref(String)
+  for i in 1:n, j in 1:p
+  	val = string(c[j][i])
+    if j < p
+    	push!(t,val*"\t")
+    else
+        push!(t,val*"\n")
+    end
+  end
+  clipboard(column_names*chomp(join(t)))
+end


### PR DESCRIPTION
Base recently added clipboard(x) for copying string(object) to the clipboard. This is the overload I've been personally using for copying dataframes to the clipboard to be able to paste in a delimited format.
