### PR TITLE
Implementation of a DataFrame row as a parameterized SubDataFrame (fixes #375)

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -75,13 +75,14 @@ export # reconcile_groups,
        complete_cases!,
        cut,
        DataFrame,
+       DataFrameRow,
        DataStream,
        describe,
        dict,
        drop_duplicates!,
        duplicated,
-       EachCol,
-       EachRow,
+       eachcol,
+       eachrow,
        findat,
        flipud!,
        flipud,
@@ -217,5 +218,8 @@ Base.@deprecate merge(df1::AbstractDataFrame, df2::AbstractDataFrame; on::Any = 
 Base.@deprecate colnames(adf::AbstractDataFrame) Base.names
 Base.@deprecate colnames!(adf::AbstractDataFrame, vals) names!
 Base.@deprecate coltypes(adf::AbstractDataFrame) types
+Base.@deprecate EachRow eachrow
+Base.@deprecate EachCol eachcol
+Base.@deprecate subset sub
 
 end # module DataFrames

--- a/src/show.jl
+++ b/src/show.jl
@@ -266,6 +266,16 @@ function Base.show(adf::AbstractDataFrame,
     show(STDOUT, adf, splitchunks)
 end
 
+function Base.show(io::IO, r::DataFrameRow)
+    labelwidth = mapreduce(length, max, names(r)) + 2
+    @printf("DataFrameRow (row %d)\n", r.row)
+    for (label, value) in r
+        println(io, rpad(label, labelwidth, ' '), value)
+    end
+end
+
+Base.show(row::DataFrameRow) = show(STDOUT, row)
+
 function Base.showall(io::IO,
                       adf::AbstractDataFrame,
                       splitchunks::Bool = false,

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -21,16 +21,37 @@ module TestIteration
 	    @assert ndims(el) == 0
 	end
 
-	for row in EachRow(df)
-	    @assert isa(row, DataFrame)
+	for row in eachrow(df)
+	    @assert isa(row, DataFrameRow)
+	    @assert row["B"]-row["A"] == 1
 	end
 
-	for col in EachCol(df)
+	for col in eachcol(df)
 	    @assert isa(col, AbstractDataVector)
 	end
 
-	@assert isequal(map(x -> minimum(array(x)), EachRow(df)), {1,2})
-	@assert isequal(map(minimum, EachCol(df)), DataFrame(A = [1], B = [2]))
+	@assert isequal(map(x -> minimum(array(x)), eachrow(df)), {1,2})
+	@assert isequal(map(minimum, eachcol(df)), DataFrame(A = [1], B = [2]))
+
+	row = DataFrameRow(df, 1)
+
+	row["A"] = 100
+	@assert df[1, "A"] == 100
+
+	row[1] = 101
+	@assert df[1, "A"] == 101
+
+        df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
+
+        s1 = sub(df, 1:3)
+        s1[2,"A"] = 4
+        @assert df[2, "A"] == 4
+        @assert sub(s1, 1:2) == sub(df, 1:2)
+
+        s2 = sub(df, 1:2:3)
+        s2[2, "B"] = "M"
+        @assert df[3, "B"] == "M"
+        @assert sub(s2, 1:1:2) == sub(df, [1,3])
 
 	# @test_fail for x in df; end # Raises an error
 end


### PR DESCRIPTION
As suggested by @StefanKarpinski [here](https://github.com/JuliaStats/DataFrames.jl/issues/375#issuecomment-26205839), this PR parameterizes `SubDataFrames` by the type of `rows`.  

At this point, I've only implemented `Int` (for individual rows) and `Vector{Int}` (for everything else).  Parameterizing by `Range1{Int}`, as Stefan suggested, would also be a good addition.

This makes indexing within rows more natural, as requested in #375--i.e., the elements of each row can be accessed either by name (`Dict`-like), or numerical index (`Array`-like).  

Some examples:

``` julia
julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
4x2 DataFrame
|-------|---|---|
| Row # | A | B |
| 1     | 1 | M |
| 2     | 2 | F |
| 3     | 3 | F |
| 4     | 4 | M |

julia> for row in EachRow(df)
          println(row)
       end
1x2 SubDataFrame{Int64}
|-------|---|---|
| Row # | A | B |
| 1     | 1 | M |

1x2 SubDataFrame{Int64}
|-------|---|---|
| Row # | A | B |
| 1     | 2 | F |

1x2 SubDataFrame{Int64}
|-------|---|---|
| Row # | A | B |
| 1     | 3 | F |

1x2 SubDataFrame{Int64}
|-------|---|---|
| Row # | A | B |
| 1     | 4 | M |


julia> for row in EachRow(df)
          println(row["A"], " ", row[2])
       end
1 M
2 F
3 F
4 M

julia> row = sub(df, 2)
1x2 SubDataFrame{Int64}
|-------|---|---|
| Row # | A | B |
| 1     | 2 | F |

julia> row["A"] = 200
200

julia> df
4x2 DataFrame
|-------|-----|---|
| Row # | A   | B |
| 1     | 1   | M |
| 2     | 200 | F |
| 3     | 3   | F |
| 4     | 4   | M |

```

Note that this is a **BREAKING** change

Before:

``` julia
julia> row = EachRow(df)[1]
1x2 DataFrame
|-------|---|---|
| Row # | A | B |
| 1     | 1 | M |

julia> row[1]
1-element DataArray{Int64,1}:
 1

julia> typeof(row)
DataFrame (constructor with 22 methods)
```

After:

``` julia
julia> row = EachRow(df)[1]
1x2 SubDataFrame{Int64}
|-------|---|---|
| Row # | A | B |
| 1     | 1 | M |

julia> row[1]
1

julia> typeof(row)
SubDataFrame{Int64} (constructor with 1 method)
```
