### PR TITLE
Add TranscodingStreams to REQUIRES

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -7,4 +7,5 @@ Reexport
 WeakRefStrings 0.4.0
 DataStreams 0.3.0
 CodecZlib 0.4
+TranscodingStreams
 Compat 0.41.0


### PR DESCRIPTION
CodecZlib depends on it, but since it is used directly in DataFrames it should be listed in REQUIRES, and it's needed for Pkg3.