### PR TITLE
[Experimental] An AbstractDataFrame that's a composite type with columns as type members

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -179,7 +179,9 @@ export # reconcile_groups,
        class,                              # in the S3 sense of "class"
        inherits,
        read_rda,
-       vecbind
+       vecbind,
+       cdataframe,
+       CDataFrame
 
 ##############################################################################
 ##
@@ -191,6 +193,7 @@ include("utils.jl")
 include("index.jl")
 include("namedarray.jl")
 include("dataframe.jl")
+include("cdataframe.jl")
 include("show.jl")
 include("merge.jl")
 include("grouping.jl")

--- a/src/cdataframe.jl
+++ b/src/cdataframe.jl
@@ -1,0 +1,97 @@
+abstract CDataFrame <: AbstractDataFrame
+
+expr_typeof(d::DataType) = :($(d.name))
+
+symb(x::Type) = x.name.name
+symb(x::Int) = x
+symb(x) = symbol(x)
+
+function expr_typeof(d)
+    # return an expression representing the type of d
+    # This is used to build up the member list in the CDataFrame type
+    t = typeof(d)
+    return :($(t.name.name){$(map(symb, t.parameters)...)})
+end
+
+
+function cdataframe(df::AbstractDataFrame)
+    # t = symbol("CDataFrame" * string(gensym()))
+    t = symbol("CDataFrame" * string(rand(Uint16)))
+    typedef = quote
+        type $(t) <: CDataFrame
+        end
+    end
+    type_exprs = Any[]
+    for i in 1:ncol(df)
+        push!(type_exprs, :($(symbol(colnames(df)[i]))::$(expr_typeof(df[:,i]))))
+    end
+    typedef.args[2].args[3].args = type_exprs
+    # typedef.args[2].args[3].args = Any[symbol(x) for x in colnames(df)]
+    eval(typedef)
+    T = eval(:($t))
+    a = Any[]
+    for colname in colnames(df)
+        push!(a, df[colname])
+    end
+    T(a...)
+end
+
+cdataframe(df::CDataFrame) = df
+
+cdataframe(df::CDataFrame; kwargs...) = cdataframe(cbind(DataFrame(df), DataFrame(; kwargs...)))
+
+DataFrame(df::CDataFrame) = DataFrame(Any[df[i] for i in 1:ncol(df)], colnames(df))
+
+colnames(df::CDataFrame) = [string(x)::ByteString for x in names(typeof(df))]
+colsymbols(df::CDataFrame) = [x::Symbol for x in names(typeof(df))]
+
+nrow(df::CDataFrame) = ncol(df) > 0 ? length(getfield(df, names(typeof(df))[1])) : 0
+ncol(df::CDataFrame) = length(typeof(df).types)
+
+index(df::CDataFrame) = Index(colnames(df))
+
+function Base.getindex(df::CDataFrame, col_ind::Real)
+    getfield(df, colsymbols(df)[col_ind])
+end
+
+function Base.getindex(df::CDataFrame, col_ind::String)
+    getfield(df, symbol(col_ind))
+end
+
+function Base.getindex(df::CDataFrame, col_ind::Symbol)
+    getfield(df, col_ind)
+end
+
+function Base.getindex{T <: ColumnIndex}(df::CDataFrame, col_inds::AbstractVector{T})
+    CDataFrame(DataFrame(df)[col_inds])
+end
+
+function Base.getindex(df::CDataFrame, row_ind::Real, col_ind::ColumnIndex)
+    df[col_ind][row_ind]
+end
+
+# df[SingleRowIndex, MultiColumnIndex] => (Sub)?DataFrame
+function Base.getindex{T <: ColumnIndex}(df::CDataFrame, row_ind::Real, col_inds::AbstractVector{T})
+    cdataframe(DataFrame(df)[row_ind, col_inds])
+end
+
+# df[MultiRowIndex, SingleColumnIndex] => (Sub)?AbstractDataVector
+function Base.getindex{T <: Real}(df::CDataFrame, row_inds::AbstractVector{T}, col_ind::ColumnIndex)
+    df[col_ind][row_inds]
+end
+
+# df[MultiRowIndex, MultiColumnIndex] => (Sub)?DataFrame
+function Base.getindex{R <: Real, T <: ColumnIndex}(df::CDataFrame, row_inds::AbstractVector{R}, col_inds::AbstractVector{T})
+    cdataframe(DataFrame(df)[row_inds, col_inds])
+end
+
+# two-argument form, two dfs, references only
+function Base.hcat(df1::CDataFrame, df2::CDataFrame)
+    cdataframe(hcat(DataFrame(df1), DataFrame(df2)))
+end
+
+function Base.hcat(df::CDataFrame, x)
+    cdataframe(hcat(DataFrame(df), DataFrame(x)))
+end
+
+Base.similar(df::CDataFrame, dims) = cdataframe(similar(DataFrame(df), dims))

--- a/test/cdataframe.jl
+++ b/test/cdataframe.jl
@@ -1,0 +1,40 @@
+using Base.Test
+using DataFrames
+
+let
+    N = 5000000
+    x1 = rand(N)
+    x2 = rand(N)
+    df = DataFrame({x1, x2})
+    cdf = cdataframe(df)
+
+    function test_sum_1(d)
+        res = 0.0
+        for i = 1:nrow(d)
+            res += d[i,"x1"] * d[i,"x2"]
+        end
+        res
+    end
+
+    function test_sum_2(d)
+        res = 0.0
+        for i = 1:nrow(d)
+            res += d.x1[i] * d.x2[i]
+        end
+        res
+    end
+
+    function test_sum_3(x1,x2)
+        res = 0.0
+        for i = 1:length(x1)
+            res += x1[i] * x2[i]
+        end
+        res
+    end
+
+    @time test_sum_1(df)
+    @time test_sum_1(cdf)
+    @time test_sum_2(cdf)
+    @time test_sum_3(x1, x2)
+
+end


### PR DESCRIPTION
This is related to #451. `CDataFrame` is an `AbstractDataFrame` made of composite types made on the fly. Columns are directly type members. This has some advantages:
- You can directly access columns with `df.colA`.
- Column access is quite fast. 

It has some disadvantages:
- You cannot do `df["newcol"] = something`. We would need an API that treats DataFrames as immutable. For example, to add a column, I used this: `newdf = tdataframe(olddf, newcol = something)`.
- It might eat up memory with all the type creation.

Here are the results of some tests in [test/cdataframe.jl](https://github.com/tshort/DataFrames.jl/blob/composite-dataframe/test/cdataframe.jl):

```
julia> include("cdataframe.jl")
# standard DataFrame indexing:
elapsed time: 3.495338932 seconds (560157268 bytes allocated)  
# standard DataFrame indexing with a CDataFrame:
elapsed time: 3.249076907 seconds (176956 bytes allocated)  
# composite-style indexing:
elapsed time: 0.020856282 seconds (97116 bytes allocated)
# straight-vector indexing:
elapsed time: 0.018481679 seconds (94796 bytes allocated)
```

The composite-style indexing is nearly as fast as indexing with the raw vectors.

Note that I didn't implement everything needed for it to be an AbstractDataFrame. Here are some things that do work:

```
julia> d = cdataframe(DataFrame(a = 1:10, b = 11:20, c = 21:30))
10x3 CDataFrame63741
|-------|----|----|----|
| Row # | a  | b  | c  |
| 1     | 1  | 11 | 21 |
| 2     | 2  | 12 | 22 |
| 3     | 3  | 13 | 23 |
| 4     | 4  | 14 | 24 |
| 5     | 5  | 15 | 25 |
| 6     | 6  | 16 | 26 |
| 7     | 7  | 17 | 27 |
| 8     | 8  | 18 | 28 |
| 9     | 9  | 19 | 29 |
| 10    | 10 | 20 | 30 |

julia> d.a
10-element DataArray{Int64,1}:
  1
  2
  3
  4
  5
  6
  7
  8
  9
 10

julia> d["a"]
10-element DataArray{Int64,1}:
  1
  2
  3
  4
  5
  6
  7
  8
  9
 10

julia> d[:,["a","c"]]
10x2 CDataFrame36884
|-------|----|----|
| Row # | a  | c  |
| 1     | 1  | 21 |
| 2     | 2  | 22 |
| 3     | 3  | 23 |
| 4     | 4  | 24 |
| 5     | 5  | 25 |
| 6     | 6  | 26 |
| 7     | 7  | 27 |
| 8     | 8  | 28 |
| 9     | 9  | 29 |
| 10    | 10 | 30 |

julia> d[1:2,["a","c"]]
2x2 CDataFrame1687
|-------|---|----|
| Row # | a | c  |
| 1     | 1 | 21 |
| 2     | 2 | 22 |

julia> d[1:2,"a"]
2-element DataArray{Int64,1}:
 1
 2

julia> cdataframe(d, x = d.a .* d.c)
WARNING: cbind is deprecated, use hcat instead.
 in cbind at deprecated.jl:8
 in cdataframe at /home/tshort/.julia/DataFrames/src/cdataframe.jl:41
10x4 CDataFrame62646
|-------|----|----|----|-----|
| Row # | a  | b  | c  | x   |
| 1     | 1  | 11 | 21 | 21  |
| 2     | 2  | 12 | 22 | 44  |
| 3     | 3  | 13 | 23 | 69  |
| 4     | 4  | 14 | 24 | 96  |
| 5     | 5  | 15 | 25 | 125 |
| 6     | 6  | 16 | 26 | 156 |
| 7     | 7  | 17 | 27 | 189 |
| 8     | 8  | 18 | 28 | 224 |
| 9     | 9  | 19 | 29 | 261 |
| 10    | 10 | 20 | 30 | 300 |
```

I'm not sure this is a good idea, but we do need some way to get these speed advantages and also to get `df.colA`.
