### PR TITLE
Add deprecation for vcat(Vector{<:AbstractDataFrame})

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1312,3 +1312,6 @@ function Base.getindex(x::AbstractIndex, idx::AbstractRange{Bool})
     collect(Int, idx)
 end
 
+import Base: vcat
+@deprecate vcat(x::Vector{<:AbstractDataFrame}) vcat(x...)
+


### PR DESCRIPTION
Together with #1341 this should fix the tests of `RDatasets` on `DataFrames` master (although there are still lots of deprecation warnings which will be fixed by https://github.com/johnmyleswhite/RDatasets.jl/pull/48)