### PR TITLE
Fix getindex() type ambiguity in DataArray

### DIFF
--- a/src/dataarray.jl
+++ b/src/dataarray.jl
@@ -344,7 +344,7 @@ function getindex(d::DataArray, inds::Union(BitVector, Vector{Bool}))
     res
 end
 
-function getindex(d::DataArray, inds::Union(Vector, Ranges, Range1))
+function getindex(d::DataArray, inds::Union(Vector, Ranges, Range1, BitVector))
     res = similar(d, length(inds))
     for i in 1:length(inds)
         ix = inds[i]


### PR DESCRIPTION
This fixes the error

```
Warning: New definition 
    getindex(DataArray{T,N},Union(Array{T,1},Ranges{T})) at /home/bork/.julia/DataFrames/src/dataarray.jl:348
is ambiguous with 
    getindex(DataArray{T<:Number,N},Union(Array{T,1},Ranges{T},BitArray{1})) at /home/bork/.julia/DataFrames/src/dataarray.jl:332.
Make sure 
    getindex(DataArray{T<:Number,N},Union(Array{T,1},Ranges{T}))
is defined first.
Warning: New definition 
```

from #372

I'm still learning the type system a bit, but I think this is right --

`DataArray(["abc", "def"])[BitVector(2)]` comes out to the right thing
