### PR TITLE
improve iteration protocol and fix assignment in combine

### DIFF
--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -233,4 +233,11 @@ module TestGrouping
             @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
         end
     end
+
+    @testset "iteration protocol" begin
+        gd = groupby(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+        for v in gd
+            @test size(v) == (2,2)
+        end
+    end
 end


### PR DESCRIPTION
This resolves #1431.

@nalimilan I was not sure which version of Julia should be a cutoff (or is there some other canonical way of supporting old and new iteration protocol).