### PR TITLE
This adds documentation and a few more methods for `stack` and `unstack`.

### DIFF
--- a/sphinxdoc/source/reshaping_and_pivoting.rst
+++ b/sphinxdoc/source/reshaping_and_pivoting.rst
@@ -1,10 +1,89 @@
 Reshaping and Pivoting Data
 ===========================
 
-Reshape data using the ``stack`` function::
+Reshape data from wide to long format using the ``stack`` function::
 
     using DataFrames, RDatasets
-
     iris = dataset("datasets", "iris")
+    iris[:id] = 1:size(iris, 1)  # this makes it easier to unstack
+    d = stack(iris, [1:4])
+    
+The second optional argument to ``stack`` indicates the columns to be
+stacked. These are normally referred to as the measured variables.
+Column names can also be given:
 
-    stack(iris, :SepalLength)
+    d = stack(iris, [:SepalLength, :SepalWidth, :PetalLength, :PetalWidth])
+    
+Note that all columns can be of different types. Type promotion
+follows the rules of ``vcat``.
+
+The stacked DataFrame that results includes all of the columns not
+specified to be stacked. These are repeated for each stacked column.
+These are normally refered to as identifier (id) columns. In addition
+to the id columns, two additional columns labeled ``:variable`` and
+``:values`` contain the column identifier and the stacked columns.
+
+A third optional argument to ``stack`` represents the id columns that
+are repeated. This makes it easier to specify which variables you want
+included in the long format:
+
+    d = stack(iris, [:SepalLength, :SepalWidth], :Species)
+
+``melt`` is an alternative function to reshape from wide to long
+format. It is based on ``stack``, but it prefers specification of the
+id columns as:
+
+    d = melt(iris, :Species)
+
+All other columns are assumed to be measured variables (they are
+stacked). 
+    
+You can also stack an entire DataFrame. The default stacks all
+floating-point columns.
+
+    d = stack(iris)
+
+``unstack`` converts from a long format to a wide format. The default
+is requires specifying which columns are an id variable, column
+variable names, and column values.
+
+    longdf = melt(iris, :id)
+    widedf = unstack(longdf, :id, :variable, :value)
+
+If the remaining columns are unique, you can skip the id variable and
+use:
+
+    widedf = unstack(longdf, :variable, :value)
+
+``stackdf`` and ``meltdf`` are two additional functions that work like
+``stack`` and ``melt``, but they provide a view into the original wide
+DataFrame. Here is an example:
+
+    d = stackdf(iris)
+
+This saves memory. To create the view, several AbstractVectors are
+defined:
+
+``:variable`` column -- ``EachRepeatedVector``
+  This repeats the variables N times where N is the number of rows of
+  the original AbstractDataFrame.
+
+``:value`` column -- ``StackedVector``
+  This is provides a view of the original columns stacked together.
+  
+Id columns -- ``RepeatedVector``
+  This repeats the original columns N times where N is the number of
+  columns stacked.
+
+For more details on the storage representation, see:
+
+    dump(stackdf(iris))
+
+None of these reshaping functions perform any aggregation. To do
+aggregation, use the split-apply-combine functions in combination with
+reshaping. Here is an example:
+
+    d = stack(iris)
+    x = by(d, [:variable, :Species], df -> DataFrame(vsum = mean(df[:value])))
+    unstack(x, :Species, :vsum)
+

--- a/test/data.jl
+++ b/test/data.jl
@@ -138,40 +138,51 @@ module TestData
     d1 = DataFrame(a = repeat([1:3], inner = [4]),
                    b = repeat([1:4], inner = [3]),
                    c = randn(12),
-                   d = randn(12))
+                   d = randn(12),
+                   e = map(string, ['a':'l']))
 
     stack(d1, :a)
     d1s = stack(d1, [:a, :b])
     d1s2 = stack(d1, [:c, :d])
-    d1m = melt(d1, [:c, :d])
+    d1s3 = stack(d1)
+    d1m = melt(d1, [:c, :d, :e])
     @test isequal(d1s[1:12, :c], d1[:c])
     @test isequal(d1s[13:24, :c], d1[:c])
-    @test names(d1s) == [:variable, :value, :c, :d]
+    @test isequal(d1s2, d1s3)
+    @test names(d1s) == [:variable, :value, :c, :d, :e]
     @test isequal(d1s, d1m)
+    d1m = melt(d1[[1,3,4]], :a)
+    @test names(d1m) == [:variable, :value, :a]
 
     stackdf(d1, :a)
-    d1s_df = stackdf(d1, [:a, :b])
-    d1m_df = meltdf(d1, [:c, :d])
-    @test isequal(d1s[:variable], d1s_df[:variable][:])
-    @test isequal(d1s[:value], d1s_df[:value][:])
-    @test isequal(d1s[:c], d1s_df[:c][:])
-    @test isequal(d1s[1,:], d1s_df[1,:])
-    @test isequal(d1s_df, d1m_df)
+    d1s = stackdf(d1, [:a, :b])
+    d1s2 = stackdf(d1, [:c, :d])
+    d1s3 = stackdf(d1)
+    d1m = meltdf(d1, [:c, :d, :e])
+    @test isequal(d1s[1:12, :c], d1[:c])
+    @test isequal(d1s[13:24, :c], d1[:c])
+    @test isequal(d1s2, d1s3)
+    @test names(d1s) == [:variable, :value, :c, :d, :e]
+    @test isequal(d1s, d1m)
+    d1m = meltdf(d1[[1,3,4]], :a)
+    @test names(d1m) == [:variable, :value, :a]
 
-    d1s[:idx] = [1:12, 1:12]
-    d1s2[:idx] = [1:12, 1:12]
-    d1us = unstack(d1s, :idx, :variable, :value)
-    d1us2 = unstack(d1s2, :idx, :variable, :value)
+    d1s[:id] = [1:12, 1:12]
+    d1s2[:id] = [1:12, 1:12]
+    d1us = unstack(d1s, :id, :variable, :value)
+    d1us2 = unstack(d1s2)
+    d1us3 = unstack(d1s2, :variable, :value)
     @test isequal(d1us[:a], d1[:a])
     @test isequal(d1us2[:d], d1[:d])
+    @test isequal(d1us2[:3], d1[:d])
+
+    
 
     d2 = DataFrame(id1 = [:a, :a, :a, :b],
                    id2 = [:A, :B, :B, :B],
                    id3 = [:t, :f, :t, :f],
                    val = [.1, .2, .3, .4])
 
-    @test isequal(pivottable(d2, :id1, [:id2, :id3], :val)[:B_t], @data([0.3, NA]))
-    @test isequal(pivottable(d2, :id2, :id1, :val)[:a], [0.1, 0.25])
 
     #test_group("merge")
 


### PR DESCRIPTION
The main changes are:
- Added defaults for stack and unstack with fewer arguments.
- Added a method for unstack, so an id column isn't needed.
- Removed pivottable. It wasn't documented, and there are better ways to
  aggregate.
- A few little bug fixes.
