### PR TITLE
Fix GroupedDataFrame printing

### DIFF
--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -6,9 +6,10 @@ function Base.show(io::IO, gd::GroupedDataFrame;
                    rowlabel::Symbol = :Row,
                    summary::Bool = true)
     N = length(gd)
-    keystr = N > 1 ? "keys" : "key"
-    keys = join(':' .* string.([:A, :B]), ", ")
-    summary && print(io, "$(typeof(gd)) with $N groups based on $keystr: $keys")
+    keys = join(':' .* string.(gd.cols), ", ")
+    keystr = length(gd.cols) > 1 ? "keys" : "key"
+    groupstr = N > 1 ? "groups" : "group"
+    summary && print(io, "$(typeof(gd)) with $N $groupstr based on $keystr: $keys")
     if allgroups
         for i = 1:N
             nrows = size(gd[i], 1)

--- a/test/show.jl
+++ b/test/show.jl
@@ -234,7 +234,7 @@ module TestShow
     show(io, gd)
     str = String(take!(io.io))
     @test str == """
-    GroupedDataFrame with 4 groups based on keys: :A, :B
+    GroupedDataFrame with 4 groups based on key: :A
     First Group: 1 row
     │ Row │ A     │ B      │ C       │
     │     │ Int64 │ String │ Float32 │
@@ -249,7 +249,7 @@ module TestShow
     show(io, gd, allgroups=true)
     str = String(take!(io.io))
     @test str == """
-    GroupedDataFrame with 4 groups based on keys: :A, :B
+    GroupedDataFrame with 4 groups based on key: :A
     Group 1: 1 row
     │ Row │ A     │ B      │ C       │
     │     │ Int64 │ String │ Float32 │


### PR DESCRIPTION
Actually print grouping columns instead of always `:A, :B`. Also use singular or plural depending on number of groups.

Fixes #1538.