### PR TITLE
Avoid aliasing columns on assignment

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -344,7 +344,8 @@ function insert_multiple_entries!{T <: Real}(df::DataFrame,
     end
 end
 
-upgrade_vector(v::Union{Vector,Range,BitVector}) =
+upgrade_vector(v::Vector) = DataArray(copy(v), falses(length(v)))
+upgrade_vector(v::Union{Range,BitVector}) =
     DataArray(collect(v), falses(length(v)))
 upgrade_vector(adv::AbstractDataArray) = copy(adv)
 function upgrade_scalar(df::DataFrame, v::AbstractArray)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -344,10 +344,9 @@ function insert_multiple_entries!{T <: Real}(df::DataFrame,
     end
 end
 
-upgrade_vector(v::Vector) = DataArray(v, falses(length(v)))
-upgrade_vector(v::Range) = DataArray([v;], falses(length(v)))
-upgrade_vector(v::BitVector) = DataArray(convert(Array{Bool}, v), falses(length(v)))
-upgrade_vector(adv::AbstractDataArray) = adv
+upgrade_vector(v::Union{Vector,Range,BitVector}) =
+    DataArray(collect(v), falses(length(v)))
+upgrade_vector(adv::AbstractDataArray) = copy(adv)
 function upgrade_scalar(df::DataFrame, v::AbstractArray)
     msg = "setindex!(::DataFrame, ...) only broadcasts scalars, not arrays"
     throw(ArgumentError(msg))
@@ -395,8 +394,8 @@ end
 function Base.setindex!{T <: ColumnIndex}(df::DataFrame,
                                   v::AbstractVector,
                                   col_inds::AbstractVector{T})
-    dv = upgrade_vector(v)
     for col_ind in col_inds
+        dv = upgrade_vector(v)
         insert_single_column!(df, dv, col_ind)
     end
     return df
@@ -411,8 +410,8 @@ end
 function Base.setindex!{T <: ColumnIndex}(df::DataFrame,
                                   val::Any,
                                   col_inds::AbstractVector{T})
-    dv = upgrade_scalar(df, val)
     for col_ind in col_inds
+        dv = upgrade_scalar(df, val)
         insert_single_column!(df, dv, col_ind)
     end
     return df

--- a/test/mutation.jl
+++ b/test/mutation.jl
@@ -1,0 +1,21 @@
+module TestMutation
+    using Base.Test, DataFrames
+
+    # columns should not alias if scalar broadcasted
+    df = DataFrame(A=[0],B=[0])
+    df[1:end] = 0.0
+    df[1,:A] = 1.0
+    @test df[1,:B] === 0.0
+
+    # columns should not alias if vector assigned
+    df = DataFrame(A=[0],B=[0])
+    df[1:end] = [0.0]
+    df[1,:A] = 1.0
+    @test df[1,:B] === 0.0
+
+    # columns should not alias if DataVector assigned
+    df = DataFrame(A=[0],B=[0])
+    df[:A] = df[:B]
+    df[1,:A] = 1
+    @test df[1,:B] === 0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,8 @@ my_tests = ["utils.jl",
             "duplicates.jl",
             "show.jl",
             "statsmodel.jl",
-            "contrasts.jl"]
+            "contrasts.jl",
+            "mutation.jl"]
 
 println("Running tests:")
 


### PR DESCRIPTION
A Stack Overflow user has reported behaviour that I thought was strange, with regard to aliasing between columns: http://stackoverflow.com/questions/39320783/julia-dataframe-changing-one-cell-changes-entire-row

This makes `upgrade_vector` copying and also unhoists the broadcasting, to remove aliasing. Of course, the performance of these operations will be much worse.

Fixes #1051.
