### PR TITLE
fixed index lookup to handle non unique names

### DIFF
--- a/src/index.jl
+++ b/src/index.jl
@@ -11,9 +11,10 @@ type Index <: AbstractIndex   # an OrderedDict would be nice here...
     lookup::Dict{ByteString, Indices}      # name => names array position
     names::Vector{ByteString}
 end
-Index{T <: ByteString}(x::Vector{T}) =
-    Index(Dict{ByteString, Indices}(tuple(x...), tuple([1:length(x)]...)),
-          make_unique(convert(Vector{ByteString}, x)))
+function Index{T <: ByteString}(x::Vector{T}) 
+    x = make_unique(convert(Vector{ByteString}, x))
+    Index(Dict{ByteString, Indices}(tuple(x...), tuple([1:length(x)]...)), x)
+end
 Index() = Index(Dict{ByteString, Indices}(), ByteString[])
 length(x::Index) = length(x.names)
 names(x::Index) = copy(x.names)


### PR DESCRIPTION
With a CSV with non unique column names, the `make_unique` method is used to generate unique column names internally. But it was not possible to lookup using a generated column name as the `lookup` dict in `Index` was not getting updated.

With a CSV like:

```
A,B,C,C,C,D,E,F
0,1,2,3,4,5,6,7
1,2,3,4,5,6,7,8
2,3,4,5,6,7,8,9
```

Before:

```
julia> df = readtable("t.csv")
3x8 DataFrame:
        A B C C_1 C_2 D E F
[1,]    0 1 2   3   4 5 6 7
[2,]    1 2 3   4   5 6 7 8
[3,]    2 3 4   5   6 7 8 9

julia> df["C_1"]
ERROR: key not found: "C_1"
 in getindex at dict.jl:502
 in getindex at /Users/tan/.julia/DataFrames/src/dataframe.jl:388
```

With this change:

```
julia> df = readtable("t.csv");

julia> df["C_1"]
3-element DataArray{Int64,1}:
 3
 4
 5
```
