### PR TITLE
Fix element type declaration of AbstractDataFrame

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -4,7 +4,7 @@
 #'
 #' An AbstractDataFrame is a Julia abstract type for which all concrete
 #' types expose an database-like interface.
-abstract AbstractDataFrame <: Associative{String, Any}
+abstract AbstractDataFrame <: Associative{Symbol, Any}
 
 #' @@name colmissing
 #'


### PR DESCRIPTION
This happens to fix the `jld_dataframes.jl` test in HDF5. However, I should warn you that DataFrames `runtests.jl` failed for me:

```
$ julia runtests.jl
WARNING: Set(a,b...) is deprecated, use Set({a,b...}) instead.
 in Set at deprecated.jl:19
 in reload_path at loading.jl:144
 in _require at loading.jl:59
 in require at loading.jl:43
 in include_from_node1 at loading.jl:120
Running tests:
        PASSED: data.jl
        PASSED: index.jl
        PASSED: dataframe.jl
        PASSED: io.jl
        PASSED: constructors.jl
        PASSED: RDA.jl
        PASSED: sort.jl
        PASSED: grouping.jl
        PASSED: join.jl
        PASSED: vcat.jl
        PASSED: iteration.jl
        PASSED: duplicates.jl
        PASSED: show.jl
cat: test/data/utf8/utf8.csv: No such file or directory
ERROR: could not open file /home/tim/.julia/DataFrames/test/test/stdin.jl
 in include_from_node1 at loading.jl:120

ERROR: failed process: Process(`bash /home/tim/.julia/DataFrames/test/stdin.sh`, ProcessExited(1)) [1]
 in pipeline_error at process.jl:481
 in run at process.jl:458
 in include_from_node1 at loading.jl:120
while loading /home/tim/.julia/DataFrames/test/runtests.jl, in expression starting on line 47
```

I doubt that has to do with this PR, but in case not...

There are also multiple deprecation warnings (although it looks like @simonster fixed the `Set` one):

```
$ julia jld_dataframe.jl 
WARNING: Set(a,b...) is deprecated, use Set({a,b...}) instead.
 in Set at deprecated.jl:19
 in reload_path at loading.jl:144
 in _require at loading.jl:59
 in require at loading.jl:43
 in include_from_node1 at loading.jl:120
WARNING: Default AbstractDataFrame iterator is deprecated, use eachcol(::AbstractDataFrame) instead
 in start at /home/tim/.julia/DataFrames/src/deprecated.jl:65
 in write at /home/tim/.julia/HDF5/src/jld.jl:598
 in include_from_node1 at loading.jl:120
WARNING: Default AbstractDataFrame iterator is deprecated, use eachcol(::AbstractDataFrame) instead
 in start at /home/tim/.julia/DataFrames/src/deprecated.jl:65
 in write at /home/tim/.julia/HDF5/src/jld.jl:598
 in include_from_node1 at loading.jl:120
```

I'm not sure whether the test should be changed, or whether something in DataFrames should be changed.
