### PR TITLE
relax typing on Associatives

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1009,10 +1009,6 @@ nullable!(colnums::Array{Int,1},df::AbstractDataFrame)= (for i in colnums df[i]=
 
 
 function Base.push!(df::DataFrame, associative::Associative{Symbol,Any})    
-    if length(associative) != length(df.columns)
-        msg = "Length of iterable does not match DataFrame column count."
-        throw(ArgumentError(msg))    
-    end
     i=1
     for nm in names(df)
         try 
@@ -1030,18 +1026,14 @@ function Base.push!(df::DataFrame, associative::Associative{Symbol,Any})
 end
 
 
-function Base.push!{K<:String}(df::DataFrame, associative::Associative{K,Any}) 
-    if length(associative) != length(df.columns)
-        msg = "Length of iterable does not match DataFrame column count."
-        throw(ArgumentError(msg))    
-    end
+function Base.push!(df::DataFrame, associative::Associative) 
     i=1
     for nm in names(df)
         try 
             push!(df[nm], associative[string(nm)])
         catch
             #clean up partial row
-            colnames=[symbol(c) for c in names(df)]
+            colnames=[c for c in names(df)]
             for j in 1:(i-1)
                 pop!(df[colnames[j]])
             end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -157,14 +157,19 @@ module TestDataFrame
     push!(dfb, [ :first=>3,:second=>"pear" ])
     @test df==dfb
     
+    df=DataFrame( first=[1,2,3], second=["apple","orange","banana"] )
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    push!(dfb, [ "first"=>3,"second"=>"pear" ])
+    push!(dfb, [ "first"=>3,"second"=>"banana" ])
     @test df==dfb
 
+    df0= DataFrame( first=[1,2], second=["apple","orange"] )
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
     @test_throws ArgumentError push!(dfb, [ :first=>true,:second=>false ])
+    @test df0==dfb
 
+    df0= DataFrame( first=[1,2], second=["apple","orange"] )
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
     @test_throws ArgumentError push!(dfb, ["first"=>"chicken", "second"=>"stuff" ])
+    @test df0==dfb
 
 end


### PR DESCRIPTION
1. Parsing operations sometimes result in Dict{Any,Any} which did not match the previous  
   function Base.push!{K<:String}(df::DataFrame, associative::Associative{K,Any})  method.
2. There is no reason to require the length of a Dict to match the DataFrame column count, and sometimes we may want to load a subset of Dict fields into a DataFrame.

Also added a couple of tests for proper clean-up of Associatives following a type mis-match error.
