### PR TITLE
Don't parse '+' and '-' as integers.

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -254,9 +254,9 @@ function bytestoint{T <: ByteString}(bytes::Vector{Uint8},
     end
 
     if byte == '-'
-        return -value, true, false
+        return -value, left < right, false
     elseif byte == '+'
-        return value, true, false
+        return value, left < right, false
     elseif '0' <= byte <= '9'
         value += (byte - '0') * power
         return value, true, false


### PR DESCRIPTION
Currently if a column in a file contains all '+' and '-', they are treated as 0 integers. This change requires that '+' and '-' be followed by one or more digits to be parsed as an integer.
