### PR TITLE
Fix a bug in unstack(df)

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -323,7 +323,7 @@ function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Symbol},
     hcat(df1, df2)
 end
 
-unstack(df::AbstractDataFrame) = unstack(df, :id, :variable, :value)
+unstack(df::AbstractDataFrame) = unstack(df, :variable, :value)
 
 
 ##############################################################################

--- a/test/data.jl
+++ b/test/data.jl
@@ -209,7 +209,8 @@ module TestData
         d1us3 = unstack(d1s2, :variable, :value)
         @test d1us[:a] == d1[:a]
         @test d1us2[:d] == d1[:d]
-        @test d1us2[:3] == d1[:d]
+        @test d1us2[6] == d1[:d]
+        @test d1us2 == d1us3
 
         # test unstack with exactly one key column that is not passed
         df1 = melt(DataFrame(rand(10,10)))

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -426,7 +426,7 @@ module TestDataFrame
     # test empty set of grouping variables
     @test_throws ArgumentError unstack(df, Int[], :Key, :Value)
     @test_throws ArgumentError unstack(df, Symbol[], :Key, :Value)
-    @test_throws KeyError unstack(stack(DataFrame(rand(10, 10))))
+    @test_throws ArgumentError unstack(stack(DataFrame(rand(10, 10))))
 
     # test missing value in grouping variable
     mdf = DataFrame(id=[missing,1,2,3], a=1:4, b=1:4)


### PR DESCRIPTION
Currently `unstack(df)` defaults to `:id` being a rowkey. This is not documented, and actually against documentation (which says that we take all columns except `colkey` and `value` as `rowkeys`) and not intuitive (why `:id` should be special?). Therefore I fix it as a bug.

However, this is breaking as in some cases a resulting data frame will contain more columns than before (it is not very painful I guess because we produce more not less but still breaking).

Therefore we might also go through deprecation period (or change the behavior but print a warning if we produce more than `:id` column in this case). Not sure what to do