### PR TITLE
fix show for DataFrameRow

### DIFF
--- a/src/dataframerow/show.jl
+++ b/src/dataframerow/show.jl
@@ -19,8 +19,7 @@ function Base.show(io::IO, r::DataFrameRow)
     labelwidth = mapreduce(n -> length(string(n)), max, _names(r)) + 2
     @printf(io, "DataFrameRow (row %d)\n", row(r))
     for (label, value) in r
-        println(io, rpad(label, labelwidth, ' '),
-                value === nothing ? "" : value)
+        println(io, rpad(label, labelwidth, ' '), something(value, ""))
     end
 end
 

--- a/src/dataframerow/show.jl
+++ b/src/dataframerow/show.jl
@@ -19,6 +19,8 @@ function Base.show(io::IO, r::DataFrameRow)
     labelwidth = mapreduce(n -> length(string(n)), max, _names(r)) + 2
     @printf(io, "DataFrameRow (row %d)\n", row(r))
     for (label, value) in r
-        println(io, rpad(label, labelwidth, ' '), value)
+        println(io, rpad(label, labelwidth, ' '),
+                value === nothing ? "" : value)
     end
 end
+

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -83,4 +83,10 @@ module TestDataFrameRow
     @test r.a === 2
     r.b = 1
     @test r.b === 1.0
+
+    df = DataFrame(a=nothing, b=1)
+    io = IOBuffer()
+    show(io, DataFrameRow(df, 1))
+    @test String(take!(io)) == "DataFrameRow (row 1)\na  \nb  1\n"
 end
+


### PR DESCRIPTION
Fix implementation of `show` for `DataFrameRow` which threw an error when `nothing` was passed. Now nothing (empty string) is printed - the same as when displaying `DataFrame`.