### PR TITLE
tweak show(GroupedDataFrame) to match other show methods

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -76,8 +76,7 @@ function Base.show(io::IO, gd::GroupedDataFrame)
     println(io, "First Group:")
     show(io, gd[1])
     if N > 1
-        println(io, "       :")
-        println(io, "       :")
+        print(io, "\n⋮\n")
         println(io, "Last Group:")
         show(io, gd[N])
     end


### PR DESCRIPTION
Was missing a newline now that upstream show method doesn't close with one.
