### PR TITLE
Move Missing to it's own page in the Docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,6 +19,7 @@ makedocs(
             "Reshaping" => "man/reshaping_and_pivoting.md",
             "Sorting" => "man/sorting.md",
             "Categorical Data" => "man/categorical.md",
+            "Missing Data" => "man/missing.md", 
             "Querying frameworks" => "man/querying_frameworks.md"
         ],
         "API" => Any[

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -171,6 +171,33 @@ julia> colwise(sum, df)
 
 ```
 
+### Data frames with Missing values
+If your dataset has missing values, most functions will require you to remove them
+beforehand. Here we will replace all odd-numbered rows in the first column with missing data
+to show how to handle the above example when missing values are present in your dataset.
+For more information see [Missing Data](@ref).
+
+```jldoctest dataframe
+julia> df[:A] = [isodd(i) ? missing : value for (i, value) in enumerate(df[:A])];
+
+julia> df
+8×2 DataFrames.DataFrame
+│ Row │ A       │ B │
+├─────┼─────────┼───┤
+│ 1   │ missing │ M │
+│ 2   │ 2       │ F │
+│ 3   │ missing │ F │
+│ 4   │ 4       │ M │
+│ 5   │ missing │ F │
+│ 6   │ 6       │ M │
+│ 7   │ missing │ M │
+│ 8   │ 8       │ F │
+
+julia> mean(skipmissing(df[:A]))
+5.0
+
+```
+
 ## Importing and Exporting Data (I/O)
 
 For reading and writing tabular data from CSV and other delimited text files, use the [CSV.jl](https://github.com/JuliaData/CSV.jl) package.

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -9,106 +9,7 @@ Pkg.add("DataFrames")
 
 Throughout the rest of this tutorial, we will assume that you have installed the DataFrames package and have already typed `using DataFrames` to bring all of the relevant variables into your current namespace.
 
-## The `Missing` Type
 
-To get started, let's examine the `Missing` type. `Missing` is a type implemented by the [Missings.jl](https://github.com/JuliaData/Missings.jl) package to represent missing data. `missing` is an instance of the type `Missing` used to represent a missing value.
-
-```jldoctest missings
-julia> using DataFrames
-
-julia> missing
-missing
-
-julia> typeof(missing)
-Missings.Missing
-
-```
-
-The `Missing` type lets users create `Vector`s and `DataFrame` columns with missing values. Here we create a vector with a missing value and the element-type of the returned vector is `Union{Missings.Missing, Int64}`.
-
-```jldoctest missings
-julia> x = [1, 2, missing]
-3-element Array{Union{Missings.Missing, Int64},1}:
- 1
- 2
-  missing
-
-julia> eltype(x)
-Union{Missings.Missing, Int64}
-
-julia> Union{Missing, Int}
-Union{Missings.Missing, Int64}
-
-julia> eltype(x) == Union{Missing, Int}
-true
-
-```
-
-`missing` values can be excluded when performing operations by using `skipmissing`, which returns a memory-efficient iterator.
-
-```jldoctest missings
-julia> skipmissing(x)
-Missings.EachSkipMissing{Array{Union{$Int, Missings.Missing},1}}(Union{$Int, Missings.Missing}[1, 2, missing])
-
-```
-
-The output of `skipmissing` can be passed directly into functions as an argument. For example, we can find the `sum` of all non-missing values or `collect` the non-missing values into a new missing-free vector.
-
-```jldoctest missings
-julia> sum(skipmissing(x))
-3
-
-julia> collect(skipmissing(x))
-2-element Array{Int64,1}:
- 1
- 2
-
-```
-
-`missing` elements can be replaced with other values via `Missings.replace`.
-
-```jldoctest missings
-julia> collect(Missings.replace(x, 1))
-3-element Array{Int64,1}:
- 1
- 2
- 1
-
-```
-
-The function `Missings.T` returns the element-type `T` in `Union{T, Missing}`.
-
-```jldoctest missings
-julia> eltype(x)
-Union{Int64, Missings.Missing}
-
-julia> Missings.T(eltype(x))
-Int64
-
-```
-
-Use `missings` to generate `Vector`s and `Array`s supporting missing values, using the optional first argument to specify the element-type.
-
-```jldoctest missings
-julia> missings(1)
-1-element Array{Missings.Missing,1}:
- missing
-
-julia> missings(3)
-3-element Array{Missings.Missing,1}:
- missing
- missing
- missing
-
-julia> missings(1, 3)
-1×3 Array{Missings.Missing,2}:
- missing  missing  missing
-
-julia> missings(Int, 1, 3)
-1×3 Array{Union{Missings.Missing, Int64},2}:
- missing  missing  missing
-
-```
 
 ## The `DataFrame` Type
 
@@ -343,6 +244,9 @@ julia> head(iris)
 │ 6   │ 5.4         │ 3.9        │ 1.7         │ 0.4        │ setosa  │
 
 ```
+
+
+
 
 ## Querying DataFrames
 

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -9,8 +9,6 @@ Pkg.add("DataFrames")
 
 Throughout the rest of this tutorial, we will assume that you have installed the DataFrames package and have already typed `using DataFrames` to bring all of the relevant variables into your current namespace.
 
-
-
 ## The `DataFrame` Type
 
 The `DataFrame` type can be used to represent data tables, each column of which is a vector. You can specify the columns using keyword arguments or pairs:
@@ -246,9 +244,6 @@ julia> head(iris)
 │ 6   │ 5.4         │ 3.9        │ 1.7         │ 0.4        │ setosa  │
 
 ```
-
-
-
 
 ## Querying DataFrames
 

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -166,34 +166,6 @@ julia> colwise(sum, df)
 2-element Array{Real,1}:
  10
  10.0
-
-```
-
-### Data frames with Missing values
-If your dataset has missing values, most functions will require you to remove them
-beforehand. Here we will replace all odd-numbered rows in the first column with missing data
-to show how to handle the above example when missing values are present in your dataset.
-For more information see [Missing Data](@ref).
-
-```jldoctest dataframe
-julia> df[:A] = [isodd(i) ? missing : value for (i, value) in enumerate(df[:A])];
-
-julia> df
-8×2 DataFrames.DataFrame
-│ Row │ A       │ B │
-├─────┼─────────┼───┤
-│ 1   │ missing │ M │
-│ 2   │ 2       │ F │
-│ 3   │ missing │ F │
-│ 4   │ 4       │ M │
-│ 5   │ missing │ F │
-│ 6   │ 6       │ M │
-│ 7   │ missing │ M │
-│ 8   │ 8       │ F │
-
-julia> mean(skipmissing(df[:A]))
-5.0
-
 ```
 
 ## Importing and Exporting Data (I/O)

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -152,31 +152,6 @@ true
 
 ```
 
-If your dataset has missing values, most functions will require you to remove them
-beforehand. Here we will replace all odd-numbered rows in the first column with missing data
-to show how to handle the above example when missing values are present in your dataset.
-
-```jldoctest dataframe
-julia> df[:A] = [isodd(i) ? missing : value for (i, value) in enumerate(df[:A])];
-
-julia> df
-8×2 DataFrames.DataFrame
-│ Row │ A       │ B │
-├─────┼─────────┼───┤
-│ 1   │ missing │ M │
-│ 2   │ 2       │ F │
-│ 3   │ missing │ F │
-│ 4   │ 4       │ M │
-│ 5   │ missing │ F │
-│ 6   │ 6       │ M │
-│ 7   │ missing │ M │
-│ 8   │ 8       │ F │
-
-julia> mean(skipmissing(df[:A]))
-5.0
-
-```
-
 We can also apply a function to each column of a `DataFrame` with the `colwise` function. For example:
 
 ```jldoctest dataframe

--- a/docs/src/man/missing.md
+++ b/docs/src/man/missing.md
@@ -1,0 +1,100 @@
+# The `Missing` Type
+
+`Missing` is a type implemented by the [Missings.jl](https://github.com/JuliaData/Missings.jl) package to represent missing data. `missing` is an instance of the type `Missing` used to represent a missing value.
+
+```jldoctest missings
+julia> using DataFrames
+
+julia> missing
+missing
+
+julia> typeof(missing)
+Missings.Missing
+
+```
+
+The `Missing` type lets users create `Vector`s and `DataFrame` columns with missing values. Here we create a vector with a missing value and the element-type of the returned vector is `Union{Missings.Missing, Int64}`.
+
+```jldoctest missings
+julia> x = [1, 2, missing]
+3-element Array{Union{Missings.Missing, Int64},1}:
+ 1
+ 2
+  missing
+
+julia> eltype(x)
+Union{Missings.Missing, Int64}
+
+julia> Union{Missing, Int}
+Union{Missings.Missing, Int64}
+
+julia> eltype(x) == Union{Missing, Int}
+true
+
+```
+
+`missing` values can be excluded when performing operations by using `skipmissing`, which returns a memory-efficient iterator.
+
+```jldoctest missings
+julia> skipmissing(x)
+Missings.EachSkipMissing{Array{Union{$Int, Missings.Missing},1}}(Union{$Int, Missings.Missing}[1, 2, missing])
+
+```
+
+The output of `skipmissing` can be passed directly into functions as an argument. For example, we can find the `sum` of all non-missing values or `collect` the non-missing values into a new missing-free vector.
+
+```jldoctest missings
+julia> sum(skipmissing(x))
+3
+
+julia> collect(skipmissing(x))
+2-element Array{Int64,1}:
+ 1
+ 2
+
+```
+
+`missing` elements can be replaced with other values via `Missings.replace`.
+
+```jldoctest missings
+julia> collect(Missings.replace(x, 1))
+3-element Array{Int64,1}:
+ 1
+ 2
+ 1
+
+```
+
+The function `Missings.T` returns the element-type `T` in `Union{T, Missing}`.
+
+```jldoctest missings
+julia> eltype(x)
+Union{Int64, Missings.Missing}
+
+julia> Missings.T(eltype(x))
+Int64
+
+```
+
+Use `missings` to generate `Vector`s and `Array`s supporting missing values, using the optional first argument to specify the element-type.
+
+```jldoctest missings
+julia> missings(1)
+1-element Array{Missings.Missing,1}:
+ missing
+
+julia> missings(3)
+3-element Array{Missings.Missing,1}:
+ missing
+ missing
+ missing
+
+julia> missings(1, 3)
+1×3 Array{Missings.Missing,2}:
+ missing  missing  missing
+
+julia> missings(Int, 1, 3)
+1×3 Array{Union{Missings.Missing, Int64},2}:
+ missing  missing  missing
+
+```


### PR DESCRIPTION
It really does not belong right at the top of getting started.
It doesn't belong on that page at all -- everything else is concerned with creating dataframes,
or basic manipulation of them.

The missing section doesn't even mention them.

It is not the *first* thing someone getting started wants to see.