### PR TITLE
Use Tables.allocatecolumn to simplify and improve code

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7.0
 Missings 0.2.3
-CategoricalArrays 0.3.11
+CategoricalArrays 0.3.14
 StatsBase 0.11.0
 SortingAlgorithms
 Reexport

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -931,7 +931,8 @@ function _vcat(dfs::AbstractVector{<:AbstractDataFrame})
     for (i, name) in enumerate(header)
         data = [df[name] for df in dfs]
         lens = map(length, data)
-        cols[i] = promote_col_type(data...)(undef, sum(lens))
+        T = mapreduce(eltype, promote_type, data)
+        cols[i] = Tables.allocatecolumn(T, sum(lens))
         offset = 1
         for j in 1:length(data)
             copyto!(cols[i], offset, data[j])

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -163,15 +163,15 @@ module TestCat
         @test typeof.(columns(df)) == [Vector{Union{Missing, Int}}]
         df = vcat(DataFrame([CategoricalArray([1])], [:x]), DataFrame([[1]], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
-        @test typeof(df[:x]) <: CategoricalVector{Int}
+        @test df[:x] isa Vector{Int}
         df = vcat(DataFrame([CategoricalArray([1])], [:x]),
                   DataFrame([Union{Missing, Int}[1]], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
-        @test typeof(df[:x]) <: CategoricalVector{Union{Int, Missing}}
+        @test df[:x] isa Vector{Union{Int, Missing}}
         df = vcat(DataFrame([CategoricalArray([1])], [:x]),
                   DataFrame([CategoricalArray{Union{Int, Missing}}([1])], [:x]))
         @test df == DataFrame([[1, 1]], [:x])
-        @test typeof(df[:x]) <: CategoricalVector{Union{Int, Missing}}
+        @test df[:x] isa CategoricalVector{Union{Int, Missing}}
         df = vcat(DataFrame([Union{Int, Missing}[1]], [:x]),
                   DataFrame([["1"]], [:x]))
         @test df == DataFrame([[1, "1"]], [:x])
@@ -179,7 +179,7 @@ module TestCat
         df = vcat(DataFrame([CategoricalArray([1])], [:x]),
                   DataFrame([CategoricalArray(["1"])], [:x]))
         @test df == DataFrame([[1, "1"]], [:x])
-        @test typeof(df[:x]) <: CategoricalVector{Any}
+        @test df[:x] isa CategoricalVector{Any}
         df = vcat(DataFrame([trues(1)], [:x]), DataFrame([[false]], [:x]))
         @test df == DataFrame([[true, false]], [:x])
         @test typeof.(columns(df)) == [Vector{Bool}]

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -126,7 +126,7 @@ module TestDataFrame
         @test df == DataFrame(a=[1, 2], b=["a", "b"], c=[:c, :d])
     end
 
-    @testset "Empty DataFrame constructors" begin
+    @testset "DataFrame constructors" begin
         df = DataFrame(Union{Int, Missing}, 10, 3)
         @test size(df, 1) == 10
         @test size(df, 2) == 3
@@ -198,6 +198,10 @@ module TestDataFrame
         df = DataFrame(x=[1:3;], y=[3:5;])
         sdf = view(df, df[:x] .== 4)
         @test size(sdf, 1) == 0
+
+        # Test that vector type is correctly determined from scalar type
+        df = DataFrame(x=categorical(["a"])[1])
+        @test df.x isa CategoricalVector{String}
 
         @test hash(convert(DataFrame, [1 2; 3 4])) == hash(convert(DataFrame, [1 2; 3 4]))
         @test hash(convert(DataFrame, [1 2; 3 4])) != hash(convert(DataFrame, [1 3; 2 4]))


### PR DESCRIPTION
This new interface allows removing special cases for `CategoricalArray` and making the code more general. It also makes it easier to stop calling `promote_col_type(data...)` which triggers a stack overflow when the number of input arguments is high.

This relies on promotion rules which have been fixed in CategoricalArrays 0.3.14 (https://github.com/JuliaData/CategoricalArrays.jl/pull/159), and which give a slightly different behavior: now combining a `CategoricalArray` with an `Array` gives an `Array`, since the number of unique levels could be very high.

Fixes https://github.com/JuliaData/DataFrames.jl/pull/1472, https://github.com/JuliaData/DataFrames.jl/issues/1532, and replaces https://github.com/JuliaData/DataFrames.jl/pull/1473.