### PR TITLE
Remove importall statements

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -25,10 +25,8 @@ using SortingAlgorithms
 ##
 ##############################################################################
 
-importall Base
-importall StatsBase
 import Base: Sort, Order
-import Base.Sort: sort, sort!, Algorithm, defalg, issorted
+import Base.Sort: sort, sort!, sortperm, sortby, sortby!, Algorithm, defalg, issorted
 import Base.Order: Ordering, By, Lt, Perm, Forward, lt, ord
 import Base.AsyncStream
 
@@ -64,7 +62,6 @@ export @~,
        interaction_design_matrix,
        loaddf,
        matrix,
-       merge,
        model_response,
        ModelFrame,
        ModelMatrix,

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -6,6 +6,7 @@ Base.@deprecate cbind hcat
 Base.@deprecate read_table readtable
 Base.@deprecate print_table printtable
 Base.@deprecate write_table writetable
+import Base.merge
 Base.@deprecate merge(df1::AbstractDataFrame, df2::AbstractDataFrame; on::Any = nothing, kind::Symbol = :inner) Base.join
 Base.@deprecate colnames(adf::AbstractDataFrame) Base.names
 Base.@deprecate colnames!(adf::AbstractDataFrame, vals) names!

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,4 +1,5 @@
 module TestData
+    importall Base # so that we get warnings for conflicts
     using Base.Test
     using DataArrays
     using DataFrames


### PR DESCRIPTION
Among other things, this gets rid of the annoying warning about `StatsBase.range` conflicting with `Base.range`, although that still needs to be fixed (JuliaStats/StatsBase.jl#57).
