### PR TITLE
`isempty(df)` should return true if either dimension == 0.

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -254,7 +254,7 @@ end
 
 Base.haskey(df::AbstractDataFrame, key::Any) = haskey(index(df), key)
 Base.get(df::AbstractDataFrame, key::Any, default::Any) = haskey(df, key) ? df[key] : default
-Base.isempty(df::AbstractDataFrame) = ncol(df) == 0
+Base.isempty(df::AbstractDataFrame) = size(df, 2) == 0 || size(df, 1) == 0
 
 ##############################################################################
 ##

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -254,7 +254,7 @@ end
 
 Base.haskey(df::AbstractDataFrame, key::Any) = haskey(index(df), key)
 Base.get(df::AbstractDataFrame, key::Any, default::Any) = haskey(df, key) ? df[key] : default
-Base.isempty(df::AbstractDataFrame) = size(df, 2) == 0 || size(df, 1) == 0
+Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0 || size(df, 2) == 0
 
 ##############################################################################
 ##

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -93,6 +93,7 @@ module TestDataFrame
     @test empty!(df) === df
     @test isempty(df.columns)
     @test isempty(df)
+    @test isempty(DataFrame(a=[], b=[]))
 
     df = DataFrame(a=Union{Int, Null}[1, 2], b=Union{Float64, Null}[3.0, 4.0])
     @test_throws BoundsError insert!(df, 5, ["a", "b"], :newcol)


### PR DESCRIPTION
Fixes #1230.