### PR TITLE
Fix tests for makeunique keyword and deprecated column indexing

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1301,17 +1301,6 @@ function Base.getindex(x::AbstractIndex, idx::Real)
     Int(idx)
 end
 
-function Base.getindex(x::AbstractIndex, idx::AbstractRange)
-    Base.depwarn("Indexing with range of values that are not Integer is deprecated", :getindex)
-    getindex(x, collect(idx))
-end
-
-
-function Base.getindex(x::AbstractIndex, idx::AbstractRange{Bool})
-    Base.depwarn("Indexing with range of Bool is deprecated", :getindex)
-    collect(Int, idx)
-end
-
 import Base: vcat
 @deprecate vcat(x::Vector{<:AbstractDataFrame}) vcat(x...)
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -135,14 +135,16 @@ end
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}})
     if any(ismissing, idx)
         # TODO: this line should be changed to throw an error after deprecation
+        # throw(ArgumentError("missing values for column indexing are not alloved"))
         Base.depwarn("using missing in column indexing is deprecated", :getindex)
     end
     getindex(x, collect(Missings.replace(idx, false)))
 end
 
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Integer})
-    # TODO: this line should be changed to throw an error after deprecation
     if any(v -> v isa Bool, idx)
+        # TODO: this line should be changed to throw an error after deprecation
+        # throw(ArgumentError("Bool values are not allowed for indexing except for Vector{Bool}"))
         Base.depwarn("Indexing with Bool values is deprecated except for Vector{Bool}")
     end
     Vector{Int}(idx)
@@ -151,15 +153,17 @@ end
 # catch all method handling cases when type of idx is not narrowest possible, Any in particular
 # also it handles passing missing values in idx
 function Base.getindex(x::AbstractIndex, idx::AbstractVector)
-    # TODO: passing missing will throw an error after deprecation
     idxs = filter(!ismissing, idx)
     if length(idxs) != length(idx)
+        # TODO: passing missing will throw an error after deprecation
+        # throw(ArgumentError("missing values for column indexing are not alloved"))
         Base.depwarn("using missing in column indexing is deprecated", :getindex)
     end
     length(idxs) == 0 && return Int[] # special case of empty idxs
     if idxs[1] isa Real
         if !all(v -> v isa Integer && !(v isa Bool), idxs)
             # TODO: this line should be changed to throw an error after deprecation
+            # throw(ArgumentError("Only Integer values allowed when indexing by vector of numbers"))
             Base.depwarn("indexing by vector of numbers other than Integer is deprecated", :getindex)
         end
         return Vector{Int}(idxs)

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -135,7 +135,7 @@ end
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}})
     if any(ismissing, idx)
         # TODO: this line should be changed to throw an error after deprecation
-        # throw(ArgumentError("missing values for column indexing are not alloved"))
+        # throw(ArgumentError("missing values are not allowed for column indexing"))
         Base.depwarn("using missing in column indexing is deprecated", :getindex)
     end
     getindex(x, collect(Missings.replace(idx, false)))
@@ -144,7 +144,7 @@ end
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Integer})
     if any(v -> v isa Bool, idx)
         # TODO: this line should be changed to throw an error after deprecation
-        # throw(ArgumentError("Bool values are not allowed for indexing except for Vector{Bool}"))
+        # throw(ArgumentError("Bool values except for Vector{Bool} are not allowed for column indexing"))
         Base.depwarn("Indexing with Bool values is deprecated except for Vector{Bool}")
     end
     Vector{Int}(idx)
@@ -156,7 +156,7 @@ function Base.getindex(x::AbstractIndex, idx::AbstractVector)
     idxs = filter(!ismissing, idx)
     if length(idxs) != length(idx)
         # TODO: passing missing will throw an error after deprecation
-        # throw(ArgumentError("missing values for column indexing are not alloved"))
+        # throw(ArgumentError("missing values are not allowed for column indexing"))
         Base.depwarn("using missing in column indexing is deprecated", :getindex)
     end
     length(idxs) == 0 && return Int[] # special case of empty idxs

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -14,17 +14,20 @@ module TestCat
     df4 = convert(DataFrame, [1:4 1:4])
     df5 = DataFrame(Any[Union{Int, Missing}[1,2,3,4], nvstr])
 
-    dfh = hcat(df3, df4)
+    dfh = hcat(df3, df4, makeunique=true)
     @test size(dfh, 2) == 3
     @test names(dfh) ≅ [:x1, :x1_1, :x2]
     @test dfh[:x1] ≅ df3[:x1]
-    @test dfh ≅ [df3 df4]
-    @test dfh ≅ DataFrames.hcat!(DataFrame(), df3, df4)
+    @test dfh ≅ DataFrames.hcat!(DataFrame(), df3, df4, makeunique=true)
 
-    dfh3 = hcat(df3, df4, df5)
+    dfa = DataFrame(a=[1,2])
+    dfb = DataFrame(b=[3,missing])
+    @test hcat(dfa, dfb) ≅ [dfa dfb]
+
+    dfh3 = hcat(df3, df4, df5, makeunique=true)
     @test names(dfh3) == [:x1, :x1_1, :x2, :x1_2, :x2_1]
-    @test dfh3 ≅ hcat(dfh, df5)
-    @test dfh3 ≅ DataFrames.hcat!(DataFrame(), df3, df4, df5)
+    @test dfh3 ≅ hcat(dfh, df5, makeunique=true)
+    @test dfh3 ≅ DataFrames.hcat!(DataFrame(), df3, df4, df5, makeunique=true)
 
     @test df2 ≅ DataFrames.hcat!(df2)
 
@@ -32,34 +35,34 @@ module TestCat
         df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)
         gd = groupby(df, :A)
         answer = DataFrame(A = fill('A', 4), B = 1:4, A_1 = 'B', B_1 = 5:8, A_2 = 'C', B_2 = 9:12)
-        @test hcat(gd...) == answer
+        @test hcat(gd..., makeunique=true) == answer
         answer = answer[1:4]
-        @test hcat(gd[1], gd[2]) == answer
+        @test hcat(gd[1], gd[2], makeunique=true) == answer
     end
 
     @testset "hcat ::AbstractDataFrame" begin
         df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)
         gd = groupby(df, :A)
         answer = DataFrame(A = fill('A', 4), B = 1:4, A_1 = 'B', B_1 = 5:8, A_2 = 'C', B_2 = 9:12)
-        @test hcat(gd...) == answer
+        @test hcat(gd..., makeunique=true) == answer
         answer = answer[1:4]
-        @test hcat(gd[1], gd[2]) == answer
+        @test hcat(gd[1], gd[2], makeunique=true) == answer
     end
 
     @testset "hcat ::AbstractVectors" begin
         df = DataFrame()
         DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10))
         @test df[1] == CategoricalVector(1:10)
-        DataFrames.hcat!(df, 1:10)
+        DataFrames.hcat!(df, 1:10, makeunique=true)
         @test df[2] == collect(1:10)
-        DataFrames.hcat!(df, collect(1:10))
+        DataFrames.hcat!(df, collect(1:10), makeunique=true)
         @test df[3] == collect(1:10)
 
         df = DataFrame()
         df2 = hcat(CategoricalVector{Union{Int, Missing}}(1:10), df)
         @test df2[1] == collect(1:10)
         @test names(df2) == [:x1]
-        df3 = hcat(11:20, df2)
+        df3 = hcat(11:20, df2, makeunique=true)
         @test df3[1] == collect(11:20)
         @test names(df3) == [:x1, :x1_1]
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -301,8 +301,8 @@ module TestData
     )
     df2 = spltdf(df2)
 
-    m1 = join(df1, df2, on = :a)
-    m2 = join(df1, df2, on = [:x1, :x2, :x3])
+    m1 = join(df1, df2, on = :a, makeunique=true)
+    m2 = join(df1, df2, on = [:x1, :x2, :x3], makeunique=true)
     @test sort(m1[:a]) == sort(m2[:a])
 
     # test nonunique() with extra argument

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -58,7 +58,8 @@ module TestDataFrame
 
     z = vcat(v, x)
 
-    # TODO: change test to throw an error after deprecation
+    # TODO: uncomment the line below after deprecation
+    # @test_throws ArgumentError z[:, [1, 1, 2]]
     z2 = z[:, [1, 1, 2]]
     @test names(z2) == [:a, :a_1, :b]
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -58,6 +58,7 @@ module TestDataFrame
 
     z = vcat(v, x)
 
+    # TODO: change test to throw an error after deprecation
     z2 = z[:, [1, 1, 2]]
     @test names(z2) == [:a, :a_1, :b]
 

--- a/test/index.jl
+++ b/test/index.jl
@@ -6,23 +6,19 @@ push!(i, :A)
 push!(i, :B)
 
 inds = Any[1,
-           1.0,
+           big(1),
            :A,
            [true, false],
            [1],
-           [1.0],
-           1.0:1.0,
+           [big(1)],
+           big(1):big(1),
            [:A],
            Union{Bool, Missing}[true, false],
            Union{Int, Missing}[1],
-           Union{Float64, Missing}[1.0],
+           Union{BigInt, Missing}[big(1)],
            Union{Symbol, Missing}[:A],
            Any[1],
-           Any[1, missing],
-           Any[true, missing],
-           Any[:A],
-           Any[:A, missing],
-           [true, missing]]
+           Any[:A]]
 
 for ind in inds
     if ind == :A || ndims(ind) == 0
@@ -31,6 +27,18 @@ for ind in inds
         @test (i[ind] == [1])
     end
 end
+
+# TODO: add tests that above indices throw error after deprecation period
+# [1.0,
+# 1.0:1.0,
+# [true],
+# [false],
+# true,
+# false,
+# Any[1, missing],
+# Any[true, missing],
+# Any[:A, missing],
+# [true, missing]]
 
 @test i[1:1] == 1:1
 
@@ -45,7 +53,7 @@ end
 @test i[Symbol[]] == Int[]
 
 @test names(i) == [:A,:B]
-@test names!(i, [:a,:a], allow_duplicates=true) == Index([:a,:a_1])
+@test names!(i, [:a,:a], makeunique=true) == Index([:a,:a_1])
 @test_throws ArgumentError names!(i, [:a,:a])
 @test names!(i, [:a,:b]) == Index([:a,:b])
 @test rename(i, Dict(:a=>:A, :b=>:B)) == Index([:A,:B])

--- a/test/index.jl
+++ b/test/index.jl
@@ -28,17 +28,31 @@ for ind in inds
     end
 end
 
-# TODO: add tests that above indices throw error after deprecation period
-# [1.0,
-# 1.0:1.0,
-# [true],
-# [false],
-# true,
-# false,
-# Any[1, missing],
-# Any[true, missing],
-# Any[:A, missing],
-# [true, missing]]
+# TODO: change this to throw an error after deprecation
+# @test_throws MethodError i[1.0]
+# @test_throws MethodError i[true]
+# @test_throws MethodError i[false]
+# @test_throws ArgumentError i[Any[1, missing]]
+# @test_throws ArgumentError i[[1, missing]]
+# @test_throws ArgumentError i[[true, missing]]
+# @test_throws ArgumentError i[Any[true, missing]]
+# @test_throws ArgumentError i[[:A, missing]]
+# @test_throws ArgumentError i[Any[:A, missing]]
+# @test_throws ArgumentError i[1.0:1.0]
+# @test_throws ArgumentError i[[1.0]]
+# @test_throws ArgumentError i[Any[1.0]]
+inds = Any[1.0, true, false,
+           Any[1, missing], [1, missing],
+           [true, missing], Any[true, missing],
+           [:A, missing], Any[:A, missing],
+           1.0:1.0, [1.0], Any[1.0]]
+for ind in inds
+    if ind == :A || ndims(ind) == 0
+        @test i[ind] == 1
+    else
+        @test (i[ind] == [1])
+    end
+end
 
 @test i[1:1] == 1:1
 

--- a/test/join.jl
+++ b/test/join.jl
@@ -66,60 +66,68 @@ module TestJoin
     @test join(df1, df2[[:C]], kind = :cross) == cross
 
     # Cross joins handle naming collisions
-    @test size(join(df1, df1, kind = :cross)) == (4, 4)
+    @test size(join(df1, df1, kind = :cross, makeunique=true)) == (4, 4)
 
     # Cross joins don't take keys
     @test_throws ArgumentError join(df1, df2, on = :A, kind = :cross)
 
-    # test empty inputs
-    simple_df(len::Int, col=:A) = (df = DataFrame();
-                                   df[col]=Vector{Union{Int, Missing}}(1:len);
-                                   df)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :left) == simple_df(0)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :left) == simple_df(2)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :left) == simple_df(0)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :right) == simple_df(0)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :right) == simple_df(2)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :right) == simple_df(0)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :inner) == simple_df(0)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :inner) == simple_df(0)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :inner) == simple_df(0)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :outer) == simple_df(0)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :outer) == simple_df(2)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :outer) == simple_df(2)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :semi) == simple_df(0)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :semi) == simple_df(0)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :semi) == simple_df(0)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :anti) == simple_df(0)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :anti) == simple_df(2)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :anti) == simple_df(0)
-    @test join(simple_df(0), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[], B=Int[])
-    @test join(simple_df(0), simple_df(2, :B), kind = :cross) == DataFrame(A=Int[], B=Int[])
-    @test join(simple_df(2), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[], B=Int[])
+    @testset "Test empty inputs 1" begin
+        simple_df(len::Int, col=:A) = (df = DataFrame();
+                                       df[col]=Vector{Union{Int, Missing}}(1:len);
+                                       df)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :left) == simple_df(0)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :left) == simple_df(2)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :left) == simple_df(0)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :right) == simple_df(0)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :right) == simple_df(2)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :right) == simple_df(0)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :inner) == simple_df(0)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :inner) == simple_df(0)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :inner) == simple_df(0)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :outer) == simple_df(0)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :outer) == simple_df(2)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :outer) == simple_df(2)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :semi) == simple_df(0)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :semi) == simple_df(0)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :semi) == simple_df(0)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :anti) == simple_df(0)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :anti) == simple_df(2)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :anti) == simple_df(0)
+        @test join(simple_df(0), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                               B=Int[])
+        @test join(simple_df(0), simple_df(2, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                               B=Int[])
+        @test join(simple_df(2), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                               B=Int[])
+    end
 
-    # test empty inputs
-    simple_df(len::Int, col=:A) = (df = DataFrame(); df[col]=collect(1:len); df)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :left) ==  simple_df(0)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :left) ==  simple_df(2)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :left) ==  simple_df(0)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :right) == simple_df(0)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :right) == simple_df(2)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :right) == simple_df(0)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :inner) == simple_df(0)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :inner) == simple_df(0)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :inner) == simple_df(0)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :outer) == simple_df(0)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :outer) == simple_df(2)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :outer) == simple_df(2)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :semi) ==  simple_df(0)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :semi) ==  simple_df(0)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :semi) ==  simple_df(0)
-    @test join(simple_df(0), simple_df(0), on = :A, kind = :anti) ==  simple_df(0)
-    @test join(simple_df(2), simple_df(0), on = :A, kind = :anti) ==  simple_df(2)
-    @test join(simple_df(0), simple_df(2), on = :A, kind = :anti) ==  simple_df(0)
-    @test join(simple_df(0), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[], B=Int[])
-    @test join(simple_df(0), simple_df(2, :B), kind = :cross) == DataFrame(A=Int[], B=Int[])
-    @test join(simple_df(2), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[], B=Int[])
+    @testset "Test empty inputs 2" begin
+        simple_df(len::Int, col=:A) = (df = DataFrame(); df[col]=collect(1:len); df)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :left) ==  simple_df(0)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :left) ==  simple_df(2)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :left) ==  simple_df(0)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :right) == simple_df(0)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :right) == simple_df(2)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :right) == simple_df(0)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :inner) == simple_df(0)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :inner) == simple_df(0)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :inner) == simple_df(0)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :outer) == simple_df(0)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :outer) == simple_df(2)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :outer) == simple_df(2)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :semi) ==  simple_df(0)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :semi) ==  simple_df(0)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :semi) ==  simple_df(0)
+        @test join(simple_df(0), simple_df(0), on = :A, kind = :anti) ==  simple_df(0)
+        @test join(simple_df(2), simple_df(0), on = :A, kind = :anti) ==  simple_df(2)
+        @test join(simple_df(0), simple_df(2), on = :A, kind = :anti) ==  simple_df(0)
+        @test join(simple_df(0), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                               B=Int[])
+        @test join(simple_df(0), simple_df(2, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                               B=Int[])
+        @test join(simple_df(2), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                               B=Int[])
+    end
 
     # issue #960
     df1 = DataFrame(A = 1:50,
@@ -127,7 +135,7 @@ module TestJoin
                     C = 1)
     categorical!(df1, :A)
     categorical!(df1, :B)
-    join(df1, df1, on = [:A, :B], kind = :inner)
+    join(df1, df1, on = [:A, :B], kind = :inner, makeunique=true)
 
     # Test that join works when mixing Array{Union{T, Missing}} with Array{T} (issue #1088)
     df = DataFrame(Name = Union{String, Missing}["A", "B", "C"],
@@ -140,31 +148,33 @@ module TestJoin
 
     # Test that join works when mixing Array{Union{T, Missing}} with Array{T} (issue #1151)
     df = DataFrame([collect(1:10), collect(2:11)], [:x, :y])
-    dfmissing = DataFrame(x = Vector{Union{Int, Missing}}(1:10), z = Vector{Union{Int, Missing}}(3:12))
+    dfmissing = DataFrame(x = Vector{Union{Int, Missing}}(1:10),
+                          z = Vector{Union{Int, Missing}}(3:12))
     @test join(df, dfmissing, on = :x) ==
         DataFrame([collect(1:10), collect(2:11), collect(3:12)], [:x, :y, :z])
     @test join(dfmissing, df, on = :x) ==
-        DataFrame([Vector{Union{Int, Missing}}(1:10), Vector{Union{Int, Missing}}(3:12), collect(2:11)], [:x, :z, :y])
+        DataFrame([Vector{Union{Int, Missing}}(1:10), Vector{Union{Int, Missing}}(3:12),
+                   collect(2:11)], [:x, :z, :y])
 
     @testset "all joins" begin
         df1 = DataFrame(Any[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
         df2 = DataFrame(Any[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
 
-        @test join(df1, df2, kind=:cross) ==
+        @test join(df1, df2, kind=:cross, makeunique=true) ==
             DataFrame(Any[repeat([1, 3, 5], inner = 5),
                           repeat([1, 3, 5], inner = 5),
                           repeat([0, 1, 2, 3, 4], outer = 3),
                           repeat([0, 1, 2, 3, 4], outer = 3)],
                       [:id, :fid, :id_1, :fid_1])
-        @test typeof.(join(df1, df2, kind=:cross).columns) ==
+        @test typeof.(join(df1, df2, kind=:cross, makeunique=true).columns) ==
             [Vector{Int}, Vector{Float64}, Vector{Int}, Vector{Float64}]
 
-        i(on) = join(df1, df2, on = on, kind = :inner)
-        l(on) = join(df1, df2, on = on, kind = :left)
-        r(on) = join(df1, df2, on = on, kind = :right)
-        o(on) = join(df1, df2, on = on, kind = :outer)
-        s(on) = join(df1, df2, on = on, kind = :semi)
-        a(on) = join(df1, df2, on = on, kind = :anti)
+        i(on) = join(df1, df2, on = on, kind = :inner, makeunique=true)
+        l(on) = join(df1, df2, on = on, kind = :left, makeunique=true)
+        r(on) = join(df1, df2, on = on, kind = :right, makeunique=true)
+        o(on) = join(df1, df2, on = on, kind = :outer, makeunique=true)
+        s(on) = join(df1, df2, on = on, kind = :semi, makeunique=true)
+        a(on) = join(df1, df2, on = on, kind = :anti, makeunique=true)
 
         @test s(:id) ==
               s(:fid) ==
@@ -204,15 +214,18 @@ module TestJoin
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
                                 id_1 = [1, 3, missing])
-        @test typeof.(l(on).columns) == [Vector{Int}, Vector{Float64}, Vector{Union{Int, Missing}}]
+        @test typeof.(l(on).columns) == [Vector{Int}, Vector{Float64},
+                                         Vector{Union{Int, Missing}}]
         @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
                                 fid = [1, 3, 0, 2, 4],
                                 id_1 = [1, 3, 0, 2, 4])
-        @test typeof.(r(on).columns) == [Vector{Union{Int, Missing}}, Vector{Float64}, Vector{Int}]
+        @test typeof.(r(on).columns) == [Vector{Union{Int, Missing}}, Vector{Float64},
+                                         Vector{Int}]
         @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
                                 fid = [1, 3, 5, 0, 2, 4],
                                 id_1 = [1, 3, missing, 0, 2, 4])
-        @test typeof.(o(on).columns) == [Vector{Union{Int, Missing}}, Vector{Float64}, Vector{Union{Int, Missing}}]
+        @test typeof.(o(on).columns) == [Vector{Union{Int, Missing}}, Vector{Float64},
+                                         Vector{Union{Int, Missing}}]
 
         on = [:id, :fid]
         @test i(on) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
@@ -231,21 +244,21 @@ module TestJoin
         df2 = DataFrame(Any[CategoricalArray([0, 1, 2, 3, 4]),
                             CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
 
-        @test join(df1, df2, kind=:cross) ==
+        @test join(df1, df2, kind=:cross, makeunique=true) ==
             DataFrame(Any[repeat([1, 3, 5], inner = 5),
                           repeat([1, 3, 5], inner = 5),
                           repeat([0, 1, 2, 3, 4], outer = 3),
                           repeat([0, 1, 2, 3, 4], outer = 3)],
                       [:id, :fid, :id_1, :fid_1])
-        @test all(isa.(join(df1, df2, kind=:cross).columns,
+        @test all(isa.(join(df1, df2, kind=:cross, makeunique=true).columns,
                        [CategoricalVector{T} for T in (Int, Float64, Int, Float64)]))
 
-        i(on) = join(df1, df2, on = on, kind = :inner)
-        l(on) = join(df1, df2, on = on, kind = :left)
-        r(on) = join(df1, df2, on = on, kind = :right)
-        o(on) = join(df1, df2, on = on, kind = :outer)
-        s(on) = join(df1, df2, on = on, kind = :semi)
-        a(on) = join(df1, df2, on = on, kind = :anti)
+        i(on) = join(df1, df2, on = on, kind = :inner, makeunique=true)
+        l(on) = join(df1, df2, on = on, kind = :left, makeunique=true)
+        r(on) = join(df1, df2, on = on, kind = :right, makeunique=true)
+        o(on) = join(df1, df2, on = on, kind = :outer, makeunique=true)
+        s(on) = join(df1, df2, on = on, kind = :semi, makeunique=true)
+        a(on) = join(df1, df2, on = on, kind = :anti, makeunique=true)
 
         @test s(:id) ==
               s(:fid) ==
@@ -481,20 +494,21 @@ module TestJoin
         @test eltypes(join(l, r, on=[:a, :b], kind=:outer)) == [Any, Int]
 
         # join by :b (Any is not on-column)
-        @test join(l, r, on=:b, kind=:inner) ≅ DataFrame(a=Any[3:7;], b=3:7, a_1=Any[3:7;])
-        @test eltypes(join(l, r, on=:b, kind=:inner)) == [Any, Int, Any]
+        @test join(l, r, on=:b, kind=:inner, makeunique=true) ≅
+            DataFrame(a=Any[3:7;], b=3:7, a_1=Any[3:7;])
+        @test eltypes(join(l, r, on=:b, kind=:inner, makeunique=true)) == [Any, Int, Any]
 
-        @test join(l, r, on=:b, kind=:left) ≅
+        @test join(l, r, on=:b, kind=:left, makeunique=true) ≅
             DataFrame(a=Any[1:7;], b=1:7, a_1=[fill(missing, 2); 3:7;])
-        @test eltypes(join(l, r, on=:b, kind=:left)) == [Any, Int, Any]
+        @test eltypes(join(l, r, on=:b, kind=:left, makeunique=true)) == [Any, Int, Any]
 
-        @test join(l, r, on=:b, kind=:right) ≅
+        @test join(l, r, on=:b, kind=:right, makeunique=true) ≅
             DataFrame(a=[3:7; fill(missing, 3)], b=3:10, a_1=Any[3:10;])
-        @test eltypes(join(l, r, on=:b, kind=:right)) == [Any, Int, Any]
+        @test eltypes(join(l, r, on=:b, kind=:right, makeunique=true)) == [Any, Int, Any]
 
-        @test join(l, r, on=:b, kind=:outer) ≅
+        @test join(l, r, on=:b, kind=:outer, makeunique=true) ≅
             DataFrame(a=[1:7; fill(missing, 3)], b=1:10, a_1=[fill(missing, 2); 3:10;])
-        @test eltypes(join(l, r, on=:b, kind=:outer)) == [Any, Int, Any]
+        @test eltypes(join(l, r, on=:b, kind=:outer, makeunique=true)) == [Any, Int, Any]
     end
 
     @testset "joins with categorical columns and no matching rows" begin
@@ -520,43 +534,47 @@ module TestJoin
         @test eltypes(join(l, r, on=[:a, :b], kind=:outer)) == [Int, CS]
 
         # joins by a
-        @test join(l, r, on=:a, kind=:inner) ≅
+        @test join(l, r, on=:a, kind=:inner, makeunique=true) ≅
             DataFrame(a=Int[], b=similar(l[:b], 0), b_1=similar(r[:b], 0))
-        @test eltypes(join(l, r, on=:a, kind=:inner)) == [Int, CS, CS]
+        @test eltypes(join(l, r, on=:a, kind=:inner, makeunique=true)) == [Int, CS, CS]
 
-        @test join(l, r, on=:a, kind=:left) ≅
+        @test join(l, r, on=:a, kind=:left, makeunique=true) ≅
             DataFrame(a=l[:a], b=l[:b], b_1=similar_missing(r[:b], nl))
-        @test eltypes(join(l, r, on=:a, kind=:left)) == [Int, CS, Union{CS, Missing}]
+        @test eltypes(join(l, r, on=:a, kind=:left, makeunique=true)) ==
+            [Int, CS, Union{CS, Missing}]
 
-        @test join(l, r, on=:a, kind=:right) ≅
+        @test join(l, r, on=:a, kind=:right, makeunique=true) ≅
             DataFrame(a=r[:a], b=similar_missing(l[:b], nr), b_1=r[:b])
-        @test eltypes(join(l, r, on=:a, kind=:right)) == [Int, Union{CS, Missing}, CS]
+        @test eltypes(join(l, r, on=:a, kind=:right, makeunique=true)) ==
+            [Int, Union{CS, Missing}, CS]
 
-        @test join(l, r, on=:a, kind=:outer) ≅
+        @test join(l, r, on=:a, kind=:outer, makeunique=true) ≅
             DataFrame(a=vcat(l[:a], r[:a]),
                       b=vcat(l[:b], fill(missing, nr)),
                       b_1=vcat(fill(missing, nl), r[:b]))
-        @test eltypes(join(l, r, on=:a, kind=:outer)) ==
+        @test eltypes(join(l, r, on=:a, kind=:outer, makeunique=true)) ==
             [Int, Union{CS, Missing}, Union{CS, Missing}]
 
         # joins by b
-        @test join(l, r, on=:b, kind=:inner) ≅
+        @test join(l, r, on=:b, kind=:inner, makeunique=true) ≅
             DataFrame(a=Int[], b=similar(l[:b], 0), a_1=similar(r[:b], 0))
-        @test eltypes(join(l, r, on=:b, kind=:inner)) == [Int, CS, Int]
+        @test eltypes(join(l, r, on=:b, kind=:inner, makeunique=true)) == [Int, CS, Int]
 
-        @test join(l, r, on=:b, kind=:left) ≅
+        @test join(l, r, on=:b, kind=:left, makeunique=true) ≅
             DataFrame(a=l[:a], b=l[:b], a_1=fill(missing, nl))
-        @test eltypes(join(l, r, on=:b, kind=:left)) == [Int, CS, Union{Int, Missing}]
+        @test eltypes(join(l, r, on=:b, kind=:left, makeunique=true)) ==
+            [Int, CS, Union{Int, Missing}]
 
-        @test join(l, r, on=:b, kind=:right) ≅
+        @test join(l, r, on=:b, kind=:right, makeunique=true) ≅
             DataFrame(a=fill(missing, nr), b=r[:b], a_1=r[:a])
-        @test eltypes(join(l, r, on=:b, kind=:right)) == [Union{Int, Missing}, CS, Int]
+        @test eltypes(join(l, r, on=:b, kind=:right, makeunique=true)) ==
+            [Union{Int, Missing}, CS, Int]
 
-        @test join(l, r, on=:b, kind=:outer) ≅
+        @test join(l, r, on=:b, kind=:outer, makeunique=true) ≅
             DataFrame(a=vcat(l[:a], fill(missing, nr)),
                       b=vcat(l[:b], r[:b]),
                       a_1=vcat(fill(missing, nl), r[:a]))
-        @test eltypes(join(l, r, on=:b, kind=:outer)) ==
+        @test eltypes(join(l, r, on=:b, kind=:outer, makeunique=true)) ==
             [Union{Int, Missing}, CS, Union{Int, Missing}]
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -9,7 +9,7 @@ module TestUtils
     @test identifier("begin") == :_begin
     @test identifier("end") == :_end
 
-    @test DataFrames.make_unique([:x, :x, :x_1, :x2]) == [:x, :x_2, :x_1, :x2]
+    @test DataFrames.make_unique([:x, :x, :x_1, :x2], makeunique=true) == [:x, :x_2, :x_1, :x2]
     # uncomment this line after deprecation period when makeunique=false throws error
     # @test_throws ArgumentError DataFrames.make_unique([:x, :x, :x_1, :x2], makeunique=false)
     @test DataFrames.make_unique([:x, :x_1, :x2], makeunique=false) == [:x, :x_1, :x2]


### PR DESCRIPTION
This is a maintenance PR of test files adding:
* `makeunique` keyword where needed (except for one place with `getindex` taking the same column twice - this test case should be changed to throw an error after deprecation);
* cases of indexing into `Index` tests that are deprecated are removed and a list of cases to test for error after deprecation period is introduced; added tests for indices being `Integer` other than `Int`;
* in *join.jl* two parts of code are wrapped in `@testset` as they defined the same function twice.