### PR TITLE
Update CI test badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
-
 language: julia
+
 julia:
   - 0.6
   - nightly
+
 os:
   - linux
   - osx
+
+matrix:
+ allow_failures:
+ - julia: nightly
+
 notifications:
   email: false
+
 before_script:
   - export PATH=$HOME/.local/bin:$PATH
+
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("DataFrames"); Pkg.test("DataFrames"; coverage=true)'
+
 after_success:
   - julia -e 'cd(Pkg.dir("DataFrames")); Pkg.add("Documenter"); Pkg.add("Query"); include(joinpath("docs", "make.jl"))'
   - julia -e 'cd(Pkg.dir("DataFrames")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ DataFrames.jl
 =============
 
 [![0.6](http://pkg.julialang.org/badges/DataFrames_0.6.svg)](http://pkg.julialang.org/?pkg=DataFrames)
-[![0.7](http://pkg.julialang.org/badges/DataFrames_0.7.svg)](http://pkg.julialang.org/?pkg=DataFrames)
 
 [![Coverage Status](https://coveralls.io/repos/JuliaData/DataFrames.jl/badge.svg?branch=master&service=github)](https://coveralls.io/github/JuliaData/DataFrames.jl?branch=master)
 [![Travis Build Status](https://travis-ci.org/JuliaData/DataFrames.jl.svg?branch=master)](https://travis-ci.org/JuliaData/DataFrames.jl)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,11 @@ branches:
     - master
     - /release-.*/
 
+matrix:
+ allow_failures:
+ - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+ - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+
 notifications:
   - provider: Email
     on_build_success: false


### PR DESCRIPTION
Allow failures on nightly for now until a release candidate for 0.7
is ready. Remove Julia package evaluator badge for 0.7 to be added back
later