### PR TITLE
make permutecols! return modified DataFrame

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1101,6 +1101,7 @@ function permutecols!(df::DataFrame, p::AbstractVector)
     end
     permute!(columns(df), p)
     setfield!(df, :colindex, Index(names(df)[p]))
+    df
 end
 
 function permutecols!(df::DataFrame, p::AbstractVector{Symbol})

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -720,9 +720,9 @@ module TestDataFrame
 
         df = deepcopy(original)
         expected = deepcopy(original)
-        permutecols!(df, [:a, :b, :c])
+        @test permutecols!(df, [:a, :b, :c]) == expected
         @test df == expected
-        permutecols!(df, 1:3)
+        @test permutecols!(df, 1:3) == expected
         @test df == expected
 
         df = deepcopy(original)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -720,49 +720,49 @@ module TestDataFrame
 
         df = deepcopy(original)
         expected = deepcopy(original)
-        @test permutecols!(df, [:a, :b, :c]) == expected
+        @test permutecols!(df, [:a, :b, :c]) === df
         @test df == expected
-        @test permutecols!(df, 1:3) == expected
+        @test permutecols!(df, 1:3) === df
         @test df == expected
 
         df = deepcopy(original)
         expected = DataFrame(b=b, c=c, a=a)
-        permutecols!(df, [:b, :c, :a])
+        permutecols!(df, [:b, :c, :a]) === df
         @test df == expected
         df = deepcopy(original)
-        permutecols!(df, [2, 3, 1])
+        permutecols!(df, [2, 3, 1]) === df
         @test df == expected
 
         df = deepcopy(original)
         expected = DataFrame(c=c, a=a, b=b)
-        permutecols!(df, [:c, :a, :b])
+        permutecols!(df, [:c, :a, :b]) === df
         @test df == expected
         df = deepcopy(original)
-        permutecols!(df, [3, 1, 2])
+        permutecols!(df, [3, 1, 2]) === df
         @test df == expected
 
         df = deepcopy(original)
         expected = DataFrame(a=a, c=c, b=b)
-        permutecols!(df, [:a, :c, :b])
+        permutecols!(df, [:a, :c, :b]) === df
         @test df == expected
         df = deepcopy(original)
-        permutecols!(df, [1, 3, 2])
+        permutecols!(df, [1, 3, 2]) === df
         @test df == expected
 
         df = deepcopy(original)
         expected = DataFrame(b=b, a=a, c=c)
-        permutecols!(df, [:b, :a, :c])
+        permutecols!(df, [:b, :a, :c]) === df
         @test df == expected
         df = deepcopy(original)
-        permutecols!(df, [2, 1, 3])
+        permutecols!(df, [2, 1, 3]) === df
         @test df == expected
 
         df = deepcopy(original)
         expected = DataFrame(c=c, b=b, a=a)
-        permutecols!(df, [:c, :b, :a])
+        permutecols!(df, [:c, :b, :a]) === df
         @test df == expected
         df = deepcopy(original)
-        permutecols!(df, [3, 2, 1])
+        permutecols!(df, [3, 2, 1]) === df
         @test df == expected
 
         # Invalid


### PR DESCRIPTION
`permutecols!` exposes internal `DataFrame` structure in its return value. This PR makes it return the modified `DataFrame`.