### PR TITLE
WIP: improve DataFrame indexing

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1299,3 +1299,10 @@ end
 import Base: vcat
 @deprecate vcat(x::Vector{<:AbstractDataFrame}) vcat(x...)
 
+# Special deletion assignment
+function Base.setindex!(df::DataFrame, x::Nothing, col_ind::Int)
+    Base.depwarn("Removing columns from DataFrame by assigning nothing " *
+                 "is deprecated. Use delete!(df, col_ind) instead.", :DataFrame)
+    delete!(df, col_ind)
+end
+

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -145,7 +145,7 @@ function Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Integer})
     if any(v -> v isa Bool, idx)
         # TODO: this line should be changed to throw an error after deprecation
         # throw(ArgumentError("Bool values except for Vector{Bool} are not allowed for column indexing"))
-        Base.depwarn("Indexing with Bool values is deprecated except for Vector{Bool}")
+        Base.depwarn("Indexing with Bool values is deprecated except for Vector{Bool}", :getindex)
     end
     Vector{Int}(idx)
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -633,9 +633,15 @@ module TestDataFrame
         df1 = DataFrame()
         df1[1:10] = rand(3)
         @test size(df1) == (3, 10)
+        for i in 2:10
+            @test df1[1] == df1[i]
+        end
         df1 = DataFrame()
         df1[1:10] = 3
         @test size(df1) == (1, 10)
+        for i in 2:10
+            @test [3] == df1[i]
+        end
 
         @test_throws ArgumentError df1[1.0] = 1
         @test_throws ArgumentError df1[true] = 1

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -617,6 +617,28 @@ module TestDataFrame
         df[3] = [1,2,3]
         df[4] = [1,2,3]
         @test names(df) == [:x3, :x3_1, :x3_2, :x4]
+        @test_throws BoundsError df[[true,false,true,false,true,false]] = df
+        @test_throws BoundsError df[[true,false,true,false,true,false]] = [1,2,3]
+        @test_throws BoundsError df[[true,false,true,false,true,false]] = 1
+        @test_throws TypeError df[[true, true, true, missing]] = df
+        @test_throws TypeError df[[true, true, true, missing]] = [1,2,3]
+        @test_throws TypeError df[[true, true, true, missing]] = 1
+        df[Union{Bool,Missing}[true, false, false, false]] = DataFrame([[100,100,100]])
+        @test df[1] == [100,100,100]
+        df[Union{Bool,Missing}[true, false, false, false]] = [0,0,0]
+        @test df[1] == [0,0,0]
+        df[Union{Bool,Missing}[true, false, false, false]] = 1000
+        @test df[1] == [1000,1000,1000]
+
+        df1 = DataFrame()
+        df1[1:10] = rand(3)
+        @test size(df1) == (3, 10)
+        df1 = DataFrame()
+        df1[1:10] = 3
+        @test size(df1) == (1, 10)
+
+        @test_throws ArgumentError df1[1.0] = 1
+        @test_throws ArgumentError df1[true] = 1
     end
 
     @testset "handling of end in indexing" begin


### PR DESCRIPTION
Following #1369 and #1372 I have proposed changes to `setindex!` (and a small fixe in `getindex` depwarn) to make it more consistent.
It does not have a full test coverage yet and I have added comments in the code where the behavior is unexpected.

Finally I am not sure if we want `df[1] = nothing` to remove columns from a `DataFrame` (this is the current behavior which makes `df[1]=x` inconsistent (it has different behavior if `x=nothing` than when e.g. `x=missing` or `x="abracadabra"`))? It is also inconsistent with `AbstractDict` interface.

When we decide if we want what I have implemented (or something else) I will update this PR and add appropriate tests.