### PR TITLE
Use faster hashing approach for first CategoricalVector grouping key

### DIFF
--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -41,12 +41,13 @@ function hashrows_col!(h::Vector{UInt},
                        n::Vector{Bool},
                        v::AbstractCategoricalVector,
                        firstcol::Bool)
+    index = CategoricalArrays.index(v.pool)
     # When hashing the first column, no need to take into account previous hash,
     # which is always zero
     if firstcol
         hashes = Vector{UInt}(undef, length(levels(v.pool))+1)
         hashes[1] = hash(missing)
-        hashes[2:end] .= hash.(CategoricalArrays.index(v.pool))
+        hashes[2:end] .= hash.(index)
         @inbounds for (i, ref) in enumerate(v.refs)
             h[i] = hashes[ref+1]
         end
@@ -55,7 +56,7 @@ function hashrows_col!(h::Vector{UInt},
             if eltype(v) >: Missing && ref == 0
                 h[i] = hash(missing, h[i])
             else
-                h[i] = hash(CategoricalArrays.index(v.pool)[ref], h[i])
+                h[i] = hash(index[ref], h[i])
             end
         end
     end


### PR DESCRIPTION
Since `hash` takes as an argument the hash for the previous keys, we cannot in general reuse precomputed hashes. However, this is possible for the first grouping key since the previous hash is always zero in that case. Since the number of keys is generally small, it makes a large difference to improve performance for this case.

This makes `groupby` twice faster on a simple benchmark with `CategoricalString`. Of course the difference is much smaller with `CategoricalValue{Int}`.
```julia
using DataFrames, BenchmarkTools
v = categorical(["AZERT", "AERDD", "DGGI", "RRFKLK", "4FGFD"][rand(1:5, 10_000)])

df = DataFrame(rand(10_000, 10))
df.key = v

# Master
julia> @btime groupby(df, :key);
  316.541 μs (49 allocations: 365.33 KiB)

# This PR
julia> @btime groupby(df, :key);
  153.849 μs (51 allocations: 365.47 KiB)
```

I suspect it would be possible to make this much faster by taking advantage of the fact that `CategoricalArray` references already represent groupings. But that would require making the code slightly more complex, by special-casing single-key groupings, and distinguishing grouping (where comparison happens with the same column) from joining (where the second column may not be categorical).