### PR TITLE
Make AbstractVector change in constructor clean and non deprecating

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -156,6 +156,15 @@ function DataFrame(; kwargs...)
     end
 end
 
+function DataFrame(columns::AbstractVector, cnames::AbstractVector{Symbol};
+                   makeunique::Bool=false)::DataFrame
+    if !all(col -> isa(col, AbstractVector), columns)
+        throw(ArgumentError("columns argument must be a vector of AbstractVector objects"))
+    end
+    return DataFrame(convert(Vector{AbstractVector}, columns),
+                     Index(convert(Vector{Symbol}, cnames), makeunique=makeunique))
+end
+
 function DataFrame(columns::AbstractVector{<:AbstractVector},
                    cnames::AbstractVector{Symbol}=gennames(length(columns));
                    makeunique::Bool=false)::DataFrame

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -83,7 +83,7 @@ size(df1)
 
 """
 mutable struct DataFrame <: AbstractDataFrame
-    columns::Vector
+    columns::Vector{AbstractVector}
     colindex::Index
 
     function DataFrame(columns::Vector{Any}, colindex::Index)
@@ -119,7 +119,7 @@ mutable struct DataFrame <: AbstractDataFrame
                 throw(DimensionMismatch("columns must be 1-dimensional"))
             end
         end
-        new(columns, colindex)
+        new(Vector{AbstractVector}(columns), colindex)
     end
 end
 
@@ -149,7 +149,7 @@ end
 
 function DataFrame(; kwargs...)
     if isempty(kwargs)
-        DataFrame(Any[], Index())
+        DataFrame(AbstractVector[], Index())
     else
         DataFrame(pairs(kwargs)...)
     end
@@ -158,7 +158,8 @@ end
 function DataFrame(columns::AbstractVector{<:AbstractVector},
                    cnames::AbstractVector{Symbol}=gennames(length(columns));
                    makeunique::Bool=false)::DataFrame
-    return DataFrame(convert(Vector{Any}, columns), Index(convert(Vector{Symbol}, cnames),
+    return DataFrame(Vector{AbstractVector}(columns),
+                     Index(convert(Vector{Symbol}, cnames),
                      makeunique=makeunique))
 end
 
@@ -169,7 +170,7 @@ DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol} = gennames(siz
 # Initialize an empty DataFrame with specific eltypes and names
 function DataFrame(column_eltypes::AbstractVector{T}, cnames::AbstractVector{Symbol},
                    nrows::Integer; makeunique::Bool=false)::DataFrame where T<:Type
-    columns = Vector{Any}(undef, length(column_eltypes))
+    columns = Vector{AbstractVector}(undef, length(column_eltypes))
     for (j, elty) in enumerate(column_eltypes)
         if elty >: Missing
             if Missings.T(elty) <: CategoricalArrays.CatValue

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -86,7 +86,7 @@ mutable struct DataFrame <: AbstractDataFrame
     columns::Vector{AbstractVector}
     colindex::Index
 
-    function DataFrame(columns::Vector{Any}, colindex::Index)
+    function DataFrame(columns::Vector, colindex::Index)
         if length(columns) == length(colindex) == 0
             return new(Vector{Any}(undef, 0), Index())
         elseif length(columns) != length(colindex)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -83,12 +83,13 @@ size(df1)
 
 """
 mutable struct DataFrame <: AbstractDataFrame
-    columns::Vector{Any}
+    columns::Vector{AbstractVector}
     colindex::Index
 
-    function DataFrame(columns::Vector{Any}, colindex::Index)
+    function DataFrame(columns::Union{Vector{Any}, Vector{AbstractVector}},
+                       colindex::Index)
         if length(columns) == length(colindex) == 0
-            return new([], Index())
+            return new(AbstractVector[], Index())
         elseif length(columns) != length(colindex)
             throw(DimensionMismatch("Number of columns ($(length(columns))) and number of" *
                                     " column names ($(length(colindex))) are not equal"))
@@ -119,7 +120,7 @@ mutable struct DataFrame <: AbstractDataFrame
                 throw(DimensionMismatch("columns must be 1-dimensional"))
             end
         end
-        new(columns, colindex)
+        new(convert(Vector{AbstractVector}, columns), colindex)
     end
 end
 
@@ -158,7 +159,7 @@ end
 function DataFrame(columns::AbstractVector{<:AbstractVector},
                    cnames::AbstractVector{Symbol}=gennames(length(columns));
                    makeunique::Bool=false)::DataFrame
-    return DataFrame(convert(Vector{Any}, columns),
+    return DataFrame(convert(Vector{AbstractVector}, columns),
                      Index(convert(Vector{Symbol}, cnames), makeunique=makeunique))
 end
 
@@ -169,7 +170,7 @@ DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol} = gennames(siz
 # Initialize an empty DataFrame with specific eltypes and names
 function DataFrame(column_eltypes::AbstractVector{T}, cnames::AbstractVector{Symbol},
                    nrows::Integer; makeunique::Bool=false)::DataFrame where T<:Type
-    columns = Vector{Any}(undef, length(column_eltypes))
+    columns = Vector{AbstractVector}(undef, length(column_eltypes))
     for (j, elty) in enumerate(column_eltypes)
         if elty >: Missing
             if Missings.T(elty) <: CategoricalArrays.CatValue

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -83,12 +83,12 @@ size(df1)
 
 """
 mutable struct DataFrame <: AbstractDataFrame
-    columns::Vector{AbstractVector}
+    columns::Vector{Any}
     colindex::Index
 
-    function DataFrame(columns::Vector, colindex::Index)
+    function DataFrame(columns::Vector{Any}, colindex::Index)
         if length(columns) == length(colindex) == 0
-            return new(Vector{Any}(undef, 0), Index())
+            return new([], Index())
         elseif length(columns) != length(colindex)
             throw(DimensionMismatch("Number of columns ($(length(columns))) and number of" *
                                     " column names ($(length(colindex))) are not equal"))
@@ -119,7 +119,7 @@ mutable struct DataFrame <: AbstractDataFrame
                 throw(DimensionMismatch("columns must be 1-dimensional"))
             end
         end
-        new(Vector{AbstractVector}(columns), colindex)
+        new(columns, colindex)
     end
 end
 
@@ -149,7 +149,7 @@ end
 
 function DataFrame(; kwargs...)
     if isempty(kwargs)
-        DataFrame(AbstractVector[], Index())
+        DataFrame([], Index())
     else
         DataFrame(pairs(kwargs)...)
     end
@@ -158,9 +158,8 @@ end
 function DataFrame(columns::AbstractVector{<:AbstractVector},
                    cnames::AbstractVector{Symbol}=gennames(length(columns));
                    makeunique::Bool=false)::DataFrame
-    return DataFrame(Vector{AbstractVector}(columns),
-                     Index(convert(Vector{Symbol}, cnames),
-                     makeunique=makeunique))
+    return DataFrame(convert(Vector{Any}, columns),
+                     Index(convert(Vector{Symbol}, cnames), makeunique=makeunique))
 end
 
 DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol} = gennames(size(columns, 2));
@@ -170,7 +169,7 @@ DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol} = gennames(siz
 # Initialize an empty DataFrame with specific eltypes and names
 function DataFrame(column_eltypes::AbstractVector{T}, cnames::AbstractVector{Symbol},
                    nrows::Integer; makeunique::Bool=false)::DataFrame where T<:Type
-    columns = Vector{AbstractVector}(undef, length(column_eltypes))
+    columns = Vector{Any}(undef, length(column_eltypes))
     for (j, elty) in enumerate(column_eltypes)
         if elty >: Missing
             if Missings.T(elty) <: CategoricalArrays.CatValue

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -26,6 +26,9 @@ function DataFrame(x)
         # non-NamedTuple or EltypeUnknown
         return fromcolumns(Tables.buildcolumns(nothing, Tables.DataValueUnwrapper(y)))
     end
+    if x isa AbstractVector && all(col -> isa(col, AbstractVector), x)
+        return DataFrame(Vector{AbstractVector}(x))
+    end
     throw(ArgumentError("unable to construct DataFrame from $(typeof(x))"))
 end
 

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -10,10 +10,10 @@ module TestCat
         nvint = [1, 2, missing, 4]
         nvstr = ["one", "two", missing, "four"]
 
-        df2 = DataFrame(AbstractVector[nvint, nvstr])
-        df3 = DataFrame(AbstractVector[nvint])
+        df2 = DataFrame([nvint, nvstr])
+        df3 = DataFrame([nvint])
         df4 = convert(DataFrame, [1:4 1:4])
-        df5 = DataFrame(AbstractVector[Union{Int, Missing}[1,2,3,4], nvstr])
+        df5 = DataFrame([Union{Int, Missing}[1,2,3,4], nvstr])
 
         dfh = hcat(df3, df4, makeunique=true)
         @test size(dfh, 2) == 3

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -17,10 +17,18 @@ module TestConstructors
         @test size(df, 1) == 3
         @test size(df, 2) == 2
 
-        @test df == DataFrame(AbstractVector[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+        @test df == DataFrame([CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+                               CategoricalVector{Union{Float64, Missing}}(ones(3))])
+        @test df == DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
                                   CategoricalVector{Union{Float64, Missing}}(ones(3))])
+        @test df == DataFrame(AbstractVector[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+                                             CategoricalVector{Union{Float64, Missing}}(ones(3))])
         @test df == DataFrame(x1 = Union{Int, Missing}[0.0, 0.0, 0.0],
                               x2 = Union{Int, Missing}[1.0, 1.0, 1.0])
+
+        @test (DataFrame([1:3, 1:3]) == DataFrame(Any[1:3, 1:3]) ==
+               DataFrame(UnitRange[1:3, 1:3]) == DataFrame(AbstractVector[1:3, 1:3]) ==
+               DataFrame([[1,2,3], [1,2,3]]) == DataFrame(Any[[1,2,3], [1,2,3]]))
 
         @test df === DataFrame(df) # in the future this will fail as constructor will return a copy
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -3,12 +3,12 @@ module TestData
     const ≅ = isequal
 
     @testset "constructors" begin
-        df1 = DataFrame(AbstractVector[[1, 2, missing, 4], ["one", "two", missing, "four"]], [:Ints, :Strs])
-        df2 = DataFrame(AbstractVector[[1, 2, missing, 4], ["one", "two", missing, "four"]])
-        df3 = DataFrame(AbstractVector[[1, 2, missing, 4]])
-        df4 = DataFrame(AbstractVector[Vector{Union{Int, Missing}}(1:4), Vector{Union{Int, Missing}}(1:4)])
-        df5 = DataFrame(AbstractVector[Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]])
-        df6 = DataFrame(AbstractVector[[1, 2, missing, 4], [1, 2, missing, 4], ["one", "two", missing, "four"]],
+        df1 = DataFrame([[1, 2, missing, 4], ["one", "two", missing, "four"]], [:Ints, :Strs])
+        df2 = DataFrame([[1, 2, missing, 4], ["one", "two", missing, "four"]])
+        df3 = DataFrame([[1, 2, missing, 4]])
+        df4 = DataFrame([Vector{Union{Int, Missing}}(1:4), Vector{Union{Int, Missing}}(1:4)])
+        df5 = DataFrame([Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]])
+        df6 = DataFrame([[1, 2, missing, 4], [1, 2, missing, 4], ["one", "two", missing, "four"]],
                         [:A, :B, :C])
         df7 = DataFrame(x = [1, 2, missing, 4], y = ["one", "two", missing, "four"])
         @test size(df7) == (4, 2)
@@ -81,7 +81,7 @@ module TestData
         d2 = CategoricalArray(["A", "B", missing])[rand(1:3, N)]
         d3 = randn(N)
         d4 = randn(N)
-        df7 = DataFrame(AbstractVector[d1, d2, d3], [:d1, :d2, :d3])
+        df7 = DataFrame([d1, d2, d3], [:d1, :d2, :d3])
 
         #test_group("groupby")
         gd = groupby(df7, :d1)
@@ -135,10 +135,9 @@ module TestData
         df9′ = aggregate(df7, 2, [sum, length], sort=true)
         @test df9′ ≅ df8
 
-        df10 = DataFrame(
-            AbstractVector[[1:4;], [2:5;], ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],
-            [:d1, :d2, :d3, :d4]
-        )
+        df10 = DataFrame([[1:4;], [2:5;],
+                          ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],
+                         [:d1, :d2, :d3, :d4])
 
         gd = groupby(df10, [:d3], sort=true)
         ggd = groupby(gd[1], [:d3, :d4], sort=true) # make sure we can groupby subDataFrames

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -491,21 +491,21 @@ module TestDataFrame
     end
 
     @testset "unstack promotion to support missing values" begin
-        df = DataFrame(AbstractVector[repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
+        df = DataFrame([repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
                        [:id, :variable, :value])
         udf = unstack(df, :variable, :value)
         @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
-        @test udf == DataFrame(AbstractVector[Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
+        @test udf == DataFrame([Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
                                    Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
                                    Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
         @test isa(udf[1], Vector{Int})
         @test all(isa.(columns(udf)[2:end], Vector{Union{Int, Missing}}))
-        df = DataFrame(AbstractVector[categorical(repeat(1:2, inner=4)),
+        df = DataFrame([categorical(repeat(1:2, inner=4)),
                            categorical(repeat('a':'d', outer=2)), categorical(1:8)],
                        [:id, :variable, :value])
         udf = unstack(df, :variable, :value)
         @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
-        @test udf == DataFrame(AbstractVector[Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
+        @test udf == DataFrame([Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
                                    Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
                                    Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
         @test isa(udf[1], CategoricalVector{Int})
@@ -610,7 +610,7 @@ module TestDataFrame
     end
 
     @testset "misc" begin
-        df = DataFrame(AbstractVector[collect('A':'C')])
+        df = DataFrame([collect('A':'C')])
         @test sprint(dump, df) == """
                                   $DataFrame  3 observations of 1 variables
                                     x1: Array{Char}((3,))
@@ -623,7 +623,7 @@ module TestDataFrame
     end
 
     @testset "column conversions" begin
-        df = DataFrame(AbstractVector[collect(1:10), collect(1:10)])
+        df = DataFrame([collect(1:10), collect(1:10)])
         @test !isa(df[1], Vector{Union{Int, Missing}})
         allowmissing!(df, 1)
         @test isa(df[1], Vector{Union{Int, Missing}})
@@ -634,20 +634,20 @@ module TestDataFrame
         disallowmissing!(df, 1)
         @test isa(df[1], Vector{Int})
 
-        df = DataFrame(AbstractVector[collect(1:10), collect(1:10)])
+        df = DataFrame([collect(1:10), collect(1:10)])
         allowmissing!(df, [1,2])
         @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
         disallowmissing!(df, [1,2])
         @test isa(df[1], Vector{Int}) && isa(df[2], Vector{Int})
 
-        df = DataFrame(AbstractVector[collect(1:10), collect(1:10)])
+        df = DataFrame([collect(1:10), collect(1:10)])
         allowmissing!(df)
         @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
         disallowmissing!(df)
         @test isa(df[1], Vector{Int}) && isa(df[2], Vector{Int})
 
-        df = DataFrame(AbstractVector[CategoricalArray(1:10),
-                           CategoricalArray(string.('a':'j'))])
+        df = DataFrame([CategoricalArray(1:10),
+                        CategoricalArray(string.('a':'j'))])
         allowmissing!(df)
         @test all(x->x <: CategoricalVector, typeof.(columns(df)))
         @test eltypes(df)[1] <: Union{CategoricalValue{Int}, Missing}

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -496,8 +496,8 @@ module TestDataFrame
         udf = unstack(df, :variable, :value)
         @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
         @test udf == DataFrame([Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
-                                   Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
-                                   Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
+                                Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
+                                Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
         @test isa(udf[1], Vector{Int})
         @test all(isa.(columns(udf)[2:end], Vector{Union{Int, Missing}}))
         df = DataFrame([categorical(repeat(1:2, inner=4)),
@@ -506,8 +506,8 @@ module TestDataFrame
         udf = unstack(df, :variable, :value)
         @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
         @test udf == DataFrame([Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
-                                   Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
-                                   Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
+                                Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
+                                Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
         @test isa(udf[1], CategoricalVector{Int})
         @test all(isa.(columns(udf)[2:end], CategoricalVector{Union{Int, Missing}}))
     end

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -54,7 +54,7 @@ module TestDataFrameRow
     # test RowGroupDict
     N = 20
     d1 = rand(map(Int64, 1:2), N)
-    df5 = DataFrame(AbstractVector[d1], [:d1])
+    df5 = DataFrame([d1], [:d1])
     df6 = DataFrame(d1 = [2,3])
 
     # test_group("groupby")

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -9,7 +9,7 @@ module TestGrouping
     #df[6, :a] = missing
     #df[7, :b] = missing
 
-    missingfree = DataFrame(AbstractVector[collect(1:10)], [:x1])
+    missingfree = DataFrame([collect(1:10)], [:x1])
     @testset "colwise" begin
         @testset "::Function, ::AbstractDataFrame" begin
             cw = colwise(sum, df)

--- a/test/join.jl
+++ b/test/join.jl
@@ -160,14 +160,14 @@ module TestJoin
     end
 
     @testset "all joins" begin
-        df1 = DataFrame([[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
-        df2 = DataFrame([[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
+        df1 = DataFrame(Any[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
+        df2 = DataFrame(Any[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
 
         @test join(df1, df2, kind=:cross, makeunique=true) ==
-            DataFrame([repeat([1, 3, 5], inner = 5),
-                       repeat([1, 3, 5], inner = 5),
-                       repeat([0, 1, 2, 3, 4], outer = 3),
-                       repeat([0, 1, 2, 3, 4], outer = 3)],
+            DataFrame(Any[repeat([1, 3, 5], inner = 5),
+                          repeat([1, 3, 5], inner = 5),
+                          repeat([0, 1, 2, 3, 4], outer = 3),
+                          repeat([0, 1, 2, 3, 4], outer = 3)],
                       [:id, :fid, :id_1, :fid_1])
         @test typeof.(columns(join(df1, df2, kind=:cross, makeunique=true))) ==
             [Vector{Int}, Vector{Float64}, Vector{Int}, Vector{Float64}]
@@ -242,10 +242,10 @@ module TestJoin
     end
 
     @testset "all joins with CategoricalArrays" begin
-        df1 = DataFrame([CategoricalArray([1, 3, 5]),
-                         CategoricalArray([1.0, 3.0, 5.0])], [:id, :fid])
-        df2 = DataFrame([CategoricalArray([0, 1, 2, 3, 4]),
-                         CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
+        df1 = DataFrame(Any[CategoricalArray([1, 3, 5]),
+                            CategoricalArray([1.0, 3.0, 5.0])], [:id, :fid])
+        df2 = DataFrame(Any[CategoricalArray([0, 1, 2, 3, 4]),
+                            CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
 
         @test join(df1, df2, kind=:cross, makeunique=true) ==
             DataFrame([repeat([1, 3, 5], inner = 5),

--- a/test/join.jl
+++ b/test/join.jl
@@ -160,14 +160,14 @@ module TestJoin
     end
 
     @testset "all joins" begin
-        df1 = DataFrame(AbstractVector[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
-        df2 = DataFrame(AbstractVector[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
+        df1 = DataFrame([[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
+        df2 = DataFrame([[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
 
         @test join(df1, df2, kind=:cross, makeunique=true) ==
-            DataFrame(AbstractVector[repeat([1, 3, 5], inner = 5),
-                          repeat([1, 3, 5], inner = 5),
-                          repeat([0, 1, 2, 3, 4], outer = 3),
-                          repeat([0, 1, 2, 3, 4], outer = 3)],
+            DataFrame([repeat([1, 3, 5], inner = 5),
+                       repeat([1, 3, 5], inner = 5),
+                       repeat([0, 1, 2, 3, 4], outer = 3),
+                       repeat([0, 1, 2, 3, 4], outer = 3)],
                       [:id, :fid, :id_1, :fid_1])
         @test typeof.(columns(join(df1, df2, kind=:cross, makeunique=true))) ==
             [Vector{Int}, Vector{Float64}, Vector{Int}, Vector{Float64}]
@@ -181,19 +181,19 @@ module TestJoin
 
         @test s(:id) ==
               s(:fid) ==
-              s([:id, :fid]) == DataFrame(AbstractVector[[1, 3], [1, 3]], [:id, :fid])
+              s([:id, :fid]) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
         @test typeof.(columns(s(:id))) ==
               typeof.(columns(s(:fid))) ==
               typeof.(columns(s([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
         @test a(:id) ==
               a(:fid) ==
-              a([:id, :fid]) == DataFrame(AbstractVector[[5], [5]], [:id, :fid])
+              a([:id, :fid]) == DataFrame([[5], [5]], [:id, :fid])
         @test typeof.(columns(a(:id))) ==
               typeof.(columns(a(:fid))) ==
               typeof.(columns(a([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
 
         on = :id
-        @test i(on) == DataFrame(AbstractVector[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
+        @test i(on) == DataFrame([[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
         @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Float64}]
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
@@ -212,7 +212,7 @@ module TestJoin
             [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Union{Float64, Missing}}]
 
         on = :fid
-        @test i(on) == DataFrame(AbstractVector[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
+        @test i(on) == DataFrame([[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
         @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Int}]
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
                                 fid = [1, 3, 5],
@@ -231,7 +231,7 @@ module TestJoin
                                          Vector{Union{Int, Missing}}]
 
         on = [:id, :fid]
-        @test i(on) == DataFrame(AbstractVector[[1, 3], [1, 3]], [:id, :fid])
+        @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
         @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}]
         @test l(on) == DataFrame(id = [1, 3, 5], fid = [1, 3, 5])
         @test typeof.(columns(l(on))) == [Vector{Int}, Vector{Float64}]
@@ -242,16 +242,16 @@ module TestJoin
     end
 
     @testset "all joins with CategoricalArrays" begin
-        df1 = DataFrame(AbstractVector[CategoricalArray([1, 3, 5]),
-                            CategoricalArray([1.0, 3.0, 5.0])], [:id, :fid])
-        df2 = DataFrame(AbstractVector[CategoricalArray([0, 1, 2, 3, 4]),
-                            CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
+        df1 = DataFrame([CategoricalArray([1, 3, 5]),
+                         CategoricalArray([1.0, 3.0, 5.0])], [:id, :fid])
+        df2 = DataFrame([CategoricalArray([0, 1, 2, 3, 4]),
+                         CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
 
         @test join(df1, df2, kind=:cross, makeunique=true) ==
-            DataFrame(AbstractVector[repeat([1, 3, 5], inner = 5),
-                          repeat([1, 3, 5], inner = 5),
-                          repeat([0, 1, 2, 3, 4], outer = 3),
-                          repeat([0, 1, 2, 3, 4], outer = 3)],
+            DataFrame([repeat([1, 3, 5], inner = 5),
+                       repeat([1, 3, 5], inner = 5),
+                       repeat([0, 1, 2, 3, 4], outer = 3),
+                       repeat([0, 1, 2, 3, 4], outer = 3)],
                       [:id, :fid, :id_1, :fid_1])
         @test all(isa.(columns(join(df1, df2, kind=:cross, makeunique=true)),
                        [CategoricalVector{T} for T in (Int, Float64, Int, Float64)]))
@@ -265,7 +265,7 @@ module TestJoin
 
         @test s(:id) ==
               s(:fid) ==
-              s([:id, :fid]) == DataFrame(AbstractVector[[1, 3], [1, 3]], [:id, :fid])
+              s([:id, :fid]) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
         @test typeof.(columns(s(:id))) ==
               typeof.(columns(s(:fid))) ==
               typeof.(columns(s([:id, :fid])))
@@ -274,7 +274,7 @@ module TestJoin
 
         @test a(:id) ==
               a(:fid) ==
-              a([:id, :fid]) == DataFrame(AbstractVector[[5], [5]], [:id, :fid])
+              a([:id, :fid]) == DataFrame([[5], [5]], [:id, :fid])
         @test typeof.(columns(a(:id))) ==
               typeof.(columns(a(:fid))) ==
               typeof.(columns(a([:id, :fid])))
@@ -282,7 +282,7 @@ module TestJoin
                        [CategoricalVector{T} for T in (Int, Float64)]))
 
         on = :id
-        @test i(on) == DataFrame(AbstractVector[[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
+        @test i(on) == DataFrame([[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
         @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64, Float64)]))
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
@@ -302,7 +302,7 @@ module TestJoin
                        [CategoricalVector{T} for T in (Int,Union{Float64,Missing},Union{Float64, Missing})]))
 
         on = :fid
-        @test i(on) == DataFrame(AbstractVector[[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
+        @test i(on) == DataFrame([[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
         @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64, Int)]))
         @test l(on) ≅ DataFrame(id = [1, 3, 5],
@@ -322,7 +322,7 @@ module TestJoin
                        [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Union{Int, Missing})]))
 
         on = [:id, :fid]
-        @test i(on) == DataFrame(AbstractVector[[1, 3], [1, 3]], [:id, :fid])
+        @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
         @test all(isa.(columns(i(on)),
                        [CategoricalVector{T} for T in (Int, Float64)]))
         @test l(on) == DataFrame(id = [1, 3, 5],

--- a/test/show.jl
+++ b/test/show.jl
@@ -334,7 +334,7 @@ module TestShow
     │ 3   │ 3.0     │        │"""
 
     # Test computing width for Array{String} columns
-    df = DataFrame(AbstractVector[["a"]], [:x])
+    df = DataFrame([["a"]], [:x])
     io = IOBuffer()
     show(io, df)
     str = String(take!(io))


### PR DESCRIPTION
This follows #1527. What I do:
1. make the that change as non-breaking as possible
2. change other constructors to follow the expected behavior
3. update tests (so that we have coverage of all cases) and clean-up tests where `AbstractVector` qualification is not needed
4. Make `DataFrame` internally use `Vector{AbstractVector}`.
5. Fix some indentation issues introduced (not sure if I spotted 100% cases)

The thing I was unsure of was what type `columns` should be. I decided for `Vector{AbstractVector}` not `Vector{<:AbstractVector}` as the latter could e.g. allow `Vector{Vector}` to sneak in, and then we would not be able to add other `AbstractVectors` to such a `DataFrame` (CC @nalimilan - any comment on this as you have also written `Vector{<:AbstractVector}` earlier).