### PR TITLE
Fix Tests on 32bit Platform

### DIFF
--- a/test/data.jl
+++ b/test/data.jl
@@ -94,8 +94,9 @@ module TestData
     #test_group("DataFrame")
     srand(1)
     N = 20
-    d1 = pdata(rand(1:2, N))
-    d2 = (@pdata ["A", "B", NA])[rand(1:3, N)]
+    #Cast to int64 as rand() behavior differs between Int32/64
+    d1 = pdata(rand(int64(1:2), N))
+    d2 = (@pdata ["A", "B", NA])[rand(int64(1:3), N)]
     d3 = data(randn(N))
     d4 = data(randn(N))
     df7 = DataFrame({d1, d2, d3}, [:d1, :d2, :d3])

--- a/test/io.jl
+++ b/test/io.jl
@@ -194,7 +194,7 @@ module TestIO
  
     filename = "$testdir/data/typeinference/standardtypes.csv"
     df = readtable(filename)
-    @assert typeof(df[:IntColumn]) == DataArray{Int64,1}
+    @assert typeof(df[:IntColumn]) == DataArray{Int,1}
     @assert typeof(df[:IntlikeColumn]) == DataArray{Float64,1}
     @assert typeof(df[:FloatColumn]) == DataArray{Float64,1}
     @assert typeof(df[:BoolColumn]) == DataArray{Bool,1}
@@ -227,7 +227,7 @@ module TestIO
     filename = "$testdir/data/definedtypes/mixedvartypes.csv"
  
     df = readtable(filename)
-    @assert typeof(df[:n]) == DataArray{Int64,1}
+    @assert typeof(df[:n]) == DataArray{Int,1}
     @assert df[:n][1] == 1
     @assert typeof(df[:s]) == DataArray{UTF8String,1}
     @assert df[:s][1] == "text"


### PR DESCRIPTION
- Change Int64->Int for general readtable() case
- Force rand to generate Int64 values due to an inconsistency in selecting
  random elements

Now the only warnings left on "julia version 0.3.0-prerelease+1492" are warnings about some copy!() functions conflicting with base, but that is independent of 32/64 bit stuff.
All tests pass.
