### PR TITLE
Add skipnull argument to groupby()

### DIFF
--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -44,7 +44,7 @@ module TestDataFrameRow
 
 
     # check that hashrows() function generates the same hashes as DataFrameRow
-    df_rowhashes = DataFrames.hashrows(df)
+    df_rowhashes, _ = DataFrames.hashrows(df, false)
     @test df_rowhashes == [hash(dr) for dr in eachrow(df)]
 
     # test incompatible frames


### PR DESCRIPTION
The new argument allows skipping values with at least one null in one
of the grouping columns. Doing this in `groupby()` is more efficient
and more convenient than dropping them before calling `groupby()`.

Fixes https://github.com/JuliaData/DataFrames.jl/issues/1249.