### PR TITLE
fix allowmissing!

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -736,7 +736,7 @@ Base.hcat(df1::DataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...) = h
 ##############################################################################
 
 function allowmissing!(df::DataFrame, col::ColumnIndex)
-    df[col] = Vector{Union{eltype(df[col]), Missing}}(df[col])
+    df[col] = allowmissing(df[col])
     df
 end
 function allowmissing!(df::DataFrame, cols::AbstractVector{<: ColumnIndex}=1:size(df, 2))


### PR DESCRIPTION
The old implementation produced an unexpected result. It created `Vector`, which was incorrect for `CategoricalArrays`:
```
julia> x = DataFrame(a=categorical([1,2,3]))
3×1 DataFrames.DataFrame
│ Row │ a │
├─────┼───┤
│ 1   │ 1 │
│ 2   │ 2 │
│ 3   │ 3 │

julia> allowmissing!(x, 1)
3×1 DataFrames.DataFrame
│ Row │ a │
├─────┼───┤
│ 1   │ 1 │
│ 2   │ 2 │
│ 3   │ 3 │

julia> eltypes(x)
1-element Array{Type,1}:
 Union{CategoricalArrays.CategoricalValue{Int64,UInt32}, Missings.Missing}
```
This PR fixes this.