### PR TITLE
Avoid aliasing columns when assigning vector

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -433,8 +433,7 @@ end
 function Base.setindex!(df::DataFrame,
                         v::AbstractVector,
                         col_inds::AbstractVector{<:ColumnIndex})
-    df[col_inds[1]] = v
-    for col_ind in col_inds[2:end]
+    for col_ind in col_inds
         df[col_ind] = copy(v)
     end
     return df

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -433,8 +433,9 @@ end
 function Base.setindex!(df::DataFrame,
                         v::AbstractVector,
                         col_inds::AbstractVector{<:ColumnIndex})
-    for col_ind in col_inds
-        df[col_ind] = v
+    df[col_inds[1]] = v
+    for col_ind in col_inds[2:end]
+        df[col_ind] = copy(v)
     end
     return df
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -735,12 +735,20 @@ module TestDataFrame
 
         # columns should not alias if vector assigned
         df = DataFrame(A=[0], B=[0])
-        df[1:end] = [0.0]
+        x = [0.0]
+        df[1:end] = x
+        x[1] = 1.0
+        @test df[1, :A] === 0.0
+        @test df[1, :B] === 0.0
         df[1, :A] = 1.0
         @test df[1, :B] === 0.0
 
         df = DataFrame(A=[0], B=[0])
-        df[:, 1:end] = [0.0]
+        x = [0.0]
+        df[:, 1:end] = x
+        x[1] = 1.0
+        @test df[1, :A] === 0.0
+        @test df[1, :B] === 0.0
         df[1, :A] = 1.0
         @test df[1, :B] === 0.0
     end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -721,6 +721,30 @@ module TestDataFrame
         end
     end
 
+    @testset "aliasing in indexing" begin
+        # columns should not alias if scalar broadcasted
+        df = DataFrame(A=[0], B=[0])
+        df[1:end] = 0.0
+        df[1, :A] = 1.0
+        @test df[1, :B] === 0
+
+        df = DataFrame(A=[0], B=[0])
+        df[:, 1:end] = 0.0
+        df[1, :A] = 1.0
+        @test df[1, :B] === 0
+
+        # columns should not alias if vector assigned
+        df = DataFrame(A=[0], B=[0])
+        df[1:end] = [0.0]
+        df[1, :A] = 1.0
+        @test df[1, :B] === 0.0
+
+        df = DataFrame(A=[0], B=[0])
+        df[:, 1:end] = [0.0]
+        df[1, :A] = 1.0
+        @test df[1, :B] === 0.0
+    end
+
     @testset "permutecols!" begin
         a, b, c = 1:5, 2:6, 3:7
         original = DataFrame(a=a, b=b, c=c)

--- a/test/index.jl
+++ b/test/index.jl
@@ -79,12 +79,4 @@ for name in names(i)
   i2[name] # Issue #715
 end
 
-#= Aliasing & Mutation =#
-
-# columns should not alias if scalar broadcasted
-df = DataFrame(A=[0],B=[0])
-df[1:end] = 0.0
-df[1,:A] = 1.0
-@test df[1,:B] === 0
-
 end


### PR DESCRIPTION
But avoid making a redundant copy for the first column.
Also move related test out of test/index.jl, which is about testing the Index type
rather than indexing.

Replaces https://github.com/JuliaData/DataFrames.jl/pull/1052, continuing https://github.com/JuliaData/DataFrames.jl/pull/1057.

It's a bit weird that only the first column would actually be `===` to the passed vector. Would it be better to make copies for all columns?