### PR TITLE
Add predict method using DataFrame predictors

### DIFF
--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -150,11 +150,9 @@ function Terms(f::Formula)
     Terms(tt, ev, facs, oo, haslhs, !any(noint))
 end
 
-function Terms(t::Terms)
-    Terms(t.terms, t.eterms, t.factors, t.order, t.response, t.intercept)
-end
-
-function removeResponse!(t::Terms)
+function remove_response(t::Terms)
+    # shallow copy original terms
+    t = Terms(t.terms, t.eterms, t.factors, t.order, t.response, t.intercept)
     if t.response
         t.order = t.order[2:end]
         t.eterms = t.eterms[2:end]
@@ -193,7 +191,6 @@ end
 
 ModelFrame(f::Formula, d::AbstractDataFrame) = ModelFrame(Terms(f), d)
 ModelFrame(ex::Expr, d::AbstractDataFrame) = ModelFrame(Formula(ex), d)
-ModelFrame(mf::ModelFrame, d::AbstractDataFrame) = ModelFrame(mf.terms, d)
 
 function StatsBase.model_response(mf::ModelFrame)
     mf.terms.response || error("Model formula one-sided")

--- a/src/statsmodels/statsmodel.jl
+++ b/src/statsmodels/statsmodel.jl
@@ -67,9 +67,8 @@ typealias DataFrameModels Union(DataFrameStatisticalModel, DataFrameRegressionMo
 
 # Predict function that takes data frame as predictor instead of matrix
 function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame)
-    # copy terms remove outcome if present
-    newTerms = Terms(mm.mf.terms)
-    removeResponse!(newTerms)
+    # copy terms, removing outcome if present
+    newTerms = remove_response(mm.mf.terms)
     # create new model frame/matrix
     newX = ModelMatrix(ModelFrame(newTerms, df)).m
     predict(mm, newX)


### PR DESCRIPTION
The StatsBase.predict method that is currently delegated to doesn't take DataFrames as predictors, just matrices.  I've added a constructor for ModelFrame which takes Terms and a DataFrame and creates a new ModelFrame based on the original but with new data, and a predict method that uses this to construct a predictor matrix suitable to pass to the StatsBase.predict. (Addresses [GLM.jl #76](https://github.com/JuliaStats/GLM.jl/issues/76))
