### PR TITLE
Disable doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,7 @@ using Documenter, DataFrames
 makedocs(
     # options
     modules = [DataFrames],
-    doctest = true,
+    doctest = false,
     clean = false,
     sitename = "DataFrames.jl",
     format = :html,


### PR DESCRIPTION
Temporary until Query has been ported to DataFrames 0.11.0, so that
the updated manual is deployed.