### PR TITLE
fix tests when julia not on path

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,5 +48,7 @@ if anyerrors
     throw("Tests failed")
 end
 
-stdin = Pkg.dir("DataFrames", "test", "stdin.sh")
-run(`bash $stdin`)
+stdin = joinpath(dirname(@__FILE__), "stdin.sh")
+ENV2 = copy(ENV)
+ENV2["JULIA_HOME"] = JULIA_HOME
+run(setenv(`bash $stdin`, ENV2))

--- a/test/stdin.sh
+++ b/test/stdin.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 TESTDIR=$(dirname $0)
-cat $TESTDIR/data/utf8/utf8.csv | julia $TESTDIR/stdin.jl
+cat $TESTDIR/data/utf8/utf8.csv | $JULIA_HOME/julia $TESTDIR/stdin.jl


### PR DESCRIPTION
Also use `dirname(@__FILE__)` rather than `Pkg.dir("DataFrames", "test")` as it's possible someone would want to install the package under a different name.
