### PR TITLE
nrow = dataframe.jl only

### DIFF
--- a/src/size
+++ b/src/size
@@ -1,2 +1,0 @@
-[detached HEAD 9133131] nrow = dataframe.jl only
- 1 file changed, 28 insertions(+), 28 deletions(-)


### PR DESCRIPTION
I'm getting this error with TimeSeries on travis. 

``` bash
Running tests: 
**   test/date.jl
ERROR: no method nrow()
 in rbind at /home/travis/.julia/DataFrames/src/dataframe.jl:1243
 in collapse at /home/travis/.julia/TimeSeries/src/date.jl:74
 in include at boot.jl:238
 in include_from_node1 at loading.jl:114
 in anonymous at no file:19
 in include at boot.jl:238
 in include_from_node1 at loading.jl:114
 in process_options at client.jl:311
 in _start at client.jl:399
while loading /home/travis/build/JuliaStats/TimeSeries.jl/test/date.jl, in expression starting on line 18
while loading /home/travis/build/JuliaStats/TimeSeries.jl/run_tests.jl, in expression starting on line 15


The command "julia ./run_tests.jl" exited with 1.
```
