### PR TITLE
Allow aggregate to use column number for aggregation

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -77,8 +77,8 @@ combine(map(d -> mean(skipmissing(d[:c])), gd))
 ```
 
 """
-function groupby(df::AbstractDataFrame, cols::Vector{T};
-                 sort::Bool = false, skipmissing::Bool = false) where T
+function groupby(df::AbstractDataFrame, cols::Vector;
+                 sort::Bool = false, skipmissing::Bool = false)
     sdf = df[cols]
     df_groups = group_rows(sdf, skipmissing)
     # sort the groups
@@ -345,7 +345,7 @@ end
 # Applies aggregate to non-key cols of each SubDataFrame of a GroupedDataFrame
 aggregate(gd::GroupedDataFrame, f::Function; sort::Bool=false) = aggregate(gd, [f], sort=sort)
 function aggregate(gd::GroupedDataFrame, fs::Vector{T}; sort::Bool=false) where T<:Function
-    headers = _makeheaders(fs, setdiff(_names(gd), gd.cols))
+    headers = _makeheaders(fs, setdiff(_names(gd), _names(gd.parent[gd.cols])))
     res = combine(map(x -> _aggregate(without(x, gd.cols), fs, headers), gd))
     sort && sort!(res, headers)
     res

--- a/test/data.jl
+++ b/test/data.jl
@@ -113,13 +113,21 @@ module TestData
     @test sum(df8[:d1_length]) == N
     @test all(df8[:d1_length] .> 0)
     @test df8[:d1_length] == [sum(isequal.(d2, "A")), sum(isequal.(d2, "B")), sum(ismissing.(d2))]
+    df8′ = aggregate(df7, 2, [sum, length], sort=true)
+    @test df8 ≅ df8′
     adf = aggregate(groupby(df7, :d2, sort=true), [sum, length])
     @test df8 ≅ adf
+    adf′ = aggregate(groupby(df7, 2, sort=true), [sum, length])
+    @test df8 ≅ adf′
     adf = aggregate(groupby(df7, :d2), [sum, length], sort=true)
     @test sort(df8, [:d1_sum, :d3_sum, :d1_length, :d3_length]) ≅ adf
+    adf′ = aggregate(groupby(df7, 2), [sum, length], sort=true)
+    @test adf ≅ adf′
 
     df9 = aggregate(df7, :d2, [sum, length], sort=true)
     @test df9 ≅ df8
+    df9′ = aggregate(df7, 2, [sum, length], sort=true)
+    @test df9′ ≅ df8
 
     df10 = DataFrame(
         Any[[1:4;], [2:5;], ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],


### PR DESCRIPTION
Implementation of `aggregate` had a bug that threw error when one used column number for indexing as later the implementation assumes that column name as a `Symbol` is passed.

Example problem that is fixed:
```
julia> using DataFrames

julia> x = DataFrame(rand(3,4))
3×4 DataFrames.DataFrame
│ Row │ x1       │ x2        │ x3        │ x4       │
├─────┼──────────┼───────────┼───────────┼──────────┤
│ 1   │ 0.748279 │ 0.0678513 │ 0.260604  │ 0.390001 │
│ 2   │ 0.446409 │ 0.401046  │ 0.0651925 │ 0.649831 │
│ 3   │ 0.40989  │ 0.0341148 │ 0.197234  │ 0.184495 │

julia> aggregate(x, 1, sum)
ERROR: MethodError: no method matching _makeheaders(::Array{Base.#sum,1}, ::Array{Any,1})
Closest candidates are:
  _makeheaders(::Array{T<:Function,1}, ::Array{Symbol,1}) where T<:Function at D:\Software\JULIA_PKG\v0.6\DataFrames\src\groupeddataframe/grouping.jl:363
Stacktrace:
 [1] #aggregate#107(::Bool, ::Function, ::DataFrames.GroupedDataFrame, ::Array{Base.#sum,1}) at D:\Software\JULIA_PKG\v0.6\DataFrames\src\groupeddataframe\grouping.jl:348
 [2] (::DataFrames.#kw##aggregate)(::Array{Any,1}, ::DataFrames.#aggregate, ::DataFrames.GroupedDataFrame, ::Array{Base.#sum,1}) at .\<missing>:0
 [3] aggregate(::DataFrames.DataFrame, ::Int64, ::Base.#sum) at D:\Software\JULIA_PKG\v0.6\DataFrames\src\groupeddataframe\grouping.jl:359
```