### PR TITLE
RFC: Adjust to eltype changes in DataArrays where the function now returns Union{T,NAtype}

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -439,9 +439,8 @@ completecases(df)
 
 """
 function completecases(df::AbstractDataFrame)
-    ## Returns a Vector{Bool} of indexes of complete cases (rows with no NA's).
-    res = (!).(isna.(df[1]))
-    for i in 2:ncol(df)
+    res = trues(size(df, 1))
+    for i in 1:ncol(df)
         res .&= (!).(isna.(df[i]))
     end
     res
@@ -480,7 +479,7 @@ function Base.convert(::Type{Array}, df::AbstractDataFrame)
     convert(Matrix, df)
 end
 function Base.convert(::Type{Matrix}, df::AbstractDataFrame)
-    T = reduce(typejoin, eltypes(df))
+    T = mapreduce(DataArrays.extractT, typejoin, eltypes(df))
     convert(Matrix{T}, df)
 end
 function Base.convert{T}(::Type{Array{T}}, df::AbstractDataFrame)
@@ -502,7 +501,7 @@ function Base.convert(::Type{DataArray}, df::AbstractDataFrame)
     convert(DataMatrix, df)
 end
 function Base.convert(::Type{DataMatrix}, df::AbstractDataFrame)
-    T = reduce(typejoin, eltypes(df))
+    T = mapreduce(DataArrays.extractT, typejoin, eltypes(df))
     convert(DataMatrix{T}, df)
 end
 function Base.convert{T}(::Type{DataArray{T}}, df::AbstractDataFrame)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -94,7 +94,7 @@ function stack(df::AbstractDataFrame, measure_vars)
     stack(df, mv_inds, _setdiff(1:ncol(df), mv_inds))
 end
 function stack(df::AbstractDataFrame)
-    idx = [1:length(df);][[t <: AbstractFloat for t in eltypes(df)]]
+    idx = [1:length(df);][[t <: DataArrays.Data{AbstractFloat} for t in eltypes(df)]]
     stack(df, idx)
 end
 
@@ -102,7 +102,7 @@ end
 Stacks a DataFrame; convert from a wide to long format; see
 `stack`.
 """
-melt(df::AbstractDataFrame, id_vars::Union{Int,Symbol}) = melt(df, [id_vars])
+melt(df::AbstractDataFrame, id_vars::DataArrays.Data{Int}) = melt(df, [id_vars])
 function melt(df::AbstractDataFrame, id_vars)
     id_inds = index(df)[id_vars]
     stack(df, _setdiff(1:ncol(df), id_inds), id_inds)
@@ -441,7 +441,7 @@ function stackdf(df::AbstractDataFrame, measure_vars)
     stackdf(df, m_inds, _setdiff(1:ncol(df), m_inds))
 end
 function stackdf(df::AbstractDataFrame)
-    idx = [1:length(df);][[t <: AbstractFloat for t in eltypes(df)]]
+    idx = [1:length(df);][[t <: DataArrays.Data{AbstractFloat} for t in eltypes(df)]]
     stackdf(df, idx)
 end
 

--- a/src/statsmodels/formula.jl
+++ b/src/statsmodels/formula.jl
@@ -62,7 +62,7 @@ type ModelFrame
     contrasts::Dict{Symbol, ContrastsMatrix}
 end
 
-const AbstractFloatMatrix{T<:AbstractFloat} = AbstractMatrix{T}
+const AbstractFloatMatrix{T<:DataArrays.Data{AbstractFloat}} = AbstractMatrix{T}
 
 type ModelMatrix{T <: AbstractFloatMatrix}
     m::T

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -81,8 +81,8 @@ module TestCat
     @test isna.(dfr[8,:x2])
 
     # Eltype promotion
-    @test eltypes(vcat(DataFrame(a = [1]), DataFrame(a = [2.1]))) == [Float64]
-    @test eltypes(vcat(DataFrame(a = [NA]), DataFrame(a = [2.1]))) == [Float64]
+    @test eltypes(vcat(DataFrame(a = [1]), DataFrame(a = [2.1])))  == [DataArrays.Data{Float64}]
+    @test eltypes(vcat(DataFrame(a = [NA]), DataFrame(a = [2.1]))) == [DataArrays.Data{Float64}]
 
     # Minimal container type promotion
     dfa = DataFrame(a = @pdata([1, 2, 2]))

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -40,11 +40,11 @@ module TestConstructors
 
     df = DataFrame(Int, 2, 2)
     @test size(df) == (2, 2)
-    @test all(eltypes(df) .== [Int, Int])
+    @test all(eltypes(df) .== [DataArrays.Data{Int}, DataArrays.Data{Int}])
 
     df = DataFrame([Int, Float64], [:x1, :x2], 2)
     @test size(df) == (2, 2)
-    @test all(eltypes(df) .== Any[Int, Float64])
+    @test all(eltypes(df) .== Any[DataArrays.Data{Int}, DataArrays.Data{Float64}])
 
     @test isequal(df, DataFrame([Int, Float64], 2))
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -144,7 +144,7 @@ module TestIO
 
     function normalize_eol!(df)
         for (name, col) in eachcol(df)
-            if eltype(col) <: AbstractString
+            if eltype(col) <: DataArrays.Data{AbstractString}
                 df[name] = map(s -> replace(s, "\r\n", "\n"), col)
             end
         end


### PR DESCRIPTION
These are the adjustments required for DataFrames's tests to pass after the changes in https://github.com/JuliaStats/DataArrays.jl/pull/280