### PR TITLE
Make describe work for a zero-row DataFrame

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -430,6 +430,11 @@ function StatsBase.describe(df::AbstractDataFrame; stats::Union{Symbol,AbstractV
         stats = allowed_fields 
     end
 
+    if size(df, 1) == 0
+        stats = [:nmissing, :eltype]
+        warn("This DataFrame has 0 rows, so describe output has been truncated")
+    end
+
     if stats isa Symbol
         if !(stats in allowed_fields)
             allowed_msg = "\nAllowed fields are: :" * join(allowed_fields, ", :")
@@ -487,8 +492,8 @@ function get_stats(col::AbstractArray{>:Missing})
         :max => ex[2],
         :nmissing => count(ismissing, col),
         :nunique => u,
-        :first => first(col),
-        :last => last(col),        
+        :first => try first(col) catch end,
+        :last => try last(col) catch end,        
         :eltype => Missings.T(eltype(col))
     )    
 end 
@@ -513,8 +518,8 @@ function get_stats(col)
         :max => ex[2],
         :nmissing => nothing,
         :nunique => u,
-        :first => first(col),
-        :last => last(col),        
+        :first => try first(col) catch end,
+        :last => try last(col) catch end,        
         :eltype => eltype(col)
     )   
 end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -430,11 +430,6 @@ function StatsBase.describe(df::AbstractDataFrame; stats::Union{Symbol,AbstractV
         stats = allowed_fields 
     end
 
-    if size(df, 1) == 0
-        stats = [:nmissing, :eltype]
-        warn("This DataFrame has 0 rows, so describe output has been truncated")
-    end
-
     if stats isa Symbol
         if !(stats in allowed_fields)
             allowed_msg = "\nAllowed fields are: :" * join(allowed_fields, ", :")
@@ -448,7 +443,7 @@ function StatsBase.describe(df::AbstractDataFrame; stats::Union{Symbol,AbstractV
         disallowed_fields = setdiff(stats, allowed_fields)
         allowed_msg = "\nAllowed fields are: :" * join(allowed_fields, ", :")
         not_allowed = "Field(s) not allowed: :" * join(disallowed_fields, ", :") * "."
-        throw(ArgumentError(not_allowed * allowed_msg)) 
+        throw(ArgumentError(not_allowed * allowed_msg))
     end
 
     
@@ -492,8 +487,8 @@ function get_stats(col::AbstractArray{>:Missing})
         :max => ex[2],
         :nmissing => count(ismissing, col),
         :nunique => u,
-        :first => try first(col) catch end,
-        :last => try last(col) catch end,        
+        :first => isempty(col) ? nothing : first(col),
+        :last => isempty(col) ? nothing : last(col),
         :eltype => Missings.T(eltype(col))
     )    
 end 
@@ -518,8 +513,8 @@ function get_stats(col)
         :max => ex[2],
         :nmissing => nothing,
         :nunique => u,
-        :first => try first(col) catch end,
-        :last => try last(col) catch end,        
+        :first => isempty(col) ? nothing : first(col),
+        :last => isempty(col) ? nothing : last(col),
         :eltype => eltype(col)
     )   
 end


### PR DESCRIPTION
Fixes issue #1467 

The issue was that we didn't wrap `first(col)` and `last(col)` in `try.. catch` blocks. 

I saw two ways to fix the issue: 

1) Be lazy and wrap `first` and `last` in `try... catch` blocks, and changing the `stats` keyword agument so that we only return whether a column contains missing and the `eltype`
2) Be more robust and change the `stats` vector at the top *and* only calculate the statistics we need to calculate, resulting in this beautiful piece of code:

```
function get_stats(col::AbstractArray{>:Missing}) # there is another one for the non-missing case
    nomissing = collect(skipmissing(col))
    data_dict = Dict{Sumbol, Any}()
    
    if :q25 in stats | :median in stats | :q75 in stats 
        q = try quantile(nomissing, [.25, .5, .75]) catch [nothing, nothing, nothing] end
        data_dict[:q25] = q[1]
        data_dict[:median] = q[2]
        data_dict[:q75] = q[3]
    end 

    if :min in stats | :max in stats 
        ex = try extrema(nomissing) catch (nothing, nothing) end
        data_dict[:min] = ex[1]
        data_dic[:max] = ex[2]
    end

    if :mean in stats | :std in stats 
        m = try mean(nomissing) catch end
    end 

    if :std in stats 
        data_dict[:std] = try Compat.std(nomissing, mean = m) catch end
    end
    
    if :nunique in stats 
        if eltype(nomissing) <: Real
            u = nothing
        else 
            u = try length(unique(nomissing)) catch end 
        end
    end 

    if :nmissing in stats 
        data_dict[:nmissing] = count(ismissing, col)
    end

    if :first in stats
        data_dict[:first] = first(col)
    end
    
    if :last in stats 
        data_dict[:last] = last(col)
    end

    if :eltype in stats 
        data_dict[:eltype] = Missings.T(eltype(col))
    end

    return data_dict 
end 
```

My proposal is actually gonna be to get rid of the multiple dispatch and use plain-old `if` statements to deal with the missing case. Then have all these other `if` statements to make sure we aren't doing unnecessary computations. 