### PR TITLE
Redesign getindex and fix stack/melt StackOverflow error

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -74,8 +74,8 @@ d1s_name = melt(d1, [:a, :b, :e], variable_name=:somemeasure)
 ```
 
 """
-function stack(df::AbstractDataFrame, measure_vars::Vector{Int},
-               id_vars::Vector{Int}; variable_name::Symbol=:variable,
+function stack(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
+               id_vars::AbstractVector{<:Integer}; variable_name::Symbol=:variable,
                value_name::Symbol=:value)
     N = length(measure_vars)
     cnames = names(df)[id_vars]
@@ -91,12 +91,12 @@ function stack(df::AbstractDataFrame, measure_var::Int, id_var::Int;
     stack(df, [measure_var], [id_var];
           variable_name=variable_name, value_name=value_name)
 end
-function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_var::Int;
+function stack(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer}, id_var::Int;
                variable_name::Symbol=:variable, value_name::Symbol=:value)
     stack(df, measure_vars, [id_var];
           variable_name=variable_name, value_name=value_name)
 end
-function stack(df::AbstractDataFrame, measure_var::Int, id_vars::Vector{Int};
+function stack(df::AbstractDataFrame, measure_var::Int, id_vars::AbstractVector{<:Integer};
                variable_name::Symbol=:variable, value_name::Symbol=:value)
     stackdf(df, [measure_var], id_vars;
             variable_name=variable_name, value_name=value_name)
@@ -516,8 +516,8 @@ d1m = meltdf(d1, [:a, :b, :e])
 ```
 
 """
-function stackdf(df::AbstractDataFrame, measure_vars::Vector{Int},
-                 id_vars::Vector{Int}; variable_name::Symbol=:variable,
+function stackdf(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
+                 id_vars::AbstractVector{<:Integer}; variable_name::Symbol=:variable,
                  value_name::Symbol=:value)
     N = length(measure_vars)
     cnames = names(df)[id_vars]

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -217,8 +217,7 @@ function Base.getindex(df::DataFrame, col_ind::ColumnIndex)
 end
 
 # df[MultiColumnIndex] => DataFrame
-function Base.getindex(df::DataFrame,
-                       col_inds::AbstractVector{<:Union{ColumnIndex, Missing}})
+function Base.getindex(df::DataFrame, col_inds::AbstractVector)
     selected_columns = index(df)[col_inds]
     new_columns = df.columns[selected_columns]
     return DataFrame(new_columns, Index(_names(df)[selected_columns]))
@@ -234,26 +233,20 @@ function Base.getindex(df::DataFrame, row_ind::Real, col_ind::ColumnIndex)
 end
 
 # df[SingleRowIndex, MultiColumnIndex] => DataFrame
-function Base.getindex(df::DataFrame,
-                       row_ind::Real,
-                       col_inds::AbstractVector{<:Union{ColumnIndex, Missing}})
+function Base.getindex(df::DataFrame, row_ind::Real, col_inds::AbstractVector)
     selected_columns = index(df)[col_inds]
     new_columns = Any[dv[[row_ind]] for dv in df.columns[selected_columns]]
     return DataFrame(new_columns, Index(_names(df)[selected_columns]))
 end
 
 # df[MultiRowIndex, SingleColumnIndex] => AbstractVector
-function Base.getindex(df::DataFrame,
-                       row_inds::AbstractVector{<:Union{Real, Missing}},
-                       col_ind::ColumnIndex)
+function Base.getindex(df::DataFrame, row_inds::AbstractVector, col_ind::ColumnIndex)
     selected_column = index(df)[col_ind]
     return df.columns[selected_column][row_inds]
 end
 
 # df[MultiRowIndex, MultiColumnIndex] => DataFrame
-function Base.getindex(df::DataFrame,
-                       row_inds::AbstractVector{<:Union{Real, Missing}},
-                       col_inds::AbstractVector{<:Union{ColumnIndex, Missing}})
+function Base.getindex(df::DataFrame, row_inds::AbstractVector, col_inds::AbstractVector)
     selected_columns = index(df)[col_inds]
     new_columns = Any[dv[row_inds] for dv in df.columns[selected_columns]]
     return DataFrame(new_columns, Index(_names(df)[selected_columns]))
@@ -261,22 +254,17 @@ end
 
 # df[:, SingleColumnIndex] => AbstractVector
 # df[:, MultiColumnIndex] => DataFrame
-Base.getindex(df::DataFrame, row_ind::Colon, col_inds::Union{T, AbstractVector{T}}) where
-    T <: Union{ColumnIndex, Missing} = df[col_inds]
+# df[:, :] => DataFrame
+Base.getindex(df::DataFrame, row_ind::Colon, col_inds) = df[col_inds]
 
 # df[SingleRowIndex, :] => DataFrame
 Base.getindex(df::DataFrame, row_ind::Real, col_inds::Colon) = df[[row_ind], col_inds]
 
 # df[MultiRowIndex, :] => DataFrame
-function Base.getindex(df::DataFrame,
-                       row_inds::AbstractVector{<:Union{Real, Missing}},
-                       col_inds::Colon)
+function Base.getindex(df::DataFrame, row_inds::AbstractVector, col_inds::Colon)
     new_columns = Any[dv[row_inds] for dv in df.columns]
     return DataFrame(new_columns, copy(index(df)))
 end
-
-# df[:, :] => DataFrame
-Base.getindex(df::DataFrame, ::Colon, ::Colon) = copy(df)
 
 ##############################################################################
 ##

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -208,6 +208,7 @@ ncol(df::DataFrame) = length(index(df))
 # Let getindex(df.columns[j], row_inds) from AbstractVector() handle
 #  the resolution of row indices
 
+# TODO: change Real to Integer in this union after deprecation period
 const ColumnIndex = Union{Real, Symbol}
 
 # df[SingleColumnIndex] => AbstractDataVector

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -254,7 +254,6 @@ end
 
 # df[:, SingleColumnIndex] => AbstractVector
 # df[:, MultiColumnIndex] => DataFrame
-# df[:, :] => DataFrame
 Base.getindex(df::DataFrame, row_ind::Colon, col_inds) = df[col_inds]
 
 # df[SingleRowIndex, :] => DataFrame
@@ -265,6 +264,9 @@ function Base.getindex(df::DataFrame, row_inds::AbstractVector, col_inds::Colon)
     new_columns = Any[dv[row_inds] for dv in df.columns]
     return DataFrame(new_columns, copy(index(df)))
 end
+
+# df[:, :] => DataFrame
+Base.getindex(df::DataFrame, ::Colon, ::Colon) = copy(df)
 
 ##############################################################################
 ##

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1285,3 +1285,18 @@ import Base: |>
 @deprecate colwise(f) x -> colwise(f, x)
 @deprecate groupby(cols::Vector{T}; sort::Bool = false, skipmissing::Bool = false) where {T} x -> groupby(x, cols, sort = sort, skipmissing = skipmissing)
 @deprecate groupby(cols; sort::Bool = false, skipmissing::Bool = false) x -> groupby(x, cols, sort = sort, skipmissing = skipmissing)
+
+function Base.getindex(x::AbstractIndex, idx::Bool)
+    Base.depwarn("Indexing with Bool values is deprecated except for Vector{Bool}", :getindex)
+    1
+end
+
+function Base.getindex(x::AbstractIndex, idx::Real)
+    Base.depwarn("Indexing with values that are not Integer is deprecated", :getindex)
+    Int(idx)
+end
+
+function Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}})
+    Base.depwarn("passing Vector{Union{Bool, Missing}} for indexing is deprecated", :getindex)
+    getindex(x, collect(Missings.replace(idx, false)))
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1296,7 +1296,3 @@ function Base.getindex(x::AbstractIndex, idx::Real)
     Int(idx)
 end
 
-function Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}})
-    Base.depwarn("passing Vector{Union{Bool, Missing}} for indexing is deprecated", :getindex)
-    getindex(x, collect(Missings.replace(idx, false)))
-end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1296,3 +1296,14 @@ function Base.getindex(x::AbstractIndex, idx::Real)
     Int(idx)
 end
 
+function Base.getindex(x::AbstractIndex, idx::AbstractRange)
+    Base.depwarn("Indexing with range of values that are not Integer is deprecated", :getindex)
+    getindex(x, collect(idx))
+end
+
+
+function Base.getindex(x::AbstractIndex, idx::AbstractRange{Bool})
+    Base.depwarn("Indexing with range of Bool is deprecated", :getindex)
+    collect(Int, idx)
+end
+

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -116,8 +116,14 @@ function Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool})
     length(x) == length(idx) || throw(BoundsError(x, idx))
     find(idx)
 end
-Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T >: Missing} =
-    getindex(x, collect(skipmissing(idx)))
+function Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T >: Missing}
+    idx2 = collect(skipmissing(idx)) # idx can be Any and we have to handle it
+    length(idx2) == 0 && return Int[] # special case of empty idx2
+    # now only accept either numbers, Bool or Symbols
+    idx2[1] isa Real && return convert(Vector{Int}, idx2)
+    idx2[1] isa Bool && return convert(Vector{Bool}, idx2)
+    getindex(x, convert(Vector{Symbol}, idx2))
+end
 Base.getindex(x::AbstractIndex, idx::AbstractRange) = [idx;]
 Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T <: Real} = convert(Vector{Int}, idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Symbol}) = [x.lookup[i] for i in idx]

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -119,6 +119,14 @@ function Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool})
     find(idx)
 end
 
+function Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}})
+    if any(ismissing, idx)
+        # TODO: this line should be changed to throw an error after deprecation
+        Base.depwarn("using missing in column indexing is deprecated", :getindex)
+    end
+    getindex(x, collect(Missings.replace(idx, false)))
+end
+
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Integer})
     # TODO: this line should be changed to throw an error after deprecation
     if any(v -> v isa Bool, idx)

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -125,8 +125,19 @@ function Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T >: Mis
     getindex(x, convert(Vector{Symbol}, idx2))
 end
 Base.getindex(x::AbstractIndex, idx::AbstractRange) = [idx;]
-Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T <: Real} = convert(Vector{Int}, idx)
+Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Union{Real, Missing}}) =
+    Int[i for i in skipmissing(idx)]
+Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Real}) = convert(Vector{Int}, idx)
+Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Symbol, Missing}}) =
+    [x.lookup[i] for i in skipmissing(idx)]
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Symbol}) = [x.lookup[i] for i in idx]
+function Base.getindex(x::AbstractIndex, idx::AbstractVector)
+    idxs = skipmissing(idx)
+    try # allow either vector of numbers
+        return Int[i for i in idxs]
+    end
+    [x.lookup[i] for i in idxs] # or Symbols
+end
 
 # Helpers
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -112,7 +112,8 @@ Base.getindex(x::AbstractIndex, idx::Symbol) = x.lookup[idx]
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Symbol}) = [x.lookup[i] for i in idx]
 Base.getindex(x::AbstractIndex, idx::Integer) = Int(idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Int}) = idx
-Base.getindex(x::AbstractIndex, idx::AbstractRange) = getindex(x, collect(idx))
+Base.getindex(x::AbstractIndex, idx::AbstractRange{Int}) = idx
+Base.getindex(x::AbstractIndex, idx::AbstractRange{<:Integer}) = collect(Int, idx)
 
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool})
     length(x) == length(idx) || throw(BoundsError(x, idx))

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -132,11 +132,10 @@ Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Symbol, Missing}}) =
     [x.lookup[i] for i in skipmissing(idx)]
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Symbol}) = [x.lookup[i] for i in idx]
 function Base.getindex(x::AbstractIndex, idx::AbstractVector)
-    idxs = skipmissing(idx)
-    try # allow either vector of numbers
-        return Int[i for i in idxs]
-    end
-    [x.lookup[i] for i in idxs] # or Symbols
+    idxs = [convert(Union{Int, Symbol, Bool}, i) for i in skipmissing(idx)]
+    eltype(idxs) <: Int && return idxs
+    eltype(idxs) <: Bool && return getindex(x, Vector{Bool}(idxs))
+    [x.lookup[i] for i in idxs]
 end
 
 # Helpers

--- a/test/data.jl
+++ b/test/data.jl
@@ -143,6 +143,20 @@ module TestData
                    d = Array{Union{Float64, Missing}}(randn(12)),
                    e = Array{Union{String, Missing}}(map(string, 'a':'l')))
 
+    # test empty measures or ids
+    dx = stack(d1, [], [:a])
+    @test size(dx) == (0, 3)
+    @test names(dx) == [:variable, :value, :a]
+    dx = stack(d1, :a, [])
+    @test size(dx) == (12, 2)
+    @test names(dx) == [:variable, :value]
+    dx = melt(d1, [], [:a])
+    @test size(dx) == (12, 2)
+    @test names(dx) == [:variable, :value]
+    dx = melt(d1, :a, [])
+    @test size(dx) == (0, 3)
+    @test names(dx) == [:variable, :value, :a]
+
     stack(d1, :a)
     d1s = stack(d1, [:a, :b])
     d1s2 = stack(d1, [:c, :d])

--- a/test/data.jl
+++ b/test/data.jl
@@ -143,20 +143,6 @@ module TestData
                    d = Array{Union{Float64, Missing}}(randn(12)),
                    e = Array{Union{String, Missing}}(map(string, 'a':'l')))
 
-    # test empty measures or ids
-    dx = stack(d1, [], [:a])
-    @test size(dx) == (0, 3)
-    @test names(dx) == [:variable, :value, :a]
-    dx = stack(d1, :a, [])
-    @test size(dx) == (12, 2)
-    @test names(dx) == [:variable, :value]
-    dx = melt(d1, [], [:a])
-    @test size(dx) == (12, 2)
-    @test names(dx) == [:variable, :value]
-    dx = melt(d1, :a, [])
-    @test size(dx) == (0, 3)
-    @test names(dx) == [:variable, :value, :a]
-
     stack(d1, :a)
     d1s = stack(d1, [:a, :b])
     d1s2 = stack(d1, [:c, :d])
@@ -175,6 +161,20 @@ module TestData
     @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
     d1m_named = melt(d1[[1,3,4]], :a, variable_name=:letter, value_name=:someval)
     @test names(d1m_named) == [:letter, :someval, :a]
+
+    # test empty measures or ids
+    dx = stack(d1, [], [:a])
+    @test size(dx) == (0, 3)
+    @test names(dx) == [:variable, :value, :a]
+    dx = stack(d1, :a, [])
+    @test size(dx) == (12, 2)
+    @test names(dx) == [:variable, :value]
+    dx = melt(d1, [], [:a])
+    @test size(dx) == (12, 2)
+    @test names(dx) == [:variable, :value]
+    dx = melt(d1, :a, [])
+    @test size(dx) == (0, 3)
+    @test names(dx) == [:variable, :value, :a]
 
     stackdf(d1, :a)
     d1s = stackdf(d1, [:a, :b])

--- a/test/index.jl
+++ b/test/index.jl
@@ -11,7 +11,6 @@ inds = Any[1,
            [true, false],
            [1],
            [1.0],
-           1:1,
            1.0:1.0,
            [:A],
            Union{Bool, Missing}[true, false],
@@ -32,6 +31,8 @@ for ind in inds
         @test (i[ind] == [1])
     end
 end
+
+@test i[1:1] == 1:1
 
 @test_throws BoundsError i[[true]]
 @test_throws BoundsError i[[true, false, true]]

--- a/test/index.jl
+++ b/test/index.jl
@@ -20,6 +20,7 @@ inds = Any[1,
            Union{Symbol, Missing}[:A],
            Any[1],
            Any[1, missing],
+           Any[true, missing],
            Any[:A],
            Any[:A, missing],
            [true, missing]]
@@ -35,7 +36,6 @@ end
 @test_throws BoundsError i[[true]]
 @test_throws BoundsError i[[true, false, true]]
 
-@test_throws ArgumentError i[Any[true, missing]]
 @test_throws ArgumentError i[["a"]]
 @test_throws ArgumentError i[Any["a"]]
 

--- a/test/index.jl
+++ b/test/index.jl
@@ -17,7 +17,13 @@ inds = Any[1,
            Union{Bool, Missing}[true, false],
            Union{Int, Missing}[1],
            Union{Float64, Missing}[1.0],
-           Union{Symbol, Missing}[:A]]
+           Union{Symbol, Missing}[:A],
+           Any[1],
+           Any[1, missing],
+           Any[:A],
+           Any[:A, missing],
+           Any[true, missing],
+           [true, missing]]
 
 for ind in inds
     if ind == :A || ndims(ind) == 0
@@ -29,6 +35,10 @@ end
 
 @test_throws BoundsError i[[true]]
 @test_throws BoundsError i[[true, false, true]]
+
+@test i[[]] == Int[]
+@test i[Int[]] == Int[]
+@test i[Symbol[]] == Int[]
 
 @test names(i) == [:A,:B]
 @test names!(i, [:a,:a], allow_duplicates=true) == Index([:a,:a_1])

--- a/test/index.jl
+++ b/test/index.jl
@@ -22,7 +22,6 @@ inds = Any[1,
            Any[1, missing],
            Any[:A],
            Any[:A, missing],
-           Any[true, missing],
            [true, missing]]
 
 for ind in inds
@@ -36,6 +35,7 @@ end
 @test_throws BoundsError i[[true]]
 @test_throws BoundsError i[[true, false, true]]
 
+@test_throws ArgumentError i[Any[true, missing]]
 @test_throws ArgumentError i[["a"]]
 @test_throws ArgumentError i[Any["a"]]
 

--- a/test/index.jl
+++ b/test/index.jl
@@ -36,6 +36,9 @@ end
 @test_throws BoundsError i[[true]]
 @test_throws BoundsError i[[true, false, true]]
 
+@test_throws ArgumentError i[["a"]]
+@test_throws ArgumentError i[Any["a"]]
+
 @test i[[]] == Int[]
 @test i[Int[]] == Int[]
 @test i[Symbol[]] == Int[]


### PR DESCRIPTION
Currently `stack(df, :a, [])` produces StackOverflow.
With this PR we check that length of `measure_vars` and `id_vars` is at least 1.