### PR TITLE
fix == for GroupedDataFrame

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -115,13 +115,11 @@ Base.getindex(gd::GroupedDataFrame, idxs::Colon) =
     GroupedDataFrame(gd.parent, gd.cols, gd.idx, gd.starts, gd.ends)
 
 function Base.:(==)(gd1::GroupedDataFrame, gd2::GroupedDataFrame)
-    res = gd1.parent == gd2.parent
-    ismissing(res) && return missing
-    res && gd1.cols == gd2.cols
+    gd1.cols == gd2.cols && gd1.parent == gd2.parent
 end
 
 Base.isequal(gd1::GroupedDataFrame, gd2::GroupedDataFrame) =
-    isequal(gd1.parent, gd2.parent) && isequal(gd1.cols, gd2.cols)
+    isequal(gd1.cols, gd2.cols) && isequal(gd1.parent, gd2.parent)
 
 Base.names(gd::GroupedDataFrame) = names(gd.parent)
 _names(gd::GroupedDataFrame) = _names(gd.parent)

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -115,11 +115,16 @@ Base.getindex(gd::GroupedDataFrame, idxs::Colon) =
     GroupedDataFrame(gd.parent, gd.cols, gd.idx, gd.starts, gd.ends)
 
 function Base.:(==)(gd1::GroupedDataFrame, gd2::GroupedDataFrame)
-    gd1.cols == gd2.cols && gd1.parent == gd2.parent
+    gd1.cols == gd2.cols &&
+    length(gd1) == length(gd2) &&
+    all(x -> ==(x...), zip(gd1, gd2))
 end
 
-Base.isequal(gd1::GroupedDataFrame, gd2::GroupedDataFrame) =
-    isequal(gd1.cols, gd2.cols) && isequal(gd1.parent, gd2.parent)
+function Base.isequal(gd1::GroupedDataFrame, gd2::GroupedDataFrame)
+    isequal(gd1.cols, gd2.cols) &&
+    isequal(length(gd1), length(gd2)) &&
+    all(x -> isequal(x...), zip(gd1, gd2))
+end
 
 Base.names(gd::GroupedDataFrame) = names(gd.parent)
 _names(gd::GroupedDataFrame) = _names(gd.parent)

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -116,14 +116,14 @@ Base.getindex(gd::GroupedDataFrame, idxs::Colon) =
 
 function Base.:(==)(gd1::GroupedDataFrame, gd2::GroupedDataFrame)
     gd1.cols == gd2.cols &&
-    length(gd1) == length(gd2) &&
-    all(x -> ==(x...), zip(gd1, gd2))
+        length(gd1) == length(gd2) &&
+        all(x -> ==(x...), zip(gd1, gd2))
 end
 
 function Base.isequal(gd1::GroupedDataFrame, gd2::GroupedDataFrame)
     isequal(gd1.cols, gd2.cols) &&
-    isequal(length(gd1), length(gd2)) &&
-    all(x -> isequal(x...), zip(gd1, gd2))
+        isequal(length(gd1), length(gd2)) &&
+        all(x -> isequal(x...), zip(gd1, gd2))
 end
 
 Base.names(gd::GroupedDataFrame) = names(gd.parent)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -287,5 +287,10 @@ module TestGrouping
         @test !isequal(gd1, gd2)
         @test ismissing(gd2 == gd2)
         @test isequal(gd2, gd2)
+        df1.c = df1.a
+        df2.c = df2.a
+        @test gd1 != groupby(df2, :c)
+        df2[7, :b] = 10
+        @test gd1 != gd2
     end
 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -292,5 +292,17 @@ module TestGrouping
         @test gd1 != groupby(df2, :c)
         df2[7, :b] = 10
         @test gd1 != gd2
+        df3 = DataFrame(a = repeat([1, 2, 3, missing], outer=[2]),
+                        b = 1:8)
+        df4 = DataFrame(a = repeat([1, 2, 3, missing], outer=[2]),
+                        b = [1:7;missing])
+        gd3 = groupby(df3, :a)
+        gd4 = groupby(df4, :a)
+        @test ismissing(gd3 == gd4)
+        @test isequal(gd3, gd4)
+        gd3 = groupby(df3, :a, skipmissing = true)
+        gd4 = groupby(df4, :a, skipmissing = true)
+        @test gd3 == gd4
+        @test isequal(gd3, gd4)
     end
 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -299,7 +299,7 @@ module TestGrouping
         gd3 = groupby(df3, :a)
         gd4 = groupby(df4, :a)
         @test ismissing(gd3 == gd4)
-        @test isequal(gd3, gd4)
+        @test !isequal(gd3, gd4)
         gd3 = groupby(df3, :a, skipmissing = true)
         gd4 = groupby(df4, :a, skipmissing = true)
         @test gd3 == gd4


### PR DESCRIPTION
@nalimilan That is how later we have to fix things 😄.
A small fix to `==` because when `cols` are different we know that `GroupedDataFrame`s do not match even if their parents have `missing`s.