### PR TITLE
Make Index work with julia0.4 after Dict revamp.

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1035,7 +1035,8 @@ function Base.push!(df::DataFrame, associative::Associative)
     i=1
     for nm in names(df)
         try
-            push!(df[nm], associative[string(nm)])
+            val = get(() -> associative[string(nm)], associative, nm)
+            push!(df[nm], val)
         catch
             #clean up partial row
             colnames=[c for c in names(df)]

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -13,7 +13,7 @@ type Index <: AbstractIndex   # an OrderedDict would be nice here...
 end
 function Index(x::Vector{Symbol})
     x = make_unique(x)
-    Index(Dict{Symbol, Indices}(tuple(x...), tuple([1:length(x)]...)), x)
+    Index(Dict{Symbol, Indices}(zip(x, 1:length(x))), x)
 end
 Index() = Index(Dict{Symbol, Indices}(), Symbol[])
 Base.length(x::Index) = length(x.names)


### PR DESCRIPTION
Also squashes bug (in push!(::DataFrame, ...)) exposed by change.
