### PR TITLE
Respecting |>

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1322,14 +1322,6 @@ end
 @deprecate rename(x::AbstractDataFrame, from::Symbol, to::Symbol) rename(x, from => to)
 @deprecate rename(x::Index, f::Function) rename(f, x)
 
-# Pipeline
-import Base: |>
-@deprecate (|>)(gd::GroupedDataFrame, fs::Function) aggregate(gd, fs)
-@deprecate (|>)(gd::GroupedDataFrame, fs::Vector{T}) where {T<:Function} aggregate(gd, fs)
-@deprecate colwise(f) x -> colwise(f, x)
-@deprecate groupby(cols::Vector{T}; sort::Bool = false, skipmissing::Bool = false) where {T} x -> groupby(x, cols, sort = sort, skipmissing = skipmissing)
-@deprecate groupby(cols; sort::Bool = false, skipmissing::Bool = false) x -> groupby(x, cols, sort = sort, skipmissing = skipmissing)
-
 import Base: vcat
 @deprecate vcat(x::Vector{<:AbstractDataFrame}) vcat(x...)
 


### PR DESCRIPTION
This breaks DataFramesMeta piping framework. The one-flavored versions could be migrated to DataFramesMeta.

Fixes https://github.com/JuliaData/DataFramesMeta.jl/issues/116