### PR TITLE
[WIP] Rename coltypes, colnames and clean_colnames

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -62,14 +62,11 @@ export # reconcile_groups,
        colmeans,
        colmedians,
        colmins,
-       colnames!,
-       colnames,
        colnorms,
        colprods,
        colranges,
        colstds,
        colsums,
-       coltypes,
        colvars,
        colwise,
        combine,
@@ -151,6 +148,7 @@ export # reconcile_groups,
        SubDataFrame,
        subset,
        table,
+       types,
        unique,
        unstack,
        vector,
@@ -217,5 +215,8 @@ Base.@deprecate read_table readtable
 Base.@deprecate print_table printtable
 Base.@deprecate write_table writetable
 Base.@deprecate merge(df1::AbstractDataFrame, df2::AbstractDataFrame; on::Any = nothing, kind::Symbol = :inner) Base.join
+Base.@deprecate colnames(adf::AbstractDataFrame) Base.names
+Base.@deprecate colnames!(adf::AbstractDataFrame, vals) names!
+Base.@deprecate coltypes(adf::AbstractDataFrame) types
 
 end # module DataFrames

--- a/src/RDA.jl
+++ b/src/RDA.jl
@@ -280,7 +280,7 @@ class(v::RVEC) = haskey(v.attr, "class") ? v.attr["class"].data : Array(ASCIIStr
 class(x) = Array(ASCIIString, 0)
 inherits(x, clnm::ASCIIString) = any(class(x) .== clnm)
 
-names(v::RVEC) = has(v.attr, "names") ? v.attr["names"].data : Array(ASCIIString,0)
+Base.names(v::RVEC) = has(v.attr, "names") ? v.attr["names"].data : Array(ASCIIString,0)
 row_names(v::RVEC) = has(v.attr, "row.names") ? v.attr["row.names"].data : Array(ASCIIString,0)
 
 data(rl::RLogical) = DataArray(rl.data, rl.missng)

--- a/src/datastream.jl
+++ b/src/datastream.jl
@@ -93,7 +93,7 @@ function Base.sum(ds::AbstractDataStream, dim::Integer)
 
     df1, df1 = next(ds, df1)
 
-    cnames = colnames(df1)
+    cnames = names(df1)
     p = length(cnames)
     sums = zeros(p)
     counts = zeros(Int, p)
@@ -147,7 +147,7 @@ function Base.prod(ds::AbstractDataStream, dim::Integer)
 
     df1, df1 = next(ds, df1)
 
-    cnames = colnames(df1)
+    cnames = names(df1)
     p = length(cnames)
     prods = ones(p)
     counts = zeros(Int, p)
@@ -201,7 +201,7 @@ function Base.mean(ds::AbstractDataStream, dim::Integer)
 
     df1, df1 = next(ds, df1)
 
-    cnames = colnames(df1)
+    cnames = names(df1)
     p = length(cnames)
     sums = zeros(p)
     counts = zeros(Int, p)

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -171,7 +171,7 @@ dropUnusedLevels!(x) = x
 function ModelFrame(f::Formula, d::AbstractDataFrame)
     trms = Terms(f)
     df,msng = na_omit(DataFrame(map(x->with(d,x),trms.eterms)))
-    colnames!(df, map(string, trms.eterms))
+    names!(df, map(string, trms.eterms))
     for c in df dropUnusedLevels!(c[2]) end
     ModelFrame(df, trms, msng)
 end

--- a/src/grouping.jl
+++ b/src/grouping.jl
@@ -227,8 +227,8 @@ end
 ## end
 colwise(d::AbstractDataFrame, s::Symbol, x) = colwise(d, [s], x)
 colwise(d::AbstractDataFrame, s::Vector{Symbol}, x::String) = colwise(d, s, [x])
-colwise(d::AbstractDataFrame, s::Symbol) = colwise(d, [s], colnames(d))
-colwise(d::AbstractDataFrame, s::Vector{Symbol}) = colwise(d, s, colnames(d))
+colwise(d::AbstractDataFrame, s::Symbol) = colwise(d, [s], names(d))
+colwise(d::AbstractDataFrame, s::Vector{Symbol}) = colwise(d, s, names(d))
 
 # TODO make this faster by applying the header just once.
 # BUG zero-rowed groupings cause problems here, because a sum of a zero-length
@@ -242,7 +242,7 @@ colwise(d::GroupedDataFrame, s::Vector{Symbol}, x::String) = colwise(d, s, [x])
 colwise(d::GroupedDataFrame, s::Symbol) = colwise(d, [s])
 Base.(:|>)(d::GroupedDataFrame, s::Vector{Symbol}) = colwise(d, s)
 Base.(:|>)(d::GroupedDataFrame, s::Symbol) = colwise(d, [s])
-colnames(d::GroupedDataFrame) = colnames(d.parent)
+Base.names(d::GroupedDataFrame) = names(d.parent)
 
 # by() convenience function
 by(d::AbstractDataFrame, cols, f::Function) = based_on(groupby(d, cols), f)

--- a/src/index.jl
+++ b/src/index.jl
@@ -17,7 +17,7 @@ function Index{T <: ByteString}(x::Vector{T})
 end
 Index() = Index(Dict{ByteString, Indices}(), ByteString[])
 Base.length(x::Index) = length(x.names)
-names(x::Index) = copy(x.names)
+Base.names(x::Index) = copy(x.names)
 Base.copy(x::Index) = Index(copy(x.lookup), copy(x.names))
 Base.deepcopy(x::Index) = Index(deepcopy(x.lookup), deepcopy(x.names))
 Base.isequal(x::Index, y::Index) = isequal(x.lookup, y.lookup) && isequal(x.names, y.names)
@@ -107,7 +107,7 @@ type SimpleIndex <: AbstractIndex
 end
 SimpleIndex() = SimpleIndex(0)
 Base.length(x::SimpleIndex) = x.length
-names(x::SimpleIndex) = nothing
+Base.names(x::SimpleIndex) = nothing
 
 # Chris's idea of namespaces adapted by Harlan for column groups
 function set_group(idx::Index, newgroup, names)

--- a/src/io.jl
+++ b/src/io.jl
@@ -586,7 +586,7 @@ function readtable!(p::ParsedCSV,
 
     # Clean up column names if requested
     if o.cleannames
-        clean_colnames!(df)
+        cleannames!(df)
     end
 
     # Return the final DataFrame
@@ -657,7 +657,7 @@ end
 function filldf!(df::DataFrame,
                  rows::Int, cols::Int, bytes::Int, fields::Int,
                  p::ParsedCSV, o::ParseOptions)
-    ctypes = coltypes(df)
+    ctypes = types(df)
 
     if rows != size(df, 1)
         for j in 1:cols
@@ -729,12 +729,12 @@ function printtable(io::IO,
                     separator::Char = ',',
                     quotemark::Char = '"')
     n, p = size(df)
-    ctypes = coltypes(df)
+    ctypes = types(df)
     if header
-        column_names = colnames(df)
+        cnames = names(df)
         for j in 1:p
             print(io, quotemark)
-            print(io, column_names[j])
+            print(io, cnames[j])
             print(io, quotemark)
             if j < p
                 print(io, separator)
@@ -806,18 +806,18 @@ function Base.writemime(io::IO,
                         ::MIME"text/html", 
                         df::DataFrame)
     n = size(df, 1)
-    column_names = colnames(df)
+    cnames = names(df)
     write(io, "<table>")
     write(io, "<tr>")
     write(io, "<th></th>")
-    for column_name in column_names
+    for column_name in cnames
         write(io, "<th>$column_name</th>")
     end
     write(io, "</tr>")
     for row in 1:n
         write(io, "<tr>")
         write(io, "<th>$row</th>")
-        for column_name in column_names
+        for column_name in cnames
             cell = string(df[row, column_name])
             write(io, "<td>$(html_escape(cell))</td>")
         end

--- a/src/merge.jl
+++ b/src/merge.jl
@@ -131,8 +131,8 @@ function Base.join(df1::AbstractDataFrame,
                    on::Any = nothing,
                    kind::Symbol = :inner)
     if on == nothing
-        on = first(collect(intersect(Set{ByteString}(colnames(df1)...),
-                                     Set{ByteString}(colnames(df2)...))))
+        on = first(collect(intersect(Set{ByteString}(names(df1)...),
+                                     Set{ByteString}(names(df2)...))))
     end
     dv1, dv2 = PooledDataVecs(df1[on], df2[on])
     left_indexer, leftonly_indexer, right_indexer, rightonly_indexer =
@@ -154,10 +154,10 @@ function Base.join(df1::AbstractDataFrame,
         mixed = hcat(df1[left_indexer, :], without(df2, on)[right_indexer, :])
         leftonly = hcat(df1[leftonly_indexer, :],
                          nas(without(df2, on), length(leftonly_indexer)))
-        leftonly = leftonly[:, colnames(mixed)]
+        leftonly = leftonly[:, names(mixed)]
         rightonly = hcat(nas(without(df1, on), length(rightonly_indexer)),
                           df2[rightonly_indexer, :])
-        rightonly = rightonly[:, colnames(mixed)]
+        rightonly = rightonly[:, names(mixed)]
         return vcat(mixed, leftonly, rightonly)
     else
         throw(ArgumentError("Unknown kind of join requested"))

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -238,7 +238,7 @@ for f in (:minimum, :maximum, :prod, :sum, :mean, :median, :std, :var, :norm)
             for j in 1:p
                 res[j] = DataArray(($f)(df[j]))
             end
-            colnames!(res, colnames(df))
+            names!(res, names(df))
             return res
         end
     end

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -14,9 +14,9 @@
 ##############################################################################
 
 function stack(df::DataFrame, measure_vars::Vector{Int}, id_vars::Vector{Int})
-    res = DataFrame[insert!(df[[i, id_vars]], 1, colnames(df)[i], "variable") for i in measure_vars]
+    res = DataFrame[insert!(df[[i, id_vars]], 1, names(df)[i], "variable") for i in measure_vars]
     # fix column names
-    map(x -> colnames!(x, ["variable", "value", colnames(df[id_vars])]), res)
+    map(x -> names!(x, ["variable", "value", names(df[id_vars])]), res)
     res = vcat(res)
     res 
 end
@@ -57,7 +57,7 @@ function unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int, value::Int)
             payload[j][i]  = valuecol[k]
         end
     end
-    insert!(payload, 1, refkeycol.pool, colnames(df)[colkey])
+    insert!(payload, 1, refkeycol.pool, names(df)[colkey])
 end
 unstack(df::AbstractDataFrame, rowkey, value, colkey) =
     unstack(df, index(df)[rowkey], index(df)[value], index(df)[colkey])
@@ -89,7 +89,7 @@ function pivot_table(df::AbstractDataFrame, rows::Vector{Int}, cols::Vector{Int}
     Ncol = length(col_pdv.pool)
     # `payload` is the main "data holding" part of the resulting DataFrame
     payload = DataFrame(Nrow, Ncol)
-    colnames!(payload, col_pdv.pool)
+    names!(payload, col_pdv.pool)
     for i in 1:length(row_idxs)
         payload[row_idxs[i], col_idxs[i]] = cmb_df[i,"x1"]
     end
@@ -261,14 +261,14 @@ end
 function stack_df(df::AbstractDataFrame, measure_vars::Vector{Int}, id_vars::Vector{Int})
     N = length(measure_vars)
     remainingcols = _setdiff([1:ncol(df)], measure_vars)
-    names = colnames(df)[id_vars]
-    insert!(names, 1, "value")
-    insert!(names, 1, "variable")
-    DataFrame({EachRepeatedVector(colnames(df)[measure_vars], nrow(df)), # variable
+    cnames = names(df)[id_vars]
+    insert!(cnames, 1, "value")
+    insert!(cnames, 1, "variable")
+    DataFrame({EachRepeatedVector(names(df)[measure_vars], nrow(df)), # variable
                StackedVector({df[:,c] for c in 1:N}),                    # value
                ## RepeatedVector([1:nrow(df)], N),                       # idx - do we want this?
                [RepeatedVector(df[:,c], N) for c in id_vars]...},        # id_var columns
-              names)
+              cnames)
 end
 stack_df(df::AbstractDataFrame, measure_vars) = stack_df(df, [index(df)[measure_vars]])
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -22,11 +22,11 @@ function getmaxwidths(adf::AbstractDataFrame,
                       rowindices2::AbstractVector{Int},
                       rowlabel::String) # -> Vector{Int}
     ncols = size(adf, 2)
-    names = colnames(adf)
+    cnames = names(adf)
     maxwidths = Array(Int, ncols + 1)
     for j in 1:ncols
         # (1) Consider length of column name
-        maxwidths[j] = ourstrwidth(names[j])
+        maxwidths[j] = ourstrwidth(cnames[j])
 
         # (2) Consider length of longest entry in that column
         for i in rowindices1
@@ -127,7 +127,7 @@ function showrows(io::IO,
                   rowlabel::String = "Row #",
                   displaysummary::Bool = true) # -> Nothing
     ncols = size(adf, 2)
-    names = colnames(adf)
+    cnames = names(adf)
 
     if displaysummary
         println(io, summary(adf))
@@ -162,7 +162,7 @@ function showrows(io::IO,
         # Print column names
         @printf io "| %s | " rowlabel
         for j in leftcol:rightcol
-            s = names[j]
+            s = cnames[j]
             ourshowcompact(io, s)
             padding = maxwidths[j] - ourstrwidth(s)
             for itr in 1:padding
@@ -280,8 +280,8 @@ end
 
 function column_summary(io::IO, adf::AbstractDataFrame) # -> Nothing
     println(io, summary(adf))
-    metadata = DataFrame(Name = colnames(adf),
-                         Type = coltypes(adf),
+    metadata = DataFrame(Name = names(adf),
+                         Type = types(adf),
                          Missing = colmissing(adf))
     showall(io, metadata, true, "Col #", false)
     return

--- a/test/colfuncs.jl
+++ b/test/colfuncs.jl
@@ -5,6 +5,6 @@ module TestColfuncs
 
 	m = [1 2 3; 3 4 6]
 	df = DataFrame(m)
-	@assert isequal(DataFrame([2.0 3.0 4.5;], colnames(df)), colmeans(df))
-	@assert isequal(DataFrame([4 6 9;], colnames(df)), colsums(df))
+	@assert isequal(DataFrame([2.0 3.0 4.5;], names(df)), colmeans(df))
+	@assert isequal(DataFrame([4 6 9;], names(df)), colsums(df))
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -37,17 +37,17 @@ module TestConstructors
 
 	df = DataFrame(Int, 2, 2)
 	@assert size(df) == (2, 2)
-	@assert all(coltypes(df) .== {Int, Int})
+	@assert all(types(df) .== {Int, Int})
 	@assert all(isna(df))
 
 	df = DataFrame(2, 2)
 	@assert size(df) == (2, 2)
-	@assert all(coltypes(df) .== {Float64, Float64})
+	@assert all(types(df) .== {Float64, Float64})
 	@assert all(isna(df))
 
 	df = DataFrame({Int, Float64}, ["x1", "x2"], 2)
 	@assert size(df) == (2, 2)
-	@assert all(coltypes(df) .== {Int, Float64})
+	@assert all(types(df) .== {Int, Float64})
 	@assert all(isna(df))
 
 	@assert isequal(df, DataFrame({Int, Float64}, 2))

--- a/test/data.jl
+++ b/test/data.jl
@@ -25,9 +25,9 @@ module TestData
     #test_group("description functions")
     @assert nrow(df6) == 4
     @assert ncol(df6) == 3
-    @assert all(colnames(df6) .== ["A", "B", "C"])
-    @assert all(colnames(df2) .== ["x1", "x2"])
-    @assert all(colnames(df7) .== ["x", "y"])
+    @assert all(names(df6) .== ["A", "B", "C"])
+    @assert all(names(df2) .== ["x1", "x2"])
+    @assert all(names(df7) .== ["x", "y"])
 
     #test_group("ref")
     @assert df6[2, 3] == "two"
@@ -45,19 +45,19 @@ module TestData
 
     dfc = hcat(df3, df4)
     @assert ncol(dfc) == 3
-    @assert all(colnames(dfc) .== ["x1", "x1_1", "x2"])
+    @assert all(names(dfc) .== ["x1", "x1_1", "x2"])
     @assert isequal(dfc["x1"], df3["x1"])
 
     @assert isequal(dfc, [df3 df4])
 
     dfr = vcat(df4, df4)
     @assert nrow(dfr) == 8
-    @assert all(colnames(df4) .== colnames(dfr))
+    @assert all(names(df4) .== names(dfr))
     @assert isequal(dfr, [df4, df4])
 
     dfr = vcat(df2, df3)
     @assert size(dfr) == (8,2)
-    @assert all(colnames(df2) .== colnames(dfr))
+    @assert all(names(df2) .== names(dfr))
     @assert isna(dfr[8,"x2"])
 
     #test_group("show")
@@ -71,7 +71,7 @@ module TestData
     df6["D"] = [true, false, true, false]
     @assert df6[1,4] == true
     delete!(df6, "D")
-    @assert all(colnames(df6) .== ["A", "B", "C"])
+    @assert all(names(df6) .== ["A", "B", "C"])
     @assert ncol(df6) == 3
 
     #test_group("NA handling")
@@ -238,7 +238,7 @@ module TestData
     d1s3 = melt(d1, ["c", "d"])
     @assert isequal(d1s[1:12, "c"], d1["c"])
     @assert isequal(d1s[13:24, "c"], d1["c"])
-    @assert all(colnames(d1s) .== ["variable", "value", "c", "d"])
+    @assert all(names(d1s) .== ["variable", "value", "c", "d"])
     @assert isequal(d1s, d1s3)
     d1s_df = stack_df(d1, ["a", "b"])
     # TODO: Fix this

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -41,14 +41,14 @@ module TestDataFrame
 
     ## del calls ref, which properly deals with groupings
     y = without(y, "c")
-    @test colnames(y) == ["d"]
+    @test names(y) == ["d"]
     #@test get_groups(y)["group2"] == ["d"]
     z1 = z[[1]]
-    @test colnames(z1) == ["a"]
+    @test names(z1) == ["a"]
     #@test get_groups(z1)["group1"] == ["a"]
 
     z2 = z[:,[1,1,2]]
-    @test colnames(z2) == ["a", "a_1", "b"]
+    @test names(z2) == ["a", "a_1", "b"]
     #@test get_groups(z2)["group1"] == ["a_1", "b"]
 
     #test_group("DataFrame assignment")

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -66,7 +66,7 @@ module TestFormula
 	@test a[:,1] == DataVector([0, 1., 0, 0])
 	@test a[:,2] == DataVector([0, 0, 1., 0])
 	@test a[:,3] == DataVector([0, 0, 0, 1.])
-	@test colnames(a) == ["x1:6.0", "x1:7.0", "x1:8.0"]
+	@test names(a) == ["x1:6.0", "x1:7.0", "x1:8.0"]
 
 	#test_group("create a design matrix from interactions from two DataFrames")
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -110,7 +110,7 @@ module TestIndexing
                       @data([1.0, 2.0]),
                       @data([true, false]),
                       @data(["A", "B"]),
-                      :(colnames(_DF) .== "B")}
+                      :(names(_DF) .== "B")}
 
     #
     # getindex()

--- a/test/rbind.jl
+++ b/test/rbind.jl
@@ -35,7 +35,7 @@ module TestRBind
 	rbind(df, alt_df)
 
 	alt_df = deepcopy(df)
-	colnames!(alt_df, ["A", "B", "C"])
+	names!(alt_df, ["A", "B", "C"])
 	# Fail on non-matching names
 	rbind(df, alt_df)
 

--- a/test/test_ddataframe.jl
+++ b/test/test_ddataframe.jl
@@ -21,8 +21,8 @@ module TestDDataFrame
 	load_pkgs()
 
 	df = dreadtable(datafile, header=false)
-	colnames(df)
-	colnames!(df, ["c1","c2","c3","c4","c5","c6","c7","c8","c9","c10"])
+	names(df)
+	names!(df, ["c1","c2","c3","c4","c5","c6","c7","c8","c9","c10"])
 
 	sum_result = df+df
 	mul_result = 2*df


### PR DESCRIPTION
This branch tries to shrink some names down: it replaces `colnames` with `names`, `colnames!` with `names!`, `coltypes` with `types` and `clean_colnames!` with `cleannames`.

It also has some small code cleanups.
