### PR TITLE
WIP: Port to Missings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,6 +4,6 @@ CategoricalArrays 0.3.0
 StatsBase 0.11.0
 SortingAlgorithms
 Reexport
-WeakRefStrings 0.3.0
-DataStreams 0.2.0
+WeakRefStrings 0.4.0
+DataStreams 0.3.0
 GZip

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
-Nulls 0.0.6
-CategoricalArrays 0.2.1
+Missings
+CategoricalArrays 0.3.0
 StatsBase 0.11.0
 SortingAlgorithms
 Reexport

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -26,13 +26,14 @@ meltdf
 ## Basics
 
 ```@docs
+allow_missing!
 categorical!
 combine
 completecases
 deleterows!
 describe
-dropnull
-dropnull!
+dropmissing
+dropmissing!
 eachcol
 eachrow
 eltypes
@@ -40,7 +41,6 @@ head
 names
 names!
 nonunique
-nullable!
 order
 rename!
 rename

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -26,7 +26,7 @@ meltdf
 ## Basics
 
 ```@docs
-allow_missing!
+allowmissing!
 categorical!
 combine
 completecases

--- a/docs/src/man/categorical.md
+++ b/docs/src/man/categorical.md
@@ -30,20 +30,20 @@ julia> cv = CategoricalArray(v)
 
 ```
 
-`CategoricalArrays` support missing values via the `Nulls` package.
+`CategoricalArrays` support missing values via the `Missings` package.
 
 ```jldoctest categorical
-julia> using Nulls
+julia> using Missings
 
-julia> cv = CategoricalArray(["Group A", null, "Group A",
-                              "Group B", "Group B", null])
-6-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32}:
+julia> cv = CategoricalArray(["Group A", missing, "Group A",
+                              "Group B", "Group B", missing])
+6-element CategoricalArrays.CategoricalArray{Union{Missings.Missing, String},1,UInt32}:
  "Group A"
- null
+ missing
  "Group A"
  "Group B"
  "Group B"
- null
+ missing
 ```
 
 In addition to representing repeated data efficiently, the `CategoricalArray` type allows us to determine efficiently the allowed levels of the variable at any time using the `levels` function (note that levels may or may not be actually used in the data):
@@ -67,13 +67,13 @@ julia> levels(cv)
  "Group A"
 
 julia> sort(cv)
-6-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt32}:
+6-element CategoricalArrays.CategoricalArray{Union{Missings.Missing, String},1,UInt32}:
  "Group B"
  "Group B"
  "Group A"
  "Group A"
- null
- null
+ missing
+ missing
 
 ```
 
@@ -81,13 +81,13 @@ By default, a `CategoricalArray` is able to represent 2<sup>32</sup>differents l
 
 ```jldoctest categorical
 julia> cv = compress(cv)
-6-element CategoricalArrays.CategoricalArray{Union{Nulls.Null, String},1,UInt8}:
+6-element CategoricalArrays.CategoricalArray{Union{Missings.Missing, String},1,UInt8}:
  "Group A"
- null
+ missing
  "Group A"
  "Group B"
  "Group B"
- null
+ missing
 
 ```
 

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -9,66 +9,66 @@ Pkg.add("DataFrames")
 
 Throughout the rest of this tutorial, we will assume that you have installed the DataFrames package and have already typed `using DataFrames` to bring all of the relevant variables into your current namespace.
 
-## The `Null` Type
+## The `Missing` Type
 
-To get started, let's examine the `Null` type. `Null` is a type implemented by the [Nulls.jl](https://github.com/JuliaData/Nulls.jl) package to represent missing data. `null` is an instance of the type `Null` used to represent a missing value.
+To get started, let's examine the `Missing` type. `Missing` is a type implemented by the [Missings.jl](https://github.com/JuliaData/Missings.jl) package to represent missing data. `missing` is an instance of the type `Missing` used to represent a missing value.
 
-```jldoctest nulls
+```jldoctest missings
 julia> using DataFrames
 
-julia> null
-null
+julia> missing
+missing
 
-julia> typeof(null)
-Nulls.Null
+julia> typeof(missing)
+Missings.Missing
 
 ```
 
-The `Null` type lets users create `Vector`s and `DataFrame` columns with missing values. Here we create a vector with a null value and the element-type of the returned vector is `Union{Nulls.Null, Int64}`.
+The `Missing` type lets users create `Vector`s and `DataFrame` columns with missing values. Here we create a vector with a missing value and the element-type of the returned vector is `Union{Missings.Missing, Int64}`.
 
-```jldoctest nulls
-julia> x = [1, 2, null]
-3-element Array{Union{Nulls.Null, Int64},1}:
+```jldoctest missings
+julia> x = [1, 2, missing]
+3-element Array{Union{Missings.Missing, Int64},1}:
  1
  2
-  null
+  missing
 
 julia> eltype(x)
-Union{Nulls.Null, Int64}
+Union{Missings.Missing, Int64}
 
-julia> Union{Null, Int}
-Union{Nulls.Null, Int64}
+julia> Union{Missing, Int}
+Union{Missings.Missing, Int64}
 
-julia> eltype(x) == Union{Null, Int}
+julia> eltype(x) == Union{Missing, Int}
 true
 
 ```
 
-`null` values can be excluded when performing operations by using `Nulls.skip`, which returns a memory-efficient iterator.
+`missing` values can be excluded when performing operations by using `Missings.skip`, which returns a memory-efficient iterator.
 
-```jldoctest nulls
-julia> Nulls.skip(x)
-Base.Generator{Base.Iterators.Filter{Nulls.##4#6,Array{Union{Int64, Nulls.Null},1}},Nulls.##3#5}(Nulls.#3, Base.Iterators.Filter{Nulls.##4#6,Array{Union{Int64, Nulls.Null},1}}(Nulls.#4, Union{Int64, Nulls.Null}[1, 2, null]))
+```jldoctest missings
+julia> Missings.skip(x)
+Base.Generator{Base.Iterators.Filter{Missings.##4#6,Array{Union{Int64, Missings.Missing},1}},Missings.##3#5}(Missings.#3, Base.Iterators.Filter{Missings.##4#6,Array{Union{Int64, Missings.Missing},1}}(Missings.#4, Union{Int64, Missings.Missing}[1, 2, missing]))
 
 ```
 
-The output of `Nulls.skip` can be passed directly into functions as an argument. For example, we can find the `sum` of all non-null values or `collect` the non-null values into a new null-free vector.
+The output of `Missings.skip` can be passed directly into functions as an argument. For example, we can find the `sum` of all non-missing values or `collect` the non-missing values into a new missing-free vector.
 
-```jldoctest nulls
-julia> sum(Nulls.skip(x))
+```jldoctest missings
+julia> sum(Missings.skip(x))
 3
 
-julia> collect(Nulls.skip(x))
+julia> collect(Missings.skip(x))
 2-element Array{Int64,1}:
  1
  2
 
 ```
 
-`null` elements can be replaced with other values via `Nulls.replace`.
+`missing` elements can be replaced with other values via `Missings.replace`.
 
-```jldoctest nulls
-julia> collect(Nulls.replace(x, 1))
+```jldoctest missings
+julia> collect(Missings.replace(x, 1))
 3-element Array{Int64,1}:
  1
  2
@@ -76,37 +76,37 @@ julia> collect(Nulls.replace(x, 1))
 
 ```
 
-The function `Nulls.T` returns the element-type `T` in `Union{T, Null}`.
+The function `Missings.T` returns the element-type `T` in `Union{T, Missing}`.
 
-```jldoctest nulls
+```jldoctest missings
 julia> eltype(x)
-Union{Int64, Nulls.Null}
+Union{Int64, Missings.Missing}
 
-julia> Nulls.T(eltype(x))
+julia> Missings.T(eltype(x))
 Int64
 
 ```
 
-Use `nulls` to generate nullable `Vector`s and `Array`s, using the optional first argument to specify the element-type.
+Use `missings` to generate `Vector`s and `Array`s supporting missing values, using the optional first argument to specify the element-type.
 
-```jldoctest nulls
-julia> nulls(1)
-1-element Array{Nulls.Null,1}:
- null
+```jldoctest missings
+julia> missings(1)
+1-element Array{Missings.Missing,1}:
+ missing
 
-julia> nulls(3)
-3-element Array{Nulls.Null,1}:
- null
- null
- null
+julia> missings(3)
+3-element Array{Missings.Missing,1}:
+ missing
+ missing
+ missing
 
-julia> nulls(1, 3)
-1×3 Array{Nulls.Null,2}:
- null  null  null
+julia> missings(1, 3)
+1×3 Array{Missings.Missing,2}:
+ missing  missing  missing
 
-julia> nulls(Int, 1, 3)
-1×3 Array{Union{Nulls.Null, Int64},2}:
- null  null  null
+julia> missings(Int, 1, 3)
+1×3 Array{Union{Missings.Missing, Int64},2}:
+ missing  missing  missing
 
 ```
 
@@ -256,22 +256,22 @@ beforehand. Here we will replace all odd-numbered rows in the first column with 
 to show how to handle the above example when missing values are present in your dataset.
 
 ```jldoctest dataframe
-julia> df[:A] = [isodd(i) ? null : value for (i, value) in enumerate(df[:A])];
+julia> df[:A] = [isodd(i) ? missing : value for (i, value) in enumerate(df[:A])];
 
 julia> df
 8×2 DataFrames.DataFrame
-│ Row │ A    │ B │
-├─────┼──────┼───┤
-│ 1   │ null │ M │
-│ 2   │ 2    │ F │
-│ 3   │ null │ F │
-│ 4   │ 4    │ M │
-│ 5   │ null │ F │
-│ 6   │ 6    │ M │
-│ 7   │ null │ M │
-│ 8   │ 8    │ F │
+│ Row │ A       │ B │
+├─────┼─────────┼───┤
+│ 1   │ missing │ M │
+│ 2   │ 2       │ F │
+│ 3   │ missing │ F │
+│ 4   │ 4       │ M │
+│ 5   │ missing │ F │
+│ 6   │ 6       │ M │
+│ 7   │ missing │ M │
+│ 8   │ 8       │ F │
 
-julia> mean(Nulls.skip(df[:A]))
+julia> mean(Missings.skip(df[:A]))
 5.0
 
 ```

--- a/docs/src/man/joins.md
+++ b/docs/src/man/joins.md
@@ -65,25 +65,25 @@ julia> join(names, jobs, on = :ID, kind = :inner)
 
 julia> join(names, jobs, on = :ID, kind = :left)
 2×3 DataFrames.DataFrame
-│ Row │ ID │ Name     │ Job    │
-├─────┼────┼──────────┼────────┤
-│ 1   │ 20 │ John Doe │ Lawyer │
-│ 2   │ 40 │ Jane Doe │ null   │
+│ Row │ ID │ Name     │ Job     │
+├─────┼────┼──────────┼─────────┤
+│ 1   │ 20 │ John Doe │ Lawyer  │
+│ 2   │ 40 │ Jane Doe │ missing │
 
 julia> join(names, jobs, on = :ID, kind = :right)
 2×3 DataFrames.DataFrame
 │ Row │ ID │ Name     │ Job       │
 ├─────┼────┼──────────┼───────────┤
 │ 1   │ 20 │ John Doe │ Lawyer    │
-│ 2   │ 60 │ null     │ Astronaut │
+│ 2   │ 60 │ missing  │ Astronaut │
 
 julia> join(names, jobs, on = :ID, kind = :outer)
 3×3 DataFrames.DataFrame
-│ Row │ ID │ Name     │ Job       │
-├─────┼────┼──────────┼───────────┤
-│ 1   │ 20 │ John Doe │ Lawyer    │
-│ 2   │ 40 │ Jane Doe │ null      │
-│ 3   │ 60 │ null     │ Astronaut │
+│ Row │ ID │ Name        │ Job       │
+├─────┼────┼─────────────┼───────────┤
+│ 1   │ 20 │ John Doe    │ Lawyer    │
+│ 2   │ 40 │ Jane Doe    │ missing   │
+│ 3   │ 60 │ missing     │ Astronaut │
 
 julia> join(names, jobs, on = :ID, kind = :semi)
 1×2 DataFrames.DataFrame

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -8,7 +8,7 @@ module DataFrames
 ##############################################################################
 
 using Reexport, StatsBase, SortingAlgorithms
-@reexport using CategoricalArrays, Nulls
+@reexport using CategoricalArrays, Missings
 
 using Base: Sort, Order
 import Base: ==, |>
@@ -26,6 +26,7 @@ export AbstractDataFrame,
        GroupedDataFrame,
        SubDataFrame,
 
+       allow_missing!,
        aggregate,
        by,
        categorical!,
@@ -34,8 +35,8 @@ export AbstractDataFrame,
        completecases,
        deleterows!,
        describe,
-       dropnull,
-       dropnull!,
+       dropmissing,
+       dropmissing!,
        eachcol,
        eachrow,
        eltypes,
@@ -47,7 +48,6 @@ export AbstractDataFrame,
        ncol,
        nonunique,
        nrow,
-       nullable!,
        order,
        rename!,
        rename,

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -26,7 +26,7 @@ export AbstractDataFrame,
        GroupedDataFrame,
        SubDataFrame,
 
-       allow_missing!,
+       allowmissing!,
        aggregate,
        by,
        categorical!,

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -17,7 +17,7 @@ function printtable(io::IO,
                     header::Bool = true,
                     separator::Char = ',',
                     quotemark::Char = '"',
-                    nastring::AbstractString = "null")
+                    nastring::AbstractString = "missing")
     n, p = size(df)
     etypes = eltypes(df)
     if header
@@ -36,7 +36,7 @@ function printtable(io::IO,
     quotestr = string(quotemark)
     for i in 1:n
         for j in 1:p
-            if !isnull(df[j][i])
+            if !ismissing(df[j][i])
                 if ! (etypes[j] <: Real)
                     print(io, quotemark)
                     escapedprint(io, df[i, j], quotestr)
@@ -61,7 +61,7 @@ function printtable(df::AbstractDataFrame;
                     header::Bool = true,
                     separator::Char = ',',
                     quotemark::Char = '"',
-                    nastring::AbstractString = "null")
+                    nastring::AbstractString = "missing")
     printtable(STDOUT,
                df,
                header = header,
@@ -164,7 +164,7 @@ function Base.show(io::IO, ::MIME"text/latex", df::AbstractDataFrame)
         for col in 1:ncols
             write(io, " & ")
             cell = df[row,col]
-            if !isnull(cell)
+            if !ismissing(cell)
                 if mimewritable(MIME("text/latex"), cell)
                     show(io, MIME("text/latex"), cell)
                 else
@@ -232,13 +232,13 @@ Data.weakrefstrings(::Type{DataFrame}) = true
 allocate(::Type{T}, rows, ref) where {T} = Vector{T}(rows)
 allocate(::Type{CategoricalValue{T, R}}, rows, ref) where {T, R} =
     CategoricalArray{T, 1, R}(rows)
-allocate(::Type{Union{Null, CategoricalValue{T, R}}}, rows, ref) where {T, R} =
-    CategoricalArray{Union{Null, T}, 1, R}(rows)
+allocate(::Type{Union{Missing, CategoricalValue{T, R}}}, rows, ref) where {T, R} =
+    CategoricalArray{Union{Missing, T}, 1, R}(rows)
 allocate(::Type{WeakRefString{T}}, rows, ref) where {T} =
     WeakRefStringArray(ref, WeakRefString{T}, rows)
-allocate(::Type{Union{Null, WeakRefString{T}}}, rows, ref) where {T} =
-    WeakRefStringArray(ref, Union{Null, WeakRefString{T}}, rows)
-allocate(::Type{Null}, rows, ref) = nulls(rows)
+allocate(::Type{Union{Missing, WeakRefString{T}}}, rows, ref) where {T} =
+    WeakRefStringArray(ref, Union{Missing, WeakRefString{T}}, rows)
+allocate(::Type{Missing}, rows, ref) = missings(rows)
 
 # Construct or modify a DataFrame to be ready to stream data from a source with `sch`
 function DataFrame(sch::Data.Schema{R}, ::Type{S}=Data.Field,

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -232,7 +232,7 @@ function unstack(df::AbstractDataFrame, colkey::Int, value::Int)
     end
     keycol = CategoricalArray{Union{eltype(df[colkey]), Missing}}(df[colkey])
     valuecol = df[value]
-    df1 = allow_missing!(df[g.idx[g.starts], g.cols], g.cols)
+    df1 = allowmissing!(df[g.idx[g.starts], g.cols], g.cols)
     Nrow = length(g)
     Ncol = length(levels(keycol))
     df2 = DataFrame(Any[similar_missing(valuecol, Nrow) for i in 1:Ncol], map(Symbol, levels(keycol)))

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -248,7 +248,7 @@ function showrowindices(io::IO,
             try
                 s = df[i, j]
                 strlen = ourstrwidth(s)
-                if isnull(s)
+                if ismissing(s)
                     print_with_color(:light_black, io, s)
                 else
                     ourshowcompact(io, s)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -722,13 +722,13 @@ Base.hcat(df1::DataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...) = h
 ##
 ##############################################################################
 
-function allow_missing!(df::DataFrame, col::ColumnIndex)
+function allowmissing!(df::DataFrame, col::ColumnIndex)
     df[col] = Vector{Union{eltype(df[col]), Missing}}(df[col])
     df
 end
-function allow_missing!(df::DataFrame, cols::Vector{T}) where T <: ColumnIndex
+function allowmissing!(df::DataFrame, cols::Vector{T}) where T <: ColumnIndex
     for col in cols
-        allow_missing!(df, col)
+        allowmissing!(df, col)
     end
     df
 end

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -41,9 +41,9 @@ Base.convert(::Type{Array}, r::DataFrameRow) = convert(Array, r.df[r.row,:])
 Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) = hash(v[i], h)
 Base.@propagate_inbounds hash_colel(v::AbstractCategoricalArray, i, h::UInt = zero(UInt)) =
     hash(CategoricalArrays.index(v.pool)[v.refs[i]], h)
-Base.@propagate_inbounds function hash_colel(v::AbstractCategoricalArray{>: Null}, i, h::UInt = zero(UInt))
+Base.@propagate_inbounds function hash_colel(v::AbstractCategoricalArray{>: Missing}, i, h::UInt = zero(UInt))
     ref = v.refs[i]
-    ref == 0 ? hash(null, h) : hash(CategoricalArrays.index(v.pool)[ref], h)
+    ref == 0 ? hash(missing, h) : hash(CategoricalArrays.index(v.pool)[ref], h)
 end
 
 # hash of DataFrame rows based on its values
@@ -62,7 +62,7 @@ Base.hash(r::DataFrameRow, h::UInt = zero(UInt)) =
 # comparison of DataFrame rows
 # only the rows of the same DataFrame could be compared
 # rows are equal if they have the same values (while the row indices could differ)
-# if all non-null values are equal, but there are nulls, returns null
+# if all non-missing values are equal, but there are missings, returns missing
 Base.:(==)(r1::DataFrameRow, r2::DataFrameRow) = isequal(r1, r2)
 
 function Base.isequal(r1::DataFrameRow, r2::DataFrameRow)
@@ -100,7 +100,7 @@ function isequal_row(df1::AbstractDataFrame, r1::Int, df2::AbstractDataFrame, r2
     return true
 end
 
-# lexicographic ordering on DataFrame rows, null > !null
+# lexicographic ordering on DataFrame rows, missing > !missing
 function Base.isless(r1::DataFrameRow, r2::DataFrameRow)
     (ncol(r1.df) == ncol(r2.df)) ||
         throw(ArgumentError("Rows of the data tables that have different number of columns cannot be compared ($(ncol(df1)) and $(ncol(df2)))"))

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -2,8 +2,11 @@ import Base: @deprecate
 
 @deprecate by(d::AbstractDataFrame, cols, s::Vector{Symbol}) aggregate(d, cols, map(eval, s))
 @deprecate by(d::AbstractDataFrame, cols, s::Symbol) aggregate(d, cols, eval(s))
-@deprecate nullable!(colnames::Array{Symbol,1}, df::AbstractDataFrame) nullable!(df, colnames)
-@deprecate nullable!(colnums::Array{Int,1}, df::AbstractDataFrame) nullable!(df, colnums)
+
+@deprecate nullable!(df::AbstractDataFrame, col::ColumnIndex) allow_missing!(df, col)
+@deprecate nullable!(df::AbstractDataFrame, cols::Vector{<:ColumnIndex}) allow_missing!(df, cols)
+@deprecate nullable!(colnames::Array{Symbol,1}, df::AbstractDataFrame) allow_missing!(df, colnames)
+@deprecate nullable!(colnums::Array{Int,1}, df::AbstractDataFrame) allow_missing!(df, colnums)
 
 import Base: keys, values, insert!
 @deprecate keys(df::AbstractDataFrame) names(df)
@@ -13,7 +16,7 @@ import Base: keys, values, insert!
 @deprecate pool categorical
 @deprecate pool! categorical!
 
-@deprecate complete_cases! dropnull!
+@deprecate complete_cases! dropmissing!
 @deprecate complete_cases completecases
 
 @deprecate sub(df::AbstractDataFrame, rows) view(df, rows)
@@ -747,12 +750,12 @@ function builddf(rows::Integer,
                           o.falsestrings)
         end
 
-        vals = similar(values, Union{eltype(values), Null})
+        vals = similar(values, Union{eltype(values), Missing})
         @inbounds for i in eachindex(vals)
-            vals[i] = missing[i] ? null : values[i]
+            vals[i] = missing[i] ? missing : values[i]
         end
         if o.makefactors && !(is_int || is_float || is_bool)
-            columns[j] = CategoricalArray{Union{eltype(values), Null}}(vals)
+            columns[j] = CategoricalArray{Union{eltype(values), Missing}}(vals)
         else
             columns[j] = vals
         end
@@ -988,7 +991,7 @@ readtable(filename, [keyword options])
 *   `separator::Char` -- Assume that fields are split by the `separator` character. If not specified, it will be guessed from the filename: `.csv` defaults to `','`, `.tsv` defaults to `'\t'`, `.wsv` defaults to `' '`.
 *   `quotemark::Vector{Char}` -- Assume that fields contained inside of two `quotemark` characters are quoted, which disables processing of separators and linebreaks. Set to `Char[]` to disable this feature and slightly improve performance. Defaults to `['"']`.
 *   `decimal::Char` -- Assume that the decimal place in numbers is written using the `decimal` character. Defaults to `'.'`.
-*   `nastrings::Vector{String}` -- Translate any of the strings into this vector into a `null`. Defaults to `["", "NA"]`.
+*   `nastrings::Vector{String}` -- Translate any of the strings into this vector into a `missing`. Defaults to `["", "NA"]`.
 *   `truestrings::Vector{String}` -- Translate any of the strings into this vector into a Boolean `true`. Defaults to `["T", "t", "TRUE", "true"]`.
 *   `falsestrings::Vector{String}` -- Translate any of the strings into this vector into a Boolean `false`. Defaults to `["F", "f", "FALSE", "false"]`.
 *   `makefactors::Bool` -- Convert string columns into `PooledDataVector`'s for use as factors. Defaults to `false`.

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -3,10 +3,10 @@ import Base: @deprecate
 @deprecate by(d::AbstractDataFrame, cols, s::Vector{Symbol}) aggregate(d, cols, map(eval, s))
 @deprecate by(d::AbstractDataFrame, cols, s::Symbol) aggregate(d, cols, eval(s))
 
-@deprecate nullable!(df::AbstractDataFrame, col::ColumnIndex) allow_missing!(df, col)
-@deprecate nullable!(df::AbstractDataFrame, cols::Vector{<:ColumnIndex}) allow_missing!(df, cols)
-@deprecate nullable!(colnames::Array{Symbol,1}, df::AbstractDataFrame) allow_missing!(df, colnames)
-@deprecate nullable!(colnums::Array{Int,1}, df::AbstractDataFrame) allow_missing!(df, colnums)
+@deprecate nullable!(df::AbstractDataFrame, col::ColumnIndex) allowmissing!(df, col)
+@deprecate nullable!(df::AbstractDataFrame, cols::Vector{<:ColumnIndex}) allowmissing!(df, cols)
+@deprecate nullable!(colnames::Array{Symbol,1}, df::AbstractDataFrame) allowmissing!(df, colnames)
+@deprecate nullable!(colnums::Array{Int,1}, df::AbstractDataFrame) allowmissing!(df, colnums)
 
 import Base: keys, values, insert!
 @deprecate keys(df::AbstractDataFrame) names(df)

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -110,11 +110,11 @@ end
 
 Base.getindex(x::Index, idx::Symbol) = x.lookup[idx]
 Base.getindex(x::AbstractIndex, idx::Real) = Int(idx)
-Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Null}}) =
-    getindex(x, collect(Nulls.replace(idx, false)))
+Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}}) =
+    getindex(x, collect(Missings.replace(idx, false)))
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool}) = find(idx)
-Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T >: Null} =
-    getindex(x, collect(Nulls.skip(idx)))
+Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T >: Missing} =
+    getindex(x, collect(Missings.skip(idx)))
 Base.getindex(x::AbstractIndex, idx::Range) = [idx;]
 Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T <: Real} = convert(Vector{Int}, idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Symbol}) = [x.lookup[i] for i in idx]

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -98,19 +98,19 @@ end
 
 
 """
-    countnull(a::AbstractArray)
+    countmissing(a::AbstractArray)
 
-Count the number of `null` values in an array.
+Count the number of `missing` values in an array.
 """
-function countnull(a::AbstractArray)
+function countmissing(a::AbstractArray)
     res = 0
     for x in a
-        res += isnull(x)
+        res += ismissing(x)
     end
     return res
 end
 
-function countnull(a::CategoricalArray)
+function countmissing(a::CategoricalArray)
     res = 0
     for x in a.refs
         res += x == 0

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -86,7 +86,7 @@ end
 
 function Base.view(adf::AbstractDataFrame, rowinds::AbstractVector{T}) where {T >: Missing}
     # Vector{>:Missing} need to be checked for missings
-    any(ismissing, rowinds) && throw(MissingException())
+    any(ismissing, rowinds) && throw(MissingException("missing values are not allowed in indices"))
     return SubDataFrame(adf, convert(Vector{Missings.T(T)}, rowinds))
 end
 

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -84,10 +84,10 @@ function SubDataFrame(sdf::SubDataFrame, rowinds::Union{T, AbstractVector{T}}) w
     return SubDataFrame(sdf.parent, sdf.rows[rowinds])
 end
 
-function Base.view(adf::AbstractDataFrame, rowinds::AbstractVector{T}) where {T >: Null}
-    # Vector{>:Null} need to be checked for nulls
-    any(isnull, rowinds) && throw(NullException())
-    return SubDataFrame(adf, convert(Vector{Nulls.T(T)}, rowinds))
+function Base.view(adf::AbstractDataFrame, rowinds::AbstractVector{T}) where {T >: Missing}
+    # Vector{>:Missing} need to be checked for missings
+    any(ismissing, rowinds) && throw(MissingException())
+    return SubDataFrame(adf, convert(Vector{Missings.T(T)}, rowinds))
 end
 
 function Base.view(adf::AbstractDataFrame, rowinds::Any)

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -6,13 +6,13 @@ module TestCat
     # hcat
     #
 
-    nvint = [1, 2, null, 4]
-    nvstr = ["one", "two", null, "four"]
+    nvint = [1, 2, missing, 4]
+    nvstr = ["one", "two", missing, "four"]
 
     df2 = DataFrame(Any[nvint, nvstr])
     df3 = DataFrame(Any[nvint])
     df4 = convert(DataFrame, [1:4 1:4])
-    df5 = DataFrame(Any[Union{Int, Null}[1,2,3,4], nvstr])
+    df5 = DataFrame(Any[Union{Int, Missing}[1,2,3,4], nvstr])
 
     dfh = hcat(df3, df4)
     @test size(dfh, 2) == 3
@@ -39,7 +39,7 @@ module TestCat
 
     @testset "hcat ::Vectors" begin
         df = DataFrame()
-        DataFrames.hcat!(df, CategoricalVector{Union{Int, Null}}(1:10))
+        DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
         @test df[1] == collect(1:10)
         DataFrames.hcat!(df, 1:10)
         @test df[2] == collect(1:10)
@@ -56,7 +56,7 @@ module TestCat
 
     @testset "hcat ::Vectors" begin
         df = DataFrame()
-        DataFrames.hcat!(df, CategoricalVector{Union{Int, Null}}(1:10))
+        DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
         @test df[1] == CategoricalVector(1:10)
         DataFrames.hcat!(df, collect(1:10))
         @test df[2] == collect(1:10)
@@ -66,7 +66,7 @@ module TestCat
     # vcat
     #
 
-    null_df = DataFrame(Int, 0, 0)
+    missing_df = DataFrame(Int, 0, 0)
     df = DataFrame(Int, 4, 3)
 
     # Assignment of rows
@@ -106,10 +106,10 @@ module TestCat
     df[1:2, 1:2] = [3,2]
     df[[true,false,false,true], 2:3] = [2,3]
 
-    @test vcat(null_df) == DataFrame()
-    @test vcat(null_df, null_df) == DataFrame()
-    @test_throws ArgumentError vcat(null_df, df)
-    @test_throws ArgumentError vcat(df, null_df)
+    @test vcat(missing_df) == DataFrame()
+    @test vcat(missing_df, missing_df) == DataFrame()
+    @test_throws ArgumentError vcat(missing_df, df)
+    @test_throws ArgumentError vcat(df, missing_df)
     @test eltypes(vcat(df, df)) == Type[Float64, Float64, Int]
     @test size(vcat(df, df)) == (size(df, 1) * 2, size(df, 2))
     @test eltypes(vcat(df, df, df)) == Type[Float64, Float64, Int]
@@ -128,19 +128,19 @@ module TestCat
     @test dfr == [df4; df4]
 
     @test eltypes(vcat(DataFrame(a = [1]), DataFrame(a = [2.1]))) == Type[Float64]
-    @test eltypes(vcat(DataFrame(a = nulls(Int, 1)), DataFrame(a = Union{Float64, Null}[2.1]))) == Type[Union{Float64, Null}]
+    @test eltypes(vcat(DataFrame(a = missings(Int, 1)), DataFrame(a = Union{Float64, Missing}[2.1]))) == Type[Union{Float64, Missing}]
 
     # Minimal container type promotion
-    dfa = DataFrame(a = CategoricalArray{Union{Int, Null}}([1, 2, 2]))
-    dfb = DataFrame(a = CategoricalArray{Union{Int, Null}}([2, 3, 4]))
-    dfc = DataFrame(a = Union{Int, Null}[2, 3, 4])
+    dfa = DataFrame(a = CategoricalArray{Union{Int, Missing}}([1, 2, 2]))
+    dfb = DataFrame(a = CategoricalArray{Union{Int, Missing}}([2, 3, 4]))
+    dfc = DataFrame(a = Union{Int, Missing}[2, 3, 4])
     dfd = DataFrame(Any[2:4], [:a])
     dfab = vcat(dfa, dfb)
     dfac = vcat(dfa, dfc)
     @test dfab[:a] == [1, 2, 2, 2, 3, 4]
     @test dfac[:a] == [1, 2, 2, 2, 3, 4]
-    @test isa(dfab[:a], CategoricalVector{Union{Int, Null}})
-    @test isa(dfac[:a], CategoricalVector{Union{Int, Null}})
+    @test isa(dfab[:a], CategoricalVector{Union{Int, Missing}})
+    @test isa(dfac[:a], CategoricalVector{Union{Int, Missing}})
     # ^^ container may flip if container promotion happens in Base/DataArrays
     dc = vcat(dfd, dfc)
     @test vcat(dfc, dfd) == dc
@@ -166,21 +166,21 @@ module TestCat
         df = vcat(DataFrame([[1]], [:x]), DataFrame([["1"]], [:x]))
         @test df == DataFrame([[1, "1"]], [:x])
         @test typeof.(df.columns) == [Vector{Any}]
-        df = vcat(DataFrame([Union{Null, Int}[1]], [:x]), DataFrame([[1]], [:x]))
+        df = vcat(DataFrame([Union{Missing, Int}[1]], [:x]), DataFrame([[1]], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
-        @test typeof.(df.columns) == [Vector{Union{Null, Int}}]
+        @test typeof.(df.columns) == [Vector{Union{Missing, Int}}]
         df = vcat(DataFrame([CategoricalArray([1])], [:x]), DataFrame([[1]], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
         @test typeof(df[:x]) <: CategoricalVector{Int}
         df = vcat(DataFrame([CategoricalArray([1])], [:x]),
-                  DataFrame([Union{Null, Int}[1]], [:x]))
+                  DataFrame([Union{Missing, Int}[1]], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
-        @test typeof(df[:x]) <: CategoricalVector{Union{Int, Null}}
+        @test typeof(df[:x]) <: CategoricalVector{Union{Int, Missing}}
         df = vcat(DataFrame([CategoricalArray([1])], [:x]),
-                  DataFrame([CategoricalArray{Union{Int, Null}}([1])], [:x]))
+                  DataFrame([CategoricalArray{Union{Int, Missing}}([1])], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
-        @test typeof(df[:x]) <: CategoricalVector{Union{Int, Null}}
-        df = vcat(DataFrame([Union{Int, Null}[1]], [:x]),
+        @test typeof(df[:x]) <: CategoricalVector{Union{Int, Missing}}
+        df = vcat(DataFrame([Union{Int, Missing}[1]], [:x]),
                   DataFrame([["1"]], [:x]))
         @test df == DataFrame([[1, "1"]], [:x])
         @test typeof.(df.columns) == [Vector{Any}]
@@ -265,7 +265,7 @@ module TestCat
         err = @test_throws ArgumentError vcat(df1, df2, df3, df4, df1, df2, df3, df4, df1, df2, df3, df4)
         @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 5 and 9, column(s) B are missing from argument(s) 2, 6 and 10, and column(s) F are missing from argument(s) 3, 7 and 11"
     end
-    x = view(DataFrame(A = Vector{Union{Null, Int}}(1:3)), 2)
+    x = view(DataFrame(A = Vector{Union{Missing, Int}}(1:3)), 2)
     y = DataFrame(A = 4:5)
     @test vcat(x, y) == DataFrame(A = [2, 4, 5])
 end

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -10,39 +10,39 @@ module TestConstructors
     @test df.columns == Any[]
     @test df.colindex == Index()
 
-    df = DataFrame(Any[CategoricalVector{Union{Float64, Null}}(zeros(3)),
-                       CategoricalVector{Union{Float64, Null}}(ones(3))],
+    df = DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+                       CategoricalVector{Union{Float64, Missing}}(ones(3))],
                    Index([:x1, :x2]))
     @test size(df, 1) == 3
     @test size(df, 2) == 2
 
-    @test df == DataFrame(Any[CategoricalVector{Union{Float64, Null}}(zeros(3)),
-                              CategoricalVector{Union{Float64, Null}}(ones(3))])
-    @test df == DataFrame(x1 = Union{Int, Null}[0.0, 0.0, 0.0],
-                          x2 = Union{Int, Null}[1.0, 1.0, 1.0])
+    @test df == DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+                              CategoricalVector{Union{Float64, Missing}}(ones(3))])
+    @test df == DataFrame(x1 = Union{Int, Missing}[0.0, 0.0, 0.0],
+                          x2 = Union{Int, Missing}[1.0, 1.0, 1.0])
 
-    df2 = convert(DataFrame, Union{Float64, Null}[0.0 1.0;
+    df2 = convert(DataFrame, Union{Float64, Missing}[0.0 1.0;
                                                   0.0 1.0;
                                                   0.0 1.0])
     names!(df2, [:x1, :x2])
     @test df[:x1] == df2[:x1]
     @test df[:x2] == df2[:x2]
 
-    @test df == DataFrame(x1 = Union{Float64, Null}[0.0, 0.0, 0.0],
-                          x2 = Union{Float64, Null}[1.0, 1.0, 1.0])
-    @test df == DataFrame(x1 = Union{Float64, Null}[0.0, 0.0, 0.0],
-                          x2 = Union{Float64, Null}[1.0, 1.0, 1.0],
-                          x3 = Union{Float64, Null}[2.0, 2.0, 2.0])[[:x1, :x2]]
+    @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],
+                          x2 = Union{Float64, Missing}[1.0, 1.0, 1.0])
+    @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],
+                          x2 = Union{Float64, Missing}[1.0, 1.0, 1.0],
+                          x3 = Union{Float64, Missing}[2.0, 2.0, 2.0])[[:x1, :x2]]
 
-    df = DataFrame(Union{Int, Null}, 2, 2)
+    df = DataFrame(Union{Int, Missing}, 2, 2)
     @test size(df) == (2, 2)
-    @test eltypes(df) == [Union{Int, Null}, Union{Int, Null}]
+    @test eltypes(df) == [Union{Int, Missing}, Union{Int, Missing}]
 
-    df = DataFrame([Union{Int, Null}, Union{Float64, Null}], [:x1, :x2], 2)
+    df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}], [:x1, :x2], 2)
     @test size(df) == (2, 2)
-    @test eltypes(df) == [Union{Int, Null}, Union{Float64, Null}]
+    @test eltypes(df) == [Union{Int, Missing}, Union{Float64, Missing}]
 
-    @test df ≅ DataFrame([Union{Int, Null}, Union{Float64, Null}], 2)
+    @test df ≅ DataFrame([Union{Int, Missing}, Union{Float64, Missing}], 2)
 
     @test_throws BoundsError SubDataFrame(DataFrame(A=1), 0)
     @test_throws BoundsError SubDataFrame(DataFrame(A=1), 0)
@@ -85,8 +85,8 @@ module TestConstructors
         df = DataFrame(A = 1:3, B = 2:4, C = 3:5)
         answer = [Array{Int,1}, Array{Int,1}, Array{Int,1}]
         @test map(typeof, df.columns) == answer
-        df[:D] = [4, 5, null]
-        push!(answer, Vector{Union{Int, Null}})
+        df[:D] = [4, 5, missing]
+        push!(answer, Vector{Union{Int, Missing}})
         @test map(typeof, df.columns) == answer
         df[:E] = 'c'
         push!(answer, Vector{Char})

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -17,34 +17,34 @@ module TestConversions
     @test isa(convert(Array{Float64}, df), Matrix{Float64})
 
     df = DataFrame()
-    df[:A] = Vector{Union{Float64, Null}}(1.0:5.0)
-    df[:B] = Vector{Union{Float64, Null}}(1.0:5.0)
+    df[:A] = Vector{Union{Float64, Missing}}(1.0:5.0)
+    df[:B] = Vector{Union{Float64, Missing}}(1.0:5.0)
     a = convert(Array, df)
     aa = convert(Array{Any}, df)
     ai = convert(Array{Int}, df)
-    @test isa(a, Matrix{Union{Float64, Null}})
-    @test a == convert(Array, convert(Array{Union{Float64, Null}}, df))
+    @test isa(a, Matrix{Union{Float64, Missing}})
+    @test a == convert(Array, convert(Array{Union{Float64, Missing}}, df))
     @test a == convert(Matrix, df)
     @test isa(aa, Matrix{Any})
     @test aa == convert(Matrix{Any}, df)
     @test isa(ai, Matrix{Int})
     @test ai == convert(Matrix{Int}, df)
 
-    df[1,1] = null
+    df[1,1] = missing
     @test_throws ErrorException convert(Array{Float64}, df)
-    na = convert(Array{Union{Float64, Null}}, df)
-    naa = convert(Array{Union{Any, Null}}, df)
-    nai = convert(Array{Union{Int, Null}}, df)
-    @test isa(na, Matrix{Union{Float64, Null}})
+    na = convert(Array{Union{Float64, Missing}}, df)
+    naa = convert(Array{Union{Any, Missing}}, df)
+    nai = convert(Array{Union{Int, Missing}}, df)
+    @test isa(na, Matrix{Union{Float64, Missing}})
     @test na ≅ convert(Matrix, df)
-    @test isa(naa, Matrix{Union{Any, Null}})
-    @test naa ≅ convert(Matrix{Union{Any, Null}}, df)
-    @test isa(nai, Matrix{Union{Int, Null}})
-    @test nai ≅ convert(Matrix{Union{Int, Null}}, df)
+    @test isa(naa, Matrix{Union{Any, Missing}})
+    @test naa ≅ convert(Matrix{Union{Any, Missing}}, df)
+    @test isa(nai, Matrix{Union{Int, Missing}})
+    @test nai ≅ convert(Matrix{Union{Int, Missing}}, df)
 
-    a = Union{Float64, Null}[1.0,2.0]
-    b = Union{Float64, Null}[-0.1,3]
-    c = Union{Float64, Null}[-3.1,7]
+    a = Union{Float64, Missing}[1.0,2.0]
+    b = Union{Float64, Missing}[-0.1,3]
+    c = Union{Float64, Missing}[-3.1,7]
     di = Dict("a"=>a, "b"=>b, "c"=>c)
 
     df = convert(DataFrame, di)

--- a/test/data.jl
+++ b/test/data.jl
@@ -4,16 +4,16 @@ module TestData
     const ≅ = isequal
 
     #test_group("constructors")
-    df1 = DataFrame(Any[[1, 2, null, 4], ["one", "two", null, "four"]], [:Ints, :Strs])
-    df2 = DataFrame(Any[[1, 2, null, 4], ["one", "two", null, "four"]])
-    df3 = DataFrame(Any[[1, 2, null, 4]])
-    df4 = DataFrame(Any[Vector{Union{Int, Null}}(1:4), Vector{Union{Int, Null}}(1:4)])
-    df5 = DataFrame(Any[Union{Int, Null}[1, 2, 3, 4], ["one", "two", null, "four"]])
-    df6 = DataFrame(Any[[1, 2, null, 4], [1, 2, null, 4], ["one", "two", null, "four"]],
+    df1 = DataFrame(Any[[1, 2, missing, 4], ["one", "two", missing, "four"]], [:Ints, :Strs])
+    df2 = DataFrame(Any[[1, 2, missing, 4], ["one", "two", missing, "four"]])
+    df3 = DataFrame(Any[[1, 2, missing, 4]])
+    df4 = DataFrame(Any[Vector{Union{Int, Missing}}(1:4), Vector{Union{Int, Missing}}(1:4)])
+    df5 = DataFrame(Any[Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]])
+    df6 = DataFrame(Any[[1, 2, missing, 4], [1, 2, missing, 4], ["one", "two", missing, "four"]],
                     [:A, :B, :C])
-    df7 = DataFrame(x = [1, 2, null, 4], y = ["one", "two", null, "four"])
+    df7 = DataFrame(x = [1, 2, missing, 4], y = ["one", "two", missing, "four"])
     @test size(df7) == (4, 2)
-    @test df7[:x] ≅ [1, 2, null, 4]
+    @test df7[:x] ≅ [1, 2, missing, 4]
 
     #test_group("description functions")
     @test size(df6, 1) == 4
@@ -24,9 +24,9 @@ module TestData
 
     #test_group("ref")
     @test df6[2, 3] == "two"
-    @test isnull(df6[3, 3])
+    @test ismissing(df6[3, 3])
     @test df6[2, :C] == "two"
-    @test df6[:B] ≅ [1, 2, null, 4]
+    @test df6[:B] ≅ [1, 2, missing, 4]
     @test size(df6[[2,3]], 2) == 2
     @test size(df6[2,:], 1) == 1
     @test size(df6[[1, 3], [1, 3]]) == (2, 2)
@@ -45,13 +45,13 @@ module TestData
     @test names(df6) == [:A, :B, :C]
     @test size(df6, 2) == 3
 
-    #test_group("null handling")
+    #test_group("missing handling")
     @test nrow(df5[completecases(df5), :]) == 3
-    @test nrow(dropnull(df5)) == 3
-    returned = dropnull(df4)
+    @test nrow(dropmissing(df5)) == 3
+    returned = dropmissing(df4)
     @test df4 == returned && df4 !== returned
-    @test nrow(dropnull!(df5)) == 3
-    returned = dropnull!(df4)
+    @test nrow(dropmissing!(df5)) == 3
+    returned = dropmissing!(df4)
     @test df4 == returned && df4 === returned
 
     #test_context("SubDataFrames")
@@ -79,8 +79,8 @@ module TestData
     srand(1)
     N = 20
     #Cast to Int64 as rand() behavior differs between Int32/64
-    d1 = Vector{Union{Int64, Null}}(rand(map(Int64, 1:2), N))
-    d2 = CategoricalArray(["A", "B", null])[rand(map(Int64, 1:3), N)]
+    d1 = Vector{Union{Int64, Missing}}(rand(map(Int64, 1:2), N))
+    d2 = CategoricalArray(["A", "B", missing])[rand(map(Int64, 1:3), N)]
     d3 = randn(N)
     d4 = randn(N)
     df7 = DataFrame(Any[d1, d2, d3], [:d1, :d2, :d3])
@@ -88,7 +88,7 @@ module TestData
     #test_group("groupby")
     gd = groupby(df7, :d1)
     @test length(gd) == 2
-    @test gd[2][:d2] ≅ ["B", null, "A", null, null, null, null, null, "A"]
+    @test gd[2][:d2] ≅ ["B", missing, "A", missing, missing, missing, missing, missing, "A"]
     @test sum(gd[2][:d3]) == sum(df7[:d3][df7[:d1] .== 2])
 
     g1 = groupby(df7, [:d1, :d2])
@@ -139,11 +139,11 @@ module TestData
     @test ggd[2][1, :d4] == "d"
 
     #test_group("reshape")
-    d1 = DataFrame(a = Array{Union{Int, Null}}(repeat([1:3;], inner = [4])),
-                   b = Array{Union{Int, Null}}(repeat([1:4;], inner = [3])),
-                   c = Array{Union{Float64, Null}}(randn(12)),
-                   d = Array{Union{Float64, Null}}(randn(12)),
-                   e = Array{Union{String, Null}}(map(string, 'a':'l')))
+    d1 = DataFrame(a = Array{Union{Int, Missing}}(repeat([1:3;], inner = [4])),
+                   b = Array{Union{Int, Missing}}(repeat([1:4;], inner = [3])),
+                   c = Array{Union{Float64, Missing}}(randn(12)),
+                   d = Array{Union{Float64, Missing}}(randn(12)),
+                   e = Array{Union{String, Missing}}(map(string, 'a':'l')))
 
     stack(d1, :a)
     d1s = stack(d1, [:a, :b])
@@ -182,8 +182,8 @@ module TestData
     d1m_named = meltdf(d1, [:c, :d, :e], variable_name=:letter, value_name=:someval)
     @test names(d1m_named) == [:letter, :someval, :c, :d, :e]
 
-    d1s[:id] = Union{Int, Null}[1:12; 1:12]
-    d1s2[:id] =  Union{Int, Null}[1:12; 1:12]
+    d1s[:id] = Union{Int, Missing}[1:12; 1:12]
+    d1s2[:id] =  Union{Int, Missing}[1:12; 1:12]
     d1us = unstack(d1s, :id, :variable, :value)
     d1us2 = unstack(d1s2)
     d1us3 = unstack(d1s2, :variable, :value)
@@ -194,13 +194,13 @@ module TestData
     #test_group("merge")
 
     srand(1)
-    df1 = DataFrame(a = shuffle!(Vector{Union{Int, Null}}(1:10)),
-                    b = rand(Union{Symbol, Null}[:A,:B], 10),
-                    v1 = Vector{Union{Float64, Null}}(randn(10)))
+    df1 = DataFrame(a = shuffle!(Vector{Union{Int, Missing}}(1:10)),
+                    b = rand(Union{Symbol, Missing}[:A,:B], 10),
+                    v1 = Vector{Union{Float64, Missing}}(randn(10)))
 
-    df2 = DataFrame(a = shuffle!(Vector{Union{Int, Null}}(1:5)),
-                    b2 = rand(Union{Symbol, Null}[:A,:B,:C], 5),
-                    v2 = Vector{Union{Float64, Null}}(randn(5)))
+    df2 = DataFrame(a = shuffle!(Vector{Union{Int, Missing}}(1:5)),
+                    b2 = rand(Union{Symbol, Missing}[:A,:B,:C], 5),
+                    v2 = Vector{Union{Float64, Missing}}(randn(5)))
 
     m1 = join(df1, df2, on = :a, kind=:inner)
     @test m1[:a] == df1[:a][df1[:a] .<= 5] # preserves df1 order
@@ -208,12 +208,12 @@ module TestData
     @test m2[:a] == df1[:a] # preserves df1 order
     @test m2[:b] == df1[:b] # preserves df1 order
     m2 = join(df1, df2, on = :a, kind = :outer)
-    @test m2[:b2] ≅ [null, :A, :A, null, :C, null, null, :B, null, :A]
+    @test m2[:b2] ≅ [missing, :A, :A, missing, :C, missing, missing, :B, missing, :A]
 
-    df1 = DataFrame(a = Union{Int, Null}[1, 2, 3],
-                    b = Union{String, Null}["America", "Europe", "Africa"])
-    df2 = DataFrame(a = Union{Int, Null}[1, 2, 4],
-                    c = Union{String, Null}["New World", "Old World", "New World"])
+    df1 = DataFrame(a = Union{Int, Missing}[1, 2, 3],
+                    b = Union{String, Missing}["America", "Europe", "Africa"])
+    df2 = DataFrame(a = Union{Int, Missing}[1, 2, 4],
+                    c = Union{String, Missing}["New World", "Old World", "New World"])
 
     m1 = join(df1, df2, on = :a, kind = :inner)
     @test m1[:a] == [1, 2]
@@ -227,42 +227,42 @@ module TestData
     m4 = join(df1, df2, on = :a, kind = :outer)
     @test m4[:a] == [1, 2, 3, 4]
 
-    # test with nulls (issue #185)
+    # test with missings (issue #185)
     df1 = DataFrame()
-    df1[:A] = ["a", "b", "a", null]
-    df1[:B] = Union{Int, Null}[1, 2, 1, 3]
+    df1[:A] = ["a", "b", "a", missing]
+    df1[:B] = Union{Int, Missing}[1, 2, 1, 3]
 
     df2 = DataFrame()
-    df2[:A] = ["a", null, "c"]
-    df2[:C] = Union{Int, Null}[1, 2, 4]
+    df2[:A] = ["a", missing, "c"]
+    df2[:C] = Union{Int, Missing}[1, 2, 4]
 
     m1 = join(df1, df2, on = :A)
     @test size(m1) == (3,3)
-    @test m1[:A] ≅ ["a","a", null]
+    @test m1[:A] ≅ ["a","a", missing]
 
     m2 = join(df1, df2, on = :A, kind = :outer)
     @test size(m2) == (5,3)
-    @test m2[:A] ≅ ["a", "b", "a", null, "c"]
+    @test m2[:A] ≅ ["a", "b", "a", missing, "c"]
 
     srand(1)
     df1 = DataFrame(
-        a = rand(Union{Symbol, Null}[:x,:y], 10),
-        b = rand(Union{Symbol, Null}[:A,:B], 10),
-        v1 = Vector{Union{Float64, Null}}(randn(10))
+        a = rand(Union{Symbol, Missing}[:x,:y], 10),
+        b = rand(Union{Symbol, Missing}[:A,:B], 10),
+        v1 = Vector{Union{Float64, Missing}}(randn(10))
     )
 
     df2 = DataFrame(
-        a = Union{Symbol, Null}[:x,:y][[1,2,1,1,2]],
-        b = Union{Symbol, Null}[:A,:B,:C][[1,1,1,2,3]],
-        v2 = Vector{Union{Float64, Null}}(randn(5))
+        a = Union{Symbol, Missing}[:x,:y][[1,2,1,1,2]],
+        b = Union{Symbol, Missing}[:A,:B,:C][[1,1,1,2,3]],
+        v2 = Vector{Union{Float64, Missing}}(randn(5))
     )
-    df2[1,:a] = null
+    df2[1,:a] = missing
 
     m1 = join(df1, df2, on = [:a,:b])
-    @test m1[:a] == Union{Nulls.Null, Symbol}[:x, :x, :y, :y, :y, :x, :x, :x]
+    @test m1[:a] == Union{Missings.Missing, Symbol}[:x, :x, :y, :y, :y, :x, :x, :x]
     m2 = join(df1, df2, on = [:a,:b], kind = :outer)
-    @test isnull(m2[10,:v2])
-    @test m2[:a] ≅ [:x, :x, :y, :y, :y, :x, :x, :y, :x, :y, null, :y]
+    @test ismissing(m2[10,:v2])
+    @test m2[:a] ≅ [:x, :x, :y, :y, :y, :x, :x, :y, :x, :y, missing, :y]
 
     srand(1)
     function spltdf(d)
@@ -287,9 +287,9 @@ module TestData
     @test sort(m1[:a]) == sort(m2[:a])
 
     # test nonunique() with extra argument
-    df1 = DataFrame(a = Union{String, Null}["a", "b", "a", "b", "a", "b"],
-                    b = Vector{Union{Int, Null}}(1:6),
-                    c = Union{Int, Null}[1:3;1:3])
+    df1 = DataFrame(a = Union{String, Missing}["a", "b", "a", "b", "a", "b"],
+                    b = Vector{Union{Int, Missing}}(1:6),
+                    c = Union{Int, Missing}[1:3;1:3])
     df = vcat(df1, df1)
     @test find(nonunique(df)) == collect(7:12)
     @test find(nonunique(df, :)) == collect(7:12)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -13,8 +13,8 @@ module TestDataFrame
     @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], c=[4, 5, 6])
     @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(b=[4, 5, 6], a=[1, 2, 3])
     @test DataFrame(a=[1, 2, 2], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) ≅
-                  DataFrame(a=[1, 2, null], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≅
+                  DataFrame(a=[1, 2, missing], b=[4, 5, 6])
 
     @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) == DataFrame(a=[1, 2, 3], b=[4, 5, 6])
     @test DataFrame(a=[1, 2], b=[4, 5]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
@@ -22,19 +22,19 @@ module TestDataFrame
     @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], c=[4, 5, 6])
     @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(b=[4, 5, 6], a=[1, 2, 3])
     @test DataFrame(a=[1, 2, 2], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-    @test DataFrame(a=[1, 3, null], b=[4, 5, 6]) !=
-             DataFrame(a=[1, 2, null], b=[4, 5, 6])
-    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) ≅
-                DataFrame(a=[1, 2, null], b=[4, 5, 6])
-    @test DataFrame(a=[1, 2, null], b=[4, 5, 6]) ≇
+    @test DataFrame(a=[1, 3, missing], b=[4, 5, 6]) !=
+             DataFrame(a=[1, 2, missing], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≅
+                DataFrame(a=[1, 2, missing], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≇
                 DataFrame(a=[1, 2, 3], b=[4, 5, 6])
 
     #
     # Copying
     #
 
-    df = DataFrame(a = Union{Int, Null}[2, 3],
-                   b = Union{DataFrame, Null}[DataFrame(c = 1), DataFrame(d = 2)])
+    df = DataFrame(a = Union{Int, Missing}[2, 3],
+                   b = Union{DataFrame, Missing}[DataFrame(c = 1), DataFrame(d = 2)])
     dfc = copy(df)
     dfdc = deepcopy(df)
 
@@ -74,14 +74,14 @@ module TestDataFrame
     x0[:d] = 3
     @test x0[:d] == Int[]
 
-    # similar / nulls
-    df = DataFrame(a = Union{Int, Null}[1],
-                   b = Union{String, Null}["b"],
-                   c = CategoricalArray{Union{Float64, Null}}([3.3]))
-    nulldf = DataFrame(a = nulls(Int, 2),
-                       b = nulls(String, 2),
-                       c = CategoricalArray{Union{Float64, Null}}(2))
-    @test nulldf ≅ similar(df, 2)
+    # similar / missings
+    df = DataFrame(a = Union{Int, Missing}[1],
+                   b = Union{String, Missing}["b"],
+                   c = CategoricalArray{Union{Float64, Missing}}([3.3]))
+    missingdf = DataFrame(a = missings(Int, 2),
+                       b = missings(String, 2),
+                       c = CategoricalArray{Union{Float64, Missing}}(2))
+    @test missingdf ≅ similar(df, 2)
 
     # Associative methods
 
@@ -97,7 +97,7 @@ module TestDataFrame
     @test isempty(df)
     @test isempty(DataFrame(a=[], b=[]))
 
-    df = DataFrame(a=Union{Int, Null}[1, 2], b=Union{Float64, Null}[3.0, 4.0])
+    df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
     @test_throws BoundsError insert!(df, 5, ["a", "b"], :newcol)
     @test_throws ErrorException insert!(df, 1, ["a"], :newcol)
     @test insert!(df, 1, ["a", "b"], :newcol) == df
@@ -112,47 +112,47 @@ module TestDataFrame
     @test df == DataFrame(a=[1, 2], b=["a", "b"], c=[:c, :d])
 
     #test_group("Empty DataFrame constructors")
-    df = DataFrame(Union{Int, Null}, 10, 3)
+    df = DataFrame(Union{Int, Missing}, 10, 3)
     @test size(df, 1) == 10
     @test size(df, 2) == 3
-    @test typeof(df[:, 1]) == Vector{Union{Int, Null}}
-    @test typeof(df[:, 2]) == Vector{Union{Int, Null}}
-    @test typeof(df[:, 3]) == Vector{Union{Int, Null}}
-    @test all(isnull, df[:, 1])
-    @test all(isnull, df[:, 2])
-    @test all(isnull, df[:, 3])
+    @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 2]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 3]) == Vector{Union{Int, Missing}}
+    @test all(ismissing, df[:, 1])
+    @test all(ismissing, df[:, 2])
+    @test all(ismissing, df[:, 3])
 
-    df = DataFrame([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}], 100)
+    df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}], 100)
     @test size(df, 1) == 100
     @test size(df, 2) == 3
-    @test typeof(df[:, 1]) == Vector{Union{Int, Null}}
-    @test typeof(df[:, 2]) == Vector{Union{Float64, Null}}
-    @test typeof(df[:, 3]) == Vector{Union{String, Null}}
-    @test all(isnull, df[:, 1])
-    @test all(isnull, df[:, 2])
-    @test all(isnull, df[:, 3])
+    @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[:, 3]) == Vector{Union{String, Missing}}
+    @test all(ismissing, df[:, 1])
+    @test all(ismissing, df[:, 2])
+    @test all(ismissing, df[:, 3])
 
-    df = DataFrame([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}],
+    df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}],
                    [:A, :B, :C], 100)
     @test size(df, 1) == 100
     @test size(df, 2) == 3
-    @test typeof(df[:, 1]) == Vector{Union{Int, Null}}
-    @test typeof(df[:, 2]) == Vector{Union{Float64, Null}}
-    @test typeof(df[:, 3]) == Vector{Union{String, Null}}
-    @test all(isnull, df[:, 1])
-    @test all(isnull, df[:, 2])
-    @test all(isnull, df[:, 3])
+    @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[:, 3]) == Vector{Union{String, Missing}}
+    @test all(ismissing, df[:, 1])
+    @test all(ismissing, df[:, 2])
+    @test all(ismissing, df[:, 3])
 
-    df = DataFrame([Union{Int, Null}, Union{Float64, Null}, Union{String, Null}],
+    df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}],
                    [:A, :B, :C], [false, false, true], 100)
     @test size(df, 1) == 100
     @test size(df, 2) == 3
-    @test typeof(df[:, 1]) == Vector{Union{Int, Null}}
-    @test typeof(df[:, 2]) == Vector{Union{Float64, Null}}
-    @test typeof(df[:, 3]) <: CategoricalVector{Union{String, Null}}
-    @test all(isnull, df[:, 1])
-    @test all(isnull, df[:, 2])
-    @test all(isnull, df[:, 3])
+    @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[:, 3]) <: CategoricalVector{Union{String, Missing}}
+    @test all(ismissing, df[:, 1])
+    @test all(ismissing, df[:, 2])
+    @test all(ismissing, df[:, 3])
 
     df = convert(DataFrame, zeros(10, 5))
     @test size(df, 1) == 10
@@ -169,9 +169,9 @@ module TestDataFrame
     @test size(df, 2) == 5
     @test typeof(df[:, 1]) == Vector{Float64}
 
-    @test DataFrame([Union{Int, Null}[1, 2, 3], Union{Float64, Null}[2.5, 4.5, 6.5]],
+    @test DataFrame([Union{Int, Missing}[1, 2, 3], Union{Float64, Missing}[2.5, 4.5, 6.5]],
                     [:A, :B]) ==
-        DataFrame(A = Union{Int, Null}[1, 2, 3], B = Union{Float64, Null}[2.5, 4.5, 6.5])
+        DataFrame(A = Union{Int, Missing}[1, 2, 3], B = Union{Float64, Missing}[2.5, 4.5, 6.5])
 
     # This assignment was missing before
     df = DataFrame(Column = [:A])
@@ -259,45 +259,45 @@ module TestDataFrame
     @test deleterows!(df, [2, 3]) === df
     @test df == DataFrame(a=[1], b=[3.0])
 
-    df = DataFrame(a=Union{Int, Null}[1, 2], b=Union{Float64, Null}[3.0, 4.0])
+    df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
     @test deleterows!(df, 1) === df
     @test df == DataFrame(a=[2], b=[4.0])
 
-    df = DataFrame(a=Union{Int, Null}[1, 2], b=Union{Float64, Null}[3.0, 4.0])
+    df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
     @test deleterows!(df, 2) === df
     @test df == DataFrame(a=[1], b=[3.0])
 
-    df = DataFrame(a=Union{Int, Null}[1, 2, 3], b=Union{Float64, Null}[3.0, 4.0, 5.0])
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3], b=Union{Float64, Missing}[3.0, 4.0, 5.0])
     @test deleterows!(df, 2:3) === df
     @test df == DataFrame(a=[1], b=[3.0])
 
-    df = DataFrame(a=Union{Int, Null}[1, 2, 3], b=Union{Float64, Null}[3.0, 4.0, 5.0])
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3], b=Union{Float64, Missing}[3.0, 4.0, 5.0])
     @test deleterows!(df, [2, 3]) === df
     @test df == DataFrame(a=[1], b=[3.0])
 
     # describe
     #suppress output and test that describe() does not throw
-    devnull = is_unix() ? "/dev/null" : "nul"
-    open(devnull, "w") do f
-        @test nothing == describe(f, DataFrame(a=[1, 2], b=Any["3", null]))
+    devmissing = is_unix() ? "/dev/null" : "nul"
+    open(devmissing, "w") do f
+        @test nothing == describe(f, DataFrame(a=[1, 2], b=Any["3", missing]))
         @test nothing ==
-              describe(f, DataFrame(a=Union{Int, Null}[1, 2],
-                                    b=["3", null]))
+              describe(f, DataFrame(a=Union{Int, Missing}[1, 2],
+                                    b=["3", missing]))
         @test nothing ==
               describe(f, DataFrame(a=CategoricalArray([1, 2]),
-                                    b=CategoricalArray(["3", null])))
+                                    b=CategoricalArray(["3", missing])))
         @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, [1, 2, 3])
         @test nothing == describe(f, CategoricalArray([1, 2, 3]))
-        @test nothing == describe(f, Any["1", "2", null])
-        @test nothing == describe(f, ["1", "2", null])
-        @test nothing == describe(f, CategoricalArray(["1", "2", null]))
+        @test nothing == describe(f, Any["1", "2", missing])
+        @test nothing == describe(f, ["1", "2", missing])
+        @test nothing == describe(f, CategoricalArray(["1", "2", missing]))
     end
 
     #Check the output of unstack
-    df = DataFrame(Fish = CategoricalArray{Union{String, Null}}(["Bob", "Bob", "Batman", "Batman"]),
-                   Key = Union{String, Null}["Mass", "Color", "Mass", "Color"],
-                   Value = Union{String, Null}["12 g", "Red", "18 g", "Grey"])
+    df = DataFrame(Fish = CategoricalArray{Union{String, Missing}}(["Bob", "Bob", "Batman", "Batman"]),
+                   Key = Union{String, Missing}["Mass", "Color", "Mass", "Color"],
+                   Value = Union{String, Missing}["12 g", "Red", "18 g", "Grey"])
     # Check that reordering levels does not confuse unstack
     levels!(df[1], ["XXX", "Bob", "Batman"])
     #Unstack specifying a row column
@@ -305,69 +305,69 @@ module TestDataFrame
     #Unstack without specifying a row column
     df3 = unstack(df, :Key, :Value)
     #The expected output
-    df4 = DataFrame(Fish = Union{String, Null}["XXX", "Bob", "Batman"],
-                    Color = Union{String, Null}[null, "Red", "Grey"],
-                    Mass = Union{String, Null}[null, "12 g", "18 g"])
+    df4 = DataFrame(Fish = Union{String, Missing}["XXX", "Bob", "Batman"],
+                    Color = Union{String, Missing}[missing, "Red", "Grey"],
+                    Mass = Union{String, Missing}[missing, "12 g", "18 g"])
     @test df2 ≅ df4
-    @test typeof(df2[:Fish]) <: CategoricalVector{Union{String, Null}}
+    @test typeof(df2[:Fish]) <: CategoricalVector{Union{String, Missing}}
     # first column stays as CategoricalArray in df3
     @test df3[:, 2:3] == df4[2:3, 2:3]
-    #Make sure unstack works with NULLs at the start of the value column
-    df[1,:Value] = null
+    #Make sure unstack works with missing values at the start of the value column
+    df[1,:Value] = missing
     df2 = unstack(df, :Fish, :Key, :Value)
     #This changes the expected result
-    df4[2,:Mass] = null
+    df4[2,:Mass] = missing
     @test df2 ≅ df4
 
     df = DataFrame(A = 1:10, B = 'A':'J')
     @test !(df[:,:] === df)
 
     @test append!(DataFrame(A = 1:2, B = 1:2), DataFrame(A = 3:4, B = 3:4)) == DataFrame(A=1:4, B = 1:4)
-    df = DataFrame(A = Vector{Union{Int, Null}}(1:3), B = Vector{Union{Int, Null}}(4:6))
+    df = DataFrame(A = Vector{Union{Int, Missing}}(1:3), B = Vector{Union{Int, Missing}}(4:6))
     DRT = CategoricalArrays.DefaultRefType
-    @test all(c -> isa(c, Vector{Union{Int, Null}}), categorical!(deepcopy(df)).columns)
-    @test all(c -> typeof(c) <: CategoricalVector{Union{Int, Null}},
+    @test all(c -> isa(c, Vector{Union{Int, Missing}}), categorical!(deepcopy(df)).columns)
+    @test all(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
               categorical!(deepcopy(df), [1,2]).columns)
-    @test all(c -> typeof(c) <: CategoricalVector{Union{Int, Null}},
+    @test all(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
               categorical!(deepcopy(df), [:A,:B]).columns)
-    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Null}},
+    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
                     categorical!(deepcopy(df), [:A]).columns) == 1
-    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Null}},
+    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
                     categorical!(deepcopy(df), :A).columns) == 1
-    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Null}},
+    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
                     categorical!(deepcopy(df), [1]).columns) == 1
-    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Null}},
+    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
                     categorical!(deepcopy(df), 1).columns) == 1
 
-    @testset "unstack nullable promotion" begin
+    @testset "unstack promotion to support missing values" begin
         df = DataFrame(Any[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
                        [:id, :variable, :value])
         udf = unstack(df)
         @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
-        @test udf == DataFrame(Any[Union{Int, Null}[1, 2], Union{Int, Null}[1, 5],
-                                   Union{Int, Null}[2, 6], Union{Int, Null}[3, 7],
-                                   Union{Int, Null}[4, 8]], [:id, :a, :b, :c, :d])
-        @test all(isa.(udf.columns, Vector{Union{Int, Null}}))
+        @test udf == DataFrame(Any[Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
+                                   Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
+                                   Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
+        @test all(isa.(udf.columns, Vector{Union{Int, Missing}}))
         df = DataFrame(Any[categorical(repeat(1:2, inner=4)),
                            categorical(repeat('a':'d', outer=2)), categorical(1:8)],
                        [:id, :variable, :value])
         udf = unstack(df)
         @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
-        @test udf == DataFrame(Any[Union{Int, Null}[1, 2], Union{Int, Null}[1, 5],
-                                   Union{Int, Null}[2, 6], Union{Int, Null}[3, 7],
-                                   Union{Int, Null}[4, 8]], [:id, :a, :b, :c, :d])
-        @test all(isa.(udf.columns, CategoricalVector{Union{Int, Null}}))
+        @test udf == DataFrame(Any[Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
+                                   Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
+                                   Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
+        @test all(isa.(udf.columns, CategoricalVector{Union{Int, Missing}}))
     end
 
     @testset "duplicate entries in unstack warnings" begin
-        df = DataFrame(id=Union{Int, Null}[1, 2, 1, 2], variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
+        df = DataFrame(id=Union{Int, Missing}[1, 2, 1, 2], variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
         @static if VERSION >= v"0.6.0-dev.1980"
             @test_warn "Duplicate entries in unstack." unstack(df, :id, :variable, :value)
             @test_warn "Duplicate entries in unstack at row 3." unstack(df, :variable, :value)
         end
         a = unstack(df, :id, :variable, :value)
         b = unstack(df, :variable, :value)
-        @test a ≅ b ≅ DataFrame(id = [1, 2], a = [5, null], b = [null, 6])
+        @test a ≅ b ≅ DataFrame(id = [1, 2], a = [5, missing], b = [missing, 6])
 
         df = DataFrame(id=1:2, variable=["a", "b"], value=3:4)
         @static if VERSION >= v"0.6.0-dev.1980"
@@ -376,7 +376,7 @@ module TestDataFrame
         end
         a = unstack(df, :id, :variable, :value)
         b = unstack(df, :variable, :value)
-        @test a ≅ b ≅ DataFrame(id = [1, 2], a = [3, null], b = [null, 4])
+        @test a ≅ b ≅ DataFrame(id = [1, 2], a = [3, missing], b = [missing, 4])
     end
 
     @testset "rename" begin
@@ -434,11 +434,11 @@ module TestDataFrame
 
     @testset "column conversions" begin
         df = DataFrame(Any[collect(1:10), collect(1:10)])
-        @test !isa(df[1], Vector{Union{Int, Null}})
-        nullable!(df, 1)
-        @test isa(df[1], Vector{Union{Int, Null}})
-        @test !isa(df[2], Vector{Union{Int, Null}})
-        nullable!(df, [1,2])
-        @test isa(df[1], Vector{Union{Int, Null}}) && isa(df[2], Vector{Union{Int, Null}})
+        @test !isa(df[1], Vector{Union{Int, Missing}})
+        allow_missing!(df, 1)
+        @test isa(df[1], Vector{Union{Int, Missing}})
+        @test !isa(df[2], Vector{Union{Int, Missing}})
+        allow_missing!(df, [1,2])
+        @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
     end
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -435,10 +435,10 @@ module TestDataFrame
     @testset "column conversions" begin
         df = DataFrame(Any[collect(1:10), collect(1:10)])
         @test !isa(df[1], Vector{Union{Int, Missing}})
-        allow_missing!(df, 1)
+        allowmissing!(df, 1)
         @test isa(df[1], Vector{Union{Int, Missing}})
         @test !isa(df[2], Vector{Union{Int, Missing}})
-        allow_missing!(df, [1,2])
+        allowmissing!(df, [1,2])
         @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
     end
 end

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -1,10 +1,10 @@
 module TestDataFrameRow
     using Base.Test, DataFrames
 
-    df = DataFrame(a=Union{Int, Null}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, null, 1.2, 2.0, null, null],
-                   c=["A", "B", "C", "A", "B", null],
-                   d=CategoricalArray([:A, null, :C, :A, null, :C]))
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing],
+                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
     df2 = DataFrame(a = [1, 2, 3])
 
     #
@@ -18,9 +18,9 @@ module TestDataFrameRow
     @test DataFrameRow(df, 2) != DataFrameRow(df, 6)
 
     # isless()
-    df4 = DataFrame(a=[1, 1, 2, 2, 2, 2, null, null],
-                    b=Union{Float64, Null}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
-                    c=[:B, null, :A, :C, :D, :D, :A, :A])
+    df4 = DataFrame(a=[1, 1, 2, 2, 2, 2, missing, missing],
+                    b=Union{Float64, Missing}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
+                    c=[:B, missing, :A, :C, :D, :D, :A, :A])
     @test isless(DataFrameRow(df4, 1), DataFrameRow(df4, 2))
     @test !isless(DataFrameRow(df4, 2), DataFrameRow(df4, 1))
     @test !isless(DataFrameRow(df4, 1), DataFrameRow(df4, 1))

--- a/test/duplicates.jl
+++ b/test/duplicates.jl
@@ -9,10 +9,10 @@ module TestDuplicates
     unique!(df)
     @test df == udf
 
-    pdf = DataFrame(a = CategoricalArray(["a", "a", null, null, "b", null, "a", null]),
-                    b = CategoricalArray(["a", "b", null, null, "b", "a", "a", "a"]))
-    updf = DataFrame(a = CategoricalArray(["a", "a", null, "b", null]),
-                     b = CategoricalArray(["a", "b", null, "b", "a"]))
+    pdf = DataFrame(a = CategoricalArray(["a", "a", missing, missing, "b", missing, "a", missing]),
+                    b = CategoricalArray(["a", "b", missing, missing, "b", "a", "a", "a"]))
+    updf = DataFrame(a = CategoricalArray(["a", "a", missing, "b", missing]),
+                     b = CategoricalArray(["a", "b", missing, "b", "a"]))
     @test nonunique(pdf) == [false, false, false, true, false, false, true, true]
     @test nonunique(updf) == falses(5)
     @test updf ≅ unique(pdf)

--- a/test/index.jl
+++ b/test/index.jl
@@ -15,10 +15,10 @@ inds = Any[1,
            1:1,
            1.0:1.0,
            [:A],
-           Union{Bool, Null}[true],
-           Union{Int, Null}[1],
-           Union{Float64, Null}[1.0],
-           Union{Symbol, Null}[:A]]
+           Union{Bool, Missing}[true],
+           Union{Int, Missing}[1],
+           Union{Float64, Missing}[1.0],
+           Union{Symbol, Missing}[:A]]
 
 for ind in inds
     if ind == :A || ndims(ind) == 0

--- a/test/io.jl
+++ b/test/io.jl
@@ -6,8 +6,8 @@ module TestIO
     df = DataFrame(A = 1:4,
                    B = ["\$10.0", "M&F", "A~B", "\\alpha"],
                    C = [L"\alpha", L"\beta", L"\gamma", L"\sum_{i=1}^n \delta_i"],
-                   D = [1.0, 2.0, null, 3.0],
-                   E = CategoricalArray(["a", null, "c", "d"])
+                   D = [1.0, 2.0, missing, 3.0],
+                   E = CategoricalArray(["a", missing, "c", "d"])
                    )
     str = """
         \\begin{tabular}{r|ccccc}
@@ -22,14 +22,14 @@ module TestIO
     @test reprmime(MIME("text/latex"), df) == str
 
     #Test HTML output for IJulia and similar
-    df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, null])
+    df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, missing])
     io = IOBuffer()
     show(io, "text/html", df)
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr></thead><tbody>" *
                  "<tr><th>1</th><td>Suzy</td><td>1.5</td></tr>" *
-                 "<tr><th>2</th><td>Amir</td><td>null</td></tr></tbody></table>"
+                 "<tr><th>2</th><td>Amir</td><td>missing</td></tr></tbody></table>"
 
     # test limit attribute of IOContext is used
     df = DataFrame(a=collect(1:1000))
@@ -45,35 +45,35 @@ module TestIO
                    B = 'a':'c',
                    C = ["A", "B", "C"],
                    D = CategoricalArray(string.('a':'c')),
-                   E = CategoricalArray(["A", "B", null]),
-                   F = Vector{Union{Int, Null}}(1:3),
-                   G = nulls(3),
-                   H = fill(null, 3))
+                   E = CategoricalArray(["A", "B", missing]),
+                   F = Vector{Union{Int, Missing}}(1:3),
+                   G = missings(3),
+                   H = fill(missing, 3))
 
     @test sprint(DataFrames.printtable, df) ==
         """
         "A","B","C","D","E","F","G","H"
-        1,"'a'","A","a","A","1",null,null
-        2,"'b'","B","b","B","2",null,null
-        3,"'c'","C","c",null,"3",null,null
+        1,"'a'","A","a","A","1",missing,missing
+        2,"'b'","B","b","B","2",missing,missing
+        3,"'c'","C","c",missing,"3",missing,missing
         """
 
     # DataStreams
     using DataStreams
     I = DataFrames.DataFrame(id = Int64[1, 2, 3, 4, 5],
-        firstname = Union{String, Null}["Benjamin", "Wayne", "Sean", "Charles", null],
+        firstname = Union{String, Missing}["Benjamin", "Wayne", "Sean", "Charles", missing],
         lastname = String["Chavez", "Burke", "Richards", "Long", "Rose"],
-        salary = Union{Float64, Null}[null, 46134.1, 45046.2, 30555.6, 88894.1],
+        salary = Union{Float64, Missing}[missing, 46134.1, 45046.2, 30555.6, 88894.1],
         rate = Float64[39.44, 33.8, 15.64, 17.67, 34.6],
-        hired = Union{Date, Null}[Date("2011-07-07"), Date("2016-02-19"), null, Date("2002-01-05"), Date("2008-05-15")],
+        hired = Union{Date, Missing}[Date("2011-07-07"), Date("2016-02-19"), missing, Date("2002-01-05"), Date("2008-05-15")],
         fired = DateTime[DateTime("2016-04-07T14:07:00"), DateTime("2015-03-19T15:01:00"), DateTime("2006-11-18T05:07:00"), DateTime("2002-07-18T06:24:00"), DateTime("2007-09-29T12:09:00")],
-        reserved = nulls(5)
+        reserved = missings(5)
     )
     sink = DataStreams.Data.close!(DataStreams.Data.stream!(I, deepcopy(I)))
     sch = DataStreams.Data.schema(sink)
     @test size(sch) == (5, 8)
     @test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired","reserved"]
-    @test DataStreams.Data.types(sch) == (Int64, Union{String, Null}, String, Union{Float64, Null}, Float64, Union{Date, Null}, DateTime, Null)
+    @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String, Union{Float64, Missing}, Float64, Union{Date, Missing}, DateTime, Missing)
     @test sink[:id] == [1,2,3,4,5]
 
     transforms = Dict(1=>x->x+1)
@@ -81,14 +81,14 @@ module TestIO
     sch = DataStreams.Data.schema(sink)
     @test size(sch) == (10, 8)
     @test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired","reserved"]
-    @test DataStreams.Data.types(sch) == (Int64, Union{String, Null}, String, Union{Float64, Null}, Float64, Union{Date, Null}, DateTime, Null)
+    @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String, Union{Float64, Missing}, Float64, Union{Date, Missing}, DateTime, Missing)
     @test sink[:id] == [1,2,3,4,5,2,3,4,5,6]
 
     sink = DataStreams.Data.close!(Data.stream!(I, DataFrame, deepcopy(I)))
     sch = DataStreams.Data.schema(sink)
     @test size(sch) == (5, 8)
     @test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired","reserved"]
-    @test DataStreams.Data.types(sch) == (Int64, Union{String, Null}, String, Union{Float64, Null}, Float64, Union{Date, Null}, DateTime, Null)
+    @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String, Union{Float64, Missing}, Float64, Union{Date, Missing}, DateTime, Missing)
     @test sink[:id] == [1,2,3,4,5]
 
     # test DataFrameStream creation

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -1,11 +1,11 @@
 module TestIteration
     using Base.Test, DataFrames
 
-    dv = [1, 2, null]
-    dm = Union{Int, Null}[1 2; 3 4]
-    df = Array{Union{Int, Null}}(zeros(2, 2, 2))
+    dv = [1, 2, missing]
+    dm = Union{Int, Missing}[1 2; 3 4]
+    df = Array{Union{Int, Missing}}(zeros(2, 2, 2))
 
-    df = DataFrame(A = Vector{Union{Int, Null}}(1:2), B = Vector{Union{Int, Null}}(2:3))
+    df = DataFrame(A = Vector{Union{Int, Missing}}(1:2), B = Vector{Union{Int, Missing}}(2:3))
 
     for row in eachrow(df)
         @test isa(row, DataFrameRow)
@@ -30,7 +30,7 @@ module TestIteration
     row[1] = 101
     @test df[1, :A] == 101
 
-    df = DataFrame(A = Vector{Union{Int, Null}}(1:4), B = Union{String, Null}["M", "F", "F", "M"])
+    df = DataFrame(A = Vector{Union{Int, Missing}}(1:4), B = Union{String, Missing}["M", "F", "F", "M"])
 
     s1 = view(df, 1:3)
     s1[2,:A] = 4

--- a/test/show.jl
+++ b/test/show.jl
@@ -264,63 +264,69 @@ module TestShow
     show(io, A)
 
     #Test show output for REPL and similar
-    df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, null])
+    df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, missing])
     io = IOBuffer()
     show(io, df)
     str = String(take!(io))
     @test str == (Base.have_color ? """
     2×2 DataFrames.DataFrame
-    │ Row │ Fish │ Mass │
-    ├─────┼──────┼──────┤
-    │ 1   │ Suzy │ 1.5  │
-    │ 2   │ Amir │ \e[90mnull\e[39m │""" : """
+    │ Row │ Fish │ Mass    │
+    ├─────┼──────┼─────────┤
+    │ 1   │ Suzy │ 1.5     │
+    │ 2   │ Amir │ \e[90mmissing\e[39m │""" : """
     2×2 DataFrames.DataFrame
-    │ Row │ Fish │ Mass │
-    ├─────┼──────┼──────┤
-    │ 1   │ Suzy │ 1.5  │
-    │ 2   │ Amir │ null │""")
+    │ Row │ Fish │ Mass    │
+    ├─────┼──────┼─────────┤
+    │ 1   │ Suzy │ 1.5     │
+    │ 2   │ Amir │ missing │""")
 
     io = IOBuffer()
     showcols(io, df)
     str = String(take!(io))
     @test str == """
     2×2 DataFrames.DataFrame
-    │ Col # │ Name │ Eltype                     │ Missing │ Values        │
-    ├───────┼──────┼────────────────────────────┼─────────┼───────────────┤
-    │ 1     │ Fish │ String                     │ 0       │ Suzy  …  Amir │
-    │ 2     │ Mass │ Union{Float64, Nulls.Null} │ 1       │ 1.5  …  null  │"""
+    │ Col # │ Name │ Eltype                           │ Missing │ Values          │
+    ├───────┼──────┼──────────────────────────────────┼─────────┼─────────────────┤
+    │ 1     │ Fish │ String                           │ 0       │ Suzy  …  Amir   │
+    │ 2     │ Mass │ Union{Float64, Missings.Missing} │ 1       │ 1.5  …  missing │"""
 
-    # Test showing null
-    df = DataFrame(A = [:Symbol, null, :null],
-                   B = [null, "String", "null"],
-                   C = [:null, "null", null])
+    # Test showing missing
+    df = DataFrame(A = [:Symbol, missing, :missing],
+                   B = [missing, "String", "missing"],
+                   C = [:missing, "missing", missing])
     io = IOBuffer()
     show(io, df)
     str = String(take!(io))
     @test str == (Base.have_color ? """
     3×3 DataFrames.DataFrame
-    │ Row │ A      │ B      │ C    │
-    ├─────┼────────┼────────┼──────┤
-    │ 1   │ Symbol │ \e[90mnull\e[39m   │ null │
-    │ 2   │ \e[90mnull\e[39m   │ String │ null │
-    │ 3   │ null   │ null   │ \e[90mnull\e[39m │""" : """
+    │ Row │ A       │ B       │ C       │
+    ├─────┼─────────┼─────────┼─────────┤
+    │ 1   │ Symbol  │ \e[90mmissing\e[39m │ missing │
+    │ 2   │ \e[90mmissing\e[39m │ String  │ missing │
+    │ 3   │ missing │ missing │ \e[90mmissing\e[39m │""" : """
     3×3 DataFrames.DataFrame
-    │ Row │ A      │ B      │ C    │
-    ├─────┼────────┼────────┼──────┤
-    │ 1   │ Symbol │ null   │ null │
-    │ 2   │ null   │ String │ null │
-    │ 3   │ null   │ null   │ null │""")
+    │ Row │ A       │ B       │ C       │
+    ├─────┼─────────┼─────────┼─────────┤
+    │ 1   │ Symbol  │ missing │ missing │
+    │ 2   │ missing │ String  │ missing │
+    │ 3   │ missing │ missing │ missing │""")
 
     io = IOBuffer()
     showcols(io, df)
     str = String(take!(io))
     @test str == """
     3×3 DataFrames.DataFrame
-    │ Col # │ Name │ Eltype                    │ Missing │ Values          │
-    ├───────┼──────┼───────────────────────────┼─────────┼─────────────────┤
-    │ 1     │ A    │ Union{Nulls.Null, Symbol} │ 1       │ Symbol  …  null │
-    │ 2     │ B    │ Union{Nulls.Null, String} │ 1       │ null  …  null   │
-    │ 3     │ C    │ Any                       │ 1       │ null  …  null   │"""
+    │ Col # │ Name │ Eltype                          │ Missing │
+    ├───────┼──────┼─────────────────────────────────┼─────────┤
+    │ 1     │ A    │ Union{Missings.Missing, Symbol} │ 1       │
+    │ 2     │ B    │ Union{Missings.Missing, String} │ 1       │
+    │ 3     │ C    │ Any                             │ 1       │
+    
+    │ Col # │ Values              │
+    ├───────┼─────────────────────┤
+    │ 1     │ Symbol  …  missing  │
+    │ 2     │ missing  …  missing │
+    │ 3     │ missing  …  missing │"""
 
     # Test computing width for Array{String} columns
     df = DataFrame(Any[["a"]], [:x])

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -1,9 +1,9 @@
 module TestSort
     using Base.Test, DataFrames
 
-    dv1 = [9, 1, 8, null, 3, 3, 7, null]
-    dv2 = [9, 1, 8, null, 3, 3, 7, null]
-    dv3 = Vector{Union{Int, Null}}(1:8)
+    dv1 = [9, 1, 8, missing, 3, 3, 7, missing]
+    dv2 = [9, 1, 8, missing, 3, 3, 7, missing]
+    dv3 = Vector{Union{Int, Missing}}(1:8)
     cv1 = CategoricalArray(dv1, ordered=true)
 
     d = DataFrame(dv1 = dv1, dv2 = dv2, dv3 = dv3, cv1 = cv1)

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -32,11 +32,11 @@ module TestSubDataFrame
         @test view(df, Integer[1, 2]) == head(df, 2)
         @test view(df, UInt[1, 2]) == head(df, 2)
         @test view(df, BigInt[1, 2]) == head(df, 2)
-        @test view(df, Union{Int, Null}[1, 2]) == head(df, 2)
-        @test view(df, Union{Integer, Null}[1, 2]) == head(df, 2)
-        @test view(df, Union{UInt, Null}[1, 2]) == head(df, 2)
-        @test view(df, Union{BigInt, Null}[1, 2]) == head(df, 2)
-        @test_throws NullException view(df, [null, 1])
+        @test view(df, Union{Int, Missing}[1, 2]) == head(df, 2)
+        @test view(df, Union{Integer, Missing}[1, 2]) == head(df, 2)
+        @test view(df, Union{UInt, Missing}[1, 2]) == head(df, 2)
+        @test view(df, Union{BigInt, Missing}[1, 2]) == head(df, 2)
+        @test_throws MissingException view(df, [missing, 1])
     end
 
     @testset "view -- SubDataFrame" begin
@@ -70,10 +70,10 @@ module TestSubDataFrame
         @test view(df, Integer[1, 2]) == head(df, 2)
         @test view(df, UInt[1, 2]) == head(df, 2)
         @test view(df, BigInt[1, 2]) == head(df, 2)
-        @test view(df, Union{Int, Null}[1, 2]) == head(df, 2)
-        @test view(df, Union{Integer, Null}[1, 2]) == head(df, 2)
-        @test view(df, Union{UInt, Null}[1, 2]) == head(df, 2)
-        @test view(df, Union{BigInt, Null}[1, 2]) == head(df, 2)
-        @test_throws NullException view(df, [null, 1])
+        @test view(df, Union{Int, Missing}[1, 2]) == head(df, 2)
+        @test view(df, Union{Integer, Missing}[1, 2]) == head(df, 2)
+        @test view(df, Union{UInt, Missing}[1, 2]) == head(df, 2)
+        @test view(df, Union{BigInt, Missing}[1, 2]) == head(df, 2)
+        @test_throws MissingException view(df, [missing, 1])
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -33,21 +33,21 @@ module TestUtils
              "Expected if Julia was not built from source.")
     end
 
-    @test DataFrames.countnull([1:3;]) == 0
+    @test DataFrames.countmissing([1:3;]) == 0
 
-    data = Vector{Union{Float64, Null}}(rand(20))
-    @test DataFrames.countnull(data) == 0
-    data[sample(1:20, 11, replace=false)] = null
-    @test DataFrames.countnull(data) == 11
-    data[1:end] = null
-    @test DataFrames.countnull(data) == 20
+    data = Vector{Union{Float64, Missing}}(rand(20))
+    @test DataFrames.countmissing(data) == 0
+    data[sample(1:20, 11, replace=false)] = missing
+    @test DataFrames.countmissing(data) == 11
+    data[1:end] = missing
+    @test DataFrames.countmissing(data) == 20
 
-    pdata = Vector{Union{Int, Null}}(sample(1:5, 20))
-    @test DataFrames.countnull(pdata) == 0
-    pdata[sample(1:20, 11, replace=false)] = null
-    @test DataFrames.countnull(pdata) == 11
-    pdata[1:end] = null
-    @test DataFrames.countnull(pdata) == 20
+    pdata = Vector{Union{Int, Missing}}(sample(1:5, 20))
+    @test DataFrames.countmissing(pdata) == 0
+    pdata[sample(1:20, 11, replace=false)] = missing
+    @test DataFrames.countmissing(pdata) == 11
+    pdata[1:end] = missing
+    @test DataFrames.countmissing(pdata) == 20
 
     funs = [mean, sum, var, x -> sum(x)]
     if string(funs[end]) == "(anonymous function)" # Julia < 0.5
@@ -58,14 +58,14 @@ module TestUtils
 
     @testset "describe" begin
         io = IOBuffer()
-        df = DataFrame(Any[collect(1:4), Vector{Union{Int, Null}}(2:5),
+        df = DataFrame(Any[collect(1:4), Vector{Union{Int, Missing}}(2:5),
                            CategoricalArray(3:6),
-                           CategoricalArray{Union{Int, Null}}(4:7)],
-                       [:arr, :nullarr, :cat, :nullcat])
+                           CategoricalArray{Union{Int, Missing}}(4:7)],
+                       [:arr, :missingarr, :cat, :missingcat])
         describe(io, df)
         DRT = CategoricalArrays.DefaultRefType
         # Julia 0.7
-        nullfirst =
+        missingfirst =
             """
             arr
             Summary Stats:
@@ -78,7 +78,7 @@ module TestUtils
             Length:         4
             Type:           $Int
 
-            nullarr
+            missingarr
             Summary Stats:
             Mean:           3.500000
             Minimum:        2.000000
@@ -87,7 +87,7 @@ module TestUtils
             3rd Quartile:   4.250000
             Maximum:        5.000000
             Length:         4
-            Type:           Union{Nulls.Null, $Int}
+            Type:           Union{Missings.Missing, $Int}
             Number Missing: 0
             % Missing:      0.000000
 
@@ -97,17 +97,17 @@ module TestUtils
             Type:           CategoricalArrays.CategoricalValue{$Int,$DRT}
             Number Unique:  4
 
-            nullcat
+            missingcat
             Summary Stats:
             Length:         4
-            Type:           Union{Nulls.Null, CategoricalArrays.CategoricalValue{$Int,$DRT}}
+            Type:           Union{Missings.Missing, CategoricalArrays.CategoricalValue{$Int,$DRT}}
             Number Unique:  4
             Number Missing: 0
             % Missing:      0.000000
 
             """
         # Julia 0.6
-        nullsecond =
+        missingsecond =
             """
             arr
             Summary Stats:
@@ -120,7 +120,7 @@ module TestUtils
             Length:         4
             Type:           $Int
 
-            nullarr
+            missingarr
             Summary Stats:
             Mean:           3.500000
             Minimum:        2.000000
@@ -129,7 +129,7 @@ module TestUtils
             3rd Quartile:   4.250000
             Maximum:        5.000000
             Length:         4
-            Type:           Union{$Int, Nulls.Null}
+            Type:           Union{$Int, Missings.Missing}
             Number Missing: 0
             % Missing:      0.000000
 
@@ -139,25 +139,25 @@ module TestUtils
             Type:           CategoricalArrays.CategoricalValue{$Int,$DRT}
             Number Unique:  4
 
-            nullcat
+            missingcat
             Summary Stats:
             Length:         4
-            Type:           Union{CategoricalArrays.CategoricalValue{$Int,$DRT}, Nulls.Null}
+            Type:           Union{CategoricalArrays.CategoricalValue{$Int,$DRT}, Missings.Missing}
             Number Unique:  4
             Number Missing: 0
             % Missing:      0.000000
 
             """
             out = String(take!(io))
-            @test (out == nullfirst || out == nullsecond)
+            @test (out == missingfirst || out == missingsecond)
     end
 
     @testset "describe" begin
         io = IOBuffer()
-        df = DataFrame(Any[collect(1:4), collect(Union{Int, Null}, 2:5),
+        df = DataFrame(Any[collect(1:4), collect(Union{Int, Missing}, 2:5),
                            CategoricalArray(3:6),
-                           CategoricalArray{Union{Int, Null}}(4:7)],
-                       [:arr, :nullarr, :cat, :nullcat])
+                           CategoricalArray{Union{Int, Missing}}(4:7)],
+                       [:arr, :missingarr, :cat, :missingcat])
         describe(io, df)
         @test String(take!(io)) ==
             """
@@ -172,7 +172,7 @@ module TestUtils
             Length:         4
             Type:           $Int
 
-            nullarr
+            missingarr
             Summary Stats:
             Mean:           3.500000
             Minimum:        2.000000
@@ -181,7 +181,7 @@ module TestUtils
             3rd Quartile:   4.250000
             Maximum:        5.000000
             Length:         4
-            Type:           Union{$Int, Nulls.Null}
+            Type:           Union{$Int, Missings.Missing}
             Number Missing: 0
             % Missing:      0.000000
 
@@ -191,10 +191,10 @@ module TestUtils
             Type:           CategoricalArrays.CategoricalValue{$Int,$(CategoricalArrays.DefaultRefType)}
             Number Unique:  4
 
-            nullcat
+            missingcat
             Summary Stats:
             Length:         4
-            Type:           Union{CategoricalArrays.CategoricalValue{$Int,$(CategoricalArrays.DefaultRefType)}, Nulls.Null}
+            Type:           Union{CategoricalArrays.CategoricalValue{$Int,$(CategoricalArrays.DefaultRefType)}, Missings.Missing}
             Number Unique:  4
             Number Missing: 0
             % Missing:      0.000000


### PR DESCRIPTION
Deprecate `nullable!()` in favor of `allow_missing!()`. `dropnull!()` does not need a deprecation
since it has been introduced since the last release.

CI won't pass until DataStreams is ported to Missings.