### PR TITLE
improve naming of anonymous functions in aggregate

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -376,13 +376,13 @@ function aggregate(d::AbstractDataFrame,
     aggregate(groupby(d, cols, sort=sort), fs)
 end
 
-function dfnameof(f)
+function funname(f)
     n = nameof(f)
-    String(n)[1] == '#' ? :λ : n
+    String(n)[1] == '#' ? :function : n
 end
 
 _makeheaders(fs::Vector{<:Function}, cn::Vector{Symbol}) =
-    [Symbol(colname, '_', dfnameof(f)) for f in fs for colname in cn]
+    [Symbol(colname, '_', funname(f)) for f in fs for colname in cn]
 
 function _aggregate(d::AbstractDataFrame, fs::Vector{T}, headers::Vector{Symbol}, sort::Bool=false) where T<:Function
     res = DataFrame(AbstractVector[vcat(f(d[i])) for f in fs for i in 1:size(d, 2)], headers, makeunique=true)

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -376,11 +376,16 @@ function aggregate(d::AbstractDataFrame,
     aggregate(groupby(d, cols, sort=sort), fs)
 end
 
+function dfnameof(f)
+    n = nameof(f)
+    String(n)[1] == '#' ? :λ : n
+end
+
 _makeheaders(fs::Vector{<:Function}, cn::Vector{Symbol}) =
-    [Symbol(colname, '_', nameof(f)) for f in fs for colname in cn]
+    [Symbol(colname, '_', dfnameof(f)) for f in fs for colname in cn]
 
 function _aggregate(d::AbstractDataFrame, fs::Vector{T}, headers::Vector{Symbol}, sort::Bool=false) where T<:Function
-    res = DataFrame(AbstractVector[vcat(f(d[i])) for f in fs for i in 1:size(d, 2)], headers)
+    res = DataFrame(AbstractVector[vcat(f(d[i])) for f in fs for i in 1:size(d, 2)], headers, makeunique=true)
     sort && sort!(res, headers)
     res
 end

--- a/test/data.jl
+++ b/test/data.jl
@@ -146,7 +146,10 @@ module TestData
         anonf = x -> sum(x)
         adf = aggregate(df7, :d2, [mean, anonf])
         @test names(adf) == [:d2, :d1_mean, :d3_mean,
-                             Symbol(:d1_, nameof(anonf)), Symbol(:d3_, nameof(anonf))]
+                             :d1_λ, :d3_λ]
+        adf = aggregate(df7, :d2, [mean, mean, anonf, anonf])
+        @test names(adf) == [:d2, :d1_mean, :d3_mean, :d1_mean_1, :d3_mean_1,
+                             :d1_λ, :d3_λ, :d1_λ_1, :d3_λ_1]
 
         df9 = aggregate(df7, :d2, [sum, length], sort=true)
         @test df9 ≅ df8

--- a/test/data.jl
+++ b/test/data.jl
@@ -146,10 +146,10 @@ module TestData
         anonf = x -> sum(x)
         adf = aggregate(df7, :d2, [mean, anonf])
         @test names(adf) == [:d2, :d1_mean, :d3_mean,
-                             :d1_λ, :d3_λ]
+                             :d1_function, :d3_function]
         adf = aggregate(df7, :d2, [mean, mean, anonf, anonf])
         @test names(adf) == [:d2, :d1_mean, :d3_mean, :d1_mean_1, :d3_mean_1,
-                             :d1_λ, :d3_λ, :d1_λ_1, :d3_λ_1]
+                             :d1_function, :d3_function, :d1_function_1, :d3_function_1]
 
         df9 = aggregate(df7, :d2, [sum, length], sort=true)
         @test df9 ≅ df8


### PR DESCRIPTION
October is about to end, so I proposed to solve #1276.

I use standard `DataFrame` constructor machinery to generate names. The default suffix for lambda function is `λ`.

Also added `makeunique` keyword argument as it was missing (as here I guess we should set it to `true` it by default).

I do not know a better approach to test if a function is anonymous than by checking if first character of its name is `#` (maybe there is a cleaner solution to this?).