### PR TITLE
Escape quotemarks that occur inside of strings when printing DF's

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -723,6 +723,14 @@ end
 #
 ##############################################################################
 
+function escapedprint(io::IO, x::Any, escapes::String)
+    print(io, x)
+end
+
+function escapedprint(io::IO, x::String, escapes::String)
+    print_escaped(io, x, escapes)
+end
+
 function printtable(io::IO,
                     df::DataFrame;
                     header::Bool = true,
@@ -747,10 +755,10 @@ function printtable(io::IO,
         for j in 1:p
             if ! (ctypes[j] <: Real)
                 print(io, quotemark)
-                print(io, df[i, j])
+                escapedprint(io, df[i, j], "\"'")
                 print(io, quotemark)
             else
-                print(io, df[i, j]) #column_names[j])
+                print(io, df[i, j])
             end
             if j < p
                 print(io, separator)


### PR DESCRIPTION
Our current printing is slightly broken, because we don't escape quotemarks that occur inside of strings when we print a DataFrame. This produces invalid CSV files that can't be read in correctly.

Getting this fix just right is a little tricky. This is a very quick patch that solves the problem, but is a bit ugly. Two main questions:
- Should we try to change `print_escaped` in Base to do what the new `escapedprint` function does?
- Should we escape both single and double quotemarks inside of strings? To make valid CSV files, we only need to escape the kind of quotemark that is being used to surround fields.
