### PR TITLE
improve DataFrame constructors and conversions for Vector and Matrix

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -131,7 +131,7 @@ end
 
 function DataFrame(columns::AbstractVector, cnames::AbstractVector{Symbol};
                    makeunique::Bool=false)::DataFrame
-    if !any(col -> isa(col, AbstractVector), columns)
+    if !all(col -> isa(col, AbstractVector), columns)
         # change to throw(ArgumentError("columns argument must be a vector containing at least one vector"))
         Base.depwarn("passing columns argument containing only scalars is deprecated", :DataFrame)
     end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -132,8 +132,8 @@ end
 function DataFrame(columns::AbstractVector, cnames::AbstractVector{Symbol};
                    makeunique::Bool=false)::DataFrame
     if !all(col -> isa(col, AbstractVector), columns)
-        # change to throw(ArgumentError("columns argument must be a vector containing at least one vector"))
-        Base.depwarn("passing columns argument containing only scalars is deprecated", :DataFrame)
+        # change to throw(ArgumentError("columns argument must be a vector of AbstractVector objects"))
+        Base.depwarn("passing columns argument with non-AbstractVector entries is deprecated", :DataFrame)
     end
     return DataFrame(convert(Vector{Any}, columns), Index(convert(Vector{Symbol}, cnames),
                      makeunique=makeunique))

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -8,6 +8,7 @@ particularly a Vector or CategoricalVector.
 
 ```julia
 DataFrame(columns::Vector, names::Vector{Symbol}; makeunique::Bool=false)
+DataFrame(columns::Matrix, names::Vector{Symbol}; makeunique::Bool=false)
 DataFrame(kwargs...)
 DataFrame(pairs::Pair{Symbol}...; makeunique::Bool=false)
 DataFrame() # an empty DataFrame
@@ -20,7 +21,7 @@ DataFrame(ds::Vector{Associative})
 
 **Arguments**
 
-* `columns` : a Vector with each column as contents
+* `columns` : a Vector with each column as contents or a Matrix
 * `names` : the column names
 * `makeunique` : if `false` (the default), an error will be raised
   if duplicates in `names` are found; if `true`, duplicate names will be suffixed
@@ -81,7 +82,8 @@ mutable struct DataFrame <: AbstractDataFrame
         if length(columns) == length(colindex) == 0
             return new(Vector{Any}(0), Index())
         elseif length(columns) != length(colindex)
-            throw(DimensionMismatch("Number of columns ($(length(columns))) and number of column names ($(length(colindex))) are not equal"))
+            throw(DimensionMismatch("Number of columns ($(length(columns))) and number of" *
+                                    " column names ($(length(colindex))) are not equal"))
         end
         lengths = [isa(col, AbstractArray) ? length(col) : 1 for col in columns]
         minlen, maxlen = extrema(lengths)
@@ -127,12 +129,19 @@ function DataFrame(; kwargs...)
     end
 end
 
-function DataFrame(columns::AbstractVector,
-                   cnames::AbstractVector{Symbol} = gennames(length(columns));
+function DataFrame(columns::AbstractVector, cnames::AbstractVector{Symbol};
                    makeunique::Bool=false)::DataFrame
+    if !any(col -> isa(col, AbstractVector), columns)
+        # change to throw(ArgumentError("columns argument must be a vector containing at least one vector"))
+        Base.depwarn("passing columns argument containing only scalars is deprecated", :DataFrame)
+    end
     return DataFrame(convert(Vector{Any}, columns), Index(convert(Vector{Symbol}, cnames),
                      makeunique=makeunique))
 end
+
+DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol} = gennames(size(columns, 2));
+          makeunique::Bool=false) =
+    DataFrame(Any[columns[:, i] for i in 1:size(columns, 2)], cnames, makeunique=makeunique)
 
 # Initialize an empty DataFrame with specific eltypes and names
 function DataFrame(column_eltypes::AbstractVector{T}, cnames::AbstractVector{Symbol},
@@ -912,14 +921,7 @@ function Base.append!(df1::DataFrame, df2::AbstractDataFrame)
    return df1
 end
 
-function Base.convert(::Type{DataFrame}, A::AbstractMatrix)
-    n = size(A, 2)
-    cols = Vector{Any}(n)
-    for i in 1:n
-        cols[i] = A[:, i]
-    end
-    return DataFrame(cols, Index(gennames(n)))
-end
+Base.convert(::Type{DataFrame}, A::AbstractMatrix) = DataFrame(A)
 
 function Base.convert(::Type{DataFrame}, d::Associative)
     colnames = keys(d)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,5 +1,10 @@
 import Base: @deprecate
 
+function DataFrame(columns::AbstractVector)
+    Base.depwarn("calling vector of vectors constructor without passing column names is deprecated", :DataFrame)
+    DataFrame(columns, gennames(length(columns)))
+end
+
 @deprecate by(d::AbstractDataFrame, cols, s::Vector{Symbol}) aggregate(d, cols, map(eval, s))
 @deprecate by(d::AbstractDataFrame, cols, s::Symbol) aggregate(d, cols, eval(s))
 

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -28,6 +28,20 @@ module TestConstructors
     @test df[:x1] == df2[:x1]
     @test df[:x2] == df2[:x2]
 
+    df2 = DataFrame([0.0 1.0;
+                     0.0 1.0;
+                     0.0 1.0])
+    names!(df2, [:x1, :x2])
+    @test df[:x1] == df2[:x1]
+    @test df[:x2] == df2[:x2]
+
+    df2 = DataFrame([0.0 1.0;
+                     0.0 1.0;
+                     0.0 1.0], [:a, :b])
+    names!(df2, [:a, :b])
+    @test df[:x1] == df2[:a]
+    @test df[:x2] == df2[:b]
+
     @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],
                           x2 = Union{Float64, Missing}[1.0, 1.0, 1.0])
     @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],


### PR DESCRIPTION
Following discussion in https://discourse.julialang.org/t/how-do-dataframes-jl-compare-to-rs-and-interoperability-between-r-and-julia/7387/14 I propose to:
1. Add a constructor of `DataFrame` from a `Matrix` that can take column names argument;
2. Add a method to `convert` allowing conversion from `Vector` to `DataFrame` (so that both the constructor and conversion work and work the same way);