### PR TITLE
implemented string getproperty

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -238,6 +238,7 @@ Compat.axes(df, i) = axes(df)[i]
 Base.ndims(::AbstractDataFrame) = 2
 
 Base.getproperty(df::AbstractDataFrame, col_ind::Symbol) = getindex(df, col_ind)
+Base.getproperty(df::AbstractDataFrame, col_ind::AbstractString) = getproperty(df, Symbol(col_ind))
 Base.setproperty!(df::AbstractDataFrame, col_ind::Symbol, x) = setindex!(df, x, col_ind)
 # Private fields are never exposed since they can conflict with column names
 Base.propertynames(df::AbstractDataFrame, private::Bool=false) = names(df)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -29,6 +29,7 @@ Base.names(r::DataFrameRow) = names(parent(r))
 _names(r::DataFrameRow) = _names(parent(r))
 
 Base.getproperty(r::DataFrameRow, idx::Symbol) = getindex(r, idx)
+Base.getproperty(r::DataFrameRow, idx::AbstractString) = getproperty(r, Symbol(idx))
 Base.setproperty!(r::DataFrameRow, idx::Symbol, x::Any) = setindex!(r, x, idx)
 # Private fields are never exposed since they can conflict with column names
 Base.propertynames(r::DataFrameRow, private::Bool=false) = names(r)


### PR DESCRIPTION
I don't see any ambiguity in what the behavior of e.g. `df."abc"` should be so I thought we should have it.  This is also helpful for getting columns with "irregular" symbol characters (such as spaces), whether or not it's a good idea to name columns that way in the first place (it probably isn't).

Thanks to @KristofferC for the suggestion.

(As I think about this a bit more, I am slightly worried it will put us on a slippery slope to allowing `String` for indexing, which I'm not quite so sure is a good idea, so I'm not feeling completely great about this being merged.  Let's see what everyone thinks.)