### PR TITLE
Fix combining DataFrames with a column of Missings

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -763,7 +763,7 @@ Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame
 
 @generated function promote_col_type(cols::AbstractVector...)
     T = mapreduce(x -> Missings.T(eltype(x)), promote_type, cols)
-    if T <: CategoricalValue
+    if T <: CategoricalValue && T !== Union{}
         T = T.parameters[1]
     end
     if any(col -> eltype(col) >: Missing, cols)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -764,7 +764,7 @@ Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame
 @generated function promote_col_type(cols::AbstractVector...)
     T = mapreduce(x -> Missings.T(eltype(x)), promote_type, cols)
     if CategoricalArrays.iscatvalue(T)
-        T = T.parameters[1]
+        T = CategoricalArrays.leveltype(T)
     end
     if any(col -> eltype(col) >: Missing, cols)
         if any(col -> col <: AbstractCategoricalArray, cols)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -763,7 +763,7 @@ Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame
 
 @generated function promote_col_type(cols::AbstractVector...)
     T = mapreduce(x -> Missings.T(eltype(x)), promote_type, cols)
-    if T <: CategoricalValue && T !== Union{}
+    if CategoricalArrays.iscatvalue(T)
         T = T.parameters[1]
     end
     if any(col -> eltype(col) >: Missing, cols)

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -157,6 +157,10 @@ module TestCat
     # vcat should be able to concatenate different implementations of AbstractDataFrame (PR #944)
     @test vcat(view(DataFrame(A=1:3),2),DataFrame(A=4:5)) == DataFrame(A=[2,4,5])
 
+    # vcat should be able to combine a DataFrame with a column full of Missings
+    df = DataFrame(A=1:3, B=missing)
+    @test isequal(vcat(df, df), DataFrame(A=repeat(1:3, outer=2), B=missing))
+
     @testset "vcat >2 args" begin
         @test vcat(DataFrame(), DataFrame(), DataFrame()) == DataFrame()
         df = DataFrame(x = trues(1), y = falses(1))


### PR DESCRIPTION
Fix for issue #1280 

I came across the same issue when using `vcat` to combine two DataFrames with a column of exclusively Missings so I figured I would just submit the fix.