### PR TITLE
exported HOFs all do thunk

### DIFF
--- a/src/dataframe/reshape.jl
+++ b/src/dataframe/reshape.jl
@@ -101,7 +101,7 @@ end
 # `mean` is the default aggregation function:
 pivottable(df::AbstractDataFrame, rows, cols, value) = pivottable(df, rows, cols, value, mean)
 pivottable(df::AbstractDataFrame, rows, cols, value, fun) = pivottable(df, [index(df)[rows]], [index(df)[cols]], index(df)[value], fun)
-
+pivottable(fun::Function, df::AbstractDataFrame, rows, cols, value) = pivottable(df, rows, cols, value, fun)
 
 ##############################################################################
 ##

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -199,5 +199,6 @@ Base.names(d::GroupedDataFrame) = names(d.parent)
 
 # by() convenience function
 by(d::AbstractDataFrame, cols, f::Function) = based_on(groupby(d, cols), f)
+by(f::Function, d::AbstractDataFrame, cols) = by(d, cols, f)
 by(d::AbstractDataFrame, cols, s::Vector{Symbol}) = colwise(groupby(d, cols), s)
 by(d::AbstractDataFrame, cols, s::Symbol) = colwise(groupby(d, cols), s)

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -66,8 +66,10 @@ end
 rename!(x::Index, from, to) = rename!(x, zip(from, to))
 rename!(x::Index, from::Symbol, to::Symbol) = rename!(x, ((from, to),))
 rename!(x::Index, f::Function) = rename!(x, [(x,f(x)) for x in x.names])
+rename!(f::Function, x::Index) = rename!(x, f)
 
 rename(x::Index, args...) = rename!(copy(x), args...)
+rename(f::Function, x::Index) = rename(x, f)
 
 Base.haskey(x::Index, key::Symbol) = haskey(x.lookup, key)
 Base.haskey(x::Index, key::Real) = 1 <= key <= length(x.names)


### PR DESCRIPTION
Changes: 
Some functions have a method whose final arg is a function.
The do block idiom doesn't work for those methods, so alternate methods
were added (exported functions with a single function arg only).

Motivations:
I expected a do block to work with `by`, and added it to the rest for consistency. I've seen this done elsewhere, so I assume it's non-controversial, but I'm not sure, so feel free to contradict.
