### PR TITLE
Reintroduce temporarily GZip dependency for deprecated CSV functions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ SortingAlgorithms
 Reexport
 WeakRefStrings 0.3.0
 DataStreams 0.2.0
+GZip

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -20,6 +20,7 @@ import Base: keys, values, insert!
 
 
 ## write.table
+using GZip
 
 export writetable
 """


### PR DESCRIPTION
Without it, the functions failed when working with compressed .csv.gz files.

Missed by https://github.com/JuliaData/DataFrames.jl/pull/1243.