### PR TITLE
Strip column names before clean_colnames!

### DIFF
--- a/src/dataframe.jl
+++ b/src/dataframe.jl
@@ -1659,7 +1659,8 @@ function Base.cov(df::DataFrame)
 end
 
 function clean_colnames!(df::DataFrame)
-    new_names = map(n -> replace(n, r"\W", "_"), colnames(df))
+    old_names = map(strip, colnames(df))
+    new_names = map(n -> replace(n, r"\W", "_"), old_names)
     colnames!(df, new_names)
     return
 end


### PR DESCRIPTION
Strip column names before clean_colnames! to remove whitespace before replacing invalid characters with '_'.
