### PR TITLE
sanitized by function

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -351,7 +351,7 @@ end
 aggregate(gd::GroupedDataFrame, f::Function; sort::Bool=false) = aggregate(gd, [f], sort=sort)
 function aggregate(gd::GroupedDataFrame, fs::Vector{T}; sort::Bool=false) where T<:Function
     headers = _makeheaders(fs, setdiff(_names(gd), _names(gd.parent[gd.cols])))
-    res = combine(map(x -> _aggregate(without(x, gd.cols), fs, headers), gd))
+    res = combine(map(x -> _aggregate(without(x, gd.cols), fs, headers), gd), append_keys=true)
     sort && sort!(res, headers)
     res
 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -92,30 +92,30 @@ module TestGrouping
     sdf = unique(df[cols])
 
     # by() without groups sorting
-    bdf = by(df, cols, f)
+    bdf = by(df, cols, f, append_keys=true)
     @test bdf[cols] == sdf
 
     # by() with groups sorting
-    sbdf = by(df, cols, f, sort=true)
+    sbdf = by(df, cols, f, sort=true, append_keys=true)
     @test sbdf[cols] == sort(sdf)
 
-    byf = by(df, :a, df -> DataFrame(bsum = sum(df[:b])))
+    byf = by(df, :a, df -> DataFrame(bsum = sum(df[:b])), append_keys=true)
 
     # groupby() without groups sorting
     gd = groupby(df, cols)
     ga = map(f, gd)
 
-    @test bdf == combine(ga)
+    @test bdf == combine(ga, append_keys=true)
 
     # groupby() with groups sorting
     gd = groupby(df, cols, sort=true)
     ga = map(f, gd)
-    @test sbdf == combine(ga)
+    @test sbdf == combine(ga, append_keys=true)
 
     g(df) = DataFrame(cmax1 = [c + 1 for c in df[:cmax]])
     h(df) = g(f(df))
 
-    @test combine(map(h, gd)) == combine(map(g, ga))
+    @test combine(map(h, gd), append_keys=true) == combine(map(g, ga), append_keys=true)
 
     # testing pool overflow
     df2 = DataFrame(v1 = categorical(collect(1:1000)), v2 = categorical(fill(1, 1000)))
@@ -142,7 +142,7 @@ module TestGrouping
     df = DataFrame(v1=x, v2=x)
     groupby(df, [:v1, :v2])
 
-    df2 = by(e->1, DataFrame(x=Int64[]), :x)
+    df2 = by(e->1, DataFrame(x=Int64[]), :x, append_keys=true)
     @test size(df2) == (0, 1)
     @test sum(df2[:x]) == 0
 


### PR DESCRIPTION
This implements #1554, in particular now
```julia
by(identity, df, cols)
```
returns `df` up to an ordering ambiguity.  You can get the old behavior by doing `append_keys=true`.

Again, I'm not entirely sure whether this is something everyone agrees on, but if it is, here's the PR.

I'm not at all attached the the keyword `append_keys`, actually it's kind of horrible, so I'm open to better suggestions.

This could use a few tests, but lets see if there's any concensus first.