### PR TITLE
Fix error with undefined values in HTML printing

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -107,7 +107,11 @@ function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame)
         write(io, "<tr>")
         write(io, "<th>$row</th>")
         for column_name in cnames
-            cell = sprint(ourshowcompact, df[row, column_name])
+            if isassigned(df[column_name], row)
+                cell = sprint(ourshowcompact, df[row, column_name])
+            else
+                cell = sprint(ourshowcompact, Base.undef_ref_str)
+            end
             write(io, "<td>$(html_escape(cell))</td>")
         end
         write(io, "</tr>")

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -102,9 +102,9 @@ function getmaxwidths(df::AbstractDataFrame,
 
         # (2) Consider length of longest entry in that column
         for indices in (rowindices1, rowindices2), i in indices
-            try
+            if isassigned(col, i)
                 maxwidth = max(maxwidth, ourstrwidth(col[i]))
-            catch
+            else
                 maxwidth = max(maxwidth, undefstrwidth)
             end
         end
@@ -245,7 +245,7 @@ function showrowindices(io::IO,
         # Print DataFrame entry
         for j in leftcol:rightcol
             strlen = 0
-            try
+            if isassigned(df[j], i)
                 s = df[i, j]
                 strlen = ourstrwidth(s)
                 if ismissing(s)
@@ -253,7 +253,7 @@ function showrowindices(io::IO,
                 else
                     ourshowcompact(io, s)
                 end
-            catch
+            else
                 strlen = ourstrwidth(Base.undef_ref_str)
                 ourshowcompact(io, Base.undef_ref_str)
             end

--- a/test/io.jl
+++ b/test/io.jl
@@ -31,6 +31,15 @@ module TestIO
                  "<tr><th>1</th><td>Suzy</td><td>1.5</td></tr>" *
                  "<tr><th>2</th><td>Amir</td><td>missing</td></tr></tbody></table>"
 
+    df = DataFrame(Fish = Vector{String}(undef, 2), Mass = [1.5, missing])
+    io = IOBuffer()
+    show(io, "text/html", df)
+    str = String(take!(io))
+    @test str == "<table class=\"data-frame\"><thead><tr><th>" *
+                 "</th><th>Fish</th><th>Mass</th></tr></thead><tbody>" *
+                 "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
+                 "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
+
     # test limit attribute of IOContext is used
     df = DataFrame(a=collect(1:1000))
     ioc = IOContext(IOBuffer(), displaysize=(10, 10), limit=false)


### PR DESCRIPTION
Also change try... catch blocks to isassigned calls in show.jl, which is more correct and can avoid hiding bugs.

Fixes #1397.