### PR TITLE
Make sure show of DataFrame fits the screen right

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -547,7 +547,7 @@ function Base.show(io::IO,
                    summary::Bool = true) # -> Nothing
     nrows = size(df, 1)
     dsize = displaysize(io)
-    availableheight = dsize[1] - 6
+    availableheight = dsize[1] - 7
     nrowssubset = fld(availableheight, 2)
     bound = min(nrowssubset - 1, nrows)
     if allrows || nrows <= availableheight

--- a/test/show.jl
+++ b/test/show.jl
@@ -37,7 +37,7 @@ module TestShow
     Random.seed!(1)
     df_big = DataFrame(rand(25,5))
 
-    io = IOContext(IOBuffer(), :displaysize=>(10,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
     show(io, df_big)
     str = String(take!(io.io))
     @test str == """
@@ -50,7 +50,7 @@ module TestShow
     │ 24  │ 0.278582 │ 0.241591 │ 0.990741 │
     │ 25  │ 0.751313 │ 0.884837 │ 0.550334 │"""
 
-    io = IOContext(IOBuffer(), :displaysize=>(10,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
     show(io, df_big, allcols=true)
     str = String(take!(io.io))
     @test str == """
@@ -71,7 +71,7 @@ module TestShow
     │ 24  │ 0.762276 │ 0.755415 │
     │ 25  │ 0.339081 │ 0.649056 │"""
 
-    io = IOContext(IOBuffer(), :displaysize=>(10,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
     show(io, df_big, allrows=true, allcols=true)
     str = String(take!(io.io))
     @test str == """
@@ -163,7 +163,7 @@ module TestShow
     │ 24  │ 0.755415  │
     │ 25  │ 0.649056  │"""
 
-    io = IOContext(IOBuffer(), :displaysize=>(10,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
     show(io, df_big, allrows=true, allcols=false)
     str = String(take!(io.io))
     @test str == """


### PR DESCRIPTION
Following https://github.com/JuliaData/DataFrames.jl/pull/1499#issuecomment-421594253.
Now it should be good. Actually I have corrected it in that old PR, but in the original code there was a problem with odd number of lines in the terminal. After that old PR there was a problem with even number of lines in the terminal (which was more visible as most terminals have 40 lines by default). Substracting `7` should fit on screen for even and odd number of lines in the terminal.