### PR TITLE
Restore old == using three-valued logic, separate from isequal()

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -234,8 +234,18 @@ Base.similar(df::AbstractDataFrame, dims::Int) =
 ##
 ##############################################################################
 
-# Imported in DataFrames.jl for compatibility across Julia 0.4 and 0.5
-Base.:(==)(df1::AbstractDataFrame, df2::AbstractDataFrame) = isequal(df1, df2)
+function Base.:(==)(df1::AbstractDataFrame, df2::AbstractDataFrame)
+    size(df1, 2) == size(df2, 2) || return false
+    isequal(index(df1), index(df2)) || return false
+    eq = true
+    for idx in 1:size(df1, 2)
+        coleq = df1[idx] == df2[idx]
+        # coleq could be null
+        !isequal(coleq, false) || return false
+        eq &= coleq
+    end
+    return eq
+end
 
 function Base.isequal(df1::AbstractDataFrame, df2::AbstractDataFrame)
     size(df1, 2) == size(df2, 2) || return false

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -18,15 +18,15 @@ module TestCat
     @test size(dfh, 2) == 3
     @test names(dfh) ≅ [:x1, :x1_1, :x2]
     @test dfh[:x1] ≅ df3[:x1]
-    @test dfh == [df3 df4]
-    @test dfh == DataFrames.hcat!(DataFrame(), df3, df4)
+    @test dfh ≅ [df3 df4]
+    @test dfh ≅ DataFrames.hcat!(DataFrame(), df3, df4)
 
     dfh3 = hcat(df3, df4, df5)
     @test names(dfh3) == [:x1, :x1_1, :x2, :x1_2, :x2_1]
-    @test dfh3 == hcat(dfh, df5)
-    @test dfh3 == DataFrames.hcat!(DataFrame(), df3, df4, df5)
+    @test dfh3 ≅ hcat(dfh, df5)
+    @test dfh3 ≅ DataFrames.hcat!(DataFrame(), df3, df4, df5)
 
-    @test df2 == DataFrames.hcat!(df2)
+    @test df2 ≅ DataFrames.hcat!(df2)
 
     @testset "hcat ::AbstractDataFrame" begin
         df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,5 +1,6 @@
 module TestConstructors
     using Base.Test, DataFrames, DataFrames.Index
+    const ≅ = isequal
 
     #
     # DataFrame
@@ -41,7 +42,7 @@ module TestConstructors
     @test size(df) == (2, 2)
     @test eltypes(df) == [Union{Int, Null}, Union{Float64, Null}]
 
-    @test df == DataFrame([Union{Int, Null}, Union{Float64, Null}], 2)
+    @test df ≅ DataFrame([Union{Int, Null}, Union{Float64, Null}], 2)
 
     @test_throws BoundsError SubDataFrame(DataFrame(A=1), 0)
     @test_throws BoundsError SubDataFrame(DataFrame(A=1), 0)

--- a/test/data.jl
+++ b/test/data.jl
@@ -113,16 +113,16 @@ module TestData
     @test sum(df8[:d1_length]) == N
     @test all(df8[:d1_length] .> 0)
     @test df8[:d1_length] == [4, 5, 11]
-    @test df8 == aggregate(groupby(df7, :d2, sort=true), [sum, length])
+    @test df8 ≅ aggregate(groupby(df7, :d2, sort=true), [sum, length])
     @test df8[1, :d1_length] == 4
     @test df8[2, :d1_length] == 5
     @test df8[3, :d1_length] == 11
-    @test df8 == aggregate(groupby(df7, :d2), [sum, length], sort=true)
+    @test df8 ≅ aggregate(groupby(df7, :d2), [sum, length], sort=true)
 
     df9 = df7 |> groupby([:d2], sort=true) |> [sum, length]
-    @test df9 == df8
+    @test df9 ≅ df8
     df9 = aggregate(df7, :d2, [sum, length], sort=true)
-    @test df9 == df8
+    @test df9 ≅ df8
 
     df10 = DataFrame(
         Any[[1:4;], [2:5;], ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1,5 +1,7 @@
 module TestDataFrame
     using Base.Test, DataFrames
+    const ≅ = isequal
+    const ≇ = !isequal
 
     #
     # Equality
@@ -11,7 +13,7 @@ module TestDataFrame
     @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], c=[4, 5, 6])
     @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(b=[4, 5, 6], a=[1, 2, 3])
     @test DataFrame(a=[1, 2, 2], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) ==
+    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) ≅
                   DataFrame(a=[1, 2, null], b=[4, 5, 6])
 
     @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) == DataFrame(a=[1, 2, 3], b=[4, 5, 6])
@@ -22,9 +24,9 @@ module TestDataFrame
     @test DataFrame(a=[1, 2, 2], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
     @test DataFrame(a=[1, 3, null], b=[4, 5, 6]) !=
              DataFrame(a=[1, 2, null], b=[4, 5, 6])
-    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) ==
+    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) ≅
                 DataFrame(a=[1, 2, null], b=[4, 5, 6])
-    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) !=
+    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) ≇
                 DataFrame(a=[1, 2, 3], b=[4, 5, 6])
 
     #
@@ -79,7 +81,7 @@ module TestDataFrame
     nulldf = DataFrame(a = nulls(Int, 2),
                        b = nulls(String, 2),
                        c = CategoricalArray{Union{Float64, Null}}(2))
-    @test nulldf == similar(df, 2)
+    @test nulldf ≅ similar(df, 2)
 
     # Associative methods
 
@@ -306,7 +308,7 @@ module TestDataFrame
     df4 = DataFrame(Fish = Union{String, Null}["XXX", "Bob", "Batman"],
                     Color = Union{String, Null}[null, "Red", "Grey"],
                     Mass = Union{String, Null}[null, "12 g", "18 g"])
-    @test df2 == df4
+    @test df2 ≅ df4
     @test typeof(df2[:Fish]) <: CategoricalVector{Union{String, Null}}
     # first column stays as CategoricalArray in df3
     @test df3[:, 2:3] == df4[2:3, 2:3]
@@ -315,7 +317,7 @@ module TestDataFrame
     df2 = unstack(df, :Fish, :Key, :Value)
     #This changes the expected result
     df4[2,:Mass] = null
-    @test df2 == df4
+    @test df2 ≅ df4
 
     df = DataFrame(A = 1:10, B = 'A':'J')
     @test !(df[:,:] === df)
@@ -365,7 +367,7 @@ module TestDataFrame
         end
         a = unstack(df, :id, :variable, :value)
         b = unstack(df, :variable, :value)
-        @test a == b == DataFrame(id = [1, 2], a = [5, null], b = [null, 6])
+        @test a ≅ b ≅ DataFrame(id = [1, 2], a = [5, null], b = [null, 6])
 
         df = DataFrame(id=1:2, variable=["a", "b"], value=3:4)
         @static if VERSION >= v"0.6.0-dev.1980"
@@ -374,7 +376,7 @@ module TestDataFrame
         end
         a = unstack(df, :id, :variable, :value)
         b = unstack(df, :variable, :value)
-        @test a == b == DataFrame(id = [1, 2], a = [3, null], b = [null, 4])
+        @test a ≅ b ≅ DataFrame(id = [1, 2], a = [3, null], b = [null, 4])
     end
 
     @testset "rename" begin

--- a/test/duplicates.jl
+++ b/test/duplicates.jl
@@ -1,5 +1,6 @@
 module TestDuplicates
     using Base.Test, DataFrames
+    const ≅ = isequal
 
     df = DataFrame(a = [1, 2, 3, 3, 4])
     udf = DataFrame(a = [1, 2, 3, 4])
@@ -14,9 +15,9 @@ module TestDuplicates
                      b = CategoricalArray(["a", "b", null, "b", "a"]))
     @test nonunique(pdf) == [false, false, false, true, false, false, true, true]
     @test nonunique(updf) == falses(5)
-    @test updf == unique(pdf)
+    @test updf ≅ unique(pdf)
     unique!(pdf)
-    @test pdf == updf
+    @test pdf ≅ updf
 
     @testset "missing" begin
         df = DataFrame(A = 1:12, B = repeat('A':'C', inner=4))

--- a/test/join.jl
+++ b/test/join.jl
@@ -1,5 +1,6 @@
 module TestJoin
     using Base.Test, DataFrames
+    const ≅ = isequal
 
     name = DataFrame(ID = Union{Int, Null}[1, 2, 3],
                      Name = Union{String, Null}["John Doe", "Jane Doe", "Joe Blogs"])
@@ -27,9 +28,9 @@ module TestJoin
 
     @test join(name, job, on = :ID) == inner
     @test join(name, job, on = :ID, kind = :inner) == inner
-    @test join(name, job, on = :ID, kind = :outer) == outer
-    @test join(name, job, on = :ID, kind = :left) == left
-    @test join(name, job, on = :ID, kind = :right) == right
+    @test join(name, job, on = :ID, kind = :outer) ≅ outer
+    @test join(name, job, on = :ID, kind = :left) ≅ left
+    @test join(name, job, on = :ID, kind = :right) ≅ right
     @test join(name, job, on = :ID, kind = :semi) == semi
     @test join(name, job, on = :ID, kind = :anti) == anti
     @test_throws ArgumentError join(name, job)
@@ -148,7 +149,6 @@ module TestJoin
     @testset "all joins" begin
         df1 = DataFrame(Any[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
         df2 = DataFrame(Any[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
-        N = null
 
         @test join(df1, df2, kind=:cross) ==
             DataFrame(Any[repeat([1, 3, 5], inner = 5),
@@ -182,36 +182,36 @@ module TestJoin
         on = :id
         @test i(on) == DataFrame(Any[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
         @test typeof.(i(on).columns) == [Vector{Int}, Vector{Float64}, Vector{Float64}]
-        @test l(on) == DataFrame(id = [1, 3, 5],
-                                 fid = [1, 3, 5],
-                                 fid_1 = [1, 3, N])
+        @test l(on) ≅ DataFrame(id = [1, 3, 5],
+                                fid = [1, 3, 5],
+                                fid_1 = [1, 3, null])
         @test typeof.(l(on).columns) ==
             [Vector{Union{T, Null}} for T in (Int, Float64, Float64)]
-        @test r(on) == DataFrame(id = [1, 3, 0, 2, 4],
-                                 fid = [1, 3, N, N, N],
-                                 fid_1 = [1, 3, 0, 2, 4])
+        @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
+                                fid = [1, 3, null, null, null],
+                                fid_1 = [1, 3, 0, 2, 4])
         @test typeof.(r(on).columns) ==
             [Vector{Union{T, Null}} for T in (Int, Float64, Float64)]
-        @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4],
-                                 fid = [1, 3, 5, N, N, N],
-                                 fid_1 = [1, 3, N, 0, 2, 4])
+        @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
+                                fid = [1, 3, 5, null, null, null],
+                                fid_1 = [1, 3, null, 0, 2, 4])
         @test typeof.(o(on).columns) ==
             [Vector{Union{T, Null}} for T in (Int, Float64, Float64)]
 
         on = :fid
         @test i(on) == DataFrame(Any[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
         @test typeof.(i(on).columns) == [Vector{Int}, Vector{Float64}, Vector{Int}]
-        @test l(on) == DataFrame(id = [1, 3, 5],
-                                 fid = [1, 3, 5],
-                                 id_1 = [1, 3, N])
+        @test l(on) ≅ DataFrame(id = [1, 3, 5],
+                                fid = [1, 3, 5],
+                                id_1 = [1, 3, null])
         @test typeof.(l(on).columns) == [Vector{Union{T, Null}} for T in (Int,Float64,Int)]
-        @test r(on) == DataFrame(id = [1, 3, N, N, N],
-                                 fid = [1, 3, 0, 2, 4],
-                                 id_1 = [1, 3, 0, 2, 4])
+        @test r(on) ≅ DataFrame(id = [1, 3, null, null, null],
+                                fid = [1, 3, 0, 2, 4],
+                                id_1 = [1, 3, 0, 2, 4])
         @test typeof.(r(on).columns) == [Vector{Union{T, Null}} for T in (Int,Float64,Int)]
-        @test o(on) == DataFrame(id = [1, 3, 5, N, N, N],
-                                 fid = [1, 3, 5, 0, 2, 4],
-                                 id_1 = [1, 3, N, 0, 2, 4])
+        @test o(on) ≅ DataFrame(id = [1, 3, 5, null, null, null],
+                                fid = [1, 3, 5, 0, 2, 4],
+                                id_1 = [1, 3, null, 0, 2, 4])
         @test typeof.(o(on).columns) == [Vector{Union{T, Null}} for T in (Int,Float64,Int)]
 
         on = [:id, :fid]
@@ -233,7 +233,6 @@ module TestJoin
                             CategoricalArray([1.0, 3.0, 5.0])], [:id, :fid])
         df2 = DataFrame(Any[CategoricalArray([0, 1, 2, 3, 4]),
                             CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
-        N = null
 
         @test join(df1, df2, kind=:cross) ==
             DataFrame(Any[repeat([1, 3, 5], inner = 5),
@@ -273,19 +272,19 @@ module TestJoin
         @test i(on) == DataFrame(Any[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
         @test all(isa.(i(on).columns,
                        [CategoricalVector{T} for T in (Int, Float64, Float64)]))
-        @test l(on) == DataFrame(id = [1, 3, 5],
-                                 fid = [1, 3, 5],
-                                 fid_1 = [1, 3, N])
+        @test l(on) ≅ DataFrame(id = [1, 3, 5],
+                                fid = [1, 3, 5],
+                                fid_1 = [1, 3, null])
         @test all(isa.(l(on).columns,
                        [CategoricalVector{Union{T, Null}} for T in (Int,Float64,Float64)]))
-        @test r(on) == DataFrame(id = [1, 3, 0, 2, 4],
-                                 fid = [1, 3, N, N, N],
-                                 fid_1 = [1, 3, 0, 2, 4])
+        @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
+                                fid = [1, 3, null, null, null],
+                                fid_1 = [1, 3, 0, 2, 4])
         @test all(isa.(r(on).columns,
                        [CategoricalVector{Union{T, Null}} for T in (Int,Float64,Float64)]))
-        @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4],
-                                 fid = [1, 3, 5, N, N, N],
-                                 fid_1 = [1, 3, N, 0, 2, 4])
+        @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
+                                fid = [1, 3, 5, null, null, null],
+                                fid_1 = [1, 3, null, 0, 2, 4])
         @test all(isa.(o(on).columns,
                        [CategoricalVector{Union{T, Null}} for T in (Int,Float64,Float64)]))
 
@@ -293,19 +292,19 @@ module TestJoin
         @test i(on) == DataFrame(Any[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
         @test all(isa.(i(on).columns,
                        [CategoricalVector{T} for T in (Int, Float64, Int)]))
-        @test l(on) == DataFrame(id = [1, 3, 5],
-                                 fid = [1, 3, 5],
-                                 id_1 = [1, 3, N])
+        @test l(on) ≅ DataFrame(id = [1, 3, 5],
+                                fid = [1, 3, 5],
+                                id_1 = [1, 3, null])
         @test all(isa.(l(on).columns,
                        [CategoricalVector{Union{T, Null}} for T in (Int, Float64, Int)]))
-        @test r(on) == DataFrame(id = [1, 3, N, N, N],
-                                 fid = [1, 3, 0, 2, 4],
-                                 id_1 = [1, 3, 0, 2, 4])
+        @test r(on) ≅ DataFrame(id = [1, 3, null, null, null],
+                                fid = [1, 3, 0, 2, 4],
+                                id_1 = [1, 3, 0, 2, 4])
         @test all(isa.(r(on).columns,
                        [CategoricalVector{Union{T, Null}} for T in (Int, Float64, Int)]))
-        @test o(on) == DataFrame(id = [1, 3, 5, N, N, N],
-                                 fid = [1, 3, 5, 0, 2, 4],
-                                 id_1 = [1, 3, N, 0, 2, 4])
+        @test o(on) ≅ DataFrame(id = [1, 3, 5, null, null, null],
+                                fid = [1, 3, 5, 0, 2, 4],
+                                id_1 = [1, 3, null, 0, 2, 4])
         @test all(isa.(o(on).columns,
                        [CategoricalVector{Union{T, Null}} for T in (Int, Float64, Int)]))
 


### PR DESCRIPTION
This is consistent with `null == null` returning `null` in the next Nulls release (https://github.com/JuliaData/Nulls.jl/pull/33), but does not depend on it. This was actually the old behavior when using DataArrays.

Note that with Nulls.jl master, things like `[1, null] == [1, null]` throw because `if null` is an error. We could probably fix that by providing a special method for `==(::AbstractArray{:>Null}, ::AbstractArray)`, but that would cover  `==(::Array{Any}, ::Array{Any})`... We should discuss that in Nulls.jl. Tests do not appear to cover this, so we should add a few when it works.