### PR TITLE
Cleanup of documentation code

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,7 +24,8 @@ makedocs(
         ],
         "API" => Any[
             "Types" => "lib/types.md",
-            "Functions" => "lib/functions.md"
+            "Functions" => "lib/functions.md",
+            "Indexing" => "lib/indexing.md"
         ]
     ]
 )

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -38,6 +38,7 @@ eltypes
 filter
 filter!
 head
+insertcols!
 names!
 nonunique
 rename!

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -11,23 +11,26 @@ Pages = ["types.md"]
 
 ## Type hierarchy design
 
-`AbstractDataFrame` is an abstract type that provides an interface for working with tabular data.
+`AbstractDataFrame` is an abstract type that provides an interface for data frame types.
+It is not intended as a fully generic interface for working with tabular data, which is the role of
+interfaces defined by [Tables.jl](https://github.com/JuliaData/Tables.jl/) instead.
 
-A key subtype of the `AbstractDataFrame` type is a `DataFrame` type that uses columnar data storage.
+`DataFrame` is the most fundamental subtype of `AbstractDataFrame`, which stores a set of columns
+as `AbstractVector` objects.
 
-The package provides a `SubDataFrame` type that is also `AbstractDataFrame` subtype.
-The `SubDataFrame` type is a view into `DataFrame`. It stores only a reference to parent `DataFrame`
-and information about which rows from the parent are selected. Typically it is created by using the `view`
-function or is returned by indexing into a `GroupedDataFrame` object.
+`SubDataFrame` is an `AbstractDataFrame` subtype representing a view into a `DataFrame`.
+It stores only a reference to the parent `DataFrame` and information about which rows from the parent are selected.
+Typically it is created using the `view` function or is returned by indexing into a `GroupedDataFrame` object.
 
-A `GroupedDataFrame` type is a type that allows to store the information about the result of grouping
-operation performed on a data frame. It is intended to be created as a result of a call to the `groupby` function.
+`GroupedDataFrame` is a type that stores the result of a  grouping operation performed on an `AbstractDataFrame`.
+It is intended to be created as a result of a call to the `groupby` function.
 
-A `DataFrameRow` type is a view into a single row of an `AbstractDataFrame`. It stores only a reference
-to a parent `AbstractDataFrame` and information about which row from the parent are selected.
-The `DataFrameRow` type supports iteration over columns of a row and is similar in functionality to
-the `NamedTuple` type, but allows for modification of data stored in the parent `AbstractDataFrame`.
-Typically objects of `DataFrameRow` type are encountered when returned by `eachrow` function.
+`DataFrameRow` is a view into a single row of an `AbstractDataFrame`. It stores only a reference
+to a parent `AbstractDataFrame` and information about which row from the parent is selected.
+The `DataFrameRow` type supports iteration over columns of the row and is similar in functionality to
+the `NamedTuple` type, but allows for modification of data stored in the parent `AbstractDataFrame`
+and reflects changes done to the parent after the creation of the view.
+Typically objects of the `DataFrameRow` type are encountered when returned by the `eachrow` function.
 In the future accessing a single row of a data frame via `getindex` or `view` will return a `DataFrameRow`.
 
 ## Types specification

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -9,11 +9,33 @@ CurrentModule = DataFrames
 Pages = ["types.md"]
 ```
 
+## Type hierarchy design
+
+`AbstractDataFrame` is an abstract type that provides database-like interface.
+
+A key subtype of the `AbstractDataFrame` type is a `DataFrame` type that uses columnar data storage.
+
+The package provides a `SubDataFrame` type that is also `AbstractDataFrame` subtype.
+Is a view into `DataFrame`. It stores only a reference to parent `DataFrame` and information about
+which rows from the parent are selected. Typically it is created by using the `view` function or
+is returned by indexing into a `GroupedDataFrame` object.
+
+A `GroupedDataFrame` type is a type that allows to store the information about the result of grouping
+operation performed on a data frame. It is intended to be created as a result of a call to the `groupby` function.
+
+A `DataFrameRow` type is a view into a single row of an `AbstractDataFrame`. It stores only a reference
+to a parent `AbstractDataFrame` and information about which row from the parent are selected.
+The `DataFrameRow` type supports iteration over columns of a row and is similar in functionality to
+the `NamedTuple` type, but allows for modification of data stored in the parent `AbstractDataFrame`.
+Typically objects of `DataFrameRow` type are encountered when returned by `eachrow` function.
+In the future accessing a single row of a data frame via `getindex` or `view` will return a `DataFrameRow`.
+
+## Types specification
+
 ```@docs
 AbstractDataFrame
 DataFrame
 DataFrameRow
-GroupApplied
 GroupedDataFrame
 SubDataFrame
 ```

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -11,14 +11,14 @@ Pages = ["types.md"]
 
 ## Type hierarchy design
 
-`AbstractDataFrame` is an abstract type that provides database-like interface.
+`AbstractDataFrame` is an abstract type that provides an interface for working with tabular data.
 
 A key subtype of the `AbstractDataFrame` type is a `DataFrame` type that uses columnar data storage.
 
 The package provides a `SubDataFrame` type that is also `AbstractDataFrame` subtype.
-Is a view into `DataFrame`. It stores only a reference to parent `DataFrame` and information about
-which rows from the parent are selected. Typically it is created by using the `view` function or
-is returned by indexing into a `GroupedDataFrame` object.
+The `SubDataFrame` type is a view into `DataFrame`. It stores only a reference to parent `DataFrame`
+and information about which rows from the parent are selected. Typically it is created by using the `view`
+function or is returned by indexing into a `GroupedDataFrame` object.
 
 A `GroupedDataFrame` type is a type that allows to store the information about the result of grouping
 operation performed on a data frame. It is intended to be created as a result of a call to the `groupby` function.

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1,8 +1,8 @@
 """
     AbstractDataFrame
 
-An abstract type for which all concrete types expose a database-like
-interface.
+An abstract type for which all concrete types expose an interface
+for working with tabular data.
 
 **Common methods**
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1,5 +1,6 @@
-
 """
+    AbstractDataFrame
+
 An abstract type for which all concrete types expose a database-like
 interface.
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1,5 +1,5 @@
 """
-    DataFrame
+    DataFrame <: AbstractDataFrame
 
 An AbstractDataFrame that stores a set of named columns
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1,4 +1,6 @@
 """
+    DataFrame
+
 An AbstractDataFrame that stores a set of named columns
 
 The columns are normally AbstractVectors stored in memory,

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -1,9 +1,9 @@
 """
-    DataFrameRow
+    DataFrameRow{<:AbstractDataFrame}
 
 A view of one row of an AbstractDataFrame.
 """
-struct DataFrameRow{T <: AbstractDataFrame}
+struct DataFrameRow{T<:AbstractDataFrame}
     df::T
     row::Int
 end

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -1,4 +1,8 @@
-# Container for a DataFrame row
+"""
+    DataFrameRow
+
+A view of one row of an AbstractDataFrame.
+"""
 struct DataFrameRow{T <: AbstractDataFrame}
     df::T
     row::Int

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1,14 +1,6 @@
-#
-#  Split - Apply - Combine operations
-#
-
-##############################################################################
-##
-## GroupedDataFrame...
-##
-##############################################################################
-
 """
+    GroupedDataFrame
+
 The result of a `groupby` operation on an AbstractDataFrame; a
 view into the AbstractDataFrame grouped by rows.
 

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -1,26 +1,6 @@
-##############################################################################
-##
-## We use SubDataFrame's to maintain a reference to a subset of a DataFrame
-## without making copies.
-##
-##############################################################################
-
-struct SubDataFrame{T <: AbstractVector{Int}} <: AbstractDataFrame
-    parent::DataFrame
-    rows::T # maps from subdf row indexes to parent row indexes
-
-    function SubDataFrame{T}(parent::DataFrame, rows::T) where {T <: AbstractVector{Int}}
-        if length(rows) > 0
-            rmin, rmax = extrema(rows)
-            if rmin < 1 || rmax > size(parent, 1)
-                throw(BoundsError())
-            end
-        end
-        new(parent, rows)
-    end
-end
-
 """
+    SubDataFrame
+
 A view of row subsets of an AbstractDataFrame
 
 A `SubDataFrame` is meant to be constructed with `view`.  A
@@ -62,7 +42,20 @@ sdf1[:,[:a,:b]]
 ```
 
 """
-SubDataFrame
+struct SubDataFrame{T <: AbstractVector{Int}} <: AbstractDataFrame
+    parent::DataFrame
+    rows::T # maps from subdf row indexes to parent row indexes
+
+    function SubDataFrame{T}(parent::DataFrame, rows::T) where {T <: AbstractVector{Int}}
+        if length(rows) > 0
+            rmin, rmax = extrema(rows)
+            if rmin < 1 || rmax > size(parent, 1)
+                throw(BoundsError())
+            end
+        end
+        new(parent, rows)
+    end
+end
 
 function SubDataFrame(parent::DataFrame, rows::T) where {T <: AbstractVector{Int}}
     return SubDataFrame{T}(parent, rows)

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -1,5 +1,5 @@
 """
-    SubDataFrame
+    SubDataFrame{<:AbstractVector{Int}} <: AbstractDataFrame
 
 A view of row subsets of an AbstractDataFrame
 
@@ -42,7 +42,7 @@ sdf1[:,[:a,:b]]
 ```
 
 """
-struct SubDataFrame{T <: AbstractVector{Int}} <: AbstractDataFrame
+struct SubDataFrame{T<:AbstractVector{Int}} <: AbstractDataFrame
     parent::DataFrame
     rows::T # maps from subdf row indexes to parent row indexes
 


### PR DESCRIPTION
Fixes:

* generation of doc page of indexing that was missing;
* hopefully makes http://juliadata.github.io/DataFrames.jl/latest/lib/types.html#Types-1 correctly contain documentation of types (not only their names)