### PR TITLE
only allow vector of vectors in DataFrame constructor

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -156,8 +156,7 @@ function DataFrame(columns::AbstractVector,
                    cnames::AbstractVector{Symbol}=gennames(length(columns));
                    makeunique::Bool=false)::DataFrame
     if !all(col -> isa(col, AbstractVector), columns)
-        # change to throw(ArgumentError("columns argument must be a vector of AbstractVector objects"))
-        Base.depwarn("passing columns argument with non-AbstractVector entries is deprecated", :DataFrame)
+        throw(ArgumentError("columns argument must be a vector of AbstractVector objects"))
     end
     return DataFrame(convert(Vector{Any}, columns), Index(convert(Vector{Symbol}, cnames),
                      makeunique=makeunique))

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -97,6 +97,7 @@ module TestConstructors
         @test_throws DimensionMismatch DataFrame(Any[collect(1:10)], DataFrames.Index([:A, :B]))
         @test_throws DimensionMismatch DataFrame(A = rand(2,2))
         @test_throws DimensionMismatch DataFrame(A = rand(2,1))
+        @test_throws ArgumentError DataFrame([1, 2, 3])
     end
 
     @testset "column types" begin


### PR DESCRIPTION
To complement #1495 I propose to finish deprecation error of vector of vectors constructor.

Now what Tables.jl integration proposed works like this:
```
julia> DataFrame([(a=1,b=2), (a=3, b=4)])
┌ Warning: passing columns argument with non-AbstractVector entries is deprecated
│   caller = top-level scope at none:0
└ @ Core none:0
1×2 DataFrame
│ Row │ x1             │ x2             │
├─────┼────────────────┼────────────────┤
│ 1   │ (a = 1, b = 2) │ (a = 3, b = 4) │
```
so the change in #1495 is breaking (although probably no one would do this 😄).

After this the above will be disallowed and Tables.jl will fill this gap.