### PR TITLE
fix getindex for Bool argument

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -285,7 +285,7 @@ end
 
 # df[SingleRowIndex, MultiColumnIndex] => DataFrame
 function Base.getindex(df::DataFrame, row_ind::Bool, col_inds::AbstractVector)
-    throw(ArgumentError("invalid index: $row_ind of type Bool"))
+    throw(ArgumentError("invalid row index: $row_ind of type Bool"))
 end
 
 # df[SingleRowIndex, MultiColumnIndex] => DataFrame

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -284,6 +284,11 @@ function Base.getindex(df::DataFrame, row_ind::Real, col_ind::ColumnIndex)
 end
 
 # df[SingleRowIndex, MultiColumnIndex] => DataFrame
+function Base.getindex(df::DataFrame, row_ind::Bool, col_inds::AbstractVector)
+    throw(ArgumentError("invalid inxdex: $row_ind of type Bool"))
+end
+
+# df[SingleRowIndex, MultiColumnIndex] => DataFrame
 function Base.getindex(df::DataFrame, row_ind::Real, col_inds::AbstractVector)
     selected_columns = index(df)[col_inds]
     new_columns = Any[dv[[row_ind]] for dv in columns(df)[selected_columns]]

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -285,7 +285,7 @@ end
 
 # df[SingleRowIndex, MultiColumnIndex] => DataFrame
 function Base.getindex(df::DataFrame, row_ind::Bool, col_inds::AbstractVector)
-    throw(ArgumentError("invalid inxdex: $row_ind of type Bool"))
+    throw(ArgumentError("invalid index: $row_ind of type Bool"))
 end
 
 # df[SingleRowIndex, MultiColumnIndex] => DataFrame

--- a/test/data.jl
+++ b/test/data.jl
@@ -378,4 +378,8 @@ module TestData
     df = DataFrame(x = [3, 1, 2, 1, missing], y = ["b", "c", "a", "b", "c"])
     @test_throws TypeError filter(r -> r[:x] > 1, df)
     @test_throws TypeError filter!(r -> r[:x] > 1, df)
+
+    #test corner case of getindex
+    df = DataFrame(x=[1], y=[1])
+    @test_throws ArgumentError df[true, 1:2]
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -378,8 +378,4 @@ module TestData
     df = DataFrame(x = [3, 1, 2, 1, missing], y = ["b", "c", "a", "b", "c"])
     @test_throws TypeError filter(r -> r[:x] > 1, df)
     @test_throws TypeError filter!(r -> r[:x] > 1, df)
-
-    #test corner case of getindex
-    df = DataFrame(x=[1], y=[1])
-    @test_throws ArgumentError df[true, 1:2]
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -693,6 +693,11 @@ module TestDataFrame
         @test all(typeof(df[i]) <: Vector for i in 1:ncol(df))
     end
 
+    @teststet "test corner case of getindex" begin
+        df = DataFrame(x=[1], y=[1])
+        @test_throws ArgumentError df[true, 1:2]
+    end
+
     @testset "handling of end in indexing" begin
         z = DataFrame(rand(4,5))
         for x in [z, view(z, 1:4)]

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -693,7 +693,7 @@ module TestDataFrame
         @test all(typeof(df[i]) <: Vector for i in 1:ncol(df))
     end
 
-    @teststet "test corner case of getindex" begin
+    @testset "test corner case of getindex" begin
         df = DataFrame(x=[1], y=[1])
         @test_throws ArgumentError df[true, 1:2]
     end


### PR DESCRIPTION
There was a one corner case that needed fixing that came out when analyzing `SubDataFrames` code 😄.
The problem is only with single-row `DataFrame` and `Bool` index.