### PR TITLE
Windows CI using AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+environment:
+  matrix:
+# Releases
+  - JULIAVERSION: "stable/win32"
+  - JULIAVERSION: "stable/win64"
+# Nightlies
+#  - JULIAVERSION: "download/win32"
+#  - JULIAVERSION: "download/win64"
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile($("http://status.julialang.org/"+$env:JULIAVERSION), "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.clone(pwd(), \"DataFrames\"); Pkg.build(\"DataFrames\")"
+
+test_script:
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"DataFrames\")"


### PR DESCRIPTION
AppVeyor is a CI service very much like Travis, but for Windows. DataFrames has been working nicely in Windows for me, but it's good to test that it stays that way. Oddly the `data.jl` and `io.jl` tests don't run properly on AppVeyor, I'm not sure why. The `io.jl` test fails locally for me when I do `Pkg.checkout("DataFrames"); Pkg.test("DataFrames")`, and the `data.jl` test is also failing in Travis, so neither of these seem specific to AppVeyor. See test results for 32 bit: https://ci.appveyor.com/project/tkelman/dataframes-jl/build/1.0.1 and 64 bit: https://ci.appveyor.com/project/tkelman/dataframes-jl/build/1.0.2/job/1j3h47gf82f6n5dw
