### PR TITLE
stack called stackdf and should call stack

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -98,8 +98,8 @@ function stack(df::AbstractDataFrame, measure_vars::Vector{Int}, id_var::Int;
 end
 function stack(df::AbstractDataFrame, measure_var::Int, id_vars::Vector{Int};
                variable_name::Symbol=:variable, value_name::Symbol=:value)
-    stackdf(df, [measure_var], id_vars;
-            variable_name=variable_name, value_name=value_name)
+    stack(df, [measure_var], id_vars;
+          variable_name=variable_name, value_name=value_name)
 end
 function stack(df::AbstractDataFrame, measure_vars, id_vars;
                variable_name::Symbol=:variable, value_name::Symbol=:value)


### PR DESCRIPTION
one method of `stack` called `stackdf` internally instead of `stack` (I guess it was a typo - not an intentional design decision).