### PR TITLE
add join pipelining

### DIFF
--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -300,6 +300,11 @@ function Base.join(df1::AbstractDataFrame,
     end
 end
 
+function Base.join(right::AbstractDataFrame; on=Symbol[], kind=:inner)
+    # for pipelining with |>
+    return left -> join(left, right; on=on, kind=kind)
+end
+
 function crossjoin(df1::AbstractDataFrame, df2::AbstractDataFrame)
     r1, r2 = size(df1, 1), size(df2, 1)
     cols = Any[[repeat(c, inner=r2) for c in columns(df1)];


### PR DESCRIPTION
This is a simple trick to pipeline joins in the same way as dplyr.

```
julia> name |> join(job, on=:ID)
2×3 DataFrames.DataFrame
│ Row │ ID │ Name     │ Job    │
├─────┼────┼──────────┼────────┤
│ 1   │ 1  │ John Doe │ Lawyer │
│ 2   │ 2  │ Jane Doe │ Doctor │

```

I think somebody has ever tried the same idea, but I couldn't find related discussions.