### PR TITLE
RFC: Index fixes/updates

### DIFF
--- a/test/index.jl
+++ b/test/index.jl
@@ -1,40 +1,51 @@
 module TestIndex
-	using Base.Test
-	using DataArrays
-	using DataFrames
+using Base.Test
+using DataArrays
+using DataFrames
 
-	i = Index()
-	push!(i, "A")
-	push!(i, "B")
+i = Index()
+push!(i, "A")
+push!(i, "B")
 
-	inds = {1,
-			1.0,
-			"A",
-			:A,
-			[true],
-			trues(1),
-			[1],
-			[1.0],
-			1:1,
-			1.0:1.0,
-			["A"],
-			[:A],
-			@data([true]),
-			@data([1]),
-			@data([1.0]),
-			@data(["A"]),
-			DataArray([:A]),
-			@pdata([true]),
-			@pdata([1]),
-			@pdata([1.0]),
-			@pdata(["A"]),
-			PooledDataArray([:A])}
+inds = {1,
+        1.0,
+        "A",
+        :A,
+        [true],
+        trues(1),
+        [1],
+        [1.0],
+        1:1,
+        1.0:1.0,
+        ["A"],
+        [:A],
+        @data([true]),
+        @data([1]),
+        @data([1.0]),
+        @data(["A"]),
+        DataArray([:A]),
+        @pdata([true]),
+        @pdata([1]),
+        @pdata([1.0]),
+        @pdata(["A"]),
+        PooledDataArray([:A])}
 
-	for ind in inds
-		if isequal(ind, "A") || isequal(ind, :A) || ndims(ind) == 0
-			@assert isequal(i[ind], 1)
-		else
-			@assert (i[ind] == [1])
-		end
-	end
+for ind in inds
+    if isequal(ind, "A") || isequal(ind, :A) || ndims(ind) == 0
+        @test isequal(i[ind], 1)
+    else
+        @test (i[ind] == [1])
+    end
+end
+
+@test names(i) == ["A","B"]
+@test names!(i, ["a","b"]) == Index(["a","b"])
+@test rename(i, ["a"=>"A", "b"=>"B"]) == Index(["A","B"])
+@test rename(i, "a", "A") == Index(["A","b"])
+@test rename(i, ["a"], ["A"]) == Index(["A","b"])
+@test rename(i, uppercase) == Index(["A","B"])
+@test delete!(i, "a") == Index(["b"])
+push!(i, "C")
+@test delete!(i, 1) == Index(["C"])
+
 end


### PR DESCRIPTION
Here are a few fixes/updates to Index
- Fix `rename!` from Dictionary (fixes #442)
- Make `names!, rename!, and delete!` to return the updated `Index`, rather than the names in the index
- Added tests for the above

Other than the bug fix, these changes bring Indexes more in line with mainline julia, and make testing of the updated functions easier.

The bug fix goes farther than the simple fix and reimplements `rename!` to work with any iterable which produces pairs of values; all of the old functionality is still there.

This file still needs some TLC (formatting, testing, and signature updates), but that can come from future PRs.

Let me know if this looks okay for now.
