### PR TITLE
Improve show in corner cases

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 Nulls 0.0.6
-CategoricalArrays 0.2.0
+CategoricalArrays 0.2.1
 StatsBase 0.11.0
 SortingAlgorithms
 Reexport

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -253,9 +253,10 @@ function showrowindices(io::IO,
         for _ in 1:padding
             write(io, ' ')
         end
-        print(io, " │ ")
+        print(io, " │")
         # Print DataFrame entry
         for j in leftcol:rightcol
+            print(io, isnull(df[i,j]) ? "*" : " ")
             strlen = 0
             try
                 strlen = ourstrwidth(df[i, j])
@@ -275,7 +276,7 @@ function showrowindices(io::IO,
                     print(io, " │\n")
                 end
             else
-                print(io, " │ ")
+                print(io, " │")
             end
         end
     end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -57,8 +57,6 @@ end
 ourshowcompact(io::IO, x::Any) = showcompact(io, x) # -> Void
 ourshowcompact(io::IO, x::AbstractString) = escape_string(io, x, "") # -> Void
 ourshowcompact(io::IO, x::Symbol) = ourshowcompact(io, string(x)) # -> Void
-ourshowcompact(io::IO, x::CategoricalValue{<:AbstractString}) =
-    ourshowcompact(io, String(x)) # -> Void
 
 #' @description
 #'
@@ -251,7 +249,7 @@ function showrowindices(io::IO,
                 s = df[i, j]
                 strlen = ourstrwidth(s)
                 if isnull(s)
-                    print_with_color(:light_yellow, io, s)
+                    print_with_color(:light_black, io, s)
                 else
                     ourshowcompact(io, s)
                 end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -582,7 +582,7 @@ function showcols(io::IO, df::AbstractDataFrame, all::Bool = false,
                                  sprint(ourshowcompact, df[end, i]) for i in 1:ncols]
         end
     end
-    (all?showall:show)(io, metadata, true, Symbol("Col #"), false)
+    (all ? showall : show)(io, metadata, true, Symbol("Col #"), false)
     return
 end
 

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -58,7 +58,7 @@ ourshowcompact(io::IO, x::Any) = showcompact(io, x) # -> Void
 ourshowcompact(io::IO, x::AbstractString) = escape_string(io, x, "") # -> Void
 ourshowcompact(io::IO, x::Symbol) = ourshowcompact(io, string(x)) # -> Void
 ourshowcompact(io::IO, x::CategoricalValue{<:AbstractString}) =
-    ourshowcompact(io, string(x)) # -> Void
+    ourshowcompact(io, String(x)) # -> Void
 
 #' @description
 #'

--- a/test/io.jl
+++ b/test/io.jl
@@ -44,7 +44,7 @@ module TestIO
     df = DataFrame(A = 1:3,
                    B = 'a':'c',
                    C = ["A", "B", "C"],
-                   D = CategoricalArray('a':'c'),
+                   D = CategoricalArray(string.('a':'c')),
                    E = CategoricalArray(["A", "B", null]),
                    F = Vector{Union{Int, Null}}(1:3),
                    G = nulls(3),
@@ -53,9 +53,9 @@ module TestIO
     @test sprint(printtable, df) ==
         """
         "A","B","C","D","E","F","G","H"
-        1,"'a'","A","'a'","A","1",null,null
-        2,"'b'","B","'b'","B","2",null,null
-        3,"'c'","C","'c'",null,"3",null,null
+        1,"'a'","A","a","A","1",null,null
+        2,"'b'","B","b","B","2",null,null
+        3,"'c'","C","c",null,"3",null,null
         """
 
     # DataStreams

--- a/test/io.jl
+++ b/test/io.jl
@@ -16,7 +16,7 @@ module TestIO
         \t1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 & a \\\\
         \t2 & 2 & M\\&F & \$\\beta\$ & 2.0 &  \\\\
         \t3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  & c \\\\
-        \t4 & 4 & \\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 & d \\\\
+        \t4 & 4 & \\textbackslash{}\\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 & d \\\\
         \\end{tabular}
         """
     @test reprmime(MIME("text/latex"), df) == str

--- a/test/show.jl
+++ b/test/show.jl
@@ -2,17 +2,17 @@ module TestShow
     using Base.Test, DataFrames
 
     # In the future newline character \n should be added to this test case
-    df = DataFrame(A = Int64[1:4;], B = ["x\"", "∀ε⫺0: x+ε⫺x", "z\$", "ABC"],
+    df = DataFrame(A = Int64[1:4;], B = ["x\"", "∀ε>0: x+ε>x", "z\$", "ABC"],
                    C = Float32[1.0, 2.0, 3.0, 4.0])
 
     refstr = """
     4×3 DataFrames.DataFrame
-    │ Row │ A │ B             │ C   │
-    ├─────┼───┼───────────────┼─────┤
-    │ 1   │ 1 │ x\"            │ 1.0 │
-    │ 2   │ 2 │ ∀ε⫺0: x+ε⫺x │ 2.0 │
-    │ 3   │ 3 │ z\$            │ 3.0 │
-    │ 4   │ 4 │ ABC           │ 4.0 │"""
+    │ Row │ A │ B           │ C   │
+    ├─────┼───┼─────────────┼─────┤
+    │ 1   │ 1 │ x\"          │ 1.0 │
+    │ 2   │ 2 │ ∀ε>0: x+ε>x │ 2.0 │
+    │ 3   │ 3 │ z\$          │ 3.0 │
+    │ 4   │ 4 │ ABC         │ 4.0 │"""
 
     for f in [show, showall], allcols in [true, false]
         io = IOBuffer()
@@ -273,7 +273,7 @@ module TestShow
     │ Row │ Fish │ Mass │
     ├─────┼──────┼──────┤
     │ 1   │ Suzy │ 1.5  │
-    │ 2   │ Amir │*null │"""
+    │ 2   │ Amir │ \e[93mnull\e[39m │"""
 
     io = IOBuffer()
     showcols(io, df)
@@ -296,9 +296,9 @@ module TestShow
     3×3 DataFrames.DataFrame
     │ Row │ A      │ B      │ C    │
     ├─────┼────────┼────────┼──────┤
-    │ 1   │ Symbol │*null   │ null │
-    │ 2   │*null   │ String │ null │
-    │ 3   │ null   │ null   │*null │"""
+    │ 1   │ Symbol │ \e[93mnull\e[39m   │ null │
+    │ 2   │ \e[93mnull\e[39m   │ String │ null │
+    │ 3   │ null   │ null   │ \e[93mnull\e[39m │"""
 
     io = IOBuffer()
     showcols(io, df)
@@ -321,4 +321,21 @@ module TestShow
     │ Row │ x │
     ├─────┼───┤
     │ 1   │ a │"""
+
+    # Test escape characters
+    df = DataFrame(a = ["1\n1", "2\t2", "3\r3", "4\$4", "5\"5", "6\\6"])
+    io = IOBuffer()
+    show(io, df)
+    str = String(take!(io))
+    @test str == """
+    6×1 DataFrames.DataFrame
+    │ Row │ a    │
+    ├─────┼──────┤
+    │ 1   │ 1\\n1 │
+    │ 2   │ 2\\t2 │
+    │ 3   │ 3\\r3 │
+    │ 4   │ 4\$4  │
+    │ 5   │ 5\"5  │
+    │ 6   │ 6\\\\6 │"""
+
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -273,7 +273,7 @@ module TestShow
     │ Row │ Fish │ Mass │
     ├─────┼──────┼──────┤
     │ 1   │ Suzy │ 1.5  │
-    │ 2   │ Amir │ null │"""
+    │ 2   │ Amir │*null │"""
 
     io = IOBuffer()
     showcols(io, df)
@@ -284,6 +284,32 @@ module TestShow
     ├───────┼──────┼────────────────────────────┼─────────┼───────────────┤
     │ 1     │ Fish │ String                     │ 0       │ Suzy  …  Amir │
     │ 2     │ Mass │ Union{Float64, Nulls.Null} │ 1       │ 1.5  …  null  │"""
+
+    # Test showing null
+    df = DataFrame(A=[:Symbol, null, :null],
+                   B=[null, "String", "null"],
+                   C=[:null, "null", null])
+    io = IOBuffer()
+    show(io, df)
+    str = String(take!(io))
+    @test str == """
+    3×3 DataFrames.DataFrame
+    │ Row │ A      │ B      │ C    │
+    ├─────┼────────┼────────┼──────┤
+    │ 1   │ Symbol │*null   │ null │
+    │ 2   │*null   │ String │ null │
+    │ 3   │ null   │ null   │*null │"""
+
+    io = IOBuffer()
+    showcols(io, df)
+    str = String(take!(io))
+    @test str == """
+    3×3 DataFrames.DataFrame
+    │ Col # │ Name │ Eltype                    │ Missing │ Values          │
+    ├───────┼──────┼───────────────────────────┼─────────┼─────────────────┤
+    │ 1     │ A    │ Union{Nulls.Null, Symbol} │ 1       │ Symbol  …  null │
+    │ 2     │ B    │ Union{Nulls.Null, String} │ 1       │ null  …  null   │
+    │ 3     │ C    │ Any                       │ 1       │ null  …  null   │"""
 
     # Test computing width for Array{String} columns
     df = DataFrame(Any[["a"]], [:x])

--- a/test/show.jl
+++ b/test/show.jl
@@ -273,7 +273,7 @@ module TestShow
     │ Row │ Fish │ Mass │
     ├─────┼──────┼──────┤
     │ 1   │ Suzy │ 1.5  │
-    │ 2   │ Amir │ \e[93mnull\e[39m │""" : """
+    │ 2   │ Amir │ \e[90mnull\e[39m │""" : """
     2×2 DataFrames.DataFrame
     │ Row │ Fish │ Mass │
     ├─────┼──────┼──────┤
@@ -291,9 +291,9 @@ module TestShow
     │ 2     │ Mass │ Union{Float64, Nulls.Null} │ 1       │ 1.5  …  null  │"""
 
     # Test showing null
-    df = DataFrame(A=[:Symbol, null, :null],
-                   B=[null, "String", "null"],
-                   C=[:null, "null", null])
+    df = DataFrame(A = [:Symbol, null, :null],
+                   B = [null, "String", "null"],
+                   C = [:null, "null", null])
     io = IOBuffer()
     show(io, df)
     str = String(take!(io))
@@ -301,9 +301,9 @@ module TestShow
     3×3 DataFrames.DataFrame
     │ Row │ A      │ B      │ C    │
     ├─────┼────────┼────────┼──────┤
-    │ 1   │ Symbol │ \e[93mnull\e[39m   │ null │
-    │ 2   │ \e[93mnull\e[39m   │ String │ null │
-    │ 3   │ null   │ null   │ \e[93mnull\e[39m │""" : """
+    │ 1   │ Symbol │ \e[90mnull\e[39m   │ null │
+    │ 2   │ \e[90mnull\e[39m   │ String │ null │
+    │ 3   │ null   │ null   │ \e[90mnull\e[39m │""" : """
     3×3 DataFrames.DataFrame
     │ Row │ A      │ B      │ C    │
     ├─────┼────────┼────────┼──────┤

--- a/test/show.jl
+++ b/test/show.jl
@@ -268,12 +268,17 @@ module TestShow
     io = IOBuffer()
     show(io, df)
     str = String(take!(io))
-    @test str == """
+    @test str == (Base.have_color ? """
     2×2 DataFrames.DataFrame
     │ Row │ Fish │ Mass │
     ├─────┼──────┼──────┤
     │ 1   │ Suzy │ 1.5  │
-    │ 2   │ Amir │ \e[93mnull\e[39m │"""
+    │ 2   │ Amir │ \e[93mnull\e[39m │""" : """
+    2×2 DataFrames.DataFrame
+    │ Row │ Fish │ Mass │
+    ├─────┼──────┼──────┤
+    │ 1   │ Suzy │ 1.5  │
+    │ 2   │ Amir │ null │""")
 
     io = IOBuffer()
     showcols(io, df)
@@ -292,13 +297,19 @@ module TestShow
     io = IOBuffer()
     show(io, df)
     str = String(take!(io))
-    @test str == """
+    @test str == (Base.have_color ? """
     3×3 DataFrames.DataFrame
     │ Row │ A      │ B      │ C    │
     ├─────┼────────┼────────┼──────┤
     │ 1   │ Symbol │ \e[93mnull\e[39m   │ null │
     │ 2   │ \e[93mnull\e[39m   │ String │ null │
-    │ 3   │ null   │ null   │ \e[93mnull\e[39m │"""
+    │ 3   │ null   │ null   │ \e[93mnull\e[39m │""" : """
+    3×3 DataFrames.DataFrame
+    │ Row │ A      │ B      │ C    │
+    ├─────┼────────┼────────┼──────┤
+    │ 1   │ Symbol │ null   │ null │
+    │ 2   │ null   │ String │ null │
+    │ 3   │ null   │ null   │ null │""")
 
     io = IOBuffer()
     showcols(io, df)


### PR DESCRIPTION
Incrementally improving `show` for `DataFrames`.
In this PR I propose to indicate `null` with a star. This way one can distinguish `null` from `"null"` and `:null` as can be seen in test cases.
Additionally as `*` is put in an unused visual column it helps to spot null values in a data frame.