### PR TITLE
Distinguish between column names and data through separator

### DIFF
--- a/src/dataframe/show.jl
+++ b/src/dataframe/show.jl
@@ -342,21 +342,7 @@ function showrows(io::IO,
     for chunkindex in 1:nchunks
         leftcol = chunkbounds[chunkindex] + 1
         rightcol = chunkbounds[chunkindex + 1]
-
-        # Print table bounding line
-        write(io, '|')
-        for itr in 1:(rowmaxwidth + 2)
-            write(io, '-')
-        end
-        write(io, '|')
-        for j in leftcol:rightcol
-            for itr in 1:(maxwidths[j] + 2)
-                write(io, '-')
-            end
-            write(io, '|')
-        end
-        write(io, '\n')
-
+        
         # Print column names
         @printf io "| %s" rowlabel
         padding = rowmaxwidth - ourstrwidth(rowlabel)
@@ -377,6 +363,20 @@ function showrows(io::IO,
                 print(io, " | ")
             end
         end
+
+        # Print table bounding line
+        write(io, '|')
+        for itr in 1:(rowmaxwidth + 2)
+            write(io, '-')
+        end
+        write(io, '|')
+        for j in leftcol:rightcol
+            for itr in 1:(maxwidths[j] + 2)
+                write(io, '-')
+            end
+            write(io, '|')
+        end
+        write(io, '\n')
 
         # Print main table body, potentially in two abbreviated sections
         showrowindices(io,


### PR DESCRIPTION
When we print a `DataFrame`, the structure looks at the moment like:

```
using DataFrames

d = data([1, 2, 3])
d[1] = NA
df = DataFrame(a = [:a, :b, :c], b = ["a", "b", "c"], N = d);

df
```

```
3x3 DataFrame
|-----|---|-----|----|
| Row | a | b   | N  |
| 1   | a | "a" | NA |
| 2   | b | "b" | 2  |
| 3   | c | "c" | 3  |
```

The "separator" line marks the beginning of the data table, followed by the column names and then the data.  As you can see with this example, it is tricky to distinguish the names from the actual data itself.

How about using the existing separator line and move it one line down?  This would help telling the variable names apart from the data values, while keeping the output the same size and using the same code:

```
3x3 DataFrame
| Row | a | b   | N  |
|-----|---|-----|----|
| 1   | a | "a" | NA |
| 2   | b | "b" | 2  |
| 3   | c | "c" | 3  |
```

Other tools use a similar output, for example http://orgmode.org/manual/Built_002din-table-editor.html
