### PR TITLE
Define getproperty for DataFrame only, not AbstractDataFrame

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -236,11 +236,6 @@ Compat.axes(df, i) = axes(df)[i]
 
 Base.ndims(::AbstractDataFrame) = 2
 
-Base.getproperty(df::AbstractDataFrame, col_ind::Symbol) = getindex(df, col_ind)
-Base.setproperty!(df::AbstractDataFrame, col_ind::Symbol, x) = setindex!(df, x, col_ind)
-# Private fields are never exposed since they can conflict with column names
-Base.propertynames(df::AbstractDataFrame, private::Bool=false) = names(df)
-
 ##############################################################################
 ##
 ## Similar

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -626,6 +626,17 @@ Base.setindex!(df::DataFrame, x::Nothing, col_ind::Int) = delete!(df, col_ind)
 
 ##############################################################################
 ##
+## getproperty/setproperty!
+##
+##############################################################################
+
+Base.getproperty(df::DataFrame, col_ind::Symbol) = getindex(df, col_ind)
+Base.setproperty!(df::DataFrame, col_ind::Symbol, x) = setindex!(df, x, col_ind)
+# Private fields are never exposed since they can conflict with column names
+Base.propertynames(df::DataFrame, private::Bool=false) = names(df)
+
+##############################################################################
+##
 ## Mutating AbstractDict methods
 ##
 ##############################################################################

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -160,3 +160,8 @@ Base.map(f::Function, sdf::SubDataFrame) = f(sdf) # TODO: deprecate
 without(sdf::SubDataFrame, c) = view(without(parent(sdf), c), rows(sdf))
 # Resolve a method ambiguity
 without(sdf::SubDataFrame, c::Vector{<:Integer}) = view(without(parent(sdf), c), rows(sdf))
+
+Base.getproperty(df::SubDataFrame, col_ind::Symbol) = getindex(df, col_ind)
+Base.setproperty!(df::SubDataFrame, col_ind::Symbol, x) = setindex!(df, x, col_ind)
+# Private fields are never exposed since they can conflict with column names
+Base.propertynames(df::SubDataFrame, private::Bool=false) = names(df)


### PR DESCRIPTION
Fixes #1465.

This is incredibly annoying and difficult to debug for `AbstractDataFrame` subtypes that contain a `DataFrame` as a field, as in the linked issue. Rather than forcing everyone to embrace this `.column` access, we should limit it to `DataFrame` (edit: and `SubDataFrame`) only and let other `AbstractDataFrame`s decide whether they want to do it.