### PR TITLE
Fix push!(df, a, b, ...)

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1006,6 +1006,7 @@ function Base.push!(df::DataFrame, dict::AbstractDict)
         end
         i += 1
     end
+    df
 end
 
 # array and tuple like collections
@@ -1028,4 +1029,5 @@ function Base.push!(df::DataFrame, iterable::Any)
         end
         i += 1
     end
+    df
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -261,6 +261,10 @@ module TestDataFrame
         dfb=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
         @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
         @test df0 == dfb
+
+        df = DataFrame(x=[1])
+        DataFrames.push!(df, Dict(:x=>2), Dict(:x=>3))
+        @test df[:x] == [1,2,3]
     end
 
     # delete!

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -263,7 +263,7 @@ module TestDataFrame
         @test df0 == dfb
 
         df = DataFrame(x=[1])
-        DataFrames.push!(df, Dict(:x=>2), Dict(:x=>3))
+        push!(df, Dict(:x=>2), Dict(:x=>3))
         @test df[:x] == [1,2,3]
     end
 


### PR DESCRIPTION
[This method](https://github.com/JuliaLang/julia/blob/d386e40c17d43b79fc89d3e579fc04547241787c/base/abstractarray.jl#L1940) assumes that `push!(df, x)` returns `df`.