### PR TITLE
tighten DataFrame of vector signature

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -927,7 +927,7 @@ function _vcat(dfs::AbstractVector{<:AbstractDataFrame})
 
     header = allheaders[1]
     length(header) == 0 && return DataFrame()
-    cols = Vector{Any}(undef, length(header))
+    cols = Vector{AbstractVector}(undef, length(header))
     for (i, name) in enumerate(header)
         data = [df[name] for df in dfs]
         lens = map(length, data)

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -310,5 +310,5 @@ DataFrame(sink, sch::Data.Schema, ::Type{S}, append::Bool;
 end
 
 Data.close!(df::DataFrameStream) =
-    DataFrame(collect(Any, df.columns), Symbol.(df.header), makeunique=true)
+    DataFrame(collect(AbstractVector, df.columns), Symbol.(df.header), makeunique=true)
 

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -86,7 +86,7 @@ function compose_joined_table(joiner::DataFrameJoiner, kind::Symbol,
     nrow = length(all_orig_left_ixs) + roil
     @assert nrow == length(all_orig_right_ixs) + loil
     ncleft = ncol(joiner.dfl)
-    cols = Vector{Any}(undef, ncleft + ncol(dfr_noon))
+    cols = Vector{AbstractVector}(undef, ncleft + ncol(dfr_noon))
     # inner and left joins preserve non-missingness of the left frame
     _similar_left = kind == :inner || kind == :left ? similar : similar_missing
     for (i, col) in enumerate(columns(joiner.dfl))

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -81,7 +81,7 @@ function stack(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
     cnames = names(df)[id_vars]
     insert!(cnames, 1, value_name)
     insert!(cnames, 1, variable_name)
-    DataFrame(Any[repeat(_names(df)[measure_vars], inner=nrow(df)),   # variable
+    DataFrame(AbstractVector[repeat(_names(df)[measure_vars], inner=nrow(df)),   # variable
                   vcat([df[c] for c in measure_vars]...),             # value
                   [repeat(df[c], outer=N) for c in id_vars]...],      # id_var columns
               cnames)
@@ -515,7 +515,7 @@ function stackdf(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
     cnames = names(df)[id_vars]
     insert!(cnames, 1, value_name)
     insert!(cnames, 1, variable_name)
-    DataFrame(Any[RepeatedVector(_names(df)[measure_vars], nrow(df), 1),   # variable
+    DataFrame(AbstractVector[RepeatedVector(_names(df)[measure_vars], nrow(df), 1),   # variable
                   StackedVector(Any[df[:,c] for c in measure_vars]),     # value
                   [RepeatedVector(df[:,c], 1, N) for c in id_vars]...],     # id_var columns
               cnames)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -164,7 +164,7 @@ end
 
 DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol} = gennames(size(columns, 2));
           makeunique::Bool=false) =
-    DataFrame(Any[columns[:, i] for i in 1:size(columns, 2)], cnames, makeunique=makeunique)
+    DataFrame(AbstractVector[columns[:, i] for i in 1:size(columns, 2)], cnames, makeunique=makeunique)
 
 # Initialize an empty DataFrame with specific eltypes and names
 function DataFrame(column_eltypes::AbstractVector{T}, cnames::AbstractVector{Symbol},
@@ -864,9 +864,9 @@ function hcat!(df1::DataFrame, df2::DataFrame; makeunique::Bool=false)
 end
 
 hcat!(df::DataFrame, x::AbstractVector; makeunique::Bool=false) =
-    hcat!(df, DataFrame(Any[x]), makeunique=makeunique)
+    hcat!(df, DataFrame(AbstractVector[x]), makeunique=makeunique)
 hcat!(x::AbstractVector, df::DataFrame; makeunique::Bool=false) =
-    hcat!(DataFrame(Any[x]), df, makeunique=makeunique)
+    hcat!(DataFrame(AbstractVector[x]), df, makeunique=makeunique)
 function hcat!(x, df::DataFrame; makeunique::Bool=false)
     throw(ArgumentError("x must be AbstractVector or AbstractDataFrame"))
 end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -155,12 +155,9 @@ function DataFrame(; kwargs...)
     end
 end
 
-function DataFrame(columns::AbstractVector,
+function DataFrame(columns::AbstractVector{<:AbstractVector},
                    cnames::AbstractVector{Symbol}=gennames(length(columns));
                    makeunique::Bool=false)::DataFrame
-    if !all(col -> isa(col, AbstractVector), columns)
-        throw(ArgumentError("columns argument must be a vector of AbstractVector objects"))
-    end
     return DataFrame(convert(Vector{Any}, columns), Index(convert(Vector{Symbol}, cnames),
                      makeunique=makeunique))
 end

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -366,7 +366,7 @@ _makeheaders(fs::Vector{<:Function}, cn::Vector{Symbol}) =
     [Symbol(colname, '_', nameof(f)) for f in fs for colname in cn]
 
 function _aggregate(d::AbstractDataFrame, fs::Vector{T}, headers::Vector{Symbol}, sort::Bool=false) where T<:Function
-    res = DataFrame(Any[vcat(f(d[i])) for f in fs for i in 1:size(d, 2)], headers)
+    res = DataFrame(AbstractVector[vcat(f(d[i])) for f in fs for i in 1:size(d, 2)], headers)
     sort && sort!(res, headers)
     res
 end

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -10,10 +10,10 @@ module TestCat
         nvint = [1, 2, missing, 4]
         nvstr = ["one", "two", missing, "four"]
 
-        df2 = DataFrame(Any[nvint, nvstr])
-        df3 = DataFrame(Any[nvint])
+        df2 = DataFrame(AbstractVector[nvint, nvstr])
+        df3 = DataFrame(AbstractVector[nvint])
         df4 = convert(DataFrame, [1:4 1:4])
-        df5 = DataFrame(Any[Union{Int, Missing}[1,2,3,4], nvstr])
+        df5 = DataFrame(AbstractVector[Union{Int, Missing}[1,2,3,4], nvstr])
 
         dfh = hcat(df3, df4, makeunique=true)
         @test size(dfh, 2) == 3

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -17,7 +17,7 @@ module TestConstructors
         @test size(df, 1) == 3
         @test size(df, 2) == 2
 
-        @test df == DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+        @test df == DataFrame(AbstractVector[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
                                   CategoricalVector{Union{Float64, Missing}}(ones(3))])
         @test df == DataFrame(x1 = Union{Int, Missing}[0.0, 0.0, 0.0],
                               x2 = Union{Int, Missing}[1.0, 1.0, 1.0])

--- a/test/data.jl
+++ b/test/data.jl
@@ -3,12 +3,12 @@ module TestData
     const ≅ = isequal
 
     @testset "constructors" begin
-        df1 = DataFrame(Any[[1, 2, missing, 4], ["one", "two", missing, "four"]], [:Ints, :Strs])
-        df2 = DataFrame(Any[[1, 2, missing, 4], ["one", "two", missing, "four"]])
-        df3 = DataFrame(Any[[1, 2, missing, 4]])
-        df4 = DataFrame(Any[Vector{Union{Int, Missing}}(1:4), Vector{Union{Int, Missing}}(1:4)])
-        df5 = DataFrame(Any[Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]])
-        df6 = DataFrame(Any[[1, 2, missing, 4], [1, 2, missing, 4], ["one", "two", missing, "four"]],
+        df1 = DataFrame(AbstractVector[[1, 2, missing, 4], ["one", "two", missing, "four"]], [:Ints, :Strs])
+        df2 = DataFrame(AbstractVector[[1, 2, missing, 4], ["one", "two", missing, "four"]])
+        df3 = DataFrame(AbstractVector[[1, 2, missing, 4]])
+        df4 = DataFrame(AbstractVector[Vector{Union{Int, Missing}}(1:4), Vector{Union{Int, Missing}}(1:4)])
+        df5 = DataFrame(AbstractVector[Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]])
+        df6 = DataFrame(AbstractVector[[1, 2, missing, 4], [1, 2, missing, 4], ["one", "two", missing, "four"]],
                         [:A, :B, :C])
         df7 = DataFrame(x = [1, 2, missing, 4], y = ["one", "two", missing, "four"])
         @test size(df7) == (4, 2)
@@ -81,7 +81,7 @@ module TestData
         d2 = CategoricalArray(["A", "B", missing])[rand(1:3, N)]
         d3 = randn(N)
         d4 = randn(N)
-        df7 = DataFrame(Any[d1, d2, d3], [:d1, :d2, :d3])
+        df7 = DataFrame(AbstractVector[d1, d2, d3], [:d1, :d2, :d3])
 
         #test_group("groupby")
         gd = groupby(df7, :d1)
@@ -136,7 +136,7 @@ module TestData
         @test df9′ ≅ df8
 
         df10 = DataFrame(
-            Any[[1:4;], [2:5;], ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],
+            AbstractVector[[1:4;], [2:5;], ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],
             [:d1, :d2, :d3, :d4]
         )
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -491,21 +491,21 @@ module TestDataFrame
     end
 
     @testset "unstack promotion to support missing values" begin
-        df = DataFrame(Any[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
+        df = DataFrame(AbstractVector[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
                        [:id, :variable, :value])
         udf = unstack(df, :variable, :value)
         @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
-        @test udf == DataFrame(Any[Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
+        @test udf == DataFrame(AbstractVector[Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
                                    Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
                                    Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
         @test isa(udf[1], Vector{Int})
         @test all(isa.(columns(udf)[2:end], Vector{Union{Int, Missing}}))
-        df = DataFrame(Any[categorical(repeat(1:2, inner=4)),
+        df = DataFrame(AbstractVector[categorical(repeat(1:2, inner=4)),
                            categorical(repeat('a':'d', outer=2)), categorical(1:8)],
                        [:id, :variable, :value])
         udf = unstack(df, :variable, :value)
         @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
-        @test udf == DataFrame(Any[Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
+        @test udf == DataFrame(AbstractVector[Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
                                    Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
                                    Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
         @test isa(udf[1], CategoricalVector{Int})
@@ -610,7 +610,7 @@ module TestDataFrame
     end
 
     @testset "misc" begin
-        df = DataFrame(Any[collect('A':'C')])
+        df = DataFrame(AbstractVector[collect('A':'C')])
         @test sprint(dump, df) == """
                                   $DataFrame  3 observations of 1 variables
                                     x1: Array{Char}((3,))
@@ -623,7 +623,7 @@ module TestDataFrame
     end
 
     @testset "column conversions" begin
-        df = DataFrame(Any[collect(1:10), collect(1:10)])
+        df = DataFrame(AbstractVector[collect(1:10), collect(1:10)])
         @test !isa(df[1], Vector{Union{Int, Missing}})
         allowmissing!(df, 1)
         @test isa(df[1], Vector{Union{Int, Missing}})
@@ -634,19 +634,19 @@ module TestDataFrame
         disallowmissing!(df, 1)
         @test isa(df[1], Vector{Int})
 
-        df = DataFrame(Any[collect(1:10), collect(1:10)])
+        df = DataFrame(AbstractVector[collect(1:10), collect(1:10)])
         allowmissing!(df, [1,2])
         @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
         disallowmissing!(df, [1,2])
         @test isa(df[1], Vector{Int}) && isa(df[2], Vector{Int})
 
-        df = DataFrame(Any[collect(1:10), collect(1:10)])
+        df = DataFrame(AbstractVector[collect(1:10), collect(1:10)])
         allowmissing!(df)
         @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
         disallowmissing!(df)
         @test isa(df[1], Vector{Int}) && isa(df[2], Vector{Int})
 
-        df = DataFrame(Any[CategoricalArray(1:10),
+        df = DataFrame(AbstractVector[CategoricalArray(1:10),
                            CategoricalArray(string.('a':'j'))])
         allowmissing!(df)
         @test all(x->x <: CategoricalVector, typeof.(columns(df)))

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -54,7 +54,7 @@ module TestDataFrameRow
     # test RowGroupDict
     N = 20
     d1 = rand(map(Int64, 1:2), N)
-    df5 = DataFrame(Any[d1], [:d1])
+    df5 = DataFrame(AbstractVector[d1], [:d1])
     df6 = DataFrame(d1 = [2,3])
 
     # test_group("groupby")

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -9,7 +9,7 @@ module TestGrouping
     #df[6, :a] = missing
     #df[7, :b] = missing
 
-    missingfree = DataFrame(Any[collect(1:10)], [:x1])
+    missingfree = DataFrame(AbstractVector[collect(1:10)], [:x1])
     @testset "colwise" begin
         @testset "::Function, ::AbstractDataFrame" begin
             cw = colwise(sum, df)

--- a/test/join.jl
+++ b/test/join.jl
@@ -160,11 +160,11 @@ module TestJoin
     end
 
     @testset "all joins" begin
-        df1 = DataFrame(Any[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
-        df2 = DataFrame(Any[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
+        df1 = DataFrame(AbstractVector[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
+        df2 = DataFrame(AbstractVector[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
 
         @test join(df1, df2, kind=:cross, makeunique=true) ==
-            DataFrame(Any[repeat([1, 3, 5], inner = 5),
+            DataFrame(AbstractVector[repeat([1, 3, 5], inner = 5),
                           repeat([1, 3, 5], inner = 5),
                           repeat([0, 1, 2, 3, 4], outer = 3),
                           repeat([0, 1, 2, 3, 4], outer = 3)],
@@ -181,19 +181,19 @@ module TestJoin
 
         @test s(:id) ==
               s(:fid) ==
-              s([:id, :fid]) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
+              s([:id, :fid]) == DataFrame(AbstractVector[[1, 3], [1, 3]], [:id, :fid])
         @test typeof.(columns(s(:id))) ==
               typeof.(columns(s(:fid))) ==
               typeof.(columns(s([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
         @test a(:id) ==
               a(:fid) ==
-              a([:id, :fid]) == DataFrame(Any[[5], [5]], [:id, :fid])
+              a([:id, :fid]) == DataFrame(AbstractVector[[5], [5]], [:id, :fid])
         @test typeof.(columns(a(:id))) ==
               typeof.(columns(a(:fid))) ==
               typeof.(columns(a([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
 
         on = :id
-        @test i(on) == DataFrame(Any[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
+        @test i(on) == DataFrame(AbstractVector[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
         @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Float64}]
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
@@ -212,7 +212,7 @@ module TestJoin
             [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Union{Float64, Missing}}]
 
         on = :fid
-        @test i(on) == DataFrame(Any[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
+        @test i(on) == DataFrame(AbstractVector[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
         @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Int}]
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
@@ -231,7 +231,7 @@ module TestJoin
                                          Vector{Union{Int, Missing}}]
 
         on = [:id, :fid]
-        @test i(on) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
+        @test i(on) == DataFrame(AbstractVector[[1, 3], [1, 3]], [:id, :fid])
         @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}]
         @test l(on) == DataFrame(id = [1, 3, 5], fid = [1, 3, 5])
         @test typeof.(columns(l(on))) == [Vector{Int}, Vector{Float64}]
@@ -242,13 +242,13 @@ module TestJoin
     end
 
     @testset "all joins with CategoricalArrays" begin
-        df1 = DataFrame(Any[CategoricalArray([1, 3, 5]),
+        df1 = DataFrame(AbstractVector[CategoricalArray([1, 3, 5]),
                             CategoricalArray([1.0, 3.0, 5.0])], [:id, :fid])
-        df2 = DataFrame(Any[CategoricalArray([0, 1, 2, 3, 4]),
+        df2 = DataFrame(AbstractVector[CategoricalArray([0, 1, 2, 3, 4]),
                             CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
 
         @test join(df1, df2, kind=:cross, makeunique=true) ==
-            DataFrame(Any[repeat([1, 3, 5], inner = 5),
+            DataFrame(AbstractVector[repeat([1, 3, 5], inner = 5),
                           repeat([1, 3, 5], inner = 5),
                           repeat([0, 1, 2, 3, 4], outer = 3),
                           repeat([0, 1, 2, 3, 4], outer = 3)],
@@ -265,7 +265,7 @@ module TestJoin
 
         @test s(:id) ==
               s(:fid) ==
-              s([:id, :fid]) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
+              s([:id, :fid]) == DataFrame(AbstractVector[[1, 3], [1, 3]], [:id, :fid])
         @test typeof.(columns(s(:id))) ==
               typeof.(columns(s(:fid))) ==
               typeof.(columns(s([:id, :fid])))
@@ -274,7 +274,7 @@ module TestJoin
 
         @test a(:id) ==
               a(:fid) ==
-              a([:id, :fid]) == DataFrame(Any[[5], [5]], [:id, :fid])
+              a([:id, :fid]) == DataFrame(AbstractVector[[5], [5]], [:id, :fid])
         @test typeof.(columns(a(:id))) ==
               typeof.(columns(a(:fid))) ==
               typeof.(columns(a([:id, :fid])))
@@ -282,7 +282,7 @@ module TestJoin
                        [CategoricalVector{T} for T in (Int, Float64)]))
 
         on = :id
-        @test i(on) == DataFrame(Any[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
+        @test i(on) == DataFrame(AbstractVector[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
         @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64, Float64)]))
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
@@ -302,7 +302,7 @@ module TestJoin
                        [CategoricalVector{T} for T in (Int,Union{Float64,Missing},Union{Float64, Missing})]))
 
         on = :fid
-        @test i(on) == DataFrame(Any[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
+        @test i(on) == DataFrame(AbstractVector[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
         @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64, Int)]))
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
@@ -322,7 +322,7 @@ module TestJoin
                        [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Union{Int, Missing})]))
 
         on = [:id, :fid]
-        @test i(on) == DataFrame(Any[[1, 3], [1, 3]], [:id, :fid])
+        @test i(on) == DataFrame(AbstractVector[[1, 3], [1, 3]], [:id, :fid])
         @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64)]))
         @test l(on) == DataFrame(id = [1, 3, 5],

--- a/test/show.jl
+++ b/test/show.jl
@@ -334,7 +334,7 @@ module TestShow
     │ 3   │ 3.0     │        │"""
 
     # Test computing width for Array{String} columns
-    df = DataFrame(Any[["a"]], [:x])
+    df = DataFrame(AbstractVector[["a"]], [:x])
     io = IOBuffer()
     show(io, df)
     str = String(take!(io))


### PR DESCRIPTION
This is needed to allow Tables integration to work with `AbstractVector` of `NamedTuples`. For example with this PR:

```julia
julia> DataFrame([(a=1, b=2)])
1×2 DataFrame
│ Row │ a     │ b     │
│     │ Int64 │ Int64 │
├─────┼───────┼───────┤
│ 1   │ 1     │ 2     │

julia> using StructArrays

julia> DataFrame(StructArray([1+3im]))
1×2 DataFrame
│ Row │ re    │ im    │
│     │ Int64 │ Int64 │
├─────┼───────┼───────┤
│ 1   │ 1     │ 3     │
```