### PR TITLE
Bump julia version in docs/make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -36,7 +36,7 @@ deploydocs(
     # options
     repo = "github.com/JuliaData/DataFrames.jl.git",
     target = "build",
-    julia = "0.6",
+    julia = "1.0",
     deps = nothing,
     make = nothing,
 )


### PR DESCRIPTION
The documentation hasn't actually deployed to gh-pages since 0.6 was dropped on Travis.