### PR TITLE
add column type in HTML show

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -90,7 +90,14 @@ function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame)
     write(io, "<tr>")
     write(io, "<th></th>")
     for column_name in cnames
-        write(io, "<th>$column_name</th>")
+        write(io, "<th>$(html_escape(String(column_name)))</th>")
+    end
+    write(io, "</tr>")
+    write(io, "<tr>")
+    write(io, "<th></th>")
+    for j in 1:ncol(df)
+        s = html_escape(compacttype(eltype(df[j])))
+        write(io, "<th>$s</th>")
     end
     write(io, "</tr>")
     write(io, "</thead>")

--- a/test/io.jl
+++ b/test/io.jl
@@ -32,7 +32,8 @@ module TestIO
         show(io, "text/html", df)
         str = String(take!(io))
         @test str == "<table class=\"data-frame\"><thead><tr><th>" *
-                    "</th><th>Fish</th><th>Mass</th></tr></thead><tbody>" *
+                    "</th><th>Fish</th><th>Mass</th></tr>" *
+                    "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
                     "<tr><th>1</th><td>Suzy</td><td>1.5</td></tr>" *
                     "<tr><th>2</th><td>Amir</td><td>missing</td></tr></tbody></table>"
 
@@ -41,7 +42,8 @@ module TestIO
         show(io, "text/html", df)
         str = String(take!(io))
         @test str == "<table class=\"data-frame\"><thead><tr><th>" *
-                    "</th><th>Fish</th><th>Mass</th></tr></thead><tbody>" *
+                    "</th><th>Fish</th><th>Mass</th></tr>" *
+                    "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
                     "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
                     "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
     end


### PR DESCRIPTION
I think in most cases `show` for HTML will be used in IJulia, where it is useful to have `eltype` printed as in terminal (I can image using this output to produce a report, where `eltype` type is uninteresting, but I would assume this is a relatively rare case; maybe we should add a kwarg that would handle this case?). This PR adds this functionality.

I left out LaTeX output without `eltype` as I guess in most cases when people use `show` to LaTeX they would want a table for publication so `eltype` is not needed.