### PR TITLE
Remove disambiguation prefix

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -50,7 +50,7 @@ df2 = DataFrame(A = 1:10, B = v, C = rand(10))
 dump(df1)
 dump(df2)
 describe(df2)
-DataFrames.head(df1)
+head(df1)
 df1[:A] + df2[:C]
 df1[1:4, 1:2]
 df1[[:A,:C]]


### PR DESCRIPTION
I think this was to get rid of a warning/error when a dependency of `DataTables` also imported `DataFrames` and the names conflicted? Either way, we don't need it anymore