### PR TITLE
Extend setindex api

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -589,14 +589,13 @@ function Base.setindex!(df::DataFrame,
                         row_ind::Real,
                         col_inds::AbstractVector{<:ColumnIndex})
     checkdimensions(new_df, row_ind, col_inds)
-    if usenames(df, new_df, col_inds)
-        for col_name in _names(new_df)
-            insert_single_entry!(df, new_df[col_name][1], row_ind, col_name)
-        end
-    else # use column order
-        for (j, col_ind) in enumerate(col_inds)
-            insert_single_entry!(df, new_df[j][1], row_ind, col_ind)
-        end
+    if !usenames(df, new_df, col_inds)
+        msg = "Column names in inserted dataframe don't match the columns " *
+              "being inserted into"
+        throw(ArgumentError(msg))
+    end
+    for col_name in _names(new_df)
+        insert_single_entry!(df, new_df[col_name][1], row_ind, col_name)
     end
     df
 end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -508,15 +508,7 @@ function Base.setindex!(df::DataFrame,
     old_row = df[row_ind, :]
     for nm in _names(df)
         try
-            # after deprecation replace this call with `val = row[nm]`
-            val = get(row, nm) do
-                v = row[string(nm)]
-                msg = "setindex!(::DataFrame, ::AbstractDict, ::Real, " *
-                      "::Colon) with AbstractDict keys other than Symbol " *
-                      "is deprecated"
-                Base.depwarn(msg, :setindex!)
-                v
-            end
+            val = row[nm]
             insert_single_entry!(df, val, row_ind, nm)
         catch
             # clean up partial row

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -4,6 +4,15 @@ struct DataFrameRow{T <: AbstractDataFrame}
     row::Int
 end
 
+# this is defined here because it has to be after the DataFrameRow definition
+# df[SingleRowIndex, MultiColumnIndex] = DataFrameRow
+function Base.setindex!(df::DataFrame,
+          val::DataFrameRow,
+          row_ind::Real,
+          col_inds::AbstractVector{<:ColumnIndex})
+    df[row_ind, col_inds] = parent(val)[row(val), :]
+    df
+end
 
 """
     parent(r::DataFrameRow)

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -108,9 +108,9 @@ module TestCat
         df[:x3] = 2
 
         # assignment of subtables
-        df[1, 1:2] = df[2, 2:3]
-        df[1:2, 1:2] = df[2:3, 2:3]
-        df[[true,false,false,true], 2:3] = df[1:2,1:2]
+        df[1, 1:2] = df[2, 1:2]
+        df[1:2, 1:2] = df[2:3, 1:2]
+        df[[true,false,false,true], 2:3] = df[1:2,2:3]
 
         # scalar broadcasting assignment of subtables
         df[1, 1:2] = 3
@@ -204,7 +204,7 @@ module TestCat
                                                 [7, 8, 9, 2, 4, 6, 2, 4, 6]], [:A, :B, :C])
         @test vcat(df2, df1, df2) == DataFrame([[2, 4, 6, 7, 8, 9, 2, 4, 6],
                                                 [8, 10, 12, 4, 5, 6, 8, 10, 12],
-                                                [14, 16, 18, 1, 2, 3, 14, 16, 18]] ,[:C, :B, :A]) 
+                                                [14, 16, 18, 1, 2, 3, 14, 16, 18]] ,[:C, :B, :A])
         @test size(vcat(df1, df1, df1, df2, df2, df2)) == (18, 3)
         df3 = df1[[1, 3, 2]]
         res = vcat(df1, df1, df1, df2, df2, df2, df3, df3, df3, df3)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -714,7 +714,7 @@ module TestDataFrame
         @test df == dfa
 
         df = DataFrame(a=[0, 0], b=['a', 'a'])
-        df[2, :] = (a=1, b='b')
+        df[2, :] = (b='b', a=1)
         @test df == dfa
 
         df = DataFrame(a=[0, 0], b=['a', 'a'])

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -707,7 +707,7 @@ module TestDataFrame
         @test names(df) == [:x3, :x3_1, :x3_2, :x4]
     end
 
-    @testset "setindex! sets row with dict" begin
+    @testset "setindex! sets row with dict/iterable" begin
         df = DataFrame(a=[0, 0], b=['a', 'a'])
         dfa = DataFrame(a=0:1, b='a':'b')
         df[2, :] = Dict(:a => 1, :b => 'b')
@@ -720,6 +720,19 @@ module TestDataFrame
         df = DataFrame(a=[0, 0], b=['a', 'a'])
         dfc = deepcopy(df)
         @test_throws ArgumentError df[2, :] = Dict(:a => 1)
+        @test df == dfc
+
+        df[2, :] = [1, 'b']
+        @test df == dfa
+
+        df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
+        dfa = DataFrame(a=0:1, b=['a', 'a'], c=0:1)
+        df[2, [:a, :c]] = [1, 1]
+        @test df == dfa
+
+        df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
+        dfc = deepcopy(df)
+        @test_throws ArgumentError df[2, :] = [1, 1]
         @test df == dfc
     end
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -707,6 +707,22 @@ module TestDataFrame
         @test names(df) == [:x3, :x3_1, :x3_2, :x4]
     end
 
+    @testset "setindex! sets row with dict" begin
+        df = DataFrame(a=[0, 0], b=['a', 'a'])
+        dfa = DataFrame(a=0:1, b='a':'b')
+        df[2, :] = Dict(:a => 1, :b => 'b')
+        @test df == dfa
+
+        df = DataFrame(a=[0, 0], b=['a', 'a'])
+        df[2, :] = (a=1, b='b')
+        @test df == dfa
+
+        df = DataFrame(a=[0, 0], b=['a', 'a'])
+        dfc = deepcopy(df)
+        @test_throws ArgumentError df[2, :] = Dict(:a => 1)
+        @test df == dfc
+    end
+
     @testset "passing range to a DataFrame" begin
         df = DataFrame(a=1:3, b='a':'c')
         df[:c] = 1:3

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -746,13 +746,13 @@ module TestDataFrame
         @test df == dfc
 
         df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
-        @test_skip begin
+        @test begin
             df[2, :] = DataFrameRow(dfa, 2)
             df == dfa
         end
 
         df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
-        @test_skip begin
+        @test_broken begin
             df[2, [:a, :c]] .= 1
             df == dfa
         end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -786,7 +786,7 @@ module TestDataFrame
             x[end] = 1:4
             y[5] = 1:4
             @test x == y
-            x[4:end] = DataFrame([11:14, 21:24])
+            x[4:end] = DataFrame(:x4 => 11:14, :x5 => 21:24)
             y[4] = [11:14;]
             y[5] = [21:24;]
             @test x == y

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -722,6 +722,9 @@ module TestDataFrame
         @test_throws ArgumentError df[2, :] = Dict(:a => 1)
         @test df == dfc
 
+        @test_throws ArgumentError df[2, :] = (a=1.5, b='b')
+        @test df == dfc
+
         df[2, :] = [1, 'b']
         @test df == dfa
 
@@ -734,6 +737,14 @@ module TestDataFrame
         df[2, [:a, :c]] = [1, 1]
         @test df == dfa
 
+        df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
+        dfc = deepcopy(df)
+        @test_throws ArgumentError df[2, :] = [1, 1]
+        @test df == dfc
+
+        @test_throws ArgumentError df[2, [:a, :c]] = [1.5, 1]
+        @test df == dfc
+
         # df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
         # df[2, :] = DataFrameRow(dfa, 2)
         # @test df == dfa
@@ -741,11 +752,6 @@ module TestDataFrame
         # df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
         # df[2, [:a, :c]] .= 1
         # @test df == dfa
-
-        df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
-        dfc = deepcopy(df)
-        @test_throws ArgumentError df[2, :] = [1, 1]
-        @test df == dfc
     end
 
     @testset "passing range to a DataFrame" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -707,7 +707,7 @@ module TestDataFrame
         @test names(df) == [:x3, :x3_1, :x3_2, :x4]
     end
 
-    @testset "setindex! sets row with dict/iterable" begin
+    @testset "setindex! tests" begin
         df = DataFrame(a=[0, 0], b=['a', 'a'])
         dfa = DataFrame(a=0:1, b='a':'b')
         df[2, :] = Dict(:a => 1, :b => 'b')
@@ -745,13 +745,21 @@ module TestDataFrame
         @test_throws ArgumentError df[2, [:a, :c]] = [1.5, 1]
         @test df == dfc
 
-        # df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
-        # df[2, :] = DataFrameRow(dfa, 2)
-        # @test df == dfa
-        #
-        # df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
-        # df[2, [:a, :c]] .= 1
-        # @test df == dfa
+        df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
+        @test_skip begin
+            df[2, :] = DataFrameRow(dfa, 2)
+            df == dfa
+        end
+
+        df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
+        @test_skip begin
+            df[2, [:a, :c]] .= 1
+            df == dfa
+        end
+
+        df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
+        df[2, :] = dfa[2, :]
+        @test df == dfa
     end
 
     @testset "passing range to a DataFrame" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -725,10 +725,22 @@ module TestDataFrame
         df[2, :] = [1, 'b']
         @test df == dfa
 
+        df = DataFrame(a=[0, 0], b=['a', 'a'])
+        df[2, :] = (1, 'b')
+        @test df == dfa
+
         df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
         dfa = DataFrame(a=0:1, b=['a', 'a'], c=0:1)
         df[2, [:a, :c]] = [1, 1]
         @test df == dfa
+
+        # df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
+        # df[2, :] = DataFrameRow(dfa, 2)
+        # @test df == dfa
+        #
+        # df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
+        # df[2, [:a, :c]] .= 1
+        # @test df == dfa
 
         df = DataFrame(a=[0, 0], b=['a', 'a'], c=[0, 0])
         dfc = deepcopy(df)


### PR DESCRIPTION
This resolves #1569 

I wasn't sure if we want the second commit, but it was pretty easy to add so I just did it (and currently, trying to make such a call interprets the iterable as a scalar and broadcasts it to all the columns in the row - that may be desirable when the columns hold collections, but that seems like an uncommon use case, if the columns don't hold collections it just throws an error and doesn't do anything). I'm happy to remove it though if we don't want it.

One thing that I considered that could be added to this is that perhaps we want to allow updating just some values in a row with a named tuple (or a dictionary), I just wasn't sure what syntax we would want. It'd be simplest to allow using a named tuple missing some columns in the assignment `df[1, :] = tuple`, and only update the columns that the tuple has, but it'd be more clear if we required `df[1, keys(tuple)] = tuple`. I'm happy to add either one to this pull request if we want.