### PR TITLE
Avoid calling vcat(dfs...) in combine()

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -715,7 +715,8 @@ julia> vcat(df1, df2)
 ```
 """
 Base.vcat(df::AbstractDataFrame) = df
-function Base.vcat(dfs::AbstractDataFrame...)
+Base.vcat(dfs::AbstractDataFrame...) = _vcat(collect(dfs))
+function _vcat(dfs::AbstractVector{<:AbstractDataFrame})
     isempty(dfs) && return DataFrame()
     allheaders = map(names, dfs)
     if all(h -> length(h) == 0, allheaders)

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -193,7 +193,7 @@ combine(map(d -> mean(Nulls.skip(d[:c])), gd))
 """
 function combine(ga::GroupApplied)
     gd, vals = ga.gd, ga.vals
-    valscat = vcat(vals...)
+    valscat = _vcat(vals)
     idx = Vector{Int}(size(valscat, 1))
     j = 0
     @inbounds for (start, val) in zip(gd.starts, vals)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -155,7 +155,7 @@ module TestGrouping
     groupby(df, [:v1, :v2])
 
     df2 = by(e->1, DataFrame(x=Int64[]), :x)
-    @test size(df2) == (0,2)
+    @test size(df2) == (0, 1)
     @test sum(df2[:x]) == 0
 
     # Check that reordering levels does not confuse groupby


### PR DESCRIPTION
This avoids compiling specialized methods for each number of arguments,
which can be very large when using `groupby()`. The code does not take
advantage at all of that information anyway. The code prior to
refactoring used to do that, by exporting
`vcat(::Vector{AbstractDataFrame})`. Use an internal method instead since
this is non-standard.

Incidentally, this fixes a small bug introduced in the refactoring: when
working with an empty data frame, `vcat()` was called, and it returns
`Any[0]`, which surprisingly implied the addition of a bogus `x1` column to
the result. The test was actually correct before refactoring.

Refactoring was done at https://github.com/JuliaData/DataTables.jl/pull/45. See also report at https://discourse.julialang.org/t/stack-overflow-in-dataframes-group-by/6357.

Cc: @ExpandingMan 