### PR TITLE
handle non-shallow clones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
     - sudo apt-get install libpcre3-dev julia -y
     - git config --global user.name "Travis User"
     - git config --global user.email "travis@example.net"
+    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 script:
-    - git fetch --unshallow
     - julia -e 'versioninfo(); Pkg.init(); Pkg.clone(pwd())'
     - julia ./run_tests.jl


### PR DESCRIPTION
For local clones and clones by travis of repos with less than 50 commits `git fetch --unshallow` was throwing a fatal error.

Also, it's probably a little cleaner to do repo manipulation stuff in the `before_install` section.
