### PR TITLE
Deprecate iterating over DataFrameRow in favor of pairs()

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -41,14 +41,22 @@ Base.length(r::DataFrameRow) = size(parent(r), 2)
 
 Compat.lastindex(r::DataFrameRow) = size(parent(r), 2)
 
-Base.collect(r::DataFrameRow) = Tuple{Symbol, Any}[x for x in r]
+function Base.iterate(r::DataFrameRow)
+    Base.depwarn("iteration over DataFrameRow will return values in the future:" *
+                 "use pairs(r::DataFrameRow) to get the current behavior",
+                 :start)
+    iterate(r, 1)
+end
 
-function Base.iterate(r::DataFrameRow, st=1)
+function Base.iterate(r::DataFrameRow, st)
     st > length(r) && return nothing
     return ((_names(r)[st], r[st]), st + 1)
 end
 
 Base.convert(::Type{Array}, r::DataFrameRow) = convert(Array, parent(r)[row(r),:])
+
+Base.keys(r::DataFrameRow) = names(parent(r))
+Base.values(r::DataFrameRow) = ntuple(col -> parent(r)[col][row(r)], length(r))
 
 # hash column element
 Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) = hash(v[i], h)

--- a/src/dataframerow/show.jl
+++ b/src/dataframerow/show.jl
@@ -18,7 +18,7 @@
 function Base.show(io::IO, r::DataFrameRow)
     labelwidth = mapreduce(n -> length(string(n)), max, _names(r)) + 2
     @printf(io, "DataFrameRow (row %d)\n", row(r))
-    for (label, value) in r
+    for (label, value) in pairs(r)
         println(io, rpad(label, labelwidth, ' '), something(value, ""))
     end
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1300,3 +1300,6 @@ import Base: vcat
 
 @deprecate showcols(df::AbstractDataFrame, all::Bool=false, values::Bool=true) describe(df, stats = [:eltype, :nmissing, :first, :last])
 @deprecate showcols(io::IO, df::AbstractDataFrame, all::Bool=false, values::Bool=true) show(io, describe(df, stats = [:eltype, :nmissing, :first, :last]), all)
+
+import Base: collect
+@deprecate collect(r::DataFrameRow) collect(pairs(r))

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -84,6 +84,12 @@ module TestDataFrameRow
     r.b = 1
     @test r.b === 1.0
 
+    # keys, values and iteration
+    r = DataFrameRow(df, 1)
+    @test keys(r) == names(df)
+    @test values(r) == (df[1, 1], df[1, 2], df[1, 3], df[1, 4])
+    @test collect(pairs(r)) == [:a=>df[1, 1], :b=>df[1, 2], :c=>df[1, 3], :d=>df[1, 4]]
+
     df = DataFrame(a=nothing, b=1)
     io = IOBuffer()
     show(io, DataFrameRow(df, 1))

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -40,4 +40,7 @@ module TestDeprecated
     @test sort(df; cols=[:b, :a]) == DataFrame(a=[2, 3, 1], b=[4, 5, 6])
     sort!(df; cols=[:b, :a])
     @test df == DataFrame(a=[2, 3, 1], b=[4, 5, 6])
+
+    @test first.(collect(DataFrameRow(df, 1))) == [:a, :b]
+    @test last.(collect(DataFrameRow(df, 1))) == [df[1, 1], df[1, 2]]
 end

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -13,7 +13,7 @@ module TestIteration
         @test isa(row, DataFrameRow)
         @test (row[:B] - row[:A]) == 1
         # issue #683 (https://github.com/JuliaData/DataFrames.jl/pull/683)
-        @test typeof(collect(row)) == Array{Tuple{Symbol, Any}, 1}
+        @test typeof(collect(row)) == Array{Pair{Symbol, Int}, 1}
     end
 
     @test size(eachcol(df)) == (size(df, 2),)


### PR DESCRIPTION
This will allow changing iteration to return values instead of pairs, which is consistent with `NamedTuple` and `Vector`.

First step to fix https://github.com/JuliaData/DataFrames.jl/issues/1400. See also https://github.com/JuliaData/DataFrames.jl/pull/1439.