### PR TITLE
Fix a deprecation warning

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -529,7 +529,7 @@ function bytestotype(::Type{N},
     end
 end
 
-let out = Vector{Float64}(1)
+let out = Vector{Float64}(undef, 1)
     global bytestotype
     function bytestotype(::Type{N},
                          bytes::Vector{UInt8},


### PR DESCRIPTION
With that I don't get any deprecation warnings anymore when loading the package on 0.7. Could we merge this and then tag a release? That would make life easier for downstream packages that are updating things to 0.7.