### PR TITLE
add DataFrame constructor accepting a DataFrame

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -122,7 +122,7 @@ end
 
 function DataFrame(df::DataFrame)
     Base.depwarn("In the future DataFrame constructor called with a `DataFrame` argument will return a copy. " *
-                 "Use `convert(DataFrame, df) to avoid copying if `df` is a `DataFrame`.", :DataFrame)
+                 "Use `convert(DataFrame, df)` to avoid copying if `df` is a `DataFrame`.", :DataFrame)
     return df
 end
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -120,6 +120,12 @@ mutable struct DataFrame <: AbstractDataFrame
     end
 end
 
+function DataFrame(df::DataFrame)
+    Base.depwarn("In the future DataFrame constructor called with a `DataFrame` argument will return a copy. " *
+                 "Use `convert(DataFrame, df) to avoid copying if `df` is a `DataFrame`.", :DataFrame)
+    return df
+end
+
 function DataFrame(pairs::Pair{Symbol,<:Any}...; makeunique::Bool=false)::DataFrame
     colnames = [Symbol(k) for (k,v) in pairs]
     columns = Any[v for (k,v) in pairs]

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -22,6 +22,8 @@ module TestConstructors
         @test df == DataFrame(x1 = Union{Int, Missing}[0.0, 0.0, 0.0],
                               x2 = Union{Int, Missing}[1.0, 1.0, 1.0])
 
+        @test df === DataFrame(df) # in the future this will fail as constructor will return a copy
+
         df2 = convert(DataFrame, Union{Float64, Missing}[0.0 1.0;
                                                          0.0 1.0;
                                                          0.0 1.0])


### PR DESCRIPTION
Now when constructors do not fall back to conversion we need to define `DataFrame(df::DataFrame)` constructor.

In general it should return a copy of a `DataFrame` but it is a breaking change, so I guess we should first keep the old behavior and return the same object and throw a deprecation - right?