### PR TITLE
Switch to CodecZlib from GZip

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,5 +6,5 @@ SortingAlgorithms
 Reexport
 WeakRefStrings 0.4.0
 DataStreams 0.3.0
-GZip
+CodecZlib 0.4
 Compat 0.36.0

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -23,7 +23,7 @@ import Base: keys, values, insert!
 
 
 ## write.table
-using GZip
+using CodecZlib, TranscodingStreams
 
 export writetable
 """
@@ -92,9 +92,9 @@ function writetable(filename::AbstractString,
         end
     end
 
-    openfunc = endswith(filename, ".gz") ? gzopen : open
+    encoder = endswith(filename, ".gz") ? GzipCompressorStream : NoopStream
 
-    openfunc(filename, append ? "a" : "w") do io
+    open(encoder, filename, append ? "a" : "w") do io
         printtable(io,
                    df,
                    header = header,


### PR DESCRIPTION
I'm not sure whether `writetable()` is already at its end-of-life stage, but if it stays for a while, it might be better to switch to `CodecZlib.jl` from `GZip.jl` as the latter is deprecated and not actively maintained.