### PR TITLE
Restrict arguments of unstack to avoid StackOverflow

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -230,7 +230,6 @@ function unstack(df::AbstractDataFrame, colkey::Int, value::Int)
     # group on anything not a key or value:
     rowkeys = setdiff(_names(df), _names(df)[[colkey, value]])
     length(rowkeys) == 0 && throw(ArgumentError("No key column found"))
-    length(rowkeys) == 1 && return unstack(df, rowkeys[1], colkey, value) # better performance
     g = groupby(df, rowkeys, sort=true)
     groupidxs = [g.idx[g.starts[i]:g.ends[i]] for i in 1:length(g.starts)]
     rowkey = zeros(Int, size(df, 1))

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -195,7 +195,7 @@ function unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int, value::Int)
     # `value` integer indicating which column has values
     refkeycol = CategoricalArray{Union{eltype(df[rowkey]), Missing}}(df[rowkey])
     # make sure we report only levels actually present in rowkey column
-    # this is consistent with how groupby works
+    # this is consistent with how the other unstack method based on groupby works
     droplevels!(refkeycol)
     valuecol = df[value]
     keycol = CategoricalArray{Union{eltype(df[colkey]), Missing}}(df[colkey])

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -194,6 +194,7 @@ function unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int, value::Int)
     # `colkey` integer indicating which column to place along column headers
     # `value` integer indicating which column has values
     refkeycol = CategoricalArray{Union{eltype(df[rowkey]), Missing}}(df[rowkey])
+    droplevels!(refkeycol)
     valuecol = df[value]
     keycol = CategoricalArray{Union{eltype(df[colkey]), Missing}}(df[colkey])
     Nrow = length(refkeycol.pool)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -194,6 +194,8 @@ function unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int, value::Int)
     # `colkey` integer indicating which column to place along column headers
     # `value` integer indicating which column has values
     refkeycol = CategoricalArray{Union{eltype(df[rowkey]), Missing}}(df[rowkey])
+    # make sure we report only levels actually present in rowkey column
+    # this is consistent with how groupby works
     droplevels!(refkeycol)
     valuecol = df[value]
     keycol = CategoricalArray{Union{eltype(df[colkey]), Missing}}(df[colkey])

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -220,7 +220,7 @@ unstack(df::AbstractDataFrame, rowkey::ColumnIndex,
     unstack(df, index(df)[rowkey], index(df)[colkey], index(df)[value])
 
 # Version of unstack with just the colkey and value columns provided
-unstack(df::AbstractDataFrame, colkey, value) =
+unstack(df::AbstractDataFrame, colkey::ColumnIndex, value::ColumnIndex) =
     unstack(df, index(df)[colkey], index(df)[value])
 
 function unstack(df::AbstractDataFrame, colkey::Int, value::Int)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -215,7 +215,8 @@ function unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int, value::Int)
     col = similar_missing(df[rowkey], length(levs))
     insert!(payload, 1, copy!(col, levs), _names(df)[rowkey])
 end
-unstack(df::AbstractDataFrame, rowkey, colkey, value) =
+unstack(df::AbstractDataFrame, rowkey::Union{Symbol, Real},
+        colkey::Union{Symbol, Real}, value::Union{Symbol, Real}) =
     unstack(df, index(df)[rowkey], index(df)[colkey], index(df)[value])
 
 # Version of unstack with just the colkey and value columns provided

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -225,7 +225,10 @@ unstack(df::AbstractDataFrame, colkey::ColumnIndex, value::ColumnIndex) =
 
 function unstack(df::AbstractDataFrame, colkey::Int, value::Int)
     # group on anything not a key or value:
-    g = groupby(df, setdiff(_names(df), _names(df)[[colkey, value]]), sort=true)
+    rowkeys = setdiff(_names(df), _names(df)[[colkey, value]])
+    length(rowkeys) == 0 && throw(ArgumentError("No key column found"))
+    length(rowkeys) == 1 && return unstack(df, rowkeys[1], colkey, value) # better performance
+    g = groupby(df, rowkeys, sort=true)
     groupidxs = [g.idx[g.starts[i]:g.ends[i]] for i in 1:length(g.starts)]
     rowkey = zeros(Int, size(df, 1))
     for i in 1:length(groupidxs)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -215,8 +215,8 @@ function unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int, value::Int)
     col = similar_missing(df[rowkey], length(levs))
     insert!(payload, 1, copy!(col, levs), _names(df)[rowkey])
 end
-unstack(df::AbstractDataFrame, rowkey::Union{Symbol, Real},
-        colkey::Union{Symbol, Real}, value::Union{Symbol, Real}) =
+unstack(df::AbstractDataFrame, rowkey::ColumnIndex,
+        colkey::ColumnIndex, value::ColumnIndex) =
     unstack(df, index(df)[rowkey], index(df)[colkey], index(df)[value])
 
 # Version of unstack with just the colkey and value columns provided

--- a/test/data.jl
+++ b/test/data.jl
@@ -193,12 +193,11 @@ module TestData
     df1 = melt(DataFrame(rand(10,10)))
     df1[:id] = 1:100
     @test size(unstack(df1, :variable, :value)) == (100, 11)
-    # test empty keycol
 
+    # test empty keycol
     @test_throws ArgumentError unstack(melt(DataFrame(rand(3,2))), :variable, :value)
 
     #test_group("merge")
-
     srand(1)
     df1 = DataFrame(a = shuffle!(Vector{Union{Int, Missing}}(1:10)),
                     b = rand(Union{Symbol, Missing}[:A,:B], 10),

--- a/test/data.jl
+++ b/test/data.jl
@@ -189,6 +189,15 @@ module TestData
     @test d1us2[:d] == d1[:d]
     @test d1us2[:3] == d1[:d]
 
+    #
+
+    df1 = melt(DataFrame(rand(10,10)))
+    df1[:id] = 1:100
+    @test size(unstack(df1, :variable, :value)) == (100, 11)
+    # test empty keycol
+
+    @test_throws ArgumentError unstack(melt(DataFrame(rand(3,2))), :variable, :value)
+
     #test_group("merge")
 
     srand(1)

--- a/test/data.jl
+++ b/test/data.jl
@@ -189,8 +189,7 @@ module TestData
     @test d1us2[:d] == d1[:d]
     @test d1us2[:3] == d1[:d]
 
-    #
-
+    # test unstack with exactly one key column that is not passed
     df1 = melt(DataFrame(rand(10,10)))
     df1[:id] = 1:100
     @test size(unstack(df1, :variable, :value)) == (100, 11)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -304,14 +304,14 @@ module TestDataFrame
     df2 = unstack(df, :Fish, :Key, :Value)
     #Unstack without specifying a row column
     df3 = unstack(df, :Key, :Value)
-    #The expected output
-    df4 = DataFrame(Fish = Union{String, Missing}["XXX", "Bob", "Batman"],
-                    Color = Union{String, Missing}[missing, "Red", "Grey"],
-                    Mass = Union{String, Missing}[missing, "12 g", "18 g"])
+    #The expected output, XXX level should be dropped as it has no rows with this key
+    df4 = DataFrame(Fish = Union{String, Missing}["Bob", "Batman"],
+                    Color = Union{String, Missing}["Red", "Grey"],
+                    Mass = Union{String, Missing}["12 g", "18 g"])
     @test df2 ≅ df4
     @test typeof(df2[:Fish]) <: CategoricalVector{Union{String, Missing}}
     # first column stays as CategoricalArray in df3
-    @test df3[:, 2:3] == df4[2:3, 2:3]
+    @test df3 == df4
     #Make sure unstack works with missing values at the start of the value column
     df[1,:Value] = missing
     df2 = unstack(df, :Fish, :Key, :Value)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -316,7 +316,7 @@ module TestDataFrame
     df[1,:Value] = missing
     df2 = unstack(df, :Fish, :Key, :Value)
     #This changes the expected result
-    df4[2,:Mass] = missing
+    df4[1,:Mass] = missing
     @test df2 ≅ df4
 
     df = DataFrame(A = 1:10, B = 'A':'J')


### PR DESCRIPTION
Now `unstack` throw StackOverflow if it is passed vector of symbols or numbers. This PR restricts the types of passed arguments only to `Symbol` and `<:Real`.