### PR TITLE
Allow indexing dataframes by a binary vector with length nrow(df)

### DIFF
--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -128,6 +128,14 @@ let
         end
     end
 
+    asym_df = DataFrame(quote
+       A = 1:10
+       B = 11:20
+    end)
+
+    asym_df[[true for i=1:10]]
+    asym_df[[true, false]]
+
     #
     # setindex!()
     #


### PR DESCRIPTION
With this pull request, `df[df["age"] .< 30]` gets all rows where `age` is less than 30. 

The easiest other way I can see this right now to do this seems to be something like

```
df[df["age"] .< 40, 1:ncol(df)]
```

which seems a bit unnecessarily verbose to me. But of course if there's an easy way to do this that I've not noticed please disregard :)
