### PR TITLE
Fix in-place associative methods so that they actually operate in-place

### DIFF
--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -85,7 +85,7 @@ function Base.delete!(x::Index, idx::Integer)
         x.lookup[x.names[i]] = i - 1
     end
     delete!(x.lookup, x.names[idx])
-    splice!(x.names, idx)
+    deleteat!(x.names, idx)
     return x
 end
 
@@ -95,6 +95,22 @@ function Base.delete!(x::Index, nm::Symbol)
     end
     idx = x.lookup[nm]
     return delete!(x, idx)
+end
+
+function Base.empty!(x::Index)
+    empty!(x.lookup)
+    empty!(x.names)
+    x
+end
+
+function Base.insert!(x::Index, idx::Integer, nm::Symbol)
+    1 <= idx <= length(x.names)+1 || error(BoundsError())
+    for i = idx:length(x.names)
+        x.lookup[x.names[i]] = i + 1
+    end
+    x.lookup[nm] = idx
+    insert!(x.names, idx, nm)
+    x
 end
 
 Base.getindex(x::Index, idx::Symbol) = x.lookup[idx]
@@ -112,4 +128,3 @@ end
 SimpleIndex() = SimpleIndex(0)
 Base.length(x::SimpleIndex) = x.length
 Base.names(x::SimpleIndex) = nothing
-

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -66,6 +66,35 @@ module TestDataFrame
     x0[:d] = 3
     @test x0[:d] == Int[]
 
+    # Associative methods
+
+    df = DataFrame(a=[1, 2], b=[3., 4.])
+    @test haskey(df, :a)
+    @test !haskey(df, :c)
+    @test get(df, :a, -1) === df.columns[1]
+    @test get(df, :c, -1) == -1
+    @test keys(df) == [:a, :b]
+    @test values(df) == {df[:a], df[:b]}
+    @test !isempty(df)
+
+    @test empty!(df) === df
+    @test isempty(df.columns)
+    @test isempty(df)
+
+    df = DataFrame(a=[1, 2], b=[3., 4.])
+    @test_throws BoundsError insert!(df, 5, ["a", "b"], :newcol)
+    @test_throws ErrorException insert!(df, 1, ["a"], :newcol)
+    @test insert!(df, 1, ["a", "b"], :newcol) == df
+    @test isequal(df, DataFrame(newcol=["a", "b"], a=[1, 2], b=[3., 4.]))
+    df = DataFrame(a=[1, 2], b=[3., 4.])
+    @test insert!(df, 3, ["a", "b"], :newcol) == df
+    @test isequal(df, DataFrame(a=[1, 2], b=[3., 4.], newcol=["a", "b"]))
+
+    df = DataFrame(a=[1, 2], b=[3., 4.])
+    df2 = DataFrame(c=["a", "b"], d=[:c, :d])
+    @test insert!(df, df2) == df
+    @test isequal(df, DataFrame(a=[1, 2], b=[3., 4.], c=["a", "b"], d=[:c, :d]))
+
     #test_group("Empty DataFrame constructors")
     df = DataFrame(Int, 10, 3)
     @test size(df, 1) == 10


### PR DESCRIPTION
Previously `empty!` and `insert!` returned new DataFrames instead of modifying their argument
