### PR TITLE
support for confidence intervals in predict

### DIFF
--- a/src/statsmodels/statsmodel.jl
+++ b/src/statsmodels/statsmodel.jl
@@ -86,7 +86,7 @@ function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame; 
     return(out)
 end
 
-# Predict function with confidence intervars
+# Predict function with confidence intervals
 function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame, interval_type::Symbol, level::Real = 0.95; kwargs...)
     newTerms = dropresponse!(mm.mf.terms)
     mf = ModelFrame(newTerms, df; contrasts = mm.mf.contrasts)

--- a/src/statsmodels/statsmodel.jl
+++ b/src/statsmodels/statsmodel.jl
@@ -86,6 +86,16 @@ function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame; 
     return(out)
 end
 
+# Predict function with confidence intervars
+function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame, interval_type::Symbol, level::Real = 0.95; kwargs...)
+    newTerms = dropresponse!(mm.mf.terms)
+    mf = ModelFrame(newTerms, df; contrasts = mm.mf.contrasts)
+    newX = ModelMatrix(mf).m
+    yp = predict(mm, newX, interval_type, level; kwargs...) # this and the below two are different from the non-confint method above
+    out = NullableArray(eltype(yp), size(df, 1), 3)
+    out[mf.msng, :] = yp
+    return(out)
+end
 
 
 # coeftable implementation


### PR DESCRIPTION
There is now support in GLM.jl for generating confidence intervals from the `predict` function for linear models. I added a method here to allow the user to supply newX as a DataFrame.

Some comments:
1. I didn't write any tests, as it seems like all essential functionality is already tested for the existing predict function. If there is something that needs to be tested I wouldn't mind writing one.
2. There has to be two predict methods to ensure type stability. I copied a lot of the code, as extracting the common code into a function called by both methods seemed like it would create less clear resulting code.