### PR TITLE
Don't unneecessarily assing NA when constructing empty DataFrames

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -136,9 +136,6 @@ function DataFrame(column_eltypes::Vector, cnames::Vector, nrows::Integer)
     columns = Array(Any, p)
     for j in 1:p
         columns[j] = DataArray(column_eltypes[j], nrows)
-        for i in 1:nrows
-            columns[j][i] = NA
-        end
     end
     return DataFrame(columns, Index(cnames))
 end
@@ -150,9 +147,6 @@ function DataFrame(column_eltypes::Vector, nrows::Integer)
     cnames = gennames(p)
     for j in 1:p
         columns[j] = DataArray(column_eltypes[j], nrows)
-        for i in 1:nrows
-            columns[j][i] = NA
-        end
     end
     return DataFrame(columns, Index(cnames))
 end
@@ -1092,4 +1086,3 @@ function Base.push!(df::DataFrame, iterable::Any)
         i=i+1
     end
 end
-

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -93,6 +93,9 @@ module TestDataFrame
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Int}
     @test typeof(df[:, 3]) == DataVector{Int}
+    @test allna(df[:, 1])
+    @test allna(df[:, 2])
+    @test allna(df[:, 3])
 
     df = DataFrame({Int, Float64, ASCIIString}, 100)
     @test size(df, 1) == 100
@@ -100,6 +103,9 @@ module TestDataFrame
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Float64}
     @test typeof(df[:, 3]) == DataVector{ASCIIString}
+    @test allna(df[:, 1])
+    @test allna(df[:, 2])
+    @test allna(df[:, 3])
 
     df = DataFrame({Int, Float64, ASCIIString}, [:A, :B, :C], 100)
     @test size(df, 1) == 100
@@ -107,6 +113,9 @@ module TestDataFrame
     @test typeof(df[:, 1]) == DataVector{Int}
     @test typeof(df[:, 2]) == DataVector{Float64}
     @test typeof(df[:, 3]) == DataVector{ASCIIString}
+    @test allna(df[:, 1])
+    @test allna(df[:, 2])
+    @test allna(df[:, 3])
 
     df = convert(DataFrame, zeros(10, 5))
     @test size(df, 1) == 10


### PR DESCRIPTION
I was reading through the DataFrames code trying to familiarize myself with it when I noticed that some of the empty DataFrame constructors loop through every value in the DataFrame and setting it to NA. This is unnecessary since the DataArray constructor already sets every value to NA on construction. This gives on the order of 1000x performance improvement. 

I also added some tests to make sure the constructed DataFrames really are all NA. 
