### PR TITLE
Tighten up constructors

### DIFF
--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -26,13 +26,11 @@ module TestConstructors
                               0.0 1.0])
     names!(df2, [:x1, :x2])
     @test isequal(df, df2)
-                  
+
     @test isequal(df,
                   convert(DataFrame, [0.0 1.0;
                                       0.0 1.0;
                                       0.0 1.0]))
-    @test isequal(df,
-                  DataFrame(data(zeros(3)), data(ones(3))))
 
     @test isequal(df, DataFrame(x1 = [0.0, 0.0, 0.0],
                                 x2 = [1.0, 1.0, 1.0]))


### PR DESCRIPTION
Since `setindex!` already can't broadcast vectors, removes broadcasting for arrays generally.

Changes instances of `Any` to `Type` where a type is expected (covers `DataType`, `UnionType`, `Constructor`, tuple types, but if I'm missing something).

Deprecates a couple constructors:
- The long-marked `DataFrame(::Any..)`
- `DataFrame(::Associative)`, which has permissive recycling, with the idea that the current `Dict` methods will cover `Associative`s
