### PR TITLE
Deprecate vecbind, rbind, cbind

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -209,6 +209,9 @@ include("dataframe_blocks.jl")
 ##
 ##############################################################################
 
+Base.@deprecate vecbind vcat
+Base.@deprecate rbind vcat
+Base.@deprecate cbind hcat
 Base.@deprecate read_table readtable
 Base.@deprecate print_table printtable
 Base.@deprecate write_table writetable

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -139,26 +139,26 @@ function Base.join(df1::AbstractDataFrame,
         join_idx(dv1.refs, dv2.refs, length(dv1.pool))
 
     if kind == :inner
-        return cbind(df1[left_indexer,:], without(df2, on)[right_indexer,:])
+        return hcat(df1[left_indexer,:], without(df2, on)[right_indexer,:])
     elseif kind == :left
         left = df1[[left_indexer,leftonly_indexer],:]
-        right = rbind(without(df2, on)[right_indexer,:],
+        right = vcat(without(df2, on)[right_indexer,:],
                       nas(without(df2, on), length(leftonly_indexer)))
-        return cbind(left, right)
+        return hcat(left, right)
     elseif kind == :right
-        left = rbind(without(df1, on)[left_indexer, :],
+        left = vcat(without(df1, on)[left_indexer, :],
                      nas(without(df1, on), length(rightonly_indexer)))
         right = df2[[right_indexer,rightonly_indexer],:]
-        return cbind(left, right)
+        return hcat(left, right)
     elseif kind == :outer
-        mixed = cbind(df1[left_indexer, :], without(df2, on)[right_indexer, :])
-        leftonly = cbind(df1[leftonly_indexer, :],
+        mixed = hcat(df1[left_indexer, :], without(df2, on)[right_indexer, :])
+        leftonly = hcat(df1[leftonly_indexer, :],
                          nas(without(df2, on), length(leftonly_indexer)))
         leftonly = leftonly[:, colnames(mixed)]
-        rightonly = cbind(nas(without(df1, on), length(rightonly_indexer)),
+        rightonly = hcat(nas(without(df1, on), length(rightonly_indexer)),
                           df2[rightonly_indexer, :])
         rightonly = rightonly[:, colnames(mixed)]
-        return rbind(mixed, leftonly, rightonly)
+        return vcat(mixed, leftonly, rightonly)
     else
         throw(ArgumentError("Unknown kind of join requested"))
     end

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -14,10 +14,10 @@
 ##############################################################################
 
 function stack(df::DataFrame, measure_vars::Vector{Int}, id_vars::Vector{Int})
-    res = [insert!(df[[i, id_vars]], 1, colnames(df)[i], "variable") for i in measure_vars]
+    res = DataFrame[insert!(df[[i, id_vars]], 1, colnames(df)[i], "variable") for i in measure_vars]
     # fix column names
     map(x -> colnames!(x, ["variable", "value", colnames(df[id_vars])]), res)
-    res = rbind(res)
+    res = vcat(res)
     res 
 end
 stack(df::DataFrame, measure_vars, id_vars) = stack(df, [df.colindex[measure_vars]], [df.colindex[id_vars]])
@@ -96,7 +96,7 @@ function pivot_table(df::AbstractDataFrame, rows::Vector{Int}, cols::Vector{Int}
     # find the "row" key DataFrame
     g = groupby(cmb_df[[1:length(rows)]], [1:length(rows)])
     row_key_df = g.parent[g.idx[g.starts],:]
-    cbind(row_key_df, payload)
+    hcat(row_key_df, payload)
 end
 # `mean` is the default aggregation function:
 pivot_table(df::AbstractDataFrame, rows, cols, value) = pivot_table(df, rows, cols, value, mean)

--- a/test/data.jl
+++ b/test/data.jl
@@ -43,19 +43,19 @@ module TestData
 
     #test_group("combining")
 
-    dfc = cbind(df3, df4)
+    dfc = hcat(df3, df4)
     @assert ncol(dfc) == 3
     @assert all(colnames(dfc) .== ["x1", "x1_1", "x2"])
     @assert isequal(dfc["x1"], df3["x1"])
 
     @assert isequal(dfc, [df3 df4])
 
-    dfr = rbind(df4, df4)
+    dfr = vcat(df4, df4)
     @assert nrow(dfr) == 8
     @assert all(colnames(df4) .== colnames(dfr))
     @assert isequal(dfr, [df4, df4])
 
-    dfr = rbind(df2, df3)
+    dfr = vcat(df2, df3)
     @assert size(dfr) == (8,2)
     @assert all(colnames(df2) .== colnames(dfr))
     @assert isna(dfr[8,"x2"])

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -20,7 +20,7 @@ module TestDataFrame
     z = deepcopy(x)  
     # @test is_group(z, "group1")
 
-    z = cbind(x, y)
+    z = hcat(x, y)
     # @test is_group(z, "group1")
     # @test is_group(z, "group2")
 
@@ -28,10 +28,10 @@ module TestDataFrame
         a = [5,6,7]
         b = [8,9,10]
     end)
-    z = rbind({v, x})
+    z = vcat(DataFrame[v, x])
     # @test is_group(z, "group1")
 
-    z = rbind(v,x)
+    z = vcat(v, x)
     # @test is_group(z, "group1")
 
     # Deleting columns removes any mention from groupings

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -13,4 +13,9 @@ module TestGrouping
     bdf = by(df, cols, :(cmax = maximum(c)))
 
     @test isequal(bdf[cols], unique(sdf[cols]))
+
+    bye = by(df, "a", :(bsum = sum(b)))
+    byf = by(df, "a", df -> DataFrame(bsum = sum(df["b"])))
+
+    @test bye["bsum"] == byf["bsum"]
 end


### PR DESCRIPTION
Also fixes typing issues in `vcat`/`rbind` due to missing columns being added as Float64s, and `rbind`/`vcat` now handle PooledData the same way `vcat` normally does (returning PooledDataVectors).

`vcat`/`rbind` no longer accept (unsplatted) Any arrays that happen to be filled with DataFrames. 
