### PR TITLE
Added Pkg3 toml files

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,160 @@
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinaryProvider]]
+deps = ["Compat", "Pkg", "SHA"]
+git-tree-sha1 = "94dac52c662ca793008fb689e3daf626b6139943"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.3.3"
+
+[[CategoricalArrays]]
+deps = ["Compat", "Future", "JSON", "Missings", "Printf", "Reexport"]
+git-tree-sha1 = "6a78981b00a954d850d923cae8500801647d843e"
+uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+version = "0.3.10"
+
+[[CodecZlib]]
+deps = ["BinaryProvider", "Compat", "Test", "TranscodingStreams"]
+git-tree-sha1 = "82742ef572290f566c6fc6d977d87586a0d3d5f1"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.4.3"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "f3e87ca1e2df8e1e4f82ea504fddf0b9b0894f61"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "0.69.0"
+
+[[DataStreams]]
+deps = ["Compat", "Missings", "NamedTuples", "WeakRefStrings"]
+git-tree-sha1 = "62d1a39a3e9634eceb7413151b48cbc95521a059"
+uuid = "9a8bc11e-79be-5b39-94d7-1ccc349a1a85"
+version = "0.3.6"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "REPL", "Random", "Serialization", "Test"]
+git-tree-sha1 = "ef6f313c82fd80ab75ab3f784353b6c65ebcaacf"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.9.0"
+
+[[Dates]]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[Future]]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[InteractiveUtils]]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "723a515212612b2175095fa5fa55da0bb4c377e5"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.18.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Markdown]]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Missings]]
+deps = ["Compat"]
+git-tree-sha1 = "866fb034899be6055dcb6cb1a70fbda379bb0b55"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "0.2.10"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[NamedTuples]]
+git-tree-sha1 = "6374851ad4b15f2a20ac20637d38c550531fa684"
+uuid = "73a701b4-84e1-5df0-88ff-1968ee2ee8dc"
+version = "4.0.2"
+
+[[Pkg]]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[Printf]]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Reexport]]
+git-tree-sha1 = "caba582b2e9ef39b9cfff911aa13c5ca1b9a9896"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "0.1.0"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SortingAlgorithms]]
+deps = ["DataStructures", "Random", "Test"]
+git-tree-sha1 = "70840f1a93da48bcc952e71b600f598532372eb0"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "0.3.0"
+
+[[SparseArrays]]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[StatsBase]]
+git-tree-sha1 = "515d9c751bc96f9680a2a19f76395ae8ac06a8f5"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.24.0"
+
+    [StatsBase.deps]
+    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+    Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+    Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+    SortingAlgorithms = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Test]]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TranscodingStreams]]
+deps = ["Compat", "Random", "Test"]
+git-tree-sha1 = "497524e8b703e67caf20cc086d20235852041fe4"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.5.2"
+
+[[UUIDs]]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[WeakRefStrings]]
+deps = ["Compat", "Missings"]
+git-tree-sha1 = "bb0464e62baf3a0767340fbb51fed584159ad9b7"
+uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+version = "0.4.7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+DataStreams = "9a8bc11e-79be-5b39-94d7-1ccc349a1a85"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SortingAlgorithms = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"


### PR DESCRIPTION
This should make it significantly easier to work on in 0.7 as it will allow you to use updated packages, and update them further using Pkg3.

Note that here I used the latest tagged versions of all packages, I figure that due to the upgrading frenzy we need *at least* that.