### PR TITLE
Deploy Documenter manual from Julia 0.6 rather than from nightlies

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -40,6 +40,7 @@ deploydocs(
     # options
     repo = "github.com/JuliaData/DataFrames.jl.git",
     target = "build",
+    julia = "0.6",
     deps = nothing,
     make = nothing,
 )


### PR DESCRIPTION
Whenever tests failed on nightlies, the manual was not deployed.