### PR TITLE
Add fast grouping method for CategoricalArray keys

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -848,7 +848,7 @@ nonunique(df, 1)
 
 """
 function nonunique(df::AbstractDataFrame)
-    gslots = row_group_slots(df)[3]
+    gslots = row_group_slots(ntuple(i -> df[i], ncol(df)), Val(true))[3]
     # unique rows are the first encountered group representatives,
     # nonunique are everything else
     res = fill(true, nrow(df))

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -4,11 +4,11 @@
 struct RowGroupDict{T<:AbstractDataFrame}
     "source data table"
     df::T
-    "number of groups"
+    "number of groups (i.e. highest group index: some groups may be empty)"
     ngroups::Int
-    "row hashes"
+    "row hashes (optional, can be empty)"
     rhashes::Vector{UInt}
-    "hashindex -> index of group-representative row"
+    "hashindex -> index of group-representative row (optional, can be empty)"
     gslots::Vector{Int}
     "group index for each row"
     groups::Vector{Int}
@@ -70,10 +70,11 @@ function hashrows_col!(h::Vector{UInt},
 end
 
 # Calculate the vector of `df` rows hash values.
-function hashrows(df::AbstractDataFrame, skipmissing::Bool)
-    rhashes = zeros(UInt, nrow(df))
-    missings = fill(false, skipmissing ? nrow(df) : 0)
-    for (i, col) in enumerate(columns(df))
+function hashrows(cols::Tuple{Vararg{AbstractVector}}, skipmissing::Bool)
+    len = length(cols[1])
+    rhashes = zeros(UInt, len)
+    missings = fill(false, skipmissing ? len : 0)
+    for (i, col) in enumerate(cols)
         hashrows_col!(rhashes, missings, col, i == 1)
     end
     return (rhashes, missings)
@@ -81,25 +82,18 @@ end
 
 # Helper function for RowGroupDict.
 # Returns a tuple:
-# 1) the number of row groups in a data table
-# 2) vector of row hashes
+# 1) the number of row groups in a data frame
+# 2) vector of row hashes (may be empty if hash=Val(false))
 # 3) slot array for a hash map, non-zero values are
 #    the indices of the first row in a group
 # Optional group vector is set to the group indices of each row
-function row_group_slots(df::AbstractDataFrame,
-                         groups::Union{Vector{Int}, Nothing} = nothing,
-                         skipmissing::Bool = false)
-    rhashes, missings = hashrows(df, skipmissing)
-    row_group_slots(ntuple(i -> df[i], ncol(df)), rhashes, missings, groups, skipmissing)
-end
-
 function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
-                         rhashes::AbstractVector{UInt},
-                         missings::AbstractVector{Bool},
+                         hash::Val = Val(true),
                          groups::Union{Vector{Int}, Nothing} = nothing,
-                         skipmissing::Bool = false)
+                         skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool, Bool}
     @assert groups === nothing || length(groups) == length(cols[1])
-    # inspired by Dict code from base cf. https://github.com/JuliaData/DataFrames.jl/pull/17#discussion_r102481481
+    rhashes, missings = hashrows(cols, skipmissing)
+    # inspired by Dict code from base cf. https://github.com/JuliaData/DataTables.jl/pull/17#discussion_r102481481
     sz = Base._tablesz(length(rhashes))
     @assert sz >= length(rhashes)
     szm1 = sz-1
@@ -112,7 +106,7 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
         # Use 0 for non-missing values to catch bugs if group is not found
         gix = skipmissing && missings[i] ? 1 : 0
         probe = 0
-        # Skip rows contaning at least one missing (assigning them to group 0)
+        # If skipmissing=true, assign rows containing at least one missing to group 1
         if !skipmissing || !missings[i]
             while true
                 g_row = gslots[slotix]
@@ -135,14 +129,47 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
             groups[i] = gix
         end
     end
-    return ngroups, rhashes, gslots
+    return ngroups, rhashes, gslots, false, true
+end
+
+function row_group_slots(cols::Tuple{CategoricalVector},
+                         hash::Val{false},
+                         groups::Union{Vector{Int}, Nothing} = nothing,
+                         skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool, Bool}
+    col = cols[1]
+    @assert groups === nothing || length(groups) == length(col)
+
+    # If missings are to be skipped, they will all go to group 1
+    ngroups = length(levels(col)) + (eltype(col) >: Missing)
+
+    if groups !== nothing
+        # When levels are in the same order as the index and there are no missing values,
+        # we could simply copy refs to groups, but the performance gain is negligible,
+        # so always sort groups in the order of levels
+        refmap = [0; CategoricalArrays.order(col.pool)]
+        if skipmissing
+            refmap .+= 1
+        else
+            refmap[1] = ngroups
+        end
+        @inbounds for i in eachindex(groups)
+            groups[i] = refmap[col.refs[i]+1]
+        end
+    end
+    return ngroups, UInt[], Int[], true, true
 end
 
 # Builds RowGroupDict for a given DataFrame.
 # Partly uses the code of Wes McKinney's groupsort_indexer in pandas (file: src/groupby.pyx).
-function group_rows(df::AbstractDataFrame, skipmissing::Bool = false)
+# - hash: whether row hashes should be computed (if false, the rhashes and gslots fields
+#   hold empty vectors)
+# - sort: whether groups should be sorted
+# - skipmissing: whether rows with missing values should be skipped rather than put into group 0
+function group_rows(df::AbstractDataFrame, hash::Bool = true, sort::Bool = false,
+                    skipmissing::Bool = false)
     groups = Vector{Int}(undef, nrow(df))
-    ngroups, rhashes, gslots = row_group_slots(df, groups, skipmissing)
+    ngroups, rhashes, gslots, sorted, empty =
+        row_group_slots(ntuple(i -> df[i], ncol(df)), Val(hash), groups, skipmissing)
 
     # count elements in each group
     stops = zeros(Int, ngroups)
@@ -170,9 +197,35 @@ function group_rows(df::AbstractDataFrame, skipmissing::Bool = false)
 
     # drop group 1 which contains rows with missings in grouping columns
     if skipmissing
-        splice!(starts, 1)
-        splice!(stops, 1)
+        popfirst!(starts)
+        popfirst!(stops)
         ngroups -= 1
+    end
+
+    # if row_group_slots can return empty groups, remove them
+    if empty
+        i = 0
+        j = 0
+        @inbounds while j < ngroups
+            j += 1
+            while stops[j] < starts[j]
+                j < ngroups || @goto done
+                j += 1
+            end
+            i += 1
+            starts[i] = starts[j]
+            stops[i] = stops[j]
+        end
+        @label done
+        resize!(starts, i)
+        resize!(stops, i)
+    end
+
+    # sort groups if row_group_slots hasn't already done that
+    if sort && !sorted
+        group_perm = sortperm(view(df, rperm[starts], :))
+        permute!(starts, group_perm)
+        Base.permute!!(stops, group_perm)
     end
 
     return RowGroupDict(df, ngroups, rhashes, gslots, groups, rperm, starts, stops)

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -80,11 +80,13 @@ end
 
 # Helper function for RowGroupDict.
 # Returns a tuple:
-# 1) the number of row groups in a data frame
+# 1) the highest group index in the `groups` vector
 # 2) vector of row hashes (may be empty if hash=Val(false))
 # 3) slot array for a hash map, non-zero values are
 #    the indices of the first row in a group
-# Optional group vector is set to the group indices of each row
+# 4) whether groups are already sorted
+# 5) whether some groups might be empty (index isn't used in `groups`)
+# Optional `groups` vector is set to the group indices of each row
 function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
                          hash::Val = Val(true),
                          groups::Union{Vector{Int}, Nothing} = nothing,

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -76,13 +76,7 @@ function groupby(df::AbstractDataFrame, cols::AbstractVector;
                  sort::Bool = false, skipmissing::Bool = false)
     intcols = index(df)[cols]
     sdf = df[intcols]
-    df_groups = group_rows(sdf, skipmissing)
-    # sort the groups
-    if sort
-        group_perm = sortperm(view(sdf, df_groups.rperm[df_groups.starts], :))
-        permute!(df_groups.starts, group_perm)
-        Base.permute!!(df_groups.stops, group_perm)
-    end
+    df_groups = group_rows(sdf, false, sort, skipmissing)
     GroupedDataFrame(df, intcols, df_groups.rperm,
                      df_groups.starts, df_groups.stops)
 end

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -28,7 +28,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
         end
         if N > 1
             print(io, "\n⋮\n")
-            nnrows = size(gd[N], 1)
+            nrows = size(gd[N], 1)
             rows = nrows > 1 ? "rows" : "row"
             print(io, "Last Group: $nrows $rows")
             show(io, gd[N], summary=false,

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -45,7 +45,7 @@ module TestDataFrameRow
     @test hash(DataFrameRow(df, 2)) != hash(DataFrameRow(df, 6))
 
     # check that hashrows() function generates the same hashes as DataFrameRow
-    df_rowhashes, _ = DataFrames.hashrows(df, false)
+    df_rowhashes, _ = DataFrames.hashrows(tuple(DataFrames.columns(df)...), false)
     @test df_rowhashes == [hash(dr) for dr in eachrow(df)]
 
     # test incompatible frames

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -45,7 +45,7 @@ module TestDataFrameRow
     @test hash(DataFrameRow(df, 2)) != hash(DataFrameRow(df, 6))
 
     # check that hashrows() function generates the same hashes as DataFrameRow
-    df_rowhashes, _ = DataFrames.hashrows(tuple(DataFrames.columns(df)...), false)
+    df_rowhashes, _ = DataFrames.hashrows(Tuple(columns(df)), false)
     @test df_rowhashes == [hash(dr) for dr in eachrow(df)]
 
     # test incompatible frames
@@ -57,9 +57,9 @@ module TestDataFrameRow
     df5 = DataFrame([d1], [:d1])
     df6 = DataFrame(d1 = [2,3])
 
-    # test_group("groupby")
+    # test_group("group_rows")
     gd = DataFrames.group_rows(df5)
-    @test gd.ngroups == 2
+    @test length(unique(gd.groups)) == 2
 
     # getting groups for the rows of the other frames
     @test length(gd[DataFrameRow(df6, 1)]) > 0
@@ -68,11 +68,11 @@ module TestDataFrameRow
 
     # grouping empty frame
     gd = DataFrames.group_rows(DataFrame(x=Int[]))
-    @test gd.ngroups == 0
+    @test length(unique(gd.groups)) == 0
 
     # grouping single row
     gd = DataFrames.group_rows(df5[1:1,:])
-    @test gd.ngroups == 1
+    @test length(unique(gd.groups)) == 1
 
     # getproperty, setproperty! and propertynames
     r = DataFrameRow(df, 1)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -355,14 +355,14 @@ module TestGrouping
                    Key2 = ["B", "A", "A", missing, "A"],
                    Value = 1:5),
          DataFrame(Key1 = categorical(["A", missing, "B", "B", "A"]),
-                  Key2 = ["B", "A", "A", missing, "A"],
-                  Value = 1:5),
+                   Key2 = ["B", "A", "A", missing, "A"],
+                   Value = 1:5),
          DataFrame(Key1 = ["A", missing, "B", "B", "A"],
-                  Key2 = categorical(["B", "A", "A", missing, "A"]),
-                  Value = 1:5),
+                   Key2 = categorical(["B", "A", "A", missing, "A"]),
+                   Value = 1:5),
          DataFrame(Key1 = categorical(["A", missing, "B", "B", "A"]),
-                  Key2 = categorical(["B", "A", "A", missing, "A"]),
-                  Value = 1:5))
+                   Key2 = categorical(["B", "A", "A", missing, "A"]),
+                   Value = 1:5))
 
         @testset "sort=false, skipmissing=false" begin
             gd = groupby(df, :Key1)


### PR DESCRIPTION
When grouping on a single `CategoricalArray` column, we don't need a `Dict` to get group codes.
This approach cannot be used when joining, as the `Dict` is needed.
`group_rows` now handles the sorting, which allows skipping this step if the grouping is guaranteed to be sorted (as is the case for `CategoricalArray`).
This mechanism can be extended in the future to handle multiple `CategoricalArray` keys, or integer keys (using radix sort).

This makes grouping about 4 times faster on simple benchmarks, even with the optimized code from https://github.com/JuliaData/DataFrames.jl/pull/1565 (which BTW is still used when grouping on several `CategoricalArray` keys). Of course grouping only represents a small part of the time taken by a split-apply-combine operation, so typically the win isn't that big.
```julia
using DataFrames, BenchmarkTools
df = DataFrame(rand(500_000, 10));
df.key = categorical(string.(rand(1:100, 500_000)));

# Master
julia> @btime groupby(df, :key);
  8.258 ms (51 allocations: 15.45 MiB)

# This PR
julia> @btime groupby(df, :key);
  2.284 ms (64 allocations: 7.64 MiB)

df = DataFrame(rand(500_000, 10));
df.key = categorical(string.(rand(1:10_000, 500_000)));

# Master
julia> @btime groupby(df, :key);
  27.451 ms (54 allocations: 15.68 MiB)

# This PR
julia> @btime groupby(df, :key);
  7.595 ms (69 allocations: 7.86 MiB)
```