### PR TITLE
add lone period to nastrings array

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -543,7 +543,7 @@ function readtable(pathname::String;
                    allowquotes::Bool = true,
                    quotemark::Char = '"',
                    decimal::Char = '.',
-                   nastrings::Vector = ASCIIString["", "NA"],
+                   nastrings::Vector = ASCIIString["", "NA", "."],
                    truestrings::Vector = ASCIIString["T", "t", "TRUE", "true"],
                    falsestrings::Vector = ASCIIString["F", "f", "FALSE", "false"],
                    makefactors::Bool = false,


### PR DESCRIPTION
Federal Reserve St. Louis has a rich set of databases and for some reason they use a single "." to denote missing data. 

Currently:

``` julia
               DATE  VALUE
[1,]     2013-10-14    "."
[2,]     2013-10-15 "2.75"
[3,]     2013-10-16 "2.69"
[4,]     2013-10-17 "2.61"
[5,]     2013-10-18 "2.60"
[6,]     2013-10-21 "2.63"
[7,]     2013-10-22 "2.54"
[8,]     2013-10-23 "2.51"
[9,]     2013-10-24 "2.53"
[10,]    2013-10-25 "2.53"
[11,]    2013-10-28 "2.54"
[12,]    2013-10-29 "2.53"
```

Pull Request result:

``` Julia
               DATE VALUE
[1,]     2013-10-14    NA
[2,]     2013-10-15  2.75
[3,]     2013-10-16  2.69
[4,]     2013-10-17  2.61
[5,]     2013-10-18   2.6
[6,]     2013-10-21  2.63
[7,]     2013-10-22  2.54
[8,]     2013-10-23  2.51
[9,]     2013-10-24  2.53
[10,]    2013-10-25  2.53
[11,]    2013-10-28  2.54
[12,]    2013-10-29  2.53

```
