### PR TITLE
Preserve non-missingness during non-inner joins

### DIFF
--- a/test/join.jl
+++ b/test/join.jl
@@ -186,17 +186,17 @@ module TestJoin
                                 fid = [1, 3, 5],
                                 fid_1 = [1, 3, missing])
         @test typeof.(l(on).columns) ==
-            [Vector{Union{T, Missing}} for T in (Int, Float64, Float64)]
+            [Vector{Int}, Vector{Float64}, Vector{Union{Float64, Missing}}]
         @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
                                 fid = [1, 3, missing, missing, missing],
                                 fid_1 = [1, 3, 0, 2, 4])
         @test typeof.(r(on).columns) ==
-            [Vector{Union{T, Missing}} for T in (Int, Float64, Float64)]
+            [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Float64}]
         @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
                                 fid = [1, 3, 5, missing, missing, missing],
                                 fid_1 = [1, 3, missing, 0, 2, 4])
         @test typeof.(o(on).columns) ==
-            [Vector{Union{T, Missing}} for T in (Int, Float64, Float64)]
+            [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Union{Float64, Missing}}]
 
         on = :fid
         @test i(on) == DataFrame(Any[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
@@ -204,28 +204,25 @@ module TestJoin
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
                                 id_1 = [1, 3, missing])
-        @test typeof.(l(on).columns) == [Vector{Union{T, Missing}} for T in (Int,Float64,Int)]
+        @test typeof.(l(on).columns) == [Vector{Int}, Vector{Float64}, Vector{Union{Int, Missing}}]
         @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
                                 fid = [1, 3, 0, 2, 4],
                                 id_1 = [1, 3, 0, 2, 4])
-        @test typeof.(r(on).columns) == [Vector{Union{T, Missing}} for T in (Int,Float64,Int)]
+        @test typeof.(r(on).columns) == [Vector{Union{Int, Missing}}, Vector{Float64}, Vector{Int}]
         @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
                                 fid = [1, 3, 5, 0, 2, 4],
                                 id_1 = [1, 3, missing, 0, 2, 4])
-        @test typeof.(o(on).columns) == [Vector{Union{T, Missing}} for T in (Int,Float64,Int)]
+        @test typeof.(o(on).columns) == [Vector{Union{Int, Missing}}, Vector{Float64}, Vector{Union{Int, Missing}}]
 
         on = [:id, :fid]
         @test i(on) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
         @test typeof.(i(on).columns) == [Vector{Int}, Vector{Float64}]
         @test l(on) == DataFrame(id = [1, 3, 5], fid = [1, 3, 5])
-        @test typeof.(l(on).columns) == [Vector{Union{Int, Missing}},
-                                         Vector{Union{Float64, Missing}}]
+        @test typeof.(l(on).columns) == [Vector{Int}, Vector{Float64}]
         @test r(on) == DataFrame(id = [1, 3, 0, 2, 4], fid = [1, 3, 0, 2, 4])
-        @test typeof.(r(on).columns) == [Vector{Union{Int, Missing}},
-                                         Vector{Union{Float64, Missing}}]
+        @test typeof.(r(on).columns) == [Vector{Int}, Vector{Float64}]
         @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4], fid = [1, 3, 5, 0, 2, 4])
-        @test typeof.(o(on).columns) == [Vector{Union{Int, Missing}},
-                                         Vector{Union{Float64, Missing}}]
+        @test typeof.(o(on).columns) == [Vector{Int}, Vector{Float64}]
     end
 
     @testset "all joins with CategoricalArrays" begin
@@ -276,17 +273,17 @@ module TestJoin
                                 fid = [1, 3, 5],
                                 fid_1 = [1, 3, missing])
         @test all(isa.(l(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int,Float64,Float64)]))
+                       [CategoricalVector{T} for T in (Int,Float64,Union{Float64, Missing})]))
         @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
                                 fid = [1, 3, missing, missing, missing],
                                 fid_1 = [1, 3, 0, 2, 4])
         @test all(isa.(r(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int,Float64,Float64)]))
+                       [CategoricalVector{T} for T in (Int,Union{Float64, Missing},Float64)]))
         @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
                                 fid = [1, 3, 5, missing, missing, missing],
                                 fid_1 = [1, 3, missing, 0, 2, 4])
         @test all(isa.(o(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int,Float64,Float64)]))
+                       [CategoricalVector{T} for T in (Int,Union{Float64,Missing},Union{Float64, Missing})]))
 
         on = :fid
         @test i(on) == DataFrame(Any[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
@@ -296,17 +293,17 @@ module TestJoin
                                 fid = [1, 3, 5],
                                 id_1 = [1, 3, missing])
         @test all(isa.(l(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int, Float64, Int)]))
+                       [CategoricalVector{T} for T in (Int, Float64, Union{Int, Missing})]))
         @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
                                 fid = [1, 3, 0, 2, 4],
                                 id_1 = [1, 3, 0, 2, 4])
         @test all(isa.(r(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int, Float64, Int)]))
+                       [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Int)]))
         @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
                                 fid = [1, 3, 5, 0, 2, 4],
                                 id_1 = [1, 3, missing, 0, 2, 4])
         @test all(isa.(o(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int, Float64, Int)]))
+                       [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Union{Int, Missing})]))
 
         on = [:id, :fid]
         @test i(on) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
@@ -315,15 +312,15 @@ module TestJoin
         @test l(on) == DataFrame(id = [1, 3, 5],
                                  fid = [1, 3, 5])
         @test all(isa.(l(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int, Float64)]))
+                       [CategoricalVector{T} for T in (Int, Float64)]))
         @test r(on) == DataFrame(id = [1, 3, 0, 2, 4],
                                  fid = [1, 3, 0, 2, 4])
         @test all(isa.(r(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int, Float64)]))
+                       [CategoricalVector{T} for T in (Int, Float64)]))
         @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4],
                                  fid = [1, 3, 5, 0, 2, 4])
         @test all(isa.(o(on).columns,
-                       [CategoricalVector{Union{T, Missing}} for T in (Int, Float64)]))
+                       [CategoricalVector{T} for T in (Int, Float64)]))
     end
 
     @testset "maintain CategoricalArray levels ordering on join - non-`on` cols" begin

--- a/test/join.jl
+++ b/test/join.jl
@@ -462,4 +462,38 @@ module TestJoin
         @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:anti) ==
             DataFrame(id = 1:2, sid = string.(1:2))
     end
+
+    @testset "join with a column of type Any" begin
+        l = DataFrame(a=Any[1:7;], b=[1:7;])
+        r = DataFrame(a=Any[3:10;], b=[3:10;])
+
+        # join by :a and :b (Any is the on-column)
+        @test join(l, r, on=[:a, :b], kind=:inner) ≅ DataFrame(a=Any[3:7;], b=3:7)
+        @test eltypes(join(l, r, on=[:a, :b], kind=:inner)) == [Any, Int]
+
+        @test join(l, r, on=[:a, :b], kind=:left) ≅ DataFrame(a=Any[1:7;], b=1:7)
+        @test eltypes(join(l, r, on=[:a, :b], kind=:left)) == [Any, Int]
+
+        @test join(l, r, on=[:a, :b], kind=:right) ≅ DataFrame(a=Any[3:10;], b=3:10)
+        @test eltypes(join(l, r, on=[:a, :b], kind=:right)) == [Any, Int]
+
+        @test join(l, r, on=[:a, :b], kind=:outer) ≅ DataFrame(a=Any[1:10;], b=1:10)
+        @test eltypes(join(l, r, on=[:a, :b], kind=:outer)) == [Any, Int]
+
+        # join by :b (Any is not on-column)
+        @test join(l, r, on=:b, kind=:inner) ≅ DataFrame(a=Any[3:7;], b=3:7, a_1=Any[3:7;])
+        @test eltypes(join(l, r, on=:b, kind=:inner)) == [Any, Int, Any]
+
+        @test join(l, r, on=:b, kind=:left) ≅
+            DataFrame(a=Any[1:7;], b=1:7, a_1=[fill(missing, 2); 3:7;])
+        @test eltypes(join(l, r, on=:b, kind=:left)) == [Any, Int, Any]
+
+        @test join(l, r, on=:b, kind=:right) ≅
+            DataFrame(a=[3:7; fill(missing, 3)], b=3:10, a_1=Any[3:10;])
+        @test eltypes(join(l, r, on=:b, kind=:right)) == [Any, Int, Any]
+
+        @test join(l, r, on=:b, kind=:outer) ≅
+            DataFrame(a=[1:7; fill(missing, 3)], b=1:10, a_1=[fill(missing, 2); 3:10;])
+        @test eltypes(join(l, r, on=:b, kind=:outer)) == [Any, Int, Any]
+    end
 end


### PR DESCRIPTION
Currently, if you do a few joins, most of the columns in your data frame become "missable" (`>: Missing`).
That's because so far `join` preserves non-missingness only for inner joins:
 * inner join doesn't introduce new missing values => non-missingness of columns from both left and right frames should be preserved.

This PR adds the other logical rules:
  * left join doesn't introduce new missing values in the left columns => non-missingness of the left frame should be preserved
  * right join doesn't introduce new missing values in the right columns => non-missingness of the right frame should be preserved
  * joins do not introduce missing values to the on-columns => non-missingness of the on columns should be preserved if both left-on and right-on columns are non-missing

The rules above are "type stable", so to say. I.e. they don't depend on the contents of the frames.
But I thought it also makes sense to introduce data-dependent rules (there's no performance penalty in checking them):
   * if all right rows have matching left rows (i.e. no missing values are introduced to the left columns) => non-missingness of the left columns is preserved
   * if all left rows have matching right rows (i.e. no missing values are introduced to the right columns) => non-missingness of the right columns is preserved

As a reasonable side effect of the rules implementation, when doing the right join, the eltype (and levels, for categorical arrays) of the right on-column has priority over the left on-column.