### PR TITLE
Add a method to StatsBase.model_response

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -179,7 +179,7 @@ function ModelFrame(f::Formula, d::AbstractDataFrame)
 end
 ModelFrame(ex::Expr, d::AbstractDataFrame) = ModelFrame(Formula(ex), d)
 
-function model_response(mf::ModelFrame)
+function StatsBase.model_response(mf::ModelFrame)
     mf.terms.response || error("Model formula one-sided")
     convert(Array, mf.df[bool(mf.terms.factors[:,1])][:,1])
 end


### PR DESCRIPTION
As it was, this function created a new generic.  It should instead add a method to the existing generic.
