### PR TITLE
Make setindex! and hcat use column alias where possible

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -844,7 +844,7 @@ without(df::AbstractDataFrame, c::Any) = without(df, index(df)[c])
 Base.hcat(df::AbstractDataFrame, x; makeunique::Bool=false) =
     hcat!(copy(df), x, makeunique=makeunique)
 Base.hcat(x, df::AbstractDataFrame; makeunique::Bool=false) =
-    hcat!(x, copy(df), makeunique=makeunique)
+    hcat!(x, df, makeunique=makeunique)
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame; makeunique::Bool=false) =
     hcat!(copy(df1), df2, makeunique=makeunique)
 Base.hcat(df::AbstractDataFrame, x, y...; makeunique::Bool=false) =

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -842,11 +842,11 @@ without(df::AbstractDataFrame, c::Any) = without(df, index(df)[c])
 # catch-all to cover cases where indexing returns a DataFrame and copy doesn't
 
 Base.hcat(df::AbstractDataFrame, x; makeunique::Bool=false) =
-    hcat!(df[:, :], x, makeunique=makeunique)
+    hcat!(df[:], x, makeunique=makeunique)
 Base.hcat(x, df::AbstractDataFrame; makeunique::Bool=false) =
-    hcat!(x, df[:, :], makeunique=makeunique)
+    hcat!(x, df[:], makeunique=makeunique)
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame; makeunique::Bool=false) =
-    hcat!(df1[:, :], df2, makeunique=makeunique)
+    hcat!(df1[:], df2, makeunique=makeunique)
 Base.hcat(df::AbstractDataFrame, x, y...; makeunique::Bool=false) =
     hcat!(hcat(df, x, makeunique=makeunique), y..., makeunique=makeunique)
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...;

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -842,11 +842,11 @@ without(df::AbstractDataFrame, c::Any) = without(df, index(df)[c])
 # catch-all to cover cases where indexing returns a DataFrame and copy doesn't
 
 Base.hcat(df::AbstractDataFrame, x; makeunique::Bool=false) =
-    hcat!(df[:], x, makeunique=makeunique)
+    hcat!(copy(df), x, makeunique=makeunique)
 Base.hcat(x, df::AbstractDataFrame; makeunique::Bool=false) =
-    hcat!(x, df[:], makeunique=makeunique)
+    hcat!(x, copy(df), makeunique=makeunique)
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame; makeunique::Bool=false) =
-    hcat!(df1[:], df2, makeunique=makeunique)
+    hcat!(copy(df1), df2, makeunique=makeunique)
 Base.hcat(df::AbstractDataFrame, x, y...; makeunique::Bool=false) =
     hcat!(hcat(df, x, makeunique=makeunique), y..., makeunique=makeunique)
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...;

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -554,7 +554,7 @@ function Base.setindex!(df::DataFrame,
                         row_inds::AbstractVector{<:Real},
                         col_inds::AbstractVector{<:ColumnIndex})
     for j in 1:length(col_inds)
-        insert_multiple_entries!(df, new_df[:, j], row_inds, col_inds[j])
+        insert_multiple_entries!(df, new_df[j], row_inds, col_inds[j])
     end
     return df
 end

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -155,7 +155,7 @@ end
 ##
 ##############################################################################
 
-copy(sdf::SubDataFrame) = sdf[:]
+Base.copy(sdf::SubDataFrame) = sdf[:]
 
 Base.map(f::Function, sdf::SubDataFrame) = f(sdf) # TODO: deprecate
 

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -155,6 +155,8 @@ end
 ##
 ##############################################################################
 
+copy(sdf::SubDataFrame) = sdf[:]
+
 Base.map(f::Function, sdf::SubDataFrame) = f(sdf) # TODO: deprecate
 
 without(sdf::SubDataFrame, c) = view(without(parent(sdf), c), rows(sdf))

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -17,7 +17,7 @@ module TestCat
 
         ref_df = copy(df3)
         dfh = hcat(df3, df4, makeunique=true)
-        @test isequal(ref_df, df3) # make sure that df3 is not mutated by hcat
+        @test ref_df == df3 # make sure that df3 is not mutated by hcat
         @test size(dfh, 2) == 3
         @test names(dfh) ≅ [:x1, :x1_1, :x2]
         @test dfh[:x1] ≅ df3[:x1]
@@ -69,7 +69,7 @@ module TestCat
         @test names(df2) == [:x1]
         ref_df = copy(df2)
         df3 = hcat(11:20, df2, makeunique=true)
-        @test isequal(df2, ref_df)
+        @test df2 == ref_df
         @test df3[1] == collect(11:20)
         @test names(df3) == [:x1, :x1_1]
 

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -17,7 +17,7 @@ module TestCat
 
         ref_df = copy(df3)
         dfh = hcat(df3, df4, makeunique=true)
-        @test ref_df == df3 # make sure that df3 is not mutated by hcat
+        @test ref_df ≅ df3 # make sure that df3 is not mutated by hcat
         @test size(dfh, 2) == 3
         @test names(dfh) ≅ [:x1, :x1_1, :x2]
         @test dfh[:x1] ≅ df3[:x1]

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -15,7 +15,9 @@ module TestCat
         df4 = convert(DataFrame, [1:4 1:4])
         df5 = DataFrame([Union{Int, Missing}[1,2,3,4], nvstr])
 
+        ref_df = copy(df3)
         dfh = hcat(df3, df4, makeunique=true)
+        @test isequal(ref_df, df3) # make sure that df3 is not mutated by hcat
         @test size(dfh, 2) == 3
         @test names(dfh) ≅ [:x1, :x1_1, :x2]
         @test dfh[:x1] ≅ df3[:x1]
@@ -62,9 +64,12 @@ module TestCat
 
         df = DataFrame()
         df2 = hcat(CategoricalVector{Union{Int,Missing}}(1:10), df, makeunique=true)
+        @test isempty(df)
         @test df2[1] == collect(1:10)
         @test names(df2) == [:x1]
+        ref_df = copy(df2)
         df3 = hcat(11:20, df2, makeunique=true)
+        @test isequal(df2, ref_df)
         @test df3[1] == collect(11:20)
         @test names(df3) == [:x1, :x1_1]
 

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -1,6 +1,14 @@
 module TestSubDataFrame
     using Test, DataFrames
 
+    @testset "copy - SubDataFrame" begin
+        df = DataFrame(x = 1:10, y = 1.0:10.0)
+        sdf = view(df, 1:2, 1:1)
+        @test sdf isa SubDataFrame
+        @test copy(sdf) isa DataFrame
+        @test isequal(sdf, copy(sdf))
+    end
+
     @testset "view -- DataFrame" begin
         df = DataFrame(x = 1:10, y = 1.0:10.0)
         @test view(df, 1) == head(df, 1)

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -6,7 +6,7 @@ module TestSubDataFrame
         sdf = view(df, 1:2, 1:1)
         @test sdf isa SubDataFrame
         @test copy(sdf) isa DataFrame
-        @test isequal(sdf, copy(sdf))
+        @test sdf == copy(sdf)
     end
 
     @testset "view -- DataFrame" begin


### PR DESCRIPTION
A small PR that prepares for `df[:, cols]` to make a copy of columns. It should introduce no functional changes as of now.