### PR TITLE
Add DataArrays 0.7.0 to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -9,3 +9,4 @@ DataStreams 0.3.0
 CodecZlib 0.4
 TranscodingStreams
 Compat 0.59.0
+DataArrays 0.7.0


### PR DESCRIPTION
With this I could change the iterable tables implementation for ``DataFrame`` to actually create ``DataArray`` columns when some other table is converted to a ``DataFrame``. That should give much better performance and memory usage on julia 0.6.

I can't solve this in IterableTables.jl itself because there the DataFrames.jl integration is behind a ``@require`` clause, and within that I can only use packages that DataFrames.jl has in its REQUIRE file, and not add any further dependencies.