### PR TITLE
only test missing values if type has Missing

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -435,7 +435,10 @@ end
 ##############################################################################
 
 function _nonmissing!(res, col)
+    
+    # workaround until JuliaLang/julia#21256 is fixed
     eltype(col) >: Missing || return
+    
     @inbounds for (i, el) in enumerate(col)
         res[i] &= !ismissing(el)
     end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -435,6 +435,7 @@ end
 ##############################################################################
 
 function _nonmissing!(res, col)
+    eltype(col) >: Missing || return
     @inbounds for (i, el) in enumerate(col)
         res[i] &= !ismissing(el)
     end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -435,7 +435,6 @@ end
 ##############################################################################
 
 function _nonmissing!(res, col)
-    
     # workaround until JuliaLang/julia#21256 is fixed
     eltype(col) >: Missing || return
     


### PR DESCRIPTION
Fixes #1358 until JuliaLang/julia#21256 is fixed.

The issue with `enumerate` somehow allocating during the loop seems fixed on Julia master (0.7/1.0).

Since this is a performance change, I don't quite know if and how to add a test. Suggestions?