### PR TITLE
Fix hash()

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -786,16 +786,17 @@ end
 ##
 ## Hashing
 ##
-## Make sure this agrees with isequals()
-##
 ##############################################################################
 
-function Base.hash(df::AbstractDataFrame)
-    h = hash(size(df)) + 1
+const hashdf_seed = UInt == UInt32 ? 0xfd8bb02e : 0x6215bada8c8c46de
+
+function Base.hash(df::AbstractDataFrame, h::UInt)
+    h += hashdf_seed
+    h += hash(size(df))
     for i in 1:size(df, 2)
         h = hash(df[i], h)
     end
-    return UInt(h)
+    return h
 end
 
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -189,7 +189,7 @@ module TestDataFrame
 
     @test hash(convert(DataFrame, [1 2; 3 4])) == hash(convert(DataFrame, [1 2; 3 4]))
     @test hash(convert(DataFrame, [1 2; 3 4])) != hash(convert(DataFrame, [1 3; 2 4]))
-
+    @test hash(convert(DataFrame, [1 2; 3 4])) == hash(convert(DataFrame, [1 2; 3 4]), zero(UInt))
 
     # push!(df, row)
     df=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )


### PR DESCRIPTION
Types should always implement the two-argument version, which is the most general method.
Follow the same approach as the AbstractArray implementation in Base.

See https://discourse.julialang.org/t/a-question-on-hashes/7742.