### PR TITLE
Deprecate sort(df, cols=c) in favor of sort(df, c) and add docstrings

### DIFF
--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -252,25 +252,176 @@ end
 ## Actual sort functions
 ########################
 
-Base.issorted(df::AbstractDataFrame; cols=Any[], lt=isless, by=identity, rev=false, order=Forward) =
-    issorted(eachrow(df), ordering(df, cols, lt, by, rev, order))
+"""
+    issorted(df::AbstractDataFrame, cols;
+             lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward)
+
+Test whether data frame `df` sorted by column(s) `cols`.
+`cols` can be either a `Symbol` or `Integer` column index, or
+a tuple of vector of such indices.
+
+If `rev` is `true`, reverse sorting is performed. To enable reverse sorting
+only for some columns, pass `order(c, rev=true)` in `cols`, with `c` the
+corresponding column index (see example below).
+See other methods for a description of other keyword arguments.
+"""
+function Base.issorted(df::AbstractDataFrame, cols_new=[]; cols=[],
+                       lt=isless, by=identity, rev=false, order=Forward)
+    if cols != []
+        Base.depwarn("issorted(df, cols=cols) is deprecated, use issorted(df, cols) instead",
+                     :issorted)
+        cols_new = cols
+    end
+    issorted(eachrow(df), ordering(df, cols_new, lt, by, rev, order))
+end
 
 # sort and sortperm functions
 
 for s in [:(Base.sort), :(Base.sortperm)]
     @eval begin
-        function $s(df::AbstractDataFrame; cols=Any[], alg=nothing,
-                    lt=isless, by=identity, rev=false, order=Forward)
+        function $s(df::AbstractDataFrame, cols_new=[]; cols=[],
+                    alg=nothing, lt=isless, by=identity, rev=false, order=Forward)
             if !(isa(by, Function) || eltype(by) <: Function)
                 msg = "'by' must be a Function or a vector of Functions. Perhaps you wanted 'cols'."
                 throw(ArgumentError(msg))
             end
-            ord = ordering(df, cols, lt, by, rev, order)
-            _alg = Sort.defalg(df, ord; alg=alg, cols=cols)
+            if cols != []
+                fname = $s
+                Base.depwarn("$fname(df, cols=cols) is deprecated, use $fname(df, cols) instead",
+                             $s)
+                cols_new = cols
+            end
+            ord = ordering(df, cols_new, lt, by, rev, order)
+            _alg = Sort.defalg(df, ord; alg=alg, cols=cols_new)
             $s(df, _alg, ord)
         end
     end
 end
+
+"""
+    sort(df::AbstractDataFrame, cols;
+         alg::Union{Algorithm, Void}=nothing, lt=isless, by=identity,
+         rev::Bool=false, order::Ordering=Forward)
+
+Return a copy of data frame `df` sorted by column(s) `cols`.
+`cols` can be either a `Symbol` or `Integer` column index, or
+a tuple of vector of such indices.
+
+If `alg` is `nothing` (the default), the most appropriate algorithm is
+chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending
+on the type of the sorting columns and on the number of rows in `df`.
+If `rev` is `true`, reverse sorting is performed. To enable reverse sorting
+only for some columns, pass `order(c, rev=true)` in `cols`, with `c` the
+corresponding column index (see example below).
+See [`sort!`](@ref) for a description of other keyword arguments.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(x = [3, 1, 2, 1], y = ["b", "c", "a", "b"])
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 3 │ b │
+│ 2   │ 1 │ c │
+│ 3   │ 2 │ a │
+│ 4   │ 1 │ b │
+
+julia> sort(df, :x)
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 1 │ c │
+│ 2   │ 1 │ b │
+│ 3   │ 2 │ a │
+│ 4   │ 3 │ b │
+
+julia> sort(df, (:x, :y))
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 1 │ b │
+│ 2   │ 1 │ c │
+│ 3   │ 2 │ a │
+│ 4   │ 3 │ b │
+
+julia> sort(df, (:x, :y), rev=true)
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 3 │ b │
+│ 2   │ 2 │ a │
+│ 3   │ 1 │ c │
+│ 4   │ 1 │ b │
+
+julia> sort(df, (:x, order(:y, rev=true)))
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 1 │ c │
+│ 2   │ 1 │ b │
+│ 3   │ 2 │ a │
+│ 4   │ 3 │ b │
+````
+"""
+sort(::AbstractDataFrame, ::Any)
+
+"""
+    sortperm(df::AbstractDataFrame, cols;
+             alg::Union{Algorithm, Void}=nothing, lt=isless, by=identity,
+             rev::Bool=false, order::Ordering=Forward)
+
+Return a permutation vector of row indices of data frame `df` that puts them in
+sorted order according to column(s) `cols`.
+
+If `alg` is `nothing` (the default), the most appropriate algorithm is
+chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending
+on the type of the sorting columns and on the number of rows in `df`.
+If `rev` is `true`, reverse sorting is performed. To enable reverse sorting
+only for some columns, pass `order(c, rev=true)` in `cols`, with `c` the
+corresponding column index (see example below).
+See other methods for a description of other keyword arguments.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(x = [3, 1, 2, 1], y = ["b", "c", "a", "b"])
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 3 │ b │
+│ 2   │ 1 │ c │
+│ 3   │ 2 │ a │
+│ 4   │ 1 │ b │
+
+julia> sortperm(df, :x)
+4-element Array{Int64,1}:
+ 2
+ 4
+ 3
+ 1
+
+julia> sortperm(df, (:x, :y))
+4-element Array{Int64,1}:
+ 4
+ 2
+ 3
+ 1
+
+julia> sortperm(df, (:x, :y), rev=true)
+4-element Array{Int64,1}:
+ 1
+ 3
+ 2
+ 4
+
+ julia> sortperm(df, (:x, order(:y, rev=true)))
+ 4-element Array{Int64,1}:
+  2
+  4
+  3
+  1
+````
+"""
+sortperm(::AbstractDataFrame, ::Any)
 
 Base.sort(df::AbstractDataFrame, a::Algorithm, o::Ordering) = df[sortperm(df, a, o),:]
 Base.sortperm(df::AbstractDataFrame, a::Algorithm, o::Union{Perm,DFPerm}) = sort!([1:size(df, 1);], a, o)

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -258,7 +258,7 @@ end
 
 Test whether data frame `df` sorted by column(s) `cols`.
 `cols` can be either a `Symbol` or `Integer` column index, or
-a tuple of vector of such indices.
+a tuple or vector of such indices.
 
 If `rev` is `true`, reverse sorting is performed. To enable reverse sorting
 only for some columns, pass `order(c, rev=true)` in `cols`, with `c` the
@@ -305,7 +305,7 @@ end
 
 Return a copy of data frame `df` sorted by column(s) `cols`.
 `cols` can be either a `Symbol` or `Integer` column index, or
-a tuple of vector of such indices.
+a tuple or vector of such indices.
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -1,11 +1,82 @@
-function Base.sort!(df::DataFrame; cols=Any[], alg=nothing,
+
+"""
+    sort!(df::AbstractDataFrame, cols;
+          alg::Union{Algorithm, Void}=nothing, lt=isless, by=identity,
+          rev::Bool=false, order::Ordering=Forward)
+
+Sort data frame `df` by column(s) `cols`.
+`cols` can be either a `Symbol` or `Integer` column index, or
+a tuple of vector of such indices.
+
+If `alg` is `nothing` (the default), the most appropriate algorithm is
+chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending
+on the type of the sorting columns and on the number of rows in `df`.
+If `rev` is `true`, reverse sorting is performed. To enable reverse sorting
+only for some columns, pass `order(c, rev=true)` in `cols`, with `c` the
+corresponding column index (see example below).
+See other methods for a description of other keyword arguments.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(x = [3, 1, 2, 1], y = ["b", "c", "a", "b"])
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 3 │ b │
+│ 2   │ 1 │ c │
+│ 3   │ 2 │ a │
+│ 4   │ 1 │ b │
+
+julia> sort!(df, :x)
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 1 │ c │
+│ 2   │ 1 │ b │
+│ 3   │ 2 │ a │
+│ 4   │ 3 │ b │
+
+julia> sort!(df, (:x, :y))
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 1 │ b │
+│ 2   │ 1 │ c │
+│ 3   │ 2 │ a │
+│ 4   │ 3 │ b │
+
+julia> sort!(df, (:x, :y), rev=true)
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 3 │ b │
+│ 2   │ 2 │ a │
+│ 3   │ 1 │ c │
+│ 4   │ 1 │ b │
+
+julia> sort!(df, (:x, order(:y, rev=true)))
+4×2 DataFrames.DataFrame
+│ Row │ x │ y │
+├─────┼───┼───┤
+│ 1   │ 1 │ c │
+│ 2   │ 1 │ b │
+│ 3   │ 2 │ a │
+│ 4   │ 3 │ b │
+````
+"""
+function Base.sort!(df::DataFrame, cols_new=[]; cols=[], alg=nothing,
                     lt=isless, by=identity, rev=false, order=Forward)
     if !(isa(by, Function) || eltype(by) <: Function)
         msg = "'by' must be a Function or a vector of Functions. Perhaps you wanted 'cols'."
         throw(ArgumentError(msg))
     end
+    if cols != []
+        Base.depwarn("sort!(df, cols=cols) is deprecated, use sort!(df, cols) instead",
+                     :sort!)
+        cols_new = cols
+    end
     ord = ordering(df, cols, lt, by, rev, order)
-    _alg = Sort.defalg(df, ord; alg=alg, cols=cols)
+    _alg = Sort.defalg(df, ord; alg=alg, cols=cols_new)
     sort!(df, _alg, ord)
 end
 

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -6,7 +6,7 @@
 
 Sort data frame `df` by column(s) `cols`.
 `cols` can be either a `Symbol` or `Integer` column index, or
-a tuple of vector of such indices.
+a tuple or vector of such indices.
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -347,7 +347,7 @@ aggregate(gd::GroupedDataFrame, f::Function; sort::Bool=false) = aggregate(gd, [
 function aggregate(gd::GroupedDataFrame, fs::Vector{T}; sort::Bool=false) where T<:Function
     headers = _makeheaders(fs, setdiff(_names(gd), gd.cols))
     res = combine(map(x -> _aggregate(without(x, gd.cols), fs, headers), gd))
-    sort && sort!(res, cols=headers)
+    sort && sort!(res, headers)
     res
 end
 
@@ -366,6 +366,6 @@ end
 
 function _aggregate(d::AbstractDataFrame, fs::Vector{T}, headers::Vector{Symbol}, sort::Bool=false) where T<:Function
     res = DataFrame(Any[vcat(f(d[i])) for f in fs for i in 1:size(d, 2)], headers)
-    sort && sort!(res, cols=headers)
+    sort && sort!(res, headers)
     res
 end

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -10,11 +10,13 @@ module TestSort
 
     @test sortperm(d) == sortperm(dv1)
     @test sortperm(d[[:dv3, :dv1]]) == sortperm(dv3)
-    @test sort(d, cols=:dv1)[:dv3] == sortperm(dv1)
-    @test sort(d, cols=:dv2)[:dv3] == sortperm(dv1)
-    @test sort(d, cols=:cv1)[:dv3] == sortperm(dv1)
-    @test sort(d, cols=[:dv1, :cv1])[:dv3] == sortperm(dv1)
-    @test sort(d, cols=[:dv1, :dv3])[:dv3] == sortperm(dv1)
+    @test sort(d, :dv1)[:dv3] == sortperm(dv1)
+    @test sort(d, :dv2)[:dv3] == sortperm(dv1)
+    @test sort(d, :cv1)[:dv3] == sortperm(dv1)
+    @test sort(d, [:dv1, :cv1])[:dv3] == sortperm(dv1)
+    @test sort(d, [:dv1, :dv3])[:dv3] == sortperm(dv1)
+    @test sort(d, (:dv1, :cv1))[:dv3] == sortperm(dv1)
+    @test sort(d, (:dv1, :dv3))[:dv3] == sortperm(dv1)
 
     df = DataFrame(rank=rand(1:12, 1000),
                    chrom=rand(1:24, 1000),
@@ -22,20 +24,20 @@ module TestSort
 
     @test issorted(sort(df))
     @test issorted(sort(df, rev=true), rev=true)
-    @test issorted(sort(df, cols=[:chrom,:pos])[[:chrom,:pos]])
+    @test issorted(sort(df, [:chrom,:pos])[[:chrom,:pos]])
 
-    ds = sort(df, cols=(order(:rank, rev=true),:chrom,:pos))
-    @test issorted(ds, cols=(order(:rank, rev=true),:chrom,:pos))
+    ds = sort(df, (order(:rank, rev=true),:chrom,:pos))
+    @test issorted(ds, (order(:rank, rev=true),:chrom,:pos))
     @test issorted(ds, rev=(true, false, false))
 
-    ds2 = sort(df, cols=(:rank, :chrom, :pos), rev=(true, false, false))
-    @test issorted(ds2, cols=(order(:rank, rev=true), :chrom, :pos))
+    ds2 = sort(df, (:rank, :chrom, :pos), rev=(true, false, false))
+    @test issorted(ds2, (order(:rank, rev=true), :chrom, :pos))
     @test issorted(ds2, rev=(true, false, false))
 
     @test ds2 == ds
 
-    sort!(df, cols=(:rank, :chrom, :pos), rev=(true, false, false))
-    @test issorted(df, cols=(order(:rank, rev=true), :chrom, :pos))
+    sort!(df, (:rank, :chrom, :pos), rev=(true, false, false))
+    @test issorted(df, (order(:rank, rev=true), :chrom, :pos))
     @test issorted(df, rev=(true, false, false))
 
     @test df == ds
@@ -43,6 +45,6 @@ module TestSort
     # Check that columns that shares the same underlying array are only permuted once PR#1072
     df = DataFrame(a=[2,1])
     df[:b] = df[:a]
-    sort!(df, cols=:a)
+    sort!(df, :a)
     @test df == DataFrame(a=[1,2],b=[1,2])
 end


### PR DESCRIPTION
Shorter, as clear as the old form, and consistent with the array method
taking a region along which to sort and with JuliaDB. Also apply this change
to sort! and issorted.