### PR TITLE
Add eltype to eachrow and eachcol

### DIFF
--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -22,6 +22,7 @@ function Base.iterate(itr::DFRowIterator, i=1)
     i > size(itr.df, 1) && return nothing
     return (DataFrameRow(itr.df, i), i + 1)
 end
+Base.eltype(::DFRowIterator{T}) where {T} = DataFrameRow{T}
 Base.size(itr::DFRowIterator) = (size(itr.df, 1), )
 Base.length(itr::DFRowIterator) = size(itr.df, 1)
 Base.getindex(itr::DFRowIterator, i::Any) = DataFrameRow(itr.df, i)
@@ -37,6 +38,7 @@ function Base.iterate(itr::DFColumnIterator, j=1)
     j > size(itr.df, 2) && return nothing
     return ((_names(itr.df)[j], itr.df[j]), j + 1)
 end
+Base.eltype(::DFColumnIterator) = Tuple{Symbol, Any}
 Base.size(itr::DFColumnIterator) = (size(itr.df, 2), )
 Base.length(itr::DFColumnIterator) = size(itr.df, 2)
 Base.getindex(itr::DFColumnIterator, j::Any) = itr.df[:, j]

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -9,6 +9,7 @@ module TestIteration
 
     @test size(eachrow(df)) == (size(df, 1),)
     @test eachrow(df)[1] == DataFrameRow(df, 1)
+    @test typeof(collect(eachrow(df))) == Vector{DataFrameRow{DataFrame}}
     for row in eachrow(df)
         @test isa(row, DataFrameRow)
         @test (row[:B] - row[:A]) == 1
@@ -19,6 +20,7 @@ module TestIteration
     @test size(eachcol(df)) == (size(df, 2),)
     @test length(eachcol(df)) == size(df, 2)
     @test eachcol(df)[1] == df[:, 1]
+    @test typeof(collect(eachcol(df))) == Vector{Tuple{Symbol, Any}}
     for col in eachcol(df)
         @test isa(col, Tuple{Symbol, AbstractVector})
     end

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -10,7 +10,7 @@ module TestIteration
     @test size(eachrow(df)) == (size(df, 1),)
     @test eachrow(df)[1] == DataFrameRow(df, 1)
     @test collect(eachrow(df)) isa Vector{DataFrameRow{DataFrame}}
-    @test eltype(collect(eachrow(df))) == DataFrameRow{DataFrame}
+    @test eltype(eachrow(df)) == DataFrameRow{DataFrame}
     for row in eachrow(df)
         @test isa(row, DataFrameRow)
         @test (row[:B] - row[:A]) == 1
@@ -22,7 +22,7 @@ module TestIteration
     @test length(eachcol(df)) == size(df, 2)
     @test eachcol(df)[1] == df[:, 1]
     @test collect(eachcol(df)) isa Vector{Tuple{Symbol, Any}}
-    @test eltype(collect(eachcol(df))) == Tuple{Symbol, Any}
+    @test eltype(eachcol(df)) == Tuple{Symbol, Any}
     for col in eachcol(df)
         @test isa(col, Tuple{Symbol, AbstractVector})
     end

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -9,18 +9,20 @@ module TestIteration
 
     @test size(eachrow(df)) == (size(df, 1),)
     @test eachrow(df)[1] == DataFrameRow(df, 1)
-    @test typeof(collect(eachrow(df))) == Vector{DataFrameRow{DataFrame}}
+    @test collect(eachrow(df)) isa Vector{DataFrameRow{DataFrame}}
+    @test eltype(collect(eachrow(df))) == DataFrameRow{DataFrame}
     for row in eachrow(df)
         @test isa(row, DataFrameRow)
         @test (row[:B] - row[:A]) == 1
         # issue #683 (https://github.com/JuliaData/DataFrames.jl/pull/683)
-        @test typeof(collect(row)) == Array{Pair{Symbol, Int}, 1}
+        @test collect(row) isa Vector{Pair{Symbol, Int}}
     end
 
     @test size(eachcol(df)) == (size(df, 2),)
     @test length(eachcol(df)) == size(df, 2)
     @test eachcol(df)[1] == df[:, 1]
-    @test typeof(collect(eachcol(df))) == Vector{Tuple{Symbol, Any}}
+    @test collect(eachcol(df)) isa Vector{Tuple{Symbol, Any}}
+    @test eltype(collect(eachcol(df))) == Tuple{Symbol, Any}
     for col in eachcol(df)
         @test isa(col, Tuple{Symbol, AbstractVector})
     end


### PR DESCRIPTION
It might help inference in some cases. For `eltype` of `eachcol` I left the second element of the tuple to be `Any` as this is what we have in `DataFrame` implementation, but maybe `AbstractVector` would be better (the performance should be the same though I think).