### PR TITLE
Update example in documentation for unstack

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -151,7 +151,7 @@ wide = DataFrame(id = 1:12,
                  c  = randn(12),
                  d  = randn(12))
 
-long = stack(wide)
+long = stack(wide,[:c,:d])
 wide0 = unstack(long)
 wide1 = unstack(long, :variable, :value)
 wide2 = unstack(long, :id, :variable, :value)


### PR DESCRIPTION
the `long = stack(wide)` didn't work for me as I was working through the docs. adding the fields, fixed it for me. (I think)