### PR TITLE
Relaxed handling of newlines.

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -33,8 +33,7 @@ macro atnewline(chr, nextchr)
     chr = esc(chr)
     nextchr = esc(nextchr)
     quote
-        $chr == '\n' ||                  # UNIX + Windows
-        $chr == '\r' && $nextchr != '\n' # Mac OS
+        $chr == '\n' || $chr == '\r'
     end
 end
 
@@ -42,9 +41,7 @@ macro atblankline(chr, nextchr)
     chr = esc(chr)
     nextchr = esc(nextchr)
     quote
-        ($chr == '\n' && $nextchr == '\n') || # UNIX
-        ($chr == '\n' && $nextchr == '\r') || # Windows
-        ($chr == '\r' && $nextchr == '\r')    # Mac OS
+        ($chr == '\n' || $chr == '\r') && ($nextchr == '\n' || $nextchr == '\r')
     end
 end
 


### PR DESCRIPTION
I came across this issue with DataFrames when parsing files when windows-style `\r\n` newlines:

Calling `readtable` on csv file like the following with `\r\n` newlines:

``` CSV
"x","y"
"a","b"
```

will result in

```
1x2 DataFrame:
          x     y
[1,]    "a" "b\r"
```

(Everything in the "y" column will have a trailing `\r`)

This is simpler handling in which `\n` and `\r` alone are both treated as newlines. Since blank lines are skipped over anyway, there shouldn't be any trouble with ambiguity.
