### PR TITLE
Add showing element types for DataFrames

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -83,7 +83,7 @@ function compacttype(T::Type, maxwidth::Int=8)
     else
         suffix = ""
     end
-    T <: Union{CategoricalString, CategoricalValue} && return "Cat…"*suffix
+    T <: Union{CategoricalString, CategoricalValue} && return "Categorical…"*suffix
     # we abbreviate consistently to total of 8 characters
     match(Regex("^.\\w{0,$(7-length(suffix))}"), sT).match * "…"*suffix
 end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -402,7 +402,7 @@ function showrows(io::IO,
         for j in leftcol:rightcol
             s = compacttype(eltype(df[j]), maxwidths[j])
             printstyled(io, s, color=:light_black)
-            padding = maxwidths[j] - textwidth(s)
+            padding = maxwidths[j] - ourstrwidth(s)
             for itr in 1:padding
                 write(io, ' ')
             end


### PR DESCRIPTION
This PR follows #1496 and adds showing of column types for `DataFrame` and avoids printing element types along their values.

The rules for abbreviating type names are the following:
1. print at least 8 characters unless type name is shorter;
2. if abbreviating print `…` at the end; when abbreviating terminate at first non-word (not `[a-zA-z_]`) character (and leave at least one character - this is a corner case if someone uses Greek etc.)
3. if type allows missing but is not `Any` print `⍰` and avoid printing `Missing` and also `Union` (if possible)
4. If column contents is wider than 8 characters and type name is wider then print as much characters as possible without widening of the column

This PR now will fail, because I have not updated tests as this is a bit cumbersome. I will prepare them when we agree that the functionality is OK.

Here is an example output:
```
julia> df = DataFrame(A = categorical(["some long name",2]), B=categorical(1.0:2.0), C=categorical(["a",missing]), D=1:2, E=Union{Float64,Int}[1,1.0], F=[[1,2], missing])
2×6 DataFrame
│ Row │ A                │ B        │ C        │ D     │ E      │ F       │
│     │ CategoricalVal…⍰ │ Categor… │ Catego…⍰ │ Int64 │ Union… │ Array…⍰ │
├─────┼──────────────────┼──────────┼──────────┼───────┼────────┼─────────┤
│ 1   │ "some long name" │ 1.0      │ a        │ 1     │ 1      │ [1, 2]  │
│ 2   │ 2                │ 2.0      │ missing  │ 2     │ 1.0    │ missing │

julia> describe(df)
6×8 DataFrame
│ Row │ variable │ mean       │ min              │ median │ max    │ nunique │ nmissing │ eltype                           │
│     │ Symbol   │ Any        │ Any              │ Union… │ Any    │ Union…  │ Union…   │ Type                             │
├─────┼──────────┼────────────┼──────────────────┼────────┼────────┼─────────┼──────────┼──────────────────────────────────┤
│ 1   │ A        │            │ "some long name" │        │ 2      │ 2       │ 0        │ CategoricalValue{Any,UInt32}     │
│ 2   │ B        │            │ 1.0              │        │ 2.0    │ 2       │          │ CategoricalValue{Float64,UInt32} │
│ 3   │ C        │            │ a                │        │ a      │ 1       │ 1        │ CategoricalString{UInt32}        │
│ 4   │ D        │ 1.5        │ 1                │ 1.5    │ 2      │         │          │ Int64                            │
│ 5   │ E        │ 1.0        │ 1.0              │ 1.0    │ 1.0    │         │          │ Union{Float64, Int64}            │
│ 6   │ F        │ [1.0, 2.0] │ [1, 2]           │        │ [1, 2] │ 1       │ 1        │ Array{Int64,1}                   │
```