### PR TITLE
Updates to reshape functions and updated documentation

### DIFF
--- a/sphinxdoc/source/reshaping_and_pivoting.rst
+++ b/sphinxdoc/source/reshaping_and_pivoting.rst
@@ -14,8 +14,8 @@ Column names can also be given:
 
     d = stack(iris, [:SepalLength, :SepalWidth, :PetalLength, :PetalWidth])
     
-Note that all columns must be of the same type. Currently, there is no
-type coersion.
+Note that all columns can be of different types. Type promotion
+follows the rules of ``vcat``.
 
 The stacked DataFrame that results includes all of the columns not
 specified to be stacked. These are repeated for each stacked column.

--- a/test/data.jl
+++ b/test/data.jl
@@ -138,29 +138,34 @@ module TestData
     d1 = DataFrame(a = repeat([1:3], inner = [4]),
                    b = repeat([1:4], inner = [3]),
                    c = randn(12),
-                   d = randn(12))
+                   d = randn(12),
+                   e = map(string, ['a':'l']))
 
     stack(d1, :a)
     d1s = stack(d1, [:a, :b])
     d1s2 = stack(d1, [:c, :d])
     d1s3 = stack(d1)
-    d1m = melt(d1, [:c, :d])
+    d1m = melt(d1, [:c, :d, :e])
     @test isequal(d1s[1:12, :c], d1[:c])
     @test isequal(d1s[13:24, :c], d1[:c])
     @test isequal(d1s2, d1s3)
-    @test names(d1s) == [:variable, :value, :c, :d]
+    @test names(d1s) == [:variable, :value, :c, :d, :e]
     @test isequal(d1s, d1m)
     d1m = melt(d1[[1,3,4]], :a)
     @test names(d1m) == [:variable, :value, :a]
 
     stackdf(d1, :a)
-    d1s_df = stackdf(d1, [:a, :b])
-    d1m_df = meltdf(d1, [:c, :d])
-    @test isequal(d1s[:variable], d1s_df[:variable][:])
-    @test isequal(d1s[:value], d1s_df[:value][:])
-    @test isequal(d1s[:c], d1s_df[:c][:])
-    @test isequal(d1s[1,:], d1s_df[1,:])
-    @test isequal(d1s_df, d1m_df)
+    d1s = stackdf(d1, [:a, :b])
+    d1s2 = stackdf(d1, [:c, :d])
+    d1s3 = stackdf(d1)
+    d1m = meltdf(d1, [:c, :d, :e])
+    @test isequal(d1s[1:12, :c], d1[:c])
+    @test isequal(d1s[13:24, :c], d1[:c])
+    @test isequal(d1s2, d1s3)
+    @test names(d1s) == [:variable, :value, :c, :d, :e]
+    @test isequal(d1s, d1m)
+    d1m = meltdf(d1[[1,3,4]], :a)
+    @test names(d1m) == [:variable, :value, :a]
 
     d1s[:id] = [1:12, 1:12]
     d1s2[:id] = [1:12, 1:12]
@@ -170,6 +175,8 @@ module TestData
     @test isequal(d1us[:a], d1[:a])
     @test isequal(d1us2[:d], d1[:d])
     @test isequal(d1us2[:3], d1[:d])
+
+    
 
     d2 = DataFrame(id1 = [:a, :a, :a, :b],
                    id2 = [:A, :B, :B, :B],


### PR DESCRIPTION
I added a few more methods for `stack` and `unstack` and added documentation. The main changes are:
- Added defaults for `stack` and `unstack` with fewer arguments.
- Added a method for `unstack`, so an id column isn't needed.
- Removed pivottable. It wasn't documented, and there are better ways to aggregate.
- A few little bug fixes.
