### PR TITLE
Small improvements to missing value support

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
-Missings 0.2.1
+Missings 0.2.3
 CategoricalArrays 0.3.0
 StatsBase 0.11.0
 SortingAlgorithms

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -46,6 +46,7 @@ rename!
 rename
 show
 showcols
+similar
 size
 sort
 sort!

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -233,8 +233,17 @@ Base.ndims(::AbstractDataFrame) = 2
 ##
 ##############################################################################
 
-Base.similar(df::AbstractDataFrame, dims::Int) =
-    DataFrame(Any[similar_missing(x, dims) for x in columns(df)], copy(index(df)))
+"""
+    similar(df::DataFrame[, rows::Int])
+
+Create a new `DataFrame` with the same column names and column element types
+as `df`. An optional second argument can be provided to request a number of rows
+that is different than the number of rows present in `df`.
+"""
+function Base.similar(df::AbstractDataFrame, rows::Integer = size(df, 1))
+    rows < 0 && throw(ArgumentError("the number of rows must be positive"))
+    DataFrame(Any[similar(x, rows) for x in columns(df)], copy(index(df)))
+end
 
 ##############################################################################
 ##

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -234,7 +234,7 @@ Base.ndims(::AbstractDataFrame) = 2
 ##############################################################################
 
 """
-    similar(df::DataFrame[, rows::Int])
+    similar(df::DataFrame[, rows::Integer])
 
 Create a new `DataFrame` with the same column names and column element types
 as `df`. An optional second argument can be provided to request a number of rows

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -721,11 +721,29 @@ Base.hcat(df1::DataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...) = h
 ## Missing values support
 ##
 ##############################################################################
+"""
+    allowmissing!(df::DataFrame)
+
+Convert all columns of a `DataFrame` from element type `T` to
+`Union{T, Missing}` to support missing values.
+
+    allowmissing!(df::DataFrame, col::Union{Integer, Symbol})
+
+Convert a single column of a `DataFrame` from element type `T` to
+`Union{T, Missing}` to support missing values.
+
+    allowmissing!(df::DataFrame, cols::AbstractVector{<:Union{Integer, Symbol}})
+
+Convert multiple columns of a `DataFrame` from element-type `T` to
+`Union{T, Missing}` to support missing values.
+"""
+function allowmissing! end
 
 function allowmissing!(df::DataFrame, col::ColumnIndex)
-    df[col] = Vector{Union{eltype(df[col]), Missing}}(df[col])
+    df[col] = allowmissing(df[col])
     df
 end
+
 function allowmissing!(df::DataFrame, cols::AbstractVector{<: ColumnIndex}=1:size(df, 2))
     for col in cols
         allowmissing!(df, col)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -724,17 +724,17 @@ Base.hcat(df1::DataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...) = h
 """
     allowmissing!(df::DataFrame)
 
-Convert all columns of a `DataFrame` from element type `T` to
+Convert all columns of a `df` from element type `T` to
 `Union{T, Missing}` to support missing values.
 
     allowmissing!(df::DataFrame, col::Union{Integer, Symbol})
 
-Convert a single column of a `DataFrame` from element type `T` to
+Convert a single column of a `df` from element type `T` to
 `Union{T, Missing}` to support missing values.
 
     allowmissing!(df::DataFrame, cols::AbstractVector{<:Union{Integer, Symbol}})
 
-Convert multiple columns of a `DataFrame` from element-type `T` to
+Convert multiple columns of a `df` from element type `T` to
 `Union{T, Missing}` to support missing values.
 """
 function allowmissing! end


### PR DESCRIPTION
- change behavior of `similar` on DataFrames to not auto-enable missing
  value support and instead use same column eltypes as parent df
- add docstrings for `similar` and `allowmissing!`
- change behavior of `allowmissing!` on CategoricalArrays to preserve
  correct Array type (which is a CategoricalArray)
- add `similar` to docs

Should fix https://github.com/JuliaData/DataFrames.jl/issues/1294 and https://github.com/JuliaData/DataFrames.jl/issues/1291, although it does not address the `append!` ideas presented in https://github.com/JuliaData/DataFrames.jl/issues/1291.

