### PR TITLE
make nunique option in describe work for integers

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -471,7 +471,7 @@ function get_stats(col::AbstractArray{>:Missing})
     q = try quantile(nomissing, [.25, .5, .75]) catch [nothing, nothing, nothing] end
     ex = try extrema(nomissing) catch (nothing, nothing) end
     m = try mean(nomissing) catch end
-    if eltype(nomissing) <: Real
+    if (eltype(nomissing) <: Real) && !(eltype(nomissing) <: Integer)
         u = nothing
     else 
         u = try length(unique(nomissing)) catch end 


### PR DESCRIPTION
I'm absolutely loving the new `describe` function, thanks to all those who worked on this!

Anyway, it was really bothering me that the `nunique` option was not working on integers, this makes it so that this option works on `Integer` types, but no other `Real` types.  

I had considered making it work for everything except `AbstractFloat`, but there are also `Rational` and `Irrational`, so I thought making this work only on integers seemed sensible.  Any thoughts on this?  Should we extend it to `Rational`?  (In practice even `Irrational` would probably be fine.)