### PR TITLE
Use project to build Documenter docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,15 @@ script:
   - julia --check-bounds=yes -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("DataFrames"); Pkg.test("DataFrames"; coverage=true)'
 
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("DataFrames")); Pkg.add("Documenter"); Pkg.add("Query"); Pkg.add("CSV"); include(joinpath("docs", "make.jl"))'
   - julia -e 'using Pkg; cd(Pkg.dir("DataFrames")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();
+                                    Pkg.develop(PackageSpec(path=pwd()))'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.19"
+

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,10 @@
 using Documenter, DataFrames
 
+# Workaround for JuliaLang/julia/pull/28625
+if Base.HOME_PROJECT[] !== nothing
+    Base.HOME_PROJECT[] = abspath(Base.HOME_PROJECT[])
+end
+
 # Build documentation.
 # ====================
 


### PR DESCRIPTION
This will ensure doctests do not regress (once they pass and we enable them).

See https://discourse.julialang.org/t/psa-use-a-project-for-building-your-docs/14974.