### PR TITLE
improve push! and categorical! test coverage

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -16,7 +16,7 @@ DataFrame(t::Type, nrows::Integer, ncols::Integer) # an empty DataFrame of arbit
 DataFrame(column_eltypes::Vector, names::Vector, nrows::Integer; makeunique::Bool=false)
 DataFrame(column_eltypes::Vector, cnames::Vector, categorical::Vector, nrows::Integer;
           makeunique::Bool=false)
-DataFrame(ds::Vector{AbstractDict})
+DataFrame(ds::AbstractDict)
 ```
 
 **Arguments**
@@ -33,7 +33,7 @@ DataFrame(ds::Vector{AbstractDict})
 * `column_eltypes` : elemental type of each column
 * `categorical` : `Vector{Bool}` indicating which columns should be converted to
                   `CategoricalVector`
-* `ds` : a vector of Associatives
+* `ds` : `AbstractDict`
 
 Each column in `columns` should be the same length.
 
@@ -620,7 +620,7 @@ Base.setindex!(df::DataFrame, x::Nothing, col_ind::Int) = delete!(df, col_ind)
 
 ##############################################################################
 ##
-## Mutating Associative methods
+## Mutating AbstractDict methods
 ##
 ##############################################################################
 
@@ -721,7 +721,7 @@ merge!(df::DataFrame, others::AbstractDataFrame...)
 For every column `c` with name `n` in `others` sequentially perform `df[n] = c`.
 In particular, if there are duplicate column names present in `df` and `others`
 the last encountered column will be retained.
-This behavior is identical with how `merge!` works for any `Associative` type.
+This behavior is identical with how `merge!` works for any `AbstractDict` type.
 Use `join` if you want to join two `DataFrame`s.
 
 **Arguments**
@@ -951,23 +951,6 @@ Base.convert(::Type{DataFrame}, d::AbstractDict) = DataFrame(d)
 ## push! a row onto a DataFrame
 ##
 ##############################################################################
-
-function Base.push!(df::DataFrame, associative::AbstractDict{Symbol,Any})
-    i = 1
-    for nm in _names(df)
-        try
-            push!(df[nm], associative[nm])
-        catch
-            #clean up partial row
-            for j in 1:(i - 1)
-                pop!(df[_names(df)[j]])
-            end
-            msg = "Error adding value to column :$nm."
-            throw(ArgumentError(msg))
-        end
-        i += 1
-    end
-end
 
 function Base.push!(df::DataFrame, associative::AbstractDict)
     i = 1

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -952,15 +952,19 @@ Base.convert(::Type{DataFrame}, d::AbstractDict) = DataFrame(d)
 ##
 ##############################################################################
 
-function Base.push!(df::DataFrame, associative::AbstractDict)
+function Base.push!(df::DataFrame, dict::AbstractDict)
     i = 1
     for nm in _names(df)
         try
-            val = get(() -> (Base.depwarn("push!(::DataFrame, ::AbstractDict) with "*
-                                          "AbstractDict keys other than Symbol is deprecated",
-                 :push!); associative[string(nm)]), associative, nm)
-            # after deprecation replace above line by
-            # val = associative[nm]
+            val = get(dict, nm) do
+                v = dict[string(nm)]
+                Base.depwarn("push!(::DataFrame, ::AbstractDict) with " *
+                             "AbstractDict keys other than Symbol is deprecated",
+                             :push!)
+                v
+            end
+            # after deprecation replace above call by
+            # val = dict[nm]
             push!(df[nm], val)
         catch
             #clean up partial row

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -33,7 +33,7 @@ DataFrame(ds::AbstractDict)
 * `column_eltypes` : elemental type of each column
 * `categorical` : `Vector{Bool}` indicating which columns should be converted to
                   `CategoricalVector`
-* `ds` : `AbstractDict`
+* `ds` : `AbstractDict` of columns
 
 Each column in `columns` should be the same length.
 
@@ -956,7 +956,11 @@ function Base.push!(df::DataFrame, associative::AbstractDict)
     i = 1
     for nm in _names(df)
         try
-            val = get(() -> associative[string(nm)], associative, nm)
+            val = get(() -> (Base.depwarn("push!(::DataFrame, ::AbstractDict) with "*
+                                          "AbstractDict keys other than Symbol is deprecated",
+                 :push!); associative[string(nm)]), associative, nm)
+            # after deprecation replace above line by
+            # val = associative[nm]
             push!(df[nm], val)
         catch
             #clean up partial row

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -205,41 +205,63 @@ module TestDataFrame
     @test hash(convert(DataFrame, [1 2; 3 4])) != hash(convert(DataFrame, [1 3; 2 4]))
     @test hash(convert(DataFrame, [1 2; 3 4])) == hash(convert(DataFrame, [1 2; 3 4]), zero(UInt))
 
-    # push!(df, row)
-    df=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
+    @testset "push!(df, row)" begin
+        df=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
 
-    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    push!(dfb, Any[3,"pear"])
-    @test df == dfb
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        dfc= DataFrame( first=[1,2], second=["apple","orange"] )
+        push!(dfb, Any[3,"pear"])
+        @test df == dfb
 
-    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    push!(dfb, (3,"pear"))
-    @test df == dfb
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        push!(dfb, (3,"pear"))
+        @test df == dfb
 
-    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, (33.33,"pear"))
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        @test_throws ArgumentError push!(dfb, (33.33,"pear"))
+        @test dfc == dfb
 
-    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, ("coconut",22))
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        @test_throws ArgumentError push!(dfb, (1,"2",3))
+        @test dfc == dfb
 
-    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    push!(dfb, Dict(:first=>3, :second=>"pear"))
-    @test df == dfb
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        @test_throws ArgumentError push!(dfb, ("coconut",22))
+        @test dfc == dfb
 
-    df=DataFrame( first=[1,2,3], second=["apple","orange","banana"] )
-    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    push!(dfb, Dict("first"=>3, "second"=>"banana"))
-    @test df == dfb
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        @test_throws ArgumentError push!(dfb, (11,22))
+        @test dfc == dfb
 
-    df0= DataFrame( first=[1,2], second=["apple","orange"] )
-    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, Dict(:first=>true, :second=>false))
-    @test df0 == dfb
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        push!(dfb, Dict(:first=>3, :second=>"pear"))
+        @test df == dfb
 
-    df0= DataFrame( first=[1,2], second=["apple","orange"] )
-    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, Dict("first"=>"chicken", "second"=>"stuff"))
-    @test df0 == dfb
+        df=DataFrame( first=[1,2,3], second=["apple","orange","banana"] )
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        push!(dfb, Dict("first"=>3, "second"=>"banana"))
+        @test df == dfb
+
+        df0= DataFrame( first=[1,2], second=["apple","orange"] )
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        @test_throws ArgumentError push!(dfb, Dict(:first=>true, :second=>false))
+        @test df0 == dfb
+
+        df0= DataFrame( first=[1,2], second=["apple","orange"] )
+        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+        @test_throws ArgumentError push!(dfb, Dict("first"=>"chicken", "second"=>"stuff"))
+        @test df0 == dfb
+
+        df0=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
+        dfb=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
+        @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
+        @test df0 == dfb
+
+        df0=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
+        dfb=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
+        @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
+        @test df0 == dfb
+    end
 
     # delete!
     df = DataFrame(a=1, b=2, c=3, d=4, e=5)
@@ -404,6 +426,18 @@ module TestDataFrame
                     categorical!(deepcopy(df), [1]).columns) == 1
     @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
                     categorical!(deepcopy(df), 1).columns) == 1
+
+    @testset "categorical!" begin
+        df = DataFrame([["a", "b"], ['a', 'b'], [true, false], 1:2, ["x", "y"]])
+        @test eltypes(categorical!(df)) == [CategoricalArrays.CategoricalString{UInt32},
+                                            Char, Bool, Int64,
+                                            CategoricalArrays.CategoricalString{UInt32}]
+        @test eltypes(categorical!(df, names(df))) == [CategoricalArrays.CategoricalString{UInt32},
+                                                       CategoricalArrays.CategoricalValue{Char,UInt32},
+                                                       CategoricalArrays.CategoricalValue{Bool,UInt32},
+                                                       CategoricalArrays.CategoricalValue{Int64,UInt32},
+                                                       CategoricalArrays.CategoricalString{UInt32}]
+    end
 
     @testset "unstack promotion to support missing values" begin
         df = DataFrame(Any[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -239,7 +239,7 @@ module TestDataFrame
 
         df=DataFrame( first=[1,2,3], second=["apple","orange","banana"] )
         dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        push!(dfb, Dict("first"=>3, "second"=>"banana"))
+        push!(dfb, Dict(:first=>3, :second=>"banana"))
         @test df == dfb
 
         df0= DataFrame( first=[1,2], second=["apple","orange"] )
@@ -249,7 +249,7 @@ module TestDataFrame
 
         df0= DataFrame( first=[1,2], second=["apple","orange"] )
         dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        @test_throws ArgumentError push!(dfb, Dict("first"=>"chicken", "second"=>"stuff"))
+        @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>"stuff"))
         @test df0 == dfb
 
         df0=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
@@ -429,14 +429,16 @@ module TestDataFrame
 
     @testset "categorical!" begin
         df = DataFrame([["a", "b"], ['a', 'b'], [true, false], 1:2, ["x", "y"]])
-        @test eltypes(categorical!(df)) == [CategoricalArrays.CategoricalString{UInt32},
-                                            Char, Bool, Int64,
-                                            CategoricalArrays.CategoricalString{UInt32}]
-        @test eltypes(categorical!(df, names(df))) == [CategoricalArrays.CategoricalString{UInt32},
-                                                       CategoricalArrays.CategoricalValue{Char,UInt32},
-                                                       CategoricalArrays.CategoricalValue{Bool,UInt32},
-                                                       CategoricalArrays.CategoricalValue{Int64,UInt32},
-                                                       CategoricalArrays.CategoricalString{UInt32}]
+        @test all(map(<:, eltypes(categorical!(df)),
+                      [CategoricalArrays.CategoricalString,
+                       Char, Bool, Int,
+                       CategoricalArrays.CategoricalString]))
+        @test all(map(<:, eltypes(categorical!(df, names(df))),
+                      [CategoricalArrays.CategoricalString,
+                       CategoricalArrays.CategoricalValue{Char},
+                       CategoricalArrays.CategoricalValue{Bool},
+                       CategoricalArrays.CategoricalValue{Int},
+                       CategoricalArrays.CategoricalString]))
     end
 
     @testset "unstack promotion to support missing values" begin


### PR DESCRIPTION
Part three of implementation of #1372.

Changes:
* full coverage of `push!`
* full coverage of `categorical!`
* removed `push!` method that was not needed (duplicate in special case with no extra functionality and the same performance)
* cleaned up deprecated `Associative` references
* corrected documentation of `DataFrame(ds::AbstractDict)` constructor (it does not accept a vector but a dictionary)