### PR TITLE
Add one-argument version of allowmissing!()

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -726,7 +726,7 @@ function allowmissing!(df::DataFrame, col::ColumnIndex)
     df[col] = Vector{Union{eltype(df[col]), Missing}}(df[col])
     df
 end
-function allowmissing!(df::DataFrame, cols::Vector{T}) where T <: ColumnIndex
+function allowmissing!(df::DataFrame, cols::AbstractVector{<: ColumnIndex}=1:size(df, 2))
     for col in cols
         allowmissing!(df, col)
     end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -438,7 +438,13 @@ module TestDataFrame
         allowmissing!(df, 1)
         @test isa(df[1], Vector{Union{Int, Missing}})
         @test !isa(df[2], Vector{Union{Int, Missing}})
+
+        df = DataFrame(Any[collect(1:10), collect(1:10)])        
         allowmissing!(df, [1,2])
+        @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
+
+        df = DataFrame(Any[collect(1:10), collect(1:10)])        
+        allowmissing!(df)
         @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
     end
 end


### PR DESCRIPTION
Convenient, and consistent with `categorical!`.