### PR TITLE
Improve copy of SubDataFrame and DataFrameRow

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -62,6 +62,8 @@ Base.convert(::Type{Array}, r::DataFrameRow) = convert(Array, parent(r)[row(r),:
 Base.keys(r::DataFrameRow) = names(parent(r))
 Base.values(r::DataFrameRow) = ntuple(col -> parent(r)[col][row(r)], length(r))
 
+Base.copy(r::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
+
 # hash column element
 Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) = hash(v[i], h)
 Base.@propagate_inbounds function hash_colel(v::AbstractCategoricalArray, i, h::UInt = zero(UInt))

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -154,7 +154,7 @@ end
 ##
 ##############################################################################
 
-Base.copy(sdf::SubDataFrame) = sdf[:]
+Base.copy(sdf::SubDataFrame) = parent(sdf)[rows(sdf), :]
 
 Base.map(f::Function, sdf::SubDataFrame) = f(sdf) # TODO: deprecate
 

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -100,5 +100,12 @@ module TestDataFrameRow
     io = IOBuffer()
     show(io, DataFrameRow(df, 1))
     @test String(take!(io)) == "DataFrameRow (row 1)\na  \nb  1"
-end
 
+    # copy
+
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing])
+    @test copy(DataFrameRow(df, 1)) == (a = 1, b = 2.0, c = "A")
+    @test isequal(copy(DataFrameRow(df, 2)), (a = 2, b = missing, c = "B"))
+end


### PR DESCRIPTION
@nalimilan This is a follow up to #1534, and should be merged if the other is merged (I separate it as we have enough of changes there).

What it does:
* change `copy` for `SubDataFrame` to ensure that it returns a `DataFrame` in the future (this is the same functionality as we have but with a syntax taking into account future changes to `getindex` that are currently in deprecation period)
* introduce `copy` for `DataFrameRow`

Actually the second point is crucial as it is a simple change that is consistent with #1534 logic but shows one important thing. Should returned `NamedTuple` have minimal (narrowest) second parametric argument (type specification). This is what is implemented now.
Or it should have a wide type specification consistent with `eltype` of `DataFrame` column.

The difference is that either:
* narrow type specification will be possibly faster when `NamedTuple` is passed to a function and it might be a bit faster to create (not 100% sure though);
* wider type specification will mean that each `NamedTuple` created from a row of a given `DataFrame` will have the same concrete type.

I am not fully clear what is better (I have implemented first, but I have the feeling that maybe the second approach is better).