### PR TITLE
fix issorted bug

### DIFF
--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -73,14 +73,14 @@ DFPerm(o::O, df::DF) where {O<:Ordering, DF<:AbstractDataFrame} = DFPerm{O,DF}(o
 col_ordering(o::DFPerm{O}, i::Int) where {O<:Ordering} = o.ord
 col_ordering(o::DFPerm{V}, i::Int) where {V<:AbstractVector} = o.ord[i]
 
-Base.@propagate_inbounds Base.getindex(o::DFPerm, i::Int, j::Int) = o.df[i, j]
-Base.@propagate_inbounds Base.getindex(o::DFPerm, a::DataFrameRow, j::Int) = a[j]
+Base.@propagate_inbounds Base.getindex(o::DFPerm, i::Int, j::Union{Int,Symbol}) = o.df[i, j]
+Base.@propagate_inbounds Base.getindex(o::DFPerm, a::DataFrameRow, j::Union{Int,Symbol}) = a[j]
 
 function Sort.lt(o::DFPerm, a, b)
-    @inbounds for i = 1:ncol(o.df)
+    @inbounds for (i,n) = enumerate(names(o.df))
         ord = col_ordering(o, i)
-        va = o[a, i]
-        vb = o[b, i]
+        va = o[a, n]
+        vb = o[b, n]
         lt(ord, va, vb) && return true
         lt(ord, vb, va) && return false
     end
@@ -272,6 +272,8 @@ function Base.issorted(df::AbstractDataFrame, cols_new=[]; cols=[],
                      :issorted)
         cols_new = cols
     end
+    cols_new isa Union{Real, Symbol} && return issorted(df[cols_new], lt=lt, by=by, rev=rev, order=order)
+    length(cols_new) == 1 && return issorted(df[cols_new[1]], lt=lt, by=by, rev=rev, order=order)
     issorted(eachrow(df), ordering(df, cols_new, lt, by, rev, order))
 end
 

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -270,11 +270,12 @@ function Base.issorted(df::AbstractDataFrame, cols_new=[]; cols=[],
         cols_new = cols
     end
     if cols_new isa ColumnIndex
-        return issorted(df[cols_new], lt=lt, by=by, rev=rev, order=order)
+        issorted(df[cols_new], lt=lt, by=by, rev=rev, order=order)
     elseif length(cols_new) == 1
-        return issorted(df[cols_new[1]], lt=lt, by=by, rev=rev, order=order)
+        issorted(df[cols_new[1]], lt=lt, by=by, rev=rev, order=order)
+    else
+        issorted(1:nrow(df), ordering(df, cols_new, lt, by, rev, order))
     end
-    issorted(1:nrow(df), ordering(df, cols_new, lt, by, rev, order))
 end
 
 # sort and sortperm functions

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -42,6 +42,17 @@ module TestSort
 
     @test df == ds
 
+    df = DataFrame(x = [3, 1, 2, 1], y = ["b", "c", "a", "b"])
+    @test issorted(df, :x) == false
+    @test issorted(sort(df, :x), :x) == true
+
+    x = DataFrame(a=1:3,b=3:-1:1,c=3:-1:1)
+    @test issorted(x) == true
+    @test issorted(x, [:b,:c]) == false
+    @test issorted(x[2:3], [:b,:c]) == false
+    @test issorted(sort(x,[2,3]), [:b,:c]) == true
+    @test issorted(sort(x[2:3]), [:b,:c]) == true
+
     # Check that columns that shares the same underlying array are only permuted once PR#1072
     df = DataFrame(a=[2,1])
     df[:b] = df[:a]

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -63,4 +63,47 @@ module TestSort
     sort!(x, :y)
     @test x[:y] == [1,2,3,4]
     @test x[:x] == [1,3,2,4]
+
+    @test_throws ArgumentError sort(x, by=:x)
+
+    srand(1)
+    df_rand = DataFrame(rand(100, 4))
+    for n1 in names(df_rand)
+        @test sort(df_rand, n1)[n1] == sort(df_rand[n1])
+        @test sort(df_rand, [n1])[n1] == sort(df_rand[n1])
+        for n2 in setdiff(names(df_rand), [n1])
+            @test sort(df_rand, [n1,n2])[n1] == sort(df_rand[n1])
+        end
+    end
+    for n1 in names(df_rand)
+        @test sort!(df_rand, n1)[n1] == sort(df_rand[n1])
+        @test issorted(df_rand, n1)
+        @test sort!(df_rand, [n1])[n1] == sort(df_rand[n1])
+        @test issorted(df_rand, [n1])
+        for n2 in setdiff(names(df_rand), [n1])
+            @test sort!(df_rand, [n1,n2])[n1] == sort(df_rand[n1])
+            @test issorted(df_rand, n1)
+        end
+    end
+
+    srand(1)
+    df_rand = DataFrame(rand(100, 4))
+    df_rand[:x1] = shuffle([fill(1, 50); fill(2, 50)])
+    df_rand[:x4] = shuffle([fill(1, 50); fill(2, 50)])
+    for n1 in [:x1, :x4]
+        for n2 in setdiff(names(df_rand), [n1])
+            v = sort(df_rand, [n1,n2])
+            @test issorted(v[n1])
+            @test issorted(v[v[n1].==1, n2])
+            @test issorted(v[v[n1].==2, n2])
+        end
+    end
+    for n1 in [:x1, :x4]
+        for n2 in setdiff(names(df_rand), [n1])
+            v = sort!(df_rand, [n1,n2])
+            @test issorted(v[n1])
+            @test issorted(v[v[n1].==1, n2])
+            @test issorted(v[v[n1].==2, n2])
+        end
+    end
 end


### PR DESCRIPTION
Resolves both problems from #1327.
In general `lt` function was broken when subsetting of `DataFrame` for `issorted` was performed.

@nalimilan CI will fail because of `CategoricalArray` bug. Need to rebase this PR after that one is merged, but currently it should be good for a review.