### PR TITLE
Add support for another TableTraits.jl interface

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -10,5 +10,5 @@ CodecZlib 0.4
 TranscodingStreams
 Compat 0.59.0
 Tables
-IteratorInterfaceExtensions
-TableTraits
+IteratorInterfaceExtensions 0.1.1
+TableTraits 0.4.0

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -16,6 +16,10 @@ function DataFrame(x)
     if Tables.istable(typeof(x))
         return fromcolumns(Tables.columns(x))
     end
+    if TableTraits.supports_get_columns_copy_using_missing(x)
+        y = TableTraits.get_columns_copy_using_missing(x)
+        return DataFrame(collect(y), collect(keys(y)))
+    end
     it = TableTraits.isiterabletable(x)
     if it === true
         # Base.depwarn("constructing a DataFrame from an iterator is deprecated; $T should support the Tables.jl interface", nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,7 @@ my_tests = ["utils.jl",
             "show.jl",
             "subdataframe.jl",
             "tables.jl",
+            "tabletraits.jl",
             "deprecated.jl"]
 
 println("Running tests:")

--- a/test/tabletraits.jl
+++ b/test/tabletraits.jl
@@ -1,0 +1,24 @@
+module TestTableTraits
+using Test, TableTraits, DataFrames
+
+struct ColumnSource
+end
+
+TableTraits.supports_get_columns_copy_using_missing(::ColumnSource) = true
+
+function TableTraits.get_columns_copy_using_missing(x::ColumnSource)
+    return (a=[1,2,3], b=[4.,5.,6.], c=["A", "B", "C"])
+end
+
+@testset "TableTraits" begin
+
+    df = DataFrame(ColumnSource())
+
+    @test size(df)==(3,3)
+    @test df.a==[1,2,3]
+    @test df.b==[4.,5.,6.]
+    @test df.c==["A", "B", "C"]
+
+end
+
+end


### PR DESCRIPTION
I've had something like this lingering around in branches for a very long time, but now finally finished it upstream.

With this PR, the current performance overhead that [CSVFiles.j](https://github.com/queryverse/CSVFiles.jl) has over a raw [TextParse.jl](https://github.com/JuliaComputing/TextParse.jl) disappears entirely. So in the benchmarks shown [here](https://discourse.julialang.org/t/textparse-jl-is-fast-again/16664/10), [CSVFiles.j](https://github.com/queryverse/CSVFiles.jl) gets the same (excellent) performance that one can see in raw [TextParse.jl](https://github.com/JuliaComputing/TextParse.jl) if used with ``DataFrame``.

We have a whole bunch of other plans for the [Queryverse.jl](https://github.com/queryverse/Queryverse.jl) that will lead to more and more sources that will utilize this interface as well, so there will be more benefits down the road. That includes the other file IO packages, but also [Query.jl](https://github.com/queryverse/Query.jl) itself (although that latter part is not going to happen overnight).

Things still to do:
- [x] Add a test.