### PR TITLE
Added RefArray import; fixes https://github.com/JuliaStats/DataArrays.jl/pull/13

### DIFF
--- a/src/RDA.jl
+++ b/src/RDA.jl
@@ -297,7 +297,7 @@ function data(ri::RInteger)
                                       Uint64
     refs = convert(Vector{REFTYPE}, dd)
     refs[msng] = zero(REFTYPE)
-    PooledDataArray(RefArray(refs), pool)
+    PooledDataArray(DataArrays.RefArray(refs), pool)
 end
 
 data(rs::RString) = DataArray(rs.data, falses(length(rs.data)))

--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1176,7 +1176,7 @@ nas{T}(dv::DataArray{T}, dims) =   # TODO move to datavector.jl?
     DataArray(zeros(T, dims), fill(true, dims))
  
 nas{T,R}(dv::PooledDataVector{T,R}, dims) =
-    PooledDataArray(RefArray(fill(one(R), dims)), dv.pool)
+    PooledDataArray(DataArrays.RefArray(fill(one(R), dims)), dv.pool)
 
 nas(df::DataFrame, dims) = 
     DataFrame([nas(x, dims) for x in df.columns], colnames(df)) 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -316,7 +316,7 @@ function DataArrays.PooledDataArray{R}(d::IndexedVector, ::Type{R})
     # skip over NAs
     nna = length(d) - length(d.x)
     if nna == length(d)
-        return PooledDataArray(RefArray(refs), pool)
+        return PooledDataArray(DataArrays.RefArray(refs), pool)
     end
     lastval = d.x[d.idx[nna+1]]
     push!(pool, d.x[d.idx[nna+1]])
@@ -331,7 +331,7 @@ function DataArrays.PooledDataArray{R}(d::IndexedVector, ::Type{R})
         end
         refs[idx] = poolidx
     end
-    return PooledDataArray(RefArray(refs), pool)
+    return PooledDataArray(DataArrays.RefArray(refs), pool)
 end
 DataArrays.PooledDataArray(d::IndexedVector) = PooledDataArray(d, DEFAULT_POOLED_REF_TYPE)
 

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -93,7 +93,7 @@ function DataArrays.PooledDataVecs(df1::AbstractDataFrame,
         ngroups = ngroups * (length(dv1.pool) + 1)
     end
     pool = [1:ngroups]
-    (PooledDataArray(RefArray(refs1), pool), PooledDataArray(RefArray(refs2), pool))
+    (PooledDataArray(DataArrays.RefArray(refs1), pool), PooledDataArray(DataArrays.RefArray(refs2), pool))
 end
 
 function DataArrays.PooledDataArray{R}(df::AbstractDataFrame, ::Type{R})
@@ -120,7 +120,7 @@ function DataArrays.PooledDataArray{R}(df::AbstractDataFrame, ::Type{R})
             j += 1
         end
     end
-    return PooledDataArray(RefArray(refs), pool)
+    return PooledDataArray(DataArrays.RefArray(refs), pool)
 end
 
 DataArrays.PooledDataArray(df::AbstractDataFrame) = PooledDataArray(df, DEFAULT_POOLED_REF_TYPE)


### PR DESCRIPTION
RefArray is only meant to be used internally for PooledDataArray construction, to distinguish an array of pool indices from an array of integers; a different mechanism should probably be implemented.
