### PR TITLE
change tests not to use deprecated DataFrame constructor

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -210,7 +210,7 @@ module TestShow
     │ 5     │ x5   │ Float64 │ 0       │ 0.138763  …  0.649056 │"""
 
     io = IOBuffer()
-    df_small = DataFrame([1.0:5.0;])
+    df_small = DataFrame(transpose([1.0:5.0;]))
     showcols(io, df_small)
     str = String(take!(io))
     @test str == """


### PR DESCRIPTION
Constructing `DataFrame` with vector of values other than vectors is deprecated so in the test I change it to transpose of such a vector and we allow constructing from `AbstractMatrix`.