### PR TITLE
Improve hcat for DataFrames

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -668,6 +668,7 @@ without(df::AbstractDataFrame, c::Any) = without(df, index(df)[c])
 ##############################################################################
 
 # hcat's first argument must be an AbstractDataFrame
+# or AbstractVector if the second argument is AbstractDataFrame
 # Trailing arguments (currently) may also be vectors or scalars.
 
 # hcat! is defined in DataFrames/DataFrames.jl
@@ -675,6 +676,7 @@ without(df::AbstractDataFrame, c::Any) = without(df, index(df)[c])
 
 # catch-all to cover cases where indexing returns a DataFrame and copy doesn't
 Base.hcat(df::AbstractDataFrame, x) = hcat!(df[:, :], x)
+Base.hcat(x, df::AbstractDataFrame) = hcat!(x, df[:, :])
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame) = hcat!(df1[:, :], df2)
 
 Base.hcat(df::AbstractDataFrame, x, y...) = hcat!(hcat(df, x), y...)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -714,10 +714,10 @@ end
 hcat!(df::DataFrame, x::AbstractVector) = hcat!(df, DataFrame(Any[x]))
 hcat!(x::AbstractVector, df::DataFrame) = hcat!(DataFrame(Any[x]), df)
 function hcat!(x, df::DataFrame)
-    throw(ArgumentError("x must be AbstaractVector or AbstaractDataFrame"))
+    throw(ArgumentError("x must be AbstaractVector or AbstractDataFrame"))
 end
-hcat!(df::DataFrame, x)
-    throw(ArgumentError("x must be AbstaractVector or AbstaractDataFrame"))
+function hcat!(df::DataFrame, x)
+    throw(ArgumentError("x must be AbstaractVector or AbstractDataFrame"))
 end
 
 # hcat! for 1-n arguments

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -713,8 +713,12 @@ end
 
 hcat!(df::DataFrame, x::AbstractVector) = hcat!(df, DataFrame(Any[x]))
 hcat!(x::AbstractVector, df::DataFrame) = hcat!(DataFrame(Any[x]), df)
-hcat!(x, df::DataFrame) = throw(ArgumentError("x must be a vector or a data frame"))
-hcat!(df::DataFrame, x) = throw(ArgumentError("x must be a vector or a data frame"))
+function hcat!(x, df::DataFrame)
+    throw(ArgumentError("x must be AbstaractVector or AbstaractDataFrame"))
+end
+hcat!(df::DataFrame, x)
+    throw(ArgumentError("x must be AbstaractVector or AbstaractDataFrame"))
+end
 
 # hcat! for 1-n arguments
 hcat!(df::DataFrame) = df

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -705,6 +705,12 @@ function hcat!(df1::DataFrame, df2::AbstractDataFrame)
     end
     return df1
 end
+
+# definition required to avoid hcat! ambiguity
+function hcat!(df1::DataFrame, df2::DataFrame)
+    invoke(hcat!, Tuple{DataFrame, AbstractDataFrame}, df1, df2)
+end
+
 hcat!(df::DataFrame, x::AbstractVector) = hcat!(df, DataFrame(Any[x]))
 hcat!(x::AbstractVector, df::DataFrame) = hcat!(DataFrame(Any[x]), df)
 hcat!(x, df::DataFrame) = throw(ArgumentError("x must be a vector or a data frame"))

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -714,10 +714,10 @@ end
 hcat!(df::DataFrame, x::AbstractVector) = hcat!(df, DataFrame(Any[x]))
 hcat!(x::AbstractVector, df::DataFrame) = hcat!(DataFrame(Any[x]), df)
 function hcat!(x, df::DataFrame)
-    throw(ArgumentError("x must be AbstaractVector or AbstractDataFrame"))
+    throw(ArgumentError("x must be AbstractVector or AbstractDataFrame"))
 end
 function hcat!(df::DataFrame, x)
-    throw(ArgumentError("x must be AbstaractVector or AbstractDataFrame"))
+    throw(ArgumentError("x must be AbstractVector or AbstractDataFrame"))
 end
 
 # hcat! for 1-n arguments

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -697,7 +697,7 @@ end
 ##
 ##############################################################################
 
-# hcat! for 2 arguments
+# hcat! for 2 arguments, only a vector or a data frame is allowed
 function hcat!(df1::DataFrame, df2::AbstractDataFrame)
     u = add_names(index(df1), index(df2))
     for i in 1:length(u)
@@ -706,6 +706,9 @@ function hcat!(df1::DataFrame, df2::AbstractDataFrame)
     return df1
 end
 hcat!(df::DataFrame, x::AbstractVector) = hcat!(df, DataFrame(Any[x]))
+hcat!(x::AbstractVector, df::DataFrame) = hcat!(DataFrame(Any[x]), df)
+hcat!(x, df::DataFrame) = throw(ArgumentError("x must be a vector or a data frame"))
+hcat!(df::DataFrame, x) = throw(ArgumentError("x must be a vector or a data frame"))
 
 # hcat! for 1-n arguments
 hcat!(df::DataFrame) = df

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -46,10 +46,9 @@ module TestCat
         @test hcat(gd[1], gd[2]) == answer
     end
 
-    @testset "hcat ::Vectors" begin
+    @testset "hcat ::AbstractVectors" begin
         df = DataFrame()
         DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
-        @test df[1] == collect(1:10)
         @test df[1] == CategoricalVector(1:10)
         DataFrames.hcat!(df, 1:10)
         @test df[2] == collect(1:10)

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -50,14 +50,11 @@ module TestCat
         df = DataFrame()
         DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
         @test df[1] == collect(1:10)
+        @test df[1] == CategoricalVector(1:10)
         DataFrames.hcat!(df, 1:10)
         @test df[2] == collect(1:10)
-
-        df = DataFrame()
-        DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
-        @test df[1] == CategoricalVector(1:10)
         DataFrames.hcat!(df, collect(1:10))
-        @test df[2] == collect(1:10)
+        @test df[3] == collect(1:10)
 
         df = DataFrame()
         df2 = hcat(CategoricalVector{Union{Int, Missing}}(1:10), df)

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -37,14 +37,6 @@ module TestCat
         @test hcat(gd[1], gd[2]) == answer
     end
 
-    @testset "hcat ::Vectors" begin
-        df = DataFrame()
-        DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
-        @test df[1] == collect(1:10)
-        DataFrames.hcat!(df, 1:10)
-        @test df[2] == collect(1:10)
-    end
-
     @testset "hcat ::AbstractDataFrame" begin
         df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)
         gd = groupby(df, :A)
@@ -57,17 +49,24 @@ module TestCat
     @testset "hcat ::Vectors" begin
         df = DataFrame()
         DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
+        @test df[1] == collect(1:10)
+        DataFrames.hcat!(df, 1:10)
+        @test df[2] == collect(1:10)
+
+        df = DataFrame()
+        DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
         @test df[1] == CategoricalVector(1:10)
         DataFrames.hcat!(df, collect(1:10))
         @test df[2] == collect(1:10)
-    end
 
-    @testset "hcat ::Vectors" begin
         df = DataFrame()
-        df2 = hcat(DataFrames.CategoricalVector{Union{Int, Missing}}(1:10), df)
+        df2 = hcat(CategoricalVector{Union{Int, Missing}}(1:10), df)
         @test df2[1] == collect(1:10)
+        @test names(df2) == ["x1"]
         df3 = hcat(11:20, df2)
         @test df3[1] == collect(11:20)
+        @test names(df3) == ["x1", "x1_1"]
+
         @test_throws ArgumentError hcat("a", df)
         @test_throws ArgumentError hcat(df, "a")
     end

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -62,6 +62,15 @@ module TestCat
         @test df[2] == collect(1:10)
     end
 
+    @testset "hcat ::Vectors" begin
+        df = DataFrame()
+        df2 = hcat(DataFrames.CategoricalVector{Union{Int, Missing}}(1:10), df)
+        @test df2[1] == collect(1:10)
+        df3 = hcat(11:20, df2)
+        @test df3[1] == collect(11:20)
+        @test_throws ArgumentError hcat("a", df)
+        @test_throws ArgumentError hcat(df, "a")
+    end
     #
     # vcat
     #

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -62,10 +62,10 @@ module TestCat
         df = DataFrame()
         df2 = hcat(CategoricalVector{Union{Int, Missing}}(1:10), df)
         @test df2[1] == collect(1:10)
-        @test names(df2) == ["x1"]
+        @test names(df2) == [:x1]
         df3 = hcat(11:20, df2)
         @test df3[1] == collect(11:20)
-        @test names(df3) == ["x1", "x1_1"]
+        @test names(df3) == [:x1, :x1_1]
 
         @test_throws ArgumentError hcat("a", df)
         @test_throws ArgumentError hcat(df, "a")


### PR DESCRIPTION
Following the discussion in #1301:

* `hcat` now accepts `AbstarctVector` as first argument if the second argument is `DataFrame` and produces a `DataFrame` in result;
* `hcat` with `DataFrame` throws an error if something else than `DataFrame` or `AbstractVector` is passed as a second argument.