### PR TITLE
make boolean indexing of Index strict

### DIFF
--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -112,7 +112,10 @@ Base.getindex(x::Index, idx::Symbol) = x.lookup[idx]
 Base.getindex(x::AbstractIndex, idx::Real) = Int(idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}}) =
     getindex(x, collect(Missings.replace(idx, false)))
-Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool}) = find(idx)
+function Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool})
+    length(x) == length(idx) || Base.throw_boundserror(x, idx)
+    find(idx)
+end
 Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T >: Missing} =
     getindex(x, collect(skipmissing(idx)))
 Base.getindex(x::AbstractIndex, idx::AbstractRange) = [idx;]

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -113,7 +113,7 @@ Base.getindex(x::AbstractIndex, idx::Real) = Int(idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}}) =
     getindex(x, collect(Missings.replace(idx, false)))
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{Bool})
-    length(x) == length(idx) || Base.throw_boundserror(x, idx)
+    length(x) == length(idx) || throw(BoundsError(x, idx))
     find(idx)
 end
 Base.getindex(x::AbstractIndex, idx::AbstractVector{T}) where {T >: Missing} =

--- a/test/index.jl
+++ b/test/index.jl
@@ -9,7 +9,6 @@ inds = Any[1,
            1.0,
            :A,
            [true, false],
-           trues(1),
            [1],
            [1.0],
            1:1,
@@ -21,6 +20,7 @@ inds = Any[1,
            Union{Symbol, Missing}[:A]]
 
 for ind in inds
+    println(ind)
     if ind == :A || ndims(ind) == 0
         @test i[ind] == 1
     else

--- a/test/index.jl
+++ b/test/index.jl
@@ -8,14 +8,14 @@ push!(i, :B)
 inds = Any[1,
            1.0,
            :A,
-           [true],
+           [true, false],
            trues(1),
            [1],
            [1.0],
            1:1,
            1.0:1.0,
            [:A],
-           Union{Bool, Missing}[true],
+           Union{Bool, Missing}[true, false],
            Union{Int, Missing}[1],
            Union{Float64, Missing}[1.0],
            Union{Symbol, Missing}[:A]]
@@ -27,6 +27,9 @@ for ind in inds
         @test (i[ind] == [1])
     end
 end
+
+@test_throws BoundsError i[[true]]
+@test_throws BoundsError i[[true, false, true]]
 
 @test names(i) == [:A,:B]
 @test names!(i, [:a,:a], allow_duplicates=true) == Index([:a,:a_1])

--- a/test/index.jl
+++ b/test/index.jl
@@ -20,7 +20,6 @@ inds = Any[1,
            Union{Symbol, Missing}[:A]]
 
 for ind in inds
-    println(ind)
     if ind == :A || ndims(ind) == 0
         @test i[ind] == 1
     else


### PR DESCRIPTION
Fixes #1321.
Additionally corrects signatures of `getindex`.