### PR TITLE
Clean up getindex

### DIFF
--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -25,7 +25,7 @@ end
 Base.eltype(::DFRowIterator{T}) where {T} = DataFrameRow{T}
 Base.size(itr::DFRowIterator) = (size(itr.df, 1), )
 Base.length(itr::DFRowIterator) = size(itr.df, 1)
-Base.getindex(itr::DFRowIterator, i::Any) = DataFrameRow(itr.df, i)
+Base.getindex(itr::DFRowIterator, i) = DataFrameRow(itr.df, i)
 Base.map(f::Function, dfri::DFRowIterator) = [f(row) for row in dfri]
 
 # Iteration by columns
@@ -41,7 +41,7 @@ end
 Base.eltype(::DFColumnIterator) = Tuple{Symbol, Any}
 Base.size(itr::DFColumnIterator) = (size(itr.df, 2), )
 Base.length(itr::DFColumnIterator) = size(itr.df, 2)
-Base.getindex(itr::DFColumnIterator, j::Any) = itr.df[:, j]
+Base.getindex(itr::DFColumnIterator, j) = itr.df[j]
 function Base.map(f::Function, dfci::DFColumnIterator)
     # note: `f` must return a consistent length
     res = DataFrame()

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -440,7 +440,7 @@ Base.length(v::RepeatedVector) = v.inner * v.outer * length(v.parent)
 Base.ndims(v::RepeatedVector) = 1
 Base.eltype(v::RepeatedVector{T}) where {T} = T
 Base.reverse(v::RepeatedVector) = RepeatedVector(reverse(v.parent), v.inner, v.outer)
-Base.similar(v::RepeatedVector, T, dims::Dims) = similar(v.parent, T, dims)
+Base.similar(v::RepeatedVector, T::Type, dims::Dims) = similar(v.parent, T, dims)
 Base.unique(v::RepeatedVector) = unique(v.parent)
 
 function CategoricalArrays.CategoricalArray(v::RepeatedVector)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -368,16 +368,6 @@ mutable struct StackedVector <: AbstractVector{Any}
     components::Vector{Any}
 end
 
-function Base.getindex(v::StackedVector,i::Bool)
-    Base.depwarn("Indexing StackedVector with Bool is deprecated", :getindex)
-    v[1]
-end
-
-function Base.getindex(v::StackedVector,i::Real)
-    Base.depwarn("Indexing StackedVector with Real is deprecated", :getindex)
-    v[Int(i)]
-end
-
 function Base.getindex(v::StackedVector,i::Integer)
     lengths = [length(x)::Int for x in v.components]
     cumlengths = [0; cumsum(lengths)]
@@ -390,19 +380,6 @@ function Base.getindex(v::StackedVector,i::Integer)
         error("indexing bounds error")
     end
     v.components[j][k]
-end
-
-function Base.getindex(v::StackedVector,i::AbstractVector)
-    result = similar(v.components[1], length(i))
-    for idx in 1:length(i)
-        result[idx] = v[i[idx]]
-    end
-    result
-end
-
-function Base.getindex(v::StackedVector, i::AbstractVector{Bool})
-    length(v) == length(i) || throw(BoundsError(v, idx))
-    v[findall(i)]
 end
 
 Base.size(v::StackedVector) = (length(v),)
@@ -452,27 +429,10 @@ mutable struct RepeatedVector{T} <: AbstractVector{T}
     outer::Int
 end
 
-function Base.getindex(v::RepeatedVector, i::Bool)
-    Base.depwarn("Indexing RepeatedVector with Bool is deprecated", :getindex)
-    v[1]
-end
-
-function Base.getindex(v::RepeatedVector, i::Real)
-    Base.depwarn("Indexing RepeatedVector with Real is deprecated", :getindex)
-    v[Int(i)]
-end
-
 function Base.getindex(v::RepeatedVector, i::Integer)
     N = length(v.parent)
     idx = Base.fld1(mod1(i,v.inner*N),v.inner)
     v.parent[idx]
-end
-
-Base.getindex(v::RepeatedVector,i::AbstractVector) = [v[j] for j in i]
-
-function Base.getindex(v::RepeatedVector, i::AbstractVector{Bool})
-    length(v) == length(i) || throw(BoundsError(v, idx))
-    v[findall(i)]
 end
 
 Base.size(v::RepeatedVector) = (length(v),)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -302,7 +302,10 @@ end
 
 # df[:, SingleColumnIndex] => AbstractVector
 # df[:, MultiColumnIndex] => DataFrame
-Base.getindex(df::DataFrame, row_ind::Colon, col_inds) = df[col_inds]
+function Base.getindex(df::DataFrame, row_ind::Colon, col_inds)
+    Base.depwarn("indexing with colon as row will create a copy of rows in the future", :getindex)
+    df[col_inds]
+end
 
 # df[SingleRowIndex, :] => DataFrame
 Base.getindex(df::DataFrame, row_ind::Real, col_inds::Colon) = df[[row_ind], col_inds]
@@ -314,7 +317,10 @@ function Base.getindex(df::DataFrame, row_inds::AbstractVector, col_inds::Colon)
 end
 
 # df[:, :] => DataFrame
-Base.getindex(df::DataFrame, ::Colon, ::Colon) = copy(df)
+function Base.getindex(df::DataFrame, ::Colon, ::Colon)
+    Base.depwarn("indexing with colon as row will create a copy of rows in the future", :getindex)
+    copy(df)
+end
 
 ##############################################################################
 ##

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -303,7 +303,8 @@ end
 # df[:, SingleColumnIndex] => AbstractVector
 # df[:, MultiColumnIndex] => DataFrame
 function Base.getindex(df::DataFrame, row_ind::Colon, col_inds)
-    Base.depwarn("indexing with colon as row will create a copy of rows in the future", :getindex)
+    Base.depwarn("indexing with colon as row will create a copy in the future" *
+                 " use df[col_inds] to get the columns without copying", :getindex)
     df[col_inds]
 end
 

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -17,7 +17,7 @@ function Base.getindex(r::DataFrameRow, idx::AbstractArray)
     return DataFrameRow(parent(r)[idx], row(r))
 end
 
-function Base.getindex(r::DataFrameRow, idx::Any)
+function Base.getindex(r::DataFrameRow, idx::ColumnIndex)
     return parent(r)[row(r), idx]
 end
 

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -21,6 +21,8 @@ function Base.getindex(r::DataFrameRow, idx::ColumnIndex)
     return parent(r)[row(r), idx]
 end
 
+Base.getindex(r::DataFrameRow, ::Colon) = r
+
 function Base.setindex!(r::DataFrameRow, value::Any, idx::Any)
     return setindex!(parent(r), value, row(r), idx)
 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1360,3 +1360,22 @@ import Base: show
 @deprecate showall(io::IO, df::GroupedDataFrame) show(io, df, allgroups=true)
 @deprecate showall(df::GroupedDataFrame) show(df, allgroups=true)
 
+function Base.getindex(v::RepeatedVector, i::Bool)
+    Base.depwarn("Indexing RepeatedVector with Bool is deprecated", :getindex)
+    v[1]
+end
+
+function Base.getindex(v::RepeatedVector, i::Real)
+    Base.depwarn("Indexing RepeatedVector with Real is deprecated", :getindex)
+    v[Int(i)]
+end
+
+function Base.getindex(v::StackedVector,i::Bool)
+    Base.depwarn("Indexing StackedVector with Bool is deprecated", :getindex)
+    v[1]
+end
+
+function Base.getindex(v::StackedVector,i::Real)
+    Base.depwarn("Indexing StackedVector with Real is deprecated", :getindex)
+    v[Int(i)]
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1330,16 +1330,6 @@ import Base: |>
 @deprecate groupby(cols::Vector{T}; sort::Bool = false, skipmissing::Bool = false) where {T} x -> groupby(x, cols, sort = sort, skipmissing = skipmissing)
 @deprecate groupby(cols; sort::Bool = false, skipmissing::Bool = false) x -> groupby(x, cols, sort = sort, skipmissing = skipmissing)
 
-function Base.getindex(x::AbstractIndex, idx::Bool)
-    Base.depwarn("Indexing with Bool values is deprecated except for Vector{Bool}", :getindex)
-    1
-end
-
-function Base.getindex(x::AbstractIndex, idx::Real)
-    Base.depwarn("Indexing with values that are not Integer is deprecated", :getindex)
-    Int(idx)
-end
-
 import Base: vcat
 @deprecate vcat(x::Vector{<:AbstractDataFrame}) vcat(x...)
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -142,7 +142,7 @@ end
 
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Integer})
     if any(v -> v isa Bool, idx)
-        throw(ArgumentError("Bool values except for Vector{Bool} are not allowed for column indexing"))
+        throw(ArgumentError("Bool values except for AbstractVector{Bool} are not allowed for column indexing"))
     end
     Vector{Int}(idx)
 end

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -122,6 +122,7 @@ end
 
 Base.getindex(x::AbstractIndex, idx::Symbol) = x.lookup[idx]
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Symbol}) = [x.lookup[i] for i in idx]
+Base.getindex(x::AbstractIndex, idx::Bool) = throw(ArgumentError("invalid index: $idx of type Bool"))
 Base.getindex(x::AbstractIndex, idx::Integer) = Int(idx)
 Base.getindex(x::AbstractIndex, idx::AbstractVector{Int}) = idx
 Base.getindex(x::AbstractIndex, idx::AbstractRange{Int}) = idx
@@ -134,18 +135,14 @@ end
 
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{Union{Bool, Missing}})
     if any(ismissing, idx)
-        # TODO: this line should be changed to throw an error after deprecation
-        # throw(ArgumentError("missing values are not allowed for column indexing"))
-        Base.depwarn("using missing in column indexing is deprecated", :getindex)
+        throw(ArgumentError("missing values are not allowed for column indexing"))
     end
     getindex(x, collect(Missings.replace(idx, false)))
 end
 
 function Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Integer})
     if any(v -> v isa Bool, idx)
-        # TODO: this line should be changed to throw an error after deprecation
-        # throw(ArgumentError("Bool values except for Vector{Bool} are not allowed for column indexing"))
-        Base.depwarn("Indexing with Bool values is deprecated except for Vector{Bool}")
+        throw(ArgumentError("Bool values except for Vector{Bool} are not allowed for column indexing"))
     end
     Vector{Int}(idx)
 end
@@ -155,16 +152,12 @@ end
 function Base.getindex(x::AbstractIndex, idx::AbstractVector)
     idxs = filter(!ismissing, idx)
     if length(idxs) != length(idx)
-        # TODO: passing missing will throw an error after deprecation
-        # throw(ArgumentError("missing values are not allowed for column indexing"))
-        Base.depwarn("using missing in column indexing is deprecated", :getindex)
+        throw(ArgumentError("missing values are not allowed for column indexing"))
     end
     length(idxs) == 0 && return Int[] # special case of empty idxs
     if idxs[1] isa Real
         if !all(v -> v isa Integer && !(v isa Bool), idxs)
-            # TODO: this line should be changed to throw an error after deprecation
-            # throw(ArgumentError("Only Integer values allowed when indexing by vector of numbers"))
-            Base.depwarn("indexing by vector of numbers other than Integer is deprecated", :getindex)
+            throw(ArgumentError("Only Integer values allowed when indexing by vector of numbers"))
         end
         return Vector{Int}(idxs)
     end

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -131,11 +131,11 @@ index(sdf::SubDataFrame) = index(parent(sdf))
 nrow(sdf::SubDataFrame) = ncol(sdf) > 0 ? length(rows(sdf))::Int : 0
 ncol(sdf::SubDataFrame) = length(index(sdf))
 
-function Base.getindex(sdf::SubDataFrame, colinds::Any)
+function Base.getindex(sdf::SubDataFrame, colinds)
     return parent(sdf)[rows(sdf), colinds]
 end
 
-function Base.getindex(sdf::SubDataFrame, rowinds::Any, colinds::Any)
+function Base.getindex(sdf::SubDataFrame, rowinds, colinds)
     return parent(sdf)[rows(sdf)[rowinds], colinds]
 end
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -190,6 +190,9 @@ module TestData
         @test size(dx) == (0, 3)
         @test names(dx) == [:variable, :value, :a]
 
+        @test stackdf(d1, :a) == stackdf(d1, [:a])
+
+        # Tests of RepeatedVector and StackedVector indexing
         d1s = stackdf(d1, [:a, :b])
         @test d1s[1][[1,24]] == [:a, :b]
         @test d1s[2][[1,24]] == [1, 4]
@@ -198,7 +201,7 @@ module TestData
         @test_broken d1s[2][true]
         @test_broken d1s[2][1.0]
         
-        # Those two tests check indexing by a vector
+        # Those tests check indexing RepeatedVector/StackedVector by a vector
         d1s[1][trues(24)] == d1s[1]
         d1s[2][trues(24)] == d1s[2]
         d1s[1][:] == d1s[1]

--- a/test/data.jl
+++ b/test/data.jl
@@ -198,9 +198,15 @@ module TestData
         @test_broken d1s[2][true]
         @test_broken d1s[2][1.0]
         
-        # Those two tests check indexing by a vector of Bool values
+        # Those two tests check indexing by a vector
         d1s[1][trues(24)] == d1s[1]
         d1s[2][trues(24)] == d1s[2]
+        d1s[1][:] == d1s[1]
+        d1s[2][:] == d1s[2]
+        d1s[1][1:24] == d1s[1]
+        d1s[2][1:24] == d1s[2]
+        [d1s[1][1:12]; d1s[1][13:24]] == d1s[1]
+        [d1s[2][1:12]; d1s[2][13:24]] == d1s[2]
 
         d1s2 = stackdf(d1, [:c, :d])
         d1s3 = stackdf(d1)

--- a/test/data.jl
+++ b/test/data.jl
@@ -190,8 +190,17 @@ module TestData
         @test size(dx) == (0, 3)
         @test names(dx) == [:variable, :value, :a]
 
-        stackdf(d1, :a)
         d1s = stackdf(d1, [:a, :b])
+        # TODO: add tests for Bool and Real for d1s columns 1 and 2 after deprecation of getindex
+        # d1s[1][true]
+        # d1s[1][1.0]
+        # d1s[2][true]
+        # d1s[2][1.0]
+        
+        # Those two tests check indexing by Vector{Bool} that were broken earlier
+        d1s[1][trues(24)] == d1s[1]
+        d1s[2][trues(24)] == d1s[2]
+
         d1s2 = stackdf(d1, [:c, :d])
         d1s3 = stackdf(d1)
         d1m = meltdf(d1, [:c, :d, :e])

--- a/test/data.jl
+++ b/test/data.jl
@@ -191,13 +191,14 @@ module TestData
         @test names(dx) == [:variable, :value, :a]
 
         d1s = stackdf(d1, [:a, :b])
-        # TODO: add tests for Bool and Real for d1s columns 1 and 2 after deprecation of getindex
-        # d1s[1][true]
-        # d1s[1][1.0]
-        # d1s[2][true]
-        # d1s[2][1.0]
+        @test d1s[1][[1,24]] == [:a, :b]
+        @test d1s[2][[1,24]] == [1, 4]
+        @test_broken d1s[1][true]
+        @test_broken d1s[1][1.0]
+        @test_broken d1s[2][true]
+        @test_broken d1s[2][1.0]
         
-        # Those two tests check indexing by Vector{Bool} that were broken earlier
+        # Those two tests check indexing by a vector of Bool values
         d1s[1][trues(24)] == d1s[1]
         d1s[2][trues(24)] == d1s[2]
 

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -84,8 +84,11 @@ module TestDataFrameRow
     r.b = 1
     @test r.b === 1.0
 
-    # keys, values and iteration
+    # getindex
     r = DataFrameRow(df, 1)
+    @test r[:] == r
+
+    # keys, values and iteration
     @test keys(r) == names(df)
     @test values(r) == (df[1, 1], df[1, 2], df[1, 3], df[1, 4])
     @test collect(pairs(r)) == [:a=>df[1, 1], :b=>df[1, 2], :c=>df[1, 3], :d=>df[1, 4]]

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,25 +1,5 @@
 module TestDeprecated
     using Test, DataFrames
-    using DataFrames: Index
-    import DataFrames: identifier
-
-    i = Index()
-
-    push!(i, :A)
-    push!(i, :B)
-
-    inds = Any[1.0, true, false,
-               Any[1, missing], [1, missing],
-               [true, missing], Any[true, missing],
-               [:A, missing], Any[:A, missing],
-               1.0:1.0, [1.0], Any[1.0]]
-    for ind in inds
-        if ind == :A || ndims(ind) == 0
-            @test i[ind] == 1
-        else
-            @test (i[ind] == [1])
-        end
-    end
 
     # deprecation warning for automatically generating dup column name from indexing
     x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,5 +1,6 @@
 module TestDeprecated
     using Test, DataFrames
+    import DataFrames: identifier
 
     # deprecation warning for automatically generating dup column name from indexing
     x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])

--- a/test/index.jl
+++ b/test/index.jl
@@ -29,19 +29,18 @@ for ind in inds
     end
 end
 
-# TODO: change this to throw an error after deprecation
-# @test_throws MethodError i[1.0]
-# @test_throws MethodError i[true]
-# @test_throws MethodError i[false]
-# @test_throws ArgumentError i[Any[1, missing]]
-# @test_throws ArgumentError i[[1, missing]]
-# @test_throws ArgumentError i[[true, missing]]
-# @test_throws ArgumentError i[Any[true, missing]]
-# @test_throws ArgumentError i[[:A, missing]]
-# @test_throws ArgumentError i[Any[:A, missing]]
-# @test_throws ArgumentError i[1.0:1.0]
-# @test_throws ArgumentError i[[1.0]]
-# @test_throws ArgumentError i[Any[1.0]]
+@test_throws MethodError i[1.0]
+@test_throws ArgumentError i[true]
+@test_throws ArgumentError i[false]
+@test_throws ArgumentError i[Any[1, missing]]
+@test_throws ArgumentError i[[1, missing]]
+@test_throws ArgumentError i[[true, missing]]
+@test_throws ArgumentError i[Any[true, missing]]
+@test_throws ArgumentError i[[:A, missing]]
+@test_throws ArgumentError i[Any[:A, missing]]
+@test_throws ArgumentError i[1.0:1.0]
+@test_throws ArgumentError i[[1.0]]
+@test_throws ArgumentError i[Any[1.0]]
 
 @test i[1:1] == 1:1
 


### PR DESCRIPTION
This is a first (simpler) part to make #1380 clean after Julia 1.0. It concentrates on `getindex`.
What was deprecated is now an error.
Additionally I have reviewed whole DataFrames.jl to fix all `getindex` occurrences. There are some new deprecation warnings.