### PR TITLE
fixed overzealous type assertion

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -225,7 +225,7 @@ index(df::DataFrame) = getfield(df, :colindex)
 columns(df::DataFrame) = getfield(df, :columns)
 
 # TODO: Remove these
-nrow(df::DataFrame) = ncol(df) > 0 ? length(columns(df)[1])::Int : 0
+nrow(df::DataFrame) = ncol(df) > 0 ? length(columns(df)[1])::Integer : 0
 ncol(df::DataFrame) = length(index(df))
 
 ##############################################################################

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -225,7 +225,7 @@ index(df::DataFrame) = getfield(df, :colindex)
 columns(df::DataFrame) = getfield(df, :columns)
 
 # TODO: Remove these
-nrow(df::DataFrame) = ncol(df) > 0 ? length(columns(df)[1])::Integer : 0
+nrow(df::DataFrame) = ncol(df) > 0 ? length(columns(df)[1]) : 0
 ncol(df::DataFrame) = length(index(df))
 
 ##############################################################################


### PR DESCRIPTION
... that was causing failures on 32-bit machines.  See discussion and appveyor link [here](https://github.com/JuliaLang/METADATA.jl/pull/17015).

This problem seems a little silly at first glance, so I fear I may be missing some part of what's going on here.

If this is indeed a proper fix, ideally it should be applied all the way back to 0.11, though to be honest I'm not sure what the easiest way of doing that would be (we could tag off new branches, but that seems somehow excessive).