### PR TITLE
Fix failure due to calling pairs() on keyword arguments on Julia 0.6

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -10,8 +10,12 @@ module DataFrames
 using Reexport, StatsBase, SortingAlgorithms, Compat
 @reexport using CategoricalArrays, Missings
 using Base: Sort, Order
-using Compat: pairs
 
+if VERSION >= v"0.7.0-DEV.2738"
+    const kwpairs = pairs
+else
+    kwpairs(x::AbstractArray) = (first(v) => last(v) for v in x)
+end
 if VERSION >= v"0.7.0-DEV.2915"
     using Unicode
 end

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -30,7 +30,7 @@ _getcol(x) = x
 # Get an Ordering for a single column
 ###
 function ordering(col_ord::UserColOrdering, lt::Function, by::Function, rev::Bool, order::Ordering)
-    for (k,v) in pairs(col_ord.kwargs)
+    for (k,v) in kwpairs(col_ord.kwargs)
         if     k == :lt;    lt    = v
         elseif k == :by;    by    = v
         elseif k == :rev;   rev   = v

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -116,7 +116,7 @@ function DataFrame(; kwargs...)
     if isempty(kwargs)
         DataFrame(Any[], Index())
     else
-        DataFrame((k => v for (k,v) in pairs(kwargs))...)
+        DataFrame(kwpairs(kwargs)...)
     end
 end
 


### PR DESCRIPTION
Introduced by https://github.com/JuliaData/DataFrames.jl/pull/1320.