### PR TITLE
document eachrow and eachcol

### DIFF
--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -34,6 +34,7 @@ disallowmissing!
 dropmissing
 dropmissing!
 eachrow
+eachcol
 eltypes
 filter
 filter!

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -33,7 +33,7 @@ and reflects changes done to the parent after the creation of the view.
 Typically objects of the `DataFrameRow` type are encountered when returned by the `eachrow` function.
 In the future accessing a single row of a data frame via `getindex` or `view` will return a `DataFrameRow`.
 
-Additionally `eachrow` and `eachcol` functions return values of `DFRowIterator` and `DFColumnIterator` types respectively.
+Additionally the `eachrow` and `eachcol` functions return values of the `DFRowIterator` and `DFColumnIterator` types respectively.
 Those types are not exported and should not be constructed directly.
 They respectively serve as iterators over rows and columns of an `AbstractDataFrame`.
 

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -33,6 +33,10 @@ and reflects changes done to the parent after the creation of the view.
 Typically objects of the `DataFrameRow` type are encountered when returned by the `eachrow` function.
 In the future accessing a single row of a data frame via `getindex` or `view` will return a `DataFrameRow`.
 
+Additionally `eachrow` and `eachcol` functions return values of `DFRowIterator` and `DFColumnIterator` types respectively.
+Those types are not exported and should not be constructed directly.
+They respectively serve as iterators over rows and columns of an `AbstractDataFrame.
+
 ## Types specification
 
 ```@docs
@@ -41,4 +45,6 @@ DataFrame
 DataFrameRow
 GroupedDataFrame
 SubDataFrame
+DFRowIterator
+DFColumnIterator
 ```

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -35,7 +35,7 @@ In the future accessing a single row of a data frame via `getindex` or `view` wi
 
 Additionally `eachrow` and `eachcol` functions return values of `DFRowIterator` and `DFColumnIterator` types respectively.
 Those types are not exported and should not be constructed directly.
-They respectively serve as iterators over rows and columns of an `AbstractDataFrame.
+They respectively serve as iterators over rows and columns of an `AbstractDataFrame`.
 
 ## Types specification
 

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -58,7 +58,7 @@ Iteration returns a tuple consisting of column name and column vector.
 
 `DFColumnIterator` has a custom implementation of the `map` function which
 returns a `DataFrame` and assumes that a function argument passed do
-the `map` function accepts only column data.
+the `map` function accepts takes only a column vector.
 
 **Examples**
 

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -13,7 +13,7 @@
 Iterator over rows of an `AbstractDataFrame`.
 Each returned value is represented as a `DataFrameRow`.
 
-A value of this type is returned by `eachrow` function.
+A value of this type is returned by the [`eachrow`](@link) function.
 """
 struct DFRowIterator{T <: AbstractDataFrame}
     df::T

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -42,7 +42,7 @@ Base.map(f::Function, dfri::DFRowIterator) = [f(row) for row in dfri]
     DFColumnIterator{<:AbstractDataFrame}
 
 Iterator over columns of an `AbstractDataFrame`.
-Each returned value is a tuple consisting of column name and column data.
+Each returned value is a tuple consisting of column name and column vector.
 
 A value of this type is returned by `eachcol` function.
 """

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -54,7 +54,7 @@ end
     eachcol(df::AbstractDataFrame)
 
 Return a `DFColumnIterator` that iterates an `AbstractDataFrame` column by column.
-Iteration returns a tuple consisting of column name and column data.
+Iteration returns a tuple consisting of column name and column vector.
 
 `DFColumnIterator` has a custom implementation of the `map` function which
 returns a `DataFrame` and assumes that a function argument passed do

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -7,14 +7,23 @@
 # TODO: Reconsider/redesign eachrow -- ~100% overhead
 
 # Iteration by rows
+"""
+    DFRowIterator{<:AbstractDataFrame}
+
+Iterator over rows of an `AbstractDataFrame`.
+Each returned value is represented as a `DataFrameRow`.
+
+A value of this type is returned by `eachrow` function.
+"""
 struct DFRowIterator{T <: AbstractDataFrame}
     df::T
 end
-"""
-    eachrow(df) => DataFrames.DFRowIterator
 
-Iterate a DataFrame row by row, with each row represented as a `DataFrameRow`,
-which is a view that acts like a one-row DataFrame.
+"""
+    eachrow(::AbstractDataFrame)
+
+Return `DFRowIterator` that iterates an `AbstractDataFrame` row by row,
+with each row represented as a `DataFrameRow`.
 """
 eachrow(df::AbstractDataFrame) = DFRowIterator(df)
 
@@ -29,16 +38,31 @@ Base.getindex(itr::DFRowIterator, i) = DataFrameRow(itr.df, i)
 Base.map(f::Function, dfri::DFRowIterator) = [f(row) for row in dfri]
 
 # Iteration by columns
+"""
+    DFColumnIterator{<:AbstractDataFrame}
+
+Iterator over columns of an `AbstractDataFrame`.
+Each returned value is a tuple consisting of column name and column data.
+
+A value of this type is returned by `eachcol` function.
+"""
 struct DFColumnIterator{T <: AbstractDataFrame}
     df::T
 end
+
+"""
+    eachcol(::AbstractDataFrame)
+
+Return `DFColumnIterator` that iterates an `AbstractDataFrame` column by column.
+Iteration returns a tuple consisting of column name and column data.
+"""
 eachcol(df::AbstractDataFrame) = DFColumnIterator(df)
 
 function Base.iterate(itr::DFColumnIterator, j=1)
     j > size(itr.df, 2) && return nothing
     return ((_names(itr.df)[j], itr.df[j]), j + 1)
 end
-Base.eltype(::DFColumnIterator) = Tuple{Symbol, Any}
+Base.eltype(::DFColumnIterator) = Tuple{Symbol, AbstractVector}
 Base.size(itr::DFColumnIterator) = (size(itr.df, 2), )
 Base.length(itr::DFColumnIterator) = size(itr.df, 2)
 Base.getindex(itr::DFColumnIterator, j) = itr.df[j]

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -53,7 +53,7 @@ end
 """
     eachcol(df::AbstractDataFrame)
 
-Return `DFColumnIterator` that iterates an `AbstractDataFrame` column by column.
+Return a `DFColumnIterator` that iterates an `AbstractDataFrame` column by column.
 Iteration returns a tuple consisting of column name and column data.
 
 `DFColumnIterator` has a custom implementation of the `map` function which

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -10,8 +10,8 @@
 """
     DFRowIterator{<:AbstractDataFrame}
 
-Iterator over rows of an `AbstractDataFrame`.
-Each returned value is represented as a `DataFrameRow`.
+Iterator over rows of an `AbstractDataFrame`,
+with each row represented as a `DataFrameRow`.
 
 A value of this type is returned by the [`eachrow`](@link) function.
 """
@@ -61,9 +61,19 @@ the `map` function accepts takes only a column vector.
 
 **Examples**
 
-```julia
-df = DataFrame(x=1:4, y=11:14)
-map(sum, eachcol(df)) == DataFrame(x=10, y=50)
+```jldoctest
+julia> df = DataFrame(x=1:4, y=11:14)
+4×2 DataFrame
+│ Row │ x     │ y     │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 1     │ 11    │
+│ 2   │ 2     │ 12    │
+│ 3   │ 3     │ 13    │
+│ 4   │ 4     │ 14    │
+
+julia> map(sum, eachcol(df)) == DataFrame(x=10, y=50)
+true
 ```
 """
 eachcol(df::AbstractDataFrame) = DFColumnIterator(df)

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -72,8 +72,12 @@ julia> df = DataFrame(x=1:4, y=11:14)
 │ 3   │ 3     │ 13    │
 │ 4   │ 4     │ 14    │
 
-julia> map(sum, eachcol(df)) == DataFrame(x=10, y=50)
-true
+julia> map(sum, eachcol(df))
+1×2 DataFrame
+│ Row │ x     │ y     │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 10    │ 50    │
 ```
 """
 eachcol(df::AbstractDataFrame) = DFColumnIterator(df)

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -51,7 +51,7 @@ struct DFColumnIterator{T <: AbstractDataFrame}
 end
 
 """
-    eachcol(::AbstractDataFrame)
+    eachcol(df::AbstractDataFrame)
 
 Return `DFColumnIterator` that iterates an `AbstractDataFrame` column by column.
 Iteration returns a tuple consisting of column name and column data.

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -55,6 +55,17 @@ end
 
 Return `DFColumnIterator` that iterates an `AbstractDataFrame` column by column.
 Iteration returns a tuple consisting of column name and column data.
+
+`DFColumnIterator` has a custom implementation of the `map` function which
+returns a `DataFrame` and assumes that a function argument passed do
+the `map` function accepts only column data.
+
+**Examples**
+
+```julia
+df = DataFrame(x=1:4, y=11:14)
+map(sum, eachcol(df)) == DataFrame(x=10, y=50)
+```
 """
 eachcol(df::AbstractDataFrame) = DFColumnIterator(df)
 

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -44,7 +44,7 @@ Base.map(f::Function, dfri::DFRowIterator) = [f(row) for row in dfri]
 Iterator over columns of an `AbstractDataFrame`.
 Each returned value is a tuple consisting of column name and column vector.
 
-A value of this type is returned by `eachcol` function.
+A value of this type is returned by the [`eachcol`](@link) function.
 """
 struct DFColumnIterator{T <: AbstractDataFrame}
     df::T

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -22,7 +22,7 @@ end
 """
     eachrow(df::AbstractDataFrame)
 
-Return `DFRowIterator` that iterates an `AbstractDataFrame` row by row,
+Return a `DFRowIterator` that iterates an `AbstractDataFrame` row by row,
 with each row represented as a `DataFrameRow`.
 """
 eachrow(df::AbstractDataFrame) = DFRowIterator(df)

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -20,7 +20,7 @@ struct DFRowIterator{T <: AbstractDataFrame}
 end
 
 """
-    eachrow(::AbstractDataFrame)
+    eachrow(df::AbstractDataFrame)
 
 Return `DFRowIterator` that iterates an `AbstractDataFrame` row by row,
 with each row represented as a `DataFrameRow`.

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -21,8 +21,8 @@ module TestIteration
     @test size(eachcol(df)) == (size(df, 2),)
     @test length(eachcol(df)) == size(df, 2)
     @test eachcol(df)[1] == df[:, 1]
-    @test collect(eachcol(df)) isa Vector{Tuple{Symbol, Any}}
-    @test eltype(eachcol(df)) == Tuple{Symbol, Any}
+    @test collect(eachcol(df)) isa Vector{Tuple{Symbol, AbstractVector}}
+    @test eltype(eachcol(df)) == Tuple{Symbol, AbstractVector}
     for col in eachcol(df)
         @test isa(col, Tuple{Symbol, AbstractVector})
     end


### PR DESCRIPTION
Improves documentation of `eachrow` and `eachcol`.
Additionally specifies `eltype` of `DFColumnIterator` to be `Tuple{Symbol, AbstractVector}`.