### PR TITLE
Always collect AbstractRange

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -40,14 +40,17 @@ Each column in `columns` should be the same length.
 **Notes**
 
 A `DataFrame` is a lightweight object. As long as columns are not
-manipulated, creation of a DataFrame from existing AbstractVectors is
+manipulated, creation of a `DataFrame` from existing AbstractVectors is
 inexpensive. For example, indexing on columns is inexpensive, but
 indexing by rows is expensive because copies are made of each column.
-An exception is assignment of `AbstractRange` as a column of
-`DataFrame` in which case it is collected to a vector.
 
-Because column types can vary, a DataFrame is not type stable. For
-performance-critical code, do not index into a DataFrame inside of
+If a column is passed to a `DataFrame` constructor or is assigned as a whole
+using `setindex!` then its reference is stored in the `DataFrame`. An exception
+to this rule is assignment of `AbstractRange` as a column in which case it is
+collected to a vector.
+
+Because column types can vary, a `DataFrame` is not type stable. For
+performance-critical code, do not index into a `DataFrame` inside of
 loops.
 
 **Examples**

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -46,8 +46,8 @@ indexing by rows is expensive because copies are made of each column.
 
 If a column is passed to a `DataFrame` constructor or is assigned as a whole
 using `setindex!` then its reference is stored in the `DataFrame`. An exception
-to this rule is assignment of `AbstractRange` as a column in which case it is
-collected to a vector.
+to this rule is assignment of an `AbstractRange` as a column, in which case the
+range is collected to a `Vector`.
 
 Because column types can vary, a `DataFrame` is not type stable. For
 performance-critical code, do not index into a `DataFrame` inside of

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -43,6 +43,8 @@ A `DataFrame` is a lightweight object. As long as columns are not
 manipulated, creation of a DataFrame from existing AbstractVectors is
 inexpensive. For example, indexing on columns is inexpensive, but
 indexing by rows is expensive because copies are made of each column.
+An exception is assignment of `AbstractRange` as a column of
+`DataFrame` in which case it is collected to a vector.
 
 Because column types can vary, a DataFrame is not type stable. For
 performance-critical code, do not index into a DataFrame inside of
@@ -325,12 +327,13 @@ end
 
 # Will automatically add a new column if needed
 function insert_single_column!(df::DataFrame,
-                               dv::AbstractVector,
+                               v::AbstractVector,
                                col_ind::ColumnIndex)
 
-    if ncol(df) != 0 && nrow(df) != length(dv)
+    if ncol(df) != 0 && nrow(df) != length(v)
         throw(ArgumentError("New columns must have the same length as old columns"))
     end
+    dv = isa(v, AbstractRange) ? collect(v) : v
     if haskey(index(df), col_ind)
         j = index(df)[col_ind]
         df.columns[j] = dv

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -619,6 +619,13 @@ module TestDataFrame
         @test names(df) == [:x3, :x3_1, :x3_2, :x4]
     end
 
+    @testset "passing range to a DataFrame" begin
+        df =DataFrame(a=1:3, b='a':'c')
+        df[:c] = 1:3
+        df[:d] = 'a':'c'
+        @test all(typeof(df[i]) <: Vector for i in 1:ncol(df))
+    end
+
     @testset "handling of end in indexing" begin
         z = DataFrame(rand(4,5))
         for x in [z, view(z, 1:4)]

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -620,7 +620,7 @@ module TestDataFrame
     end
 
     @testset "passing range to a DataFrame" begin
-        df =DataFrame(a=1:3, b='a':'c')
+        df = DataFrame(a=1:3, b='a':'c')
         df[:c] = 1:3
         df[:d] = 'a':'c'
         @test all(typeof(df[i]) <: Vector for i in 1:ncol(df))


### PR DESCRIPTION
Following #1388 this PR always collects `AbstractRange` before assignment to a `DataFrame`. In this way we have consistency between constructor and `setindex!`.