### PR TITLE
Override getproperty, setproperty! and propertynames for AbstractDataFrame and DataFrameRow

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -236,6 +236,13 @@ Compat.axes(df, i) = axes(df)[i]
 
 Base.ndims(::AbstractDataFrame) = 2
 
+if VERSION >= v"0.7.0-DEV.3067"
+    Base.getproperty(df::AbstractDataFrame, col_ind::Symbol) = getindex(df, col_ind)
+    Base.setproperty!(df::AbstractDataFrame, col_ind::Symbol, x) = setindex!(df, x, col_ind)
+    # Private fields are never exposed since they can conflict with column names
+    Base.propertynames(df::AbstractDataFrame, private::Bool=false) = names(df)
+end
+
 ##############################################################################
 ##
 ## Similar

--- a/src/dataframerow/show.jl
+++ b/src/dataframerow/show.jl
@@ -17,7 +17,7 @@
 #' end
 function Base.show(io::IO, r::DataFrameRow)
     labelwidth = mapreduce(n -> length(string(n)), max, _names(r)) + 2
-    @printf(io, "DataFrameRow (row %d)\n", r.row)
+    @printf(io, "DataFrameRow (row %d)\n", row(r))
     for (label, value) in r
         println(io, rpad(label, labelwidth, ' '), value)
     end

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -212,8 +212,8 @@ function findrows(gd::RowGroupDict,
 end
 
 function Base.getindex(gd::RowGroupDict, dfr::DataFrameRow)
-    g_row = findrow(gd, dfr.df, ntuple(i -> gd.df[i], ncol(gd.df)),
-                    ntuple(i -> dfr.df[i], ncol(dfr.df)), dfr.row)
+    g_row = findrow(gd, parent(dfr), ntuple(i -> gd.df[i], ncol(gd.df)),
+                    ntuple(i -> parent(dfr)[i], ncol(parent(dfr))), row(dfr))
     (g_row == 0) && throw(KeyError(dfr))
     gix = gd.groups[g_row]
     return view(gd.rperm, gd.starts[gix]:gd.stops[gix])

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -85,12 +85,21 @@ function SubDataFrame(parent::DataFrame, rows::AbstractVector{Bool})
 end
 
 function SubDataFrame(sdf::SubDataFrame, rowinds::Union{T, AbstractVector{T}}) where {T <: Integer}
-    return SubDataFrame(sdf.parent, sdf.rows[rowinds])
+    return SubDataFrame(parent(sdf), rows(sdf)[rowinds])
 end
 
 function SubDataFrame(sdf::SubDataFrame, rowinds::Colon)
     return sdf
 end
+
+"""
+    parent(sdf::SubDataFrame)
+
+Return the parent data frame of `sdf`.
+"""
+Base.parent(sdf::SubDataFrame) = getfield(sdf, :parent)
+
+rows(sdf::SubDataFrame) = getfield(sdf, :rows)
 
 function Base.view(adf::AbstractDataFrame, rowinds::AbstractVector{T}) where {T >: Missing}
     # Vector{>:Missing} need to be checked for missings
@@ -116,27 +125,27 @@ end
 ##
 ##############################################################################
 
-index(sdf::SubDataFrame) = index(sdf.parent)
+index(sdf::SubDataFrame) = index(parent(sdf))
 
 # TODO: Remove these
-nrow(sdf::SubDataFrame) = ncol(sdf) > 0 ? length(sdf.rows)::Int : 0
+nrow(sdf::SubDataFrame) = ncol(sdf) > 0 ? length(rows(sdf))::Int : 0
 ncol(sdf::SubDataFrame) = length(index(sdf))
 
 function Base.getindex(sdf::SubDataFrame, colinds::Any)
-    return sdf.parent[sdf.rows, colinds]
+    return parent(sdf)[rows(sdf), colinds]
 end
 
 function Base.getindex(sdf::SubDataFrame, rowinds::Any, colinds::Any)
-    return sdf.parent[sdf.rows[rowinds], colinds]
+    return parent(sdf)[rows(sdf)[rowinds], colinds]
 end
 
 function Base.setindex!(sdf::SubDataFrame, val::Any, colinds::Any)
-    sdf.parent[sdf.rows, colinds] = val
+    parent(sdf)[rows(sdf), colinds] = val
     return sdf
 end
 
 function Base.setindex!(sdf::SubDataFrame, val::Any, rowinds::Any, colinds::Any)
-    sdf.parent[sdf.rows[rowinds], colinds] = val
+    parent(sdf)[rows(sdf)[rowinds], colinds] = val
     return sdf
 end
 
@@ -148,4 +157,4 @@ end
 
 Base.map(f::Function, sdf::SubDataFrame) = f(sdf) # TODO: deprecate
 
-without(sdf::SubDataFrame, c) = view(without(sdf.parent, c), sdf.rows)
+without(sdf::SubDataFrame, c) = view(without(parent(sdf), c), rows(sdf))

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -1,5 +1,6 @@
 module TestCat
     using Compat, Compat.Test, Compat.Random, DataFrames
+    using DataFrames: columns
     const ≅ = isequal
 
     #
@@ -185,13 +186,13 @@ module TestCat
     @testset "vcat mixed coltypes" begin
         df = vcat(DataFrame([[1]], [:x]), DataFrame([[1.0]], [:x]))
         @test df == DataFrame([[1.0, 1.0]], [:x])
-        @test typeof.(df.columns) == [Vector{Float64}]
+        @test typeof.(columns(df)) == [Vector{Float64}]
         df = vcat(DataFrame([[1]], [:x]), DataFrame([["1"]], [:x]))
         @test df == DataFrame([[1, "1"]], [:x])
-        @test typeof.(df.columns) == [Vector{Any}]
+        @test typeof.(columns(df)) == [Vector{Any}]
         df = vcat(DataFrame([Union{Missing, Int}[1]], [:x]), DataFrame([[1]], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
-        @test typeof.(df.columns) == [Vector{Union{Missing, Int}}]
+        @test typeof.(columns(df)) == [Vector{Union{Missing, Int}}]
         df = vcat(DataFrame([CategoricalArray([1])], [:x]), DataFrame([[1]], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
         @test typeof(df[:x]) <: CategoricalVector{Int}
@@ -206,14 +207,14 @@ module TestCat
         df = vcat(DataFrame([Union{Int, Missing}[1]], [:x]),
                   DataFrame([["1"]], [:x]))
         @test df == DataFrame([[1, "1"]], [:x])
-        @test typeof.(df.columns) == [Vector{Any}]
+        @test typeof.(columns(df)) == [Vector{Any}]
         df = vcat(DataFrame([CategoricalArray([1])], [:x]),
                   DataFrame([CategoricalArray(["1"])], [:x]))
         @test df == DataFrame([[1, "1"]], [:x])
         @test typeof(df[:x]) <: CategoricalVector{Any}
         df = vcat(DataFrame([trues(1)], [:x]), DataFrame([[false]], [:x]))
         @test df == DataFrame([[true, false]], [:x])
-        @test typeof.(df.columns) == [Vector{Bool}]
+        @test typeof.(columns(df)) == [Vector{Bool}]
     end
 
     @testset "vcat out of order" begin

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,6 +1,6 @@
 module TestConstructors
     using Compat, Compat.Test, DataFrames
-    using DataFrames: Index
+    using DataFrames: Index, columns, index
     const ≅ = isequal
 
     #
@@ -8,8 +8,8 @@ module TestConstructors
     #
 
     df = DataFrame()
-    @test df.columns == Any[]
-    @test df.colindex == Index()
+    @test columns(df) == Any[]
+    @test index(df) == Index()
 
     df = DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
                        CategoricalVector{Union{Float64, Missing}}(ones(3))],
@@ -99,13 +99,13 @@ module TestConstructors
     @testset "column types" begin
         df = DataFrame(A = 1:3, B = 2:4, C = 3:5)
         answer = [Array{Int,1}, Array{Int,1}, Array{Int,1}]
-        @test map(typeof, df.columns) == answer
+        @test map(typeof, columns(df)) == answer
         df[:D] = [4, 5, missing]
         push!(answer, Vector{Union{Int, Missing}})
-        @test map(typeof, df.columns) == answer
+        @test map(typeof, columns(df)) == answer
         df[:E] = 'c'
         push!(answer, Vector{Char})
-        @test map(typeof, df.columns) == answer
+        @test map(typeof, columns(df)) == answer
     end
 
     @testset "categorical constructor" begin

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -72,4 +72,16 @@ module TestDataFrameRow
     # grouping single row
     gd = DataFrames.group_rows(df5[1,:])
     @test gd.ngroups == 1
+
+    # getproperty, setproperty! and propertynames
+    if VERSION >= v"0.7.0-DEV.3067"
+        r = DataFrameRow(df, 1)
+        @test Base.propertynames(r) == names(df)
+        @test r.a === 1
+        @test r.b === 2.0
+        r.a = 2
+        @test r.a === 2
+        r.b = 1
+        @test r.b === 1.0
+    end
 end

--- a/test/join.jl
+++ b/test/join.jl
@@ -1,6 +1,6 @@
 module TestJoin
     using Compat, Compat.Test, DataFrames
-    using DataFrames: similar_missing
+    using DataFrames: similar_missing, columns
     const ≅ = isequal
 
     name = DataFrame(ID = Union{Int, Missing}[1, 2, 3],
@@ -167,7 +167,7 @@ module TestJoin
                           repeat([0, 1, 2, 3, 4], outer = 3),
                           repeat([0, 1, 2, 3, 4], outer = 3)],
                       [:id, :fid, :id_1, :fid_1])
-        @test typeof.(join(df1, df2, kind=:cross, makeunique=true).columns) ==
+        @test typeof.(columns(join(df1, df2, kind=:cross, makeunique=true))) ==
             [Vector{Int}, Vector{Float64}, Vector{Int}, Vector{Float64}]
 
         i(on) = join(df1, df2, on = on, kind = :inner, makeunique=true)
@@ -180,63 +180,63 @@ module TestJoin
         @test s(:id) ==
               s(:fid) ==
               s([:id, :fid]) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
-        @test typeof.(s(:id).columns) ==
-              typeof.(s(:fid).columns) ==
-              typeof.(s([:id, :fid]).columns) == [Vector{Int}, Vector{Float64}]
+        @test typeof.(columns(s(:id))) ==
+              typeof.(columns(s(:fid))) ==
+              typeof.(columns(s([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
         @test a(:id) ==
               a(:fid) ==
               a([:id, :fid]) == DataFrame(Any[[5], [5]], [:id, :fid])
-        @test typeof.(a(:id).columns) ==
-              typeof.(a(:fid).columns) ==
-              typeof.(a([:id, :fid]).columns) == [Vector{Int}, Vector{Float64}]
+        @test typeof.(columns(a(:id))) ==
+              typeof.(columns(a(:fid))) ==
+              typeof.(columns(a([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
 
         on = :id
         @test i(on) == DataFrame(Any[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
-        @test typeof.(i(on).columns) == [Vector{Int}, Vector{Float64}, Vector{Float64}]
+        @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Float64}]
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
                                 fid_1 = [1, 3, missing])
-        @test typeof.(l(on).columns) ==
+        @test typeof.(columns(l(on))) ==
             [Vector{Int}, Vector{Float64}, Vector{Union{Float64, Missing}}]
         @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
                                 fid = [1, 3, missing, missing, missing],
                                 fid_1 = [1, 3, 0, 2, 4])
-        @test typeof.(r(on).columns) ==
+        @test typeof.(columns(r(on))) ==
             [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Float64}]
         @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
                                 fid = [1, 3, 5, missing, missing, missing],
                                 fid_1 = [1, 3, missing, 0, 2, 4])
-        @test typeof.(o(on).columns) ==
+        @test typeof.(columns(o(on))) ==
             [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Union{Float64, Missing}}]
 
         on = :fid
         @test i(on) == DataFrame(Any[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
-        @test typeof.(i(on).columns) == [Vector{Int}, Vector{Float64}, Vector{Int}]
+        @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Int}]
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
                                 id_1 = [1, 3, missing])
-        @test typeof.(l(on).columns) == [Vector{Int}, Vector{Float64},
+        @test typeof.(columns(l(on))) == [Vector{Int}, Vector{Float64},
                                          Vector{Union{Int, Missing}}]
         @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
                                 fid = [1, 3, 0, 2, 4],
                                 id_1 = [1, 3, 0, 2, 4])
-        @test typeof.(r(on).columns) == [Vector{Union{Int, Missing}}, Vector{Float64},
+        @test typeof.(columns(r(on))) == [Vector{Union{Int, Missing}}, Vector{Float64},
                                          Vector{Int}]
         @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
                                 fid = [1, 3, 5, 0, 2, 4],
                                 id_1 = [1, 3, missing, 0, 2, 4])
-        @test typeof.(o(on).columns) == [Vector{Union{Int, Missing}}, Vector{Float64},
+        @test typeof.(columns(o(on))) == [Vector{Union{Int, Missing}}, Vector{Float64},
                                          Vector{Union{Int, Missing}}]
 
         on = [:id, :fid]
         @test i(on) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
-        @test typeof.(i(on).columns) == [Vector{Int}, Vector{Float64}]
+        @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}]
         @test l(on) == DataFrame(id = [1, 3, 5], fid = [1, 3, 5])
-        @test typeof.(l(on).columns) == [Vector{Int}, Vector{Float64}]
+        @test typeof.(columns(l(on))) == [Vector{Int}, Vector{Float64}]
         @test r(on) == DataFrame(id = [1, 3, 0, 2, 4], fid = [1, 3, 0, 2, 4])
-        @test typeof.(r(on).columns) == [Vector{Int}, Vector{Float64}]
+        @test typeof.(columns(r(on))) == [Vector{Int}, Vector{Float64}]
         @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4], fid = [1, 3, 5, 0, 2, 4])
-        @test typeof.(o(on).columns) == [Vector{Int}, Vector{Float64}]
+        @test typeof.(columns(o(on))) == [Vector{Int}, Vector{Float64}]
     end
 
     @testset "all joins with CategoricalArrays" begin
@@ -251,7 +251,7 @@ module TestJoin
                           repeat([0, 1, 2, 3, 4], outer = 3),
                           repeat([0, 1, 2, 3, 4], outer = 3)],
                       [:id, :fid, :id_1, :fid_1])
-        @test all(isa.(join(df1, df2, kind=:cross, makeunique=true).columns,
+        @test all(isa.(columns(join(df1, df2, kind=:cross, makeunique=true)),
                        [CategoricalVector{T} for T in (Int, Float64, Int, Float64)]))
 
         i(on) = join(df1, df2, on = on, kind = :inner, makeunique=true)
@@ -264,76 +264,76 @@ module TestJoin
         @test s(:id) ==
               s(:fid) ==
               s([:id, :fid]) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
-        @test typeof.(s(:id).columns) ==
-              typeof.(s(:fid).columns) ==
-              typeof.(s([:id, :fid]).columns)
-        @test all(isa.(s(:id).columns,
+        @test typeof.(columns(s(:id))) ==
+              typeof.(columns(s(:fid))) ==
+              typeof.(columns(s([:id, :fid])))
+        @test all(isa.(columns(s(:id)),
                        [CategoricalVector{T} for T in (Int, Float64)]))
 
         @test a(:id) ==
               a(:fid) ==
               a([:id, :fid]) == DataFrame(Any[[5], [5]], [:id, :fid])
-        @test typeof.(a(:id).columns) ==
-              typeof.(a(:fid).columns) ==
-              typeof.(a([:id, :fid]).columns)
-        @test all(isa.(a(:id).columns,
+        @test typeof.(columns(a(:id))) ==
+              typeof.(columns(a(:fid))) ==
+              typeof.(columns(a([:id, :fid])))
+        @test all(isa.(columns(a(:id)),
                        [CategoricalVector{T} for T in (Int, Float64)]))
 
         on = :id
         @test i(on) == DataFrame(Any[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
-        @test all(isa.(i(on).columns,
+        @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64, Float64)]))
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
                                 fid_1 = [1, 3, missing])
-        @test all(isa.(l(on).columns,
+        @test all(isa.(columns(l(on)),
                        [CategoricalVector{T} for T in (Int,Float64,Union{Float64, Missing})]))
         @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
                                 fid = [1, 3, missing, missing, missing],
                                 fid_1 = [1, 3, 0, 2, 4])
-        @test all(isa.(r(on).columns,
+        @test all(isa.(columns(r(on)),
                        [CategoricalVector{T} for T in (Int,Union{Float64, Missing},Float64)]))
         @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
                                 fid = [1, 3, 5, missing, missing, missing],
                                 fid_1 = [1, 3, missing, 0, 2, 4])
-        @test all(isa.(o(on).columns,
+        @test all(isa.(columns(o(on)),
                        [CategoricalVector{T} for T in (Int,Union{Float64,Missing},Union{Float64, Missing})]))
 
         on = :fid
         @test i(on) == DataFrame(Any[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
-        @test all(isa.(i(on).columns,
+        @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64, Int)]))
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
                                 id_1 = [1, 3, missing])
-        @test all(isa.(l(on).columns,
+        @test all(isa.(columns(l(on)),
                        [CategoricalVector{T} for T in (Int, Float64, Union{Int, Missing})]))
         @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
                                 fid = [1, 3, 0, 2, 4],
                                 id_1 = [1, 3, 0, 2, 4])
-        @test all(isa.(r(on).columns,
+        @test all(isa.(columns(r(on)),
                        [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Int)]))
         @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
                                 fid = [1, 3, 5, 0, 2, 4],
                                 id_1 = [1, 3, missing, 0, 2, 4])
-        @test all(isa.(o(on).columns,
+        @test all(isa.(columns(o(on)),
                        [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Union{Int, Missing})]))
 
         on = [:id, :fid]
         @test i(on) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
-        @test all(isa.(i(on).columns,
+        @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64)]))
         @test l(on) == DataFrame(id = [1, 3, 5],
                                  fid = [1, 3, 5])
-        @test all(isa.(l(on).columns,
+        @test all(isa.(columns(l(on)),
                        [CategoricalVector{T} for T in (Int, Float64)]))
         @test r(on) == DataFrame(id = [1, 3, 0, 2, 4],
                                  fid = [1, 3, 0, 2, 4])
-        @test all(isa.(r(on).columns,
+        @test all(isa.(columns(r(on)),
                        [CategoricalVector{T} for T in (Int, Float64)]))
         @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4],
                                  fid = [1, 3, 5, 0, 2, 4])
-        @test all(isa.(o(on).columns,
+        @test all(isa.(columns(o(on)),
                        [CategoricalVector{T} for T in (Int, Float64)]))
     end
 

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -84,4 +84,27 @@ module TestSubDataFrame
         @test view(df, :, 1) == df[:, [1]]
         @test_throws MissingException view(df, [missing, 1])
     end
+
+    if VERSION >= v"0.7.0-DEV.3067"
+        @testset "getproperty, setproperty! and propertynames" begin
+            x = collect(1:10)
+            y = collect(1.0:10.0)
+            df = view(DataFrame(x = x, y = y), 2:6)
+
+            @test Base.propertynames(df) == names(df)
+
+            @test df.x == 2:6
+            @test df.y == 2:6
+            @test_throws KeyError df.z
+
+            df.x = 1:5
+            @test df.x == 1:5
+            @test x == [1; 1:5; 7:10]
+            df.y = 1
+            @test df.y == [1, 1, 1, 1, 1]
+            @test y == [1; 1; 1; 1; 1; 1; 7:10]
+            @test_throws ErrorException df.z = 1:5
+            @test_throws ErrorException df.z = 1
+        end
+    end
 end


### PR DESCRIPTION
Provides a nice shorthand syntax for simple getindex and setindex! uses, with autocompletion,
and makes `DataFrameRow` more like `NamedTuple`.
This requires replacing all direct field accesses with calls to accessor functions.
Do not mention this feature in the manual yet since it is not available on a released Julia
version. Most uses of `df[:col]` will better be changed to `df.col` when Julia 0.7 is released.

(CI failure on 0.7 is fixed with DataStreams master.)

Fixes #1336.