### PR TITLE
Deprecate length(df::AbstractDataFrame) in favor of size(df, 2)

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -231,10 +231,9 @@ function Base.size(df::AbstractDataFrame, i::Integer)
     end
 end
 
-Base.length(df::AbstractDataFrame) = ncol(df)
-Compat.lastindex(df::AbstractDataFrame) = ncol(df)
-Compat.lastindex(df::AbstractDataFrame, i) = last(axes(df, i))
-Compat.axes(df, i) = axes(df)[i]
+Base.lastindex(df::AbstractDataFrame) = ncol(df)
+Base.lastindex(df::AbstractDataFrame, i) = last(axes(df, i))
+Base.axes(df, i) = axes(df)[i]
 
 Base.ndims(::AbstractDataFrame) = 2
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -232,8 +232,8 @@ function Base.size(df::AbstractDataFrame, i::Integer)
 end
 
 Base.lastindex(df::AbstractDataFrame) = ncol(df)
-Base.lastindex(df::AbstractDataFrame, i) = last(axes(df, i))
-Base.axes(df, i) = axes(df)[i]
+Base.lastindex(df::AbstractDataFrame, i::Integer) = last(axes(df, i))
+Base.axes(df::AbstractDataFrame, i::Integer) = axes(df)[i]
 
 Base.ndims(::AbstractDataFrame) = 2
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1736,3 +1736,6 @@ end
 
 import Base: map
 @deprecate map(f::Function, sdf::SubDataFrame) f(sdf)
+
+import Base: length
+@deprecate length(df::AbstractDataFrame) size(df, 2)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -656,8 +656,9 @@ module TestDataFrame
     @testset "size" begin
         df = DataFrame(A = 1:3, B = 'A':'C')
         @test_throws ArgumentError size(df, 3)
-        @test length(df) == 2
         @test ndims(df) == 2
+        @test (nrow(df), ncol(df)) == (3, 2)
+        @test size(df) == (3, 2)
         @inferred nrow(df)
         @inferred ncol(df)
     end


### PR DESCRIPTION
This definition goes against the view of data frames as collections of rows.

Fixes #1200. Part of https://github.com/JuliaData/DataFrames.jl/issues/1514.

(Coverage drop seems to be spurious, since the `axes` method is called by the one above, which is covered.)