### PR TITLE
Rename Void to Nothing

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -424,7 +424,7 @@ end
 #'        AbstractDataFrame be rendered to the IO system before printing the
 #'        contents of the renderable rows? Defaults to `true`.
 #'
-#' @returns o::Void A `nothing` value.
+#' @returns `nothing` value.
 #'
 #' @examples
 #'
@@ -434,7 +434,7 @@ function Base.show(io::IO,
                    df::AbstractDataFrame,
                    allcols::Bool = false,
                    rowlabel::Symbol = :Row,
-                   displaysummary::Bool = true) # -> Void
+                   displaysummary::Bool = true) # -> Nothing
     nrows = size(df, 1)
     dsize = displaysize(io)
     availableheight = dsize[1] - 5
@@ -472,14 +472,14 @@ end
 #' @param allcols::Bool Should only a subset of columns that fits
 #'        the device width be printed? Defaults to `false`.
 #'
-#' @returns o::Void A `nothing` value.
+#' @returns `nothing` value.
 #'
 #' @examples
 #'
 #' df = DataFrame(A = 1:3, B = ["x", "y", "z"])
 #' show(df, true)
 function Base.show(df::AbstractDataFrame,
-                   allcols::Bool = false) # -> Void
+                   allcols::Bool = false) # -> Nothing
     return show(stdout, df, allcols)
 end
 
@@ -499,7 +499,7 @@ end
 #'        AbstractDataFrame be rendered to the IO system before printing the
 #'        contents of the renderable rows? Defaults to `true`.
 #'
-#' @returns o::Void A `nothing` value.
+#' @returns `nothing` value.
 #'
 #' @examples
 #'
@@ -509,7 +509,7 @@ function Base.showall(io::IO,
                       df::AbstractDataFrame,
                       allcols::Bool = true,
                       rowlabel::Symbol = :Row,
-                      displaysummary::Bool = true) # -> Void
+                      displaysummary::Bool = true) # -> Nothing
     rowindices1 = 1:size(df, 1)
     rowindices2 = 1:0
     maxwidths = getmaxwidths(df, rowindices1, rowindices2, rowlabel)
@@ -536,14 +536,14 @@ end
 #' @param allcols::Bool Should only a subset of columns that fits
 #'        the device width be printed? Defaults to `true`.
 #'
-#' @returns o::Void A `nothing` value.
+#' @returns `nothing` value.
 #'
 #' @examples
 #'
 #' df = DataFrame(A = 1:3, B = ["x", "y", "z"])
 #' showall(df, true)
 function Base.showall(df::AbstractDataFrame,
-                      allcols::Bool = true) # -> Void
+                      allcols::Bool = true) # -> Nothing
     showall(stdout, df, allcols)
     return
 end
@@ -561,14 +561,14 @@ end
 #' @param values::Bool If `true` (default), the first and the last value of
 #'        each column are printed.
 #'
-#' @returns o::Void A `nothing` value.
+#' @returns `nothing` value.
 #'
 #' @examples
 #'
 #' df = DataFrame(A = 1:3, B = ["x", "y", "z"])
 #' showcols(df)
 function showcols(io::IO, df::AbstractDataFrame, all::Bool = false,
-                  values::Bool = true) # -> Void
+                  values::Bool = true) # -> Nothing
     print(io, summary(df))
     metadata = DataFrame(Name = _names(df),
                          Eltype = eltypes(df),
@@ -598,12 +598,12 @@ end
 #' @param values::Bool If `true` (default), first and last value of
 #'        each column is printed.
 #'
-#' @returns o::Void A `nothing` value.
+#' @returns `nothing` value.
 #'
 #' @examples
 #'
 #' df = DataFrame(A = 1:3, B = ["x", "y", "z"])
 #' showcols(df)
 function showcols(df::AbstractDataFrame, all::Bool=false, values::Bool=true)
-    showcols(stdout, df, all, values) # -> Void
+    showcols(stdout, df, all, values) # -> Nothing
 end

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -303,7 +303,7 @@ end
 
 """
     sort(df::AbstractDataFrame, cols;
-         alg::Union{Algorithm, Void}=nothing, lt=isless, by=identity,
+         alg::Union{Algorithm, Nothing}=nothing, lt=isless, by=identity,
          rev::Bool=false, order::Ordering=Forward)
 
 Return a copy of data frame `df` sorted by column(s) `cols`.
@@ -370,7 +370,7 @@ sort(::AbstractDataFrame, ::Any)
 
 """
     sortperm(df::AbstractDataFrame, cols;
-             alg::Union{Algorithm, Void}=nothing, lt=isless, by=identity,
+             alg::Union{Algorithm, Nothing}=nothing, lt=isless, by=identity,
              rev::Bool=false, order::Ordering=Forward)
 
 Return a permutation vector of row indices of data frame `df` that puts them in

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -1,7 +1,7 @@
 
 """
     sort!(df::AbstractDataFrame, cols;
-          alg::Union{Algorithm, Void}=nothing, lt=isless, by=identity,
+          alg::Union{Algorithm, Nothing}=nothing, lt=isless, by=identity,
           rev::Bool=false, order::Ordering=Forward)
 
 Sort data frame `df` by column(s) `cols`.

--- a/src/dataframerow/show.jl
+++ b/src/dataframerow/show.jl
@@ -7,7 +7,7 @@
 #' @param io::IO The IO system where rendering will take place.
 #' @param r::DataFrameRow The DataFrameRow to be rendered to `io`.
 #'
-#' @returns o::Void A `nothing` value.
+#' @returns `nothing` value.
 #'
 #' @examples
 #'


### PR DESCRIPTION
A minor PR cleaning up remaining references to `Void` type in *DataFrames.jl* (only in documentation and comments).