### PR TITLE
minor fixes

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -5,7 +5,7 @@ immutable DataFrameRow{T <: AbstractDataFrame}
 end
 
 function Base.getindex(r::DataFrameRow, idx::AbstractArray)
-    return DataFrameRow(r.df[collect(idx)], r.row)
+    return DataFrameRow(r.df[idx], r.row)
 end
 
 function Base.getindex(r::DataFrameRow, idx::Any)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -5,7 +5,7 @@ immutable DataFrameRow{T <: AbstractDataFrame}
 end
 
 function Base.getindex(r::DataFrameRow, idx::AbstractArray)
-    return DataFrameRow(r.df[[idx]], r.row)
+    return DataFrameRow(r.df[collect(idx)], r.row)
 end
 
 function Base.getindex(r::DataFrameRow, idx::Any)
@@ -14,6 +14,16 @@ end
 
 function Base.setindex!(r::DataFrameRow, value::Any, idx::Any)
     return setindex!(r.df, value, r.row, idx)
+end
+
+function Base.setindex!{T <: AbstractDataFrame}(df::DataFrame, r::DataFrameRow{T},
+                                                ::Colon, ::Colon)
+    return setindex!(df, r.df[r.row,:], :, :)
+end
+
+function Base.setindex!{T <: AbstractDataFrame}(df::DataFrame, r::DataFrameRow{T},
+                                                row_inds, ::Colon)
+    return setindex!(df, r.df[r.row,:], row_inds, :)
 end
 
 Base.names(r::DataFrameRow) = names(r.df)
@@ -36,6 +46,10 @@ Base.next(r::DataFrameRow, s) = ((_names(r)[s], r[s]), s + 1)
 Base.done(r::DataFrameRow, s) = s > length(r)
 
 Base.convert(::Type{Array}, r::DataFrameRow) = convert(Array, r.df[r.row,:])
+
+Base.similar(r::DataFrameRow, dims::Int) = similar(r.df, dims)
+
+Base.similar(r::DataFrameRow) = DataFrameRow(similar(r, 1), 1)
 
 # hash of DataFrame rows based on its values
 # so that duplicate rows would have the same hash

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -9,6 +9,8 @@ module TestDataFrameRow
                      @data([:A,  NA,  :C,  :A,  NA,  :C])))
     df2 = DataFrame(a = @data([1, 2, 3]))
 
+    df3 = DataFrame(a = @data([1,1,1]), b = @data([2,2,2]))
+
     #
     # Equality
     #
@@ -25,4 +27,26 @@ module TestDataFrameRow
     @test isequal(hash(DataFrameRow(df, 1)), hash(DataFrameRow(df, 4)))
     @test isequal(hash(DataFrameRow(df, 2)), hash(DataFrameRow(df, 5)))
     @test !isequal(hash(DataFrameRow(df, 2)), hash(DataFrameRow(df, 6)))
+
+    # similar
+    let dfsim1=similar(DataFrameRow(df3,1))
+        @test isa(dfsim1, DataFrameRow)
+        @test length(dfsim1)==size(df3,2)
+    end
+    let dfsim2=similar(DataFrameRow(df3,1),4)
+        @test isa(dfsim2, DataFrame)
+        @test size(dfsim2)==(4,size(df3,2))
+    end
+
+    # setindex!
+    let df4 = DataFrame(a = @data([1,3,5]), b = @data([2,4,6]))
+        df4[2,:] = DataFrameRow(df3,1)
+        df4[3,:] = DataFrameRow(df3,1)
+        @test isequal(df4,df3)
+    end
+    let df5 = DataFrame(a = @data(rand(1:100,3)), b = @data(rand(1:100,3)))
+        df5[:,:] = DataFrameRow(df3,1)
+        @test isequal(df5,df3[1,:])
+    end
+
 end


### PR DESCRIPTION
- fix a deprecation warning about `[]` being used for concatenation
- add `similar` methods for `DataFrameRow`s 
- add some `setindex!` for `DataFrameRows`s as values, setting `DataFrame`s

I found the latter two idiomatic when used in loops with `eachrow`. Tests are of course included.
