### PR TITLE
Fix StackOverflow in promote_col_type() when grouping with large number of groups

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -673,7 +673,7 @@ Base.hcat(df::AbstractDataFrame, x, y...) = hcat!(hcat(df, x), y...)
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...) = hcat!(hcat(df1, df2), dfn...)
 
 @generated function promote_col_type(cols::AbstractVector...)
-    T = promote_type(map(x -> Nulls.T(eltype(x)), cols)...)
+    T = mapreduce(x -> Nulls.T(eltype(x)), promote_type, cols)
     if T <: CategoricalValue
         T = T.parameters[1]
     end


### PR DESCRIPTION
This is a fix to a rather critical stack overflow error that can occur when aggregating even modestly sized data sets.  See discussion [here](https://discourse.julialang.org/t/stack-overflow-in-dataframes-group-by/6357).

Fixes #1247.