### PR TITLE
Remove mutable structs

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -364,7 +364,7 @@ StackedVector(Any[[1,2], [9,10], [11,12]])  # [1,2,9,10,11,12]
 ```
 
 """
-mutable struct StackedVector <: AbstractVector{Any}
+struct StackedVector <: AbstractVector{Any}
     components::Vector{Any}
 end
 
@@ -423,7 +423,7 @@ RepeatedVector([1,2], 2, 2)   # [1,2,1,2,1,2,1,2]
 ```
 
 """
-mutable struct RepeatedVector{T} <: AbstractVector{T}
+struct RepeatedVector{T} <: AbstractVector{T}
     parent::AbstractVector{T}
     inner::Int
     outer::Int

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -14,7 +14,7 @@
 #                  which allows a user to specify column specific orderings
 #                  with "order(column, rev=true,...)"
 
-mutable struct UserColOrdering{T<:ColumnIndex}
+struct UserColOrdering{T<:ColumnIndex}
     col::T
     kwargs
 end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -82,7 +82,7 @@ size(df1)
 ```
 
 """
-mutable struct DataFrame <: AbstractDataFrame
+struct DataFrame <: AbstractDataFrame
     columns::Vector{AbstractVector}
     colindex::Index
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1123,7 +1123,7 @@ function permutecols!(df::DataFrame, p::AbstractVector)
         throw(ArgumentError("$p is not a valid column permutation for this DataFrame"))
     end
     permute!(columns(df), p)
-    permutecols!(getfield(df, :colindex), p)
+    @inbounds permute!(index(df), p)
     df
 end
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1123,14 +1123,10 @@ function permutecols!(df::DataFrame, p::AbstractVector)
         throw(ArgumentError("$p is not a valid column permutation for this DataFrame"))
     end
     permute!(columns(df), p)
-    newindex = Index(names(df)[p])
-    colindex = getfield!(df, :colindex)
-    colindex.names = newindex.names
-    colindex.lookup = newindex.lookup
+    permutecols!(getfield(df, :colindex), p)
     df
 end
 
 function permutecols!(df::DataFrame, p::AbstractVector{Symbol})
-    lu = index(df).lookup
-    permutecols!(df, [lu[x] for x in p])
+    permutecols!(df, index(df)[p])
 end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1123,7 +1123,10 @@ function permutecols!(df::DataFrame, p::AbstractVector)
         throw(ArgumentError("$p is not a valid column permutation for this DataFrame"))
     end
     permute!(columns(df), p)
-    setfield!(df, :colindex, Index(names(df)[p]))
+    newindex = Index(names(df)[p])
+    colindex = getfield!(df, :colindex)
+    colindex.names = newindex.names
+    colindex.lookup = newindex.lookup
     df
 end
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -3,7 +3,7 @@
 # through cleanly.
 abstract type AbstractIndex end
 
-mutable struct Index <: AbstractIndex   # an OrderedDict would be nice here...
+struct Index <: AbstractIndex   # an OrderedDict would be nice here...
     lookup::Dict{Symbol, Int}      # name => names array position
     names::Vector{Symbol}
 end
@@ -37,9 +37,11 @@ function names!(x::Index, nms::Vector{Symbol}; allow_duplicates=false, makeuniqu
     if length(nms) != length(x)
         throw(ArgumentError("Length of nms doesn't match length of x."))
     end
-    newindex = Index(nms, makeunique=makeunique)
-    x.names = newindex.names
-    x.lookup = newindex.lookup
+    make_unique!(x.names, nms, makeunique=makeunique)
+    empty!(x.lookup)
+    for (i, n) in enumerate(x.names)
+        x.lookup[n] = i
+    end
     return x
 end
 
@@ -61,12 +63,16 @@ rename!(f::Function, x::Index) = rename!(x, [(x=>f(x)) for x in x.names])
 rename(x::Index, args...) = rename!(copy(x), args...)
 rename(f::Function, x::Index) = rename!(f, copy(x))
 
-function permutecols!(x::Index, p::AbstractVector)
-    # to be callsed by permutecols! for DataFrame
-    # thefefore assumes that `p` is a valid permutation
-    newindex = Index(_names(x)[p])
-    x.names = newindex.names
-    x.lookup = newindex.lookup
+@inline function Base.permute!(x::Index, p::AbstractVector)
+    @boundscheck if !(length(p) == length(x) && isperm(p))
+        throw(ArgumentError("$p is not a valid column permutation for this Index"))
+    end
+    oldnames = copy(_names(x))
+    for (i, j) in enumerate(p)
+        n = oldnames[j]
+        x.names[i] = n
+        x.lookup[n] = i
+    end
     x
 end
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -61,6 +61,15 @@ rename!(f::Function, x::Index) = rename!(x, [(x=>f(x)) for x in x.names])
 rename(x::Index, args...) = rename!(copy(x), args...)
 rename(f::Function, x::Index) = rename!(f, copy(x))
 
+function permutecols!(x::Index, p::AbstractVector)
+    # to be callsed by permutecols! for DataFrame
+    # thefefore assumes that `p` is a valid permutation
+    newindex = Index(_names(x)[p])
+    x.names = newindex.names
+    x.lookup = newindex.lookup
+    x
+end
+
 Base.haskey(x::Index, key::Symbol) = haskey(x.lookup, key)
 Base.haskey(x::Index, key::Real) = 1 <= key <= length(x.names)
 Base.keys(x::Index) = names(x)

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -1,15 +1,22 @@
-function make_unique(names::Vector{Symbol}; makeunique::Bool=false)
+function make_unique!(names::Vector{Symbol}, src::Vector{Symbol}; makeunique::Bool=false)
+    if length(names) != length(src)
+        throw(ArgumentError("Length of src doesn't match length of names."))
+    end
     seen = Set{Symbol}()
-    names = copy(names)
     dups = Int[]
     for i in 1:length(names)
-        name = names[i]
-        in(name, seen) ? push!(dups, i) : push!(seen, name)
+        name = src[i]
+        if in(name, seen)
+            push!(dups, i)
+        else
+            names[i] = src[i]
+            push!(seen, name)
+        end
     end
 
     if length(dups) > 0
         if !makeunique
-            Base.depwarn("Duplicate variable names are deprecated: pass makeunique=true to add a suffix automatically.", :make_unique)
+            Base.depwarn("Duplicate variable names are deprecated: pass makeunique=true to add a suffix automatically.", :make_unique!)
             # TODO: uncomment the lines below after deprecation period
             # msg = """Duplicate variable names: $(u[dups]).
             #          Pass makeunique=true to make them unique using a suffix automatically."""
@@ -18,7 +25,7 @@ function make_unique(names::Vector{Symbol}; makeunique::Bool=false)
     end
 
     for i in dups
-        nm = names[i]
+        nm = src[i]
         k = 1
         while true
             newnm = Symbol("$(nm)_$k")
@@ -32,6 +39,10 @@ function make_unique(names::Vector{Symbol}; makeunique::Bool=false)
     end
 
     return names
+end
+
+function make_unique(names::Vector{Symbol}; makeunique::Bool=false)
+    make_unique!(similar(names), names, makeunique=makeunique)
 end
 
 """


### PR DESCRIPTION
This PR removes `mutable` from struct definitions where possible.
Exceptions are: `GroupedDataFrame` (this is handled in #1558) and `Index` (which is mutated internally with `names!` - but maybe we can decide to reimplement `names!` and avoid `mutable` there also).