### PR TITLE
Support type-stable map and combine on GroupedDataFrame

### DIFF
--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -57,7 +57,7 @@ julia> by(iris, :Species, :PetalLength => mean)
 │ 2   │ versicolor │ 4.26             │
 │ 3   │ virginica  │ 5.552            │
 
-julia> by(iris, :Species, (N = :Species => length,)) # Chosen column is arbitrary
+julia> by(iris, :Species, N = :Species => length) # Chosen column is arbitrary
 3×2 DataFrame
 │ Row │ Species       │ N     │
 │     │ Categorical…⍰ │ Int64 │
@@ -67,7 +67,7 @@ julia> by(iris, :Species, (N = :Species => length,)) # Chosen column is arbitrar
 │ 3   │ virginica     │ 50    │
 ```
 
-julia> by(iris, :Species, (N = :Species => length, mean = :PetalLength => mean)) # Chosen column is arbitrary
+julia> by(iris, :Species, N = :Species => length, mean = :PetalLength => mean) # Column for length is arbitrary
 3×3 DataFrame
 │ Row │ Species    │ N     │ mean    │
 │     │ String⍰    │ Int64 │ Float64 │

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -6,7 +6,7 @@ The DataFrames package supports the split-apply-combine strategy through the `by
 1. a `col => function` pair indicating that `function` should be called with the vector of values for column `col`, which can be a column name or index
 2. a `cols => function` pair indicating that `function` should be called with a named tuple holding columns `cols`, which can be a tuple or vector of names or indices
 3. several such pairs, either as positional arguments or as keyword arguments (mixing is not allowed), producing each a single separate column; keyword argument names are used as column names
-4. equivalently, a (named) tuple or vector of such pairs, producing each a single separate column
+4. equivalently, a (named) tuple or vector of such pairs
 5. a function which will be called with a `SubDataFrame` corresponding to each group; this form should be avoided due to its poor performance
 
 In all of these cases, the function can return either a single row or multiple rows, with a single or multiple columns:
@@ -18,7 +18,7 @@ In all of these cases, the function can return either a single row or multiple r
 
 The kind of return value and the number and names of columns must be the same for all groups.
 
-As a special case, if a tuple or vector of pairs is passed (form 3 above), each function is required to return a single value or vector, which will produce each a separate column.
+As a special case, if multiple pairs or a tuple of vectors or pairs is passed (forms 3 and 4 above), each function is required to return a single value or vector, which will produce each a separate column.
 
 The name for the resulting column can be chosen either by passing a named tuple of pairs, or by returning a named tuple or a data frame. If no name is provided, it is generated automatically. For functions taking a single column (first form), the input column name is concatenated with the function name: for standard functions like `mean` this will produce columns with names like `SepalLength_mean`; for anonymous functions like `x -> sqrt(x)^e`, the produced columns will be `SepalLength_function`. For functions taking multiple columns (second form), names are `x1`, `x2`, etc.
 

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -13,7 +13,7 @@ In all of these cases, the function can return either a single row or multiple r
 - a named tuple or `DataFrameRow` produces a single row and one column per field
 - a vector produces a single column with one row per entry
 - a named tuple of vectors produces one column per field with one row per entry in the vectors
-- a `DataFrame` produces as many rows and columns as it contains; this return value should be avoided due to its poor performance
+- a `DataFrame` or a matrix produces as many rows and columns as it contains; note that returning a `DataFrame` should be avoided due to its poor performance when the number of groups is large
 
 The name for the resulting column can be chosen either by passing a named tuple of pairs, or by returning a named tuple or a data frame. If no name is provided, it is generated automatically. For functions taking a single column (first form), the input column name is concatenated with the function name: for standard functions like `mean` this will produce columns with names like `SepalLength_mean`; for anonymous functions like `x -> sqrt(x)^e`, the produced columns will be `SepalLength_function`. For functions taking multiple columns (second form), names are `x1`, `x2`, etc.
 
@@ -65,7 +65,6 @@ julia> by(iris, :Species, N = :Species => length) # Chosen column is arbitrary
 │ 1   │ setosa        │ 50    │
 │ 2   │ versicolor    │ 50    │
 │ 3   │ virginica     │ 50    │
-```
 
 julia> by(iris, :Species, N = :Species => length, mean = :PetalLength => mean) # Column for length is arbitrary
 3×3 DataFrame
@@ -87,7 +86,7 @@ julia> by(iris, :Species, [:PetalLength, :SepalLength] =>
 │ 3   │ virginica  │ 0.842744 │ 277.6   │
 ```
 
-The `by` function also support the `do` block form. However, as noted above, this form is slow and should therefore be avoided when performance matters.
+The `by` function also supports the `do` block form. However, as noted above, this form is slow and should therefore be avoided when performance matters.
 
 ```jldoctest sac
 julia> by(iris, :Species) do df

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -2,11 +2,12 @@
 
 Many data analysis tasks involve splitting a data set into groups, applying some functions to each of the groups and then combining the results. A standardized framework for handling this sort of computation is described in the paper "[The Split-Apply-Combine Strategy for Data Analysis](http://www.jstatsoft.org/v40/i01)", written by Hadley Wickham.
 
-The DataFrames package supports the Split-Apply-Combine strategy through the `by` function, which takes in three arguments: (1) a `DataFrame`, (2) one or more columns to split the `DataFrame` on, and (3) a specification of one or more functions to apply to each subset of the `DataFrame`. This specification can be of the following forms:
-- a `col => function` pair indicating that `function` should be called with the vector of values for column `col`, which can be a column name or index
-- a `cols => function` pair indicating that `function` should be called with a named tuple holding columns `cols`, which can be a tuple or vector of names or indices
-- a (named) tuple or vector of such pairs, producing each a single separate column
-- a function which will be called with a `SubDataFrame` corresponding to each group; this form should be avoided due to its poor performance
+The DataFrames package supports the split-apply-combine strategy through the `by` function, which is a shorthand for `groupby` followed by `map` and/or `combine`. `by` takes in three arguments: (1) a `DataFrame`, (2) one or more columns to split the `DataFrame` on, and (3) a specification of one or more functions to apply to each subset of the `DataFrame`. This specification can be of the following forms:
+1. a `col => function` pair indicating that `function` should be called with the vector of values for column `col`, which can be a column name or index
+2. a `cols => function` pair indicating that `function` should be called with a named tuple holding columns `cols`, which can be a tuple or vector of names or indices
+3. several such pairs, either as positional arguments or as keyword arguments (mixing is not allowed), producing each a single separate column; keyword argument names are used as column names
+4. equivalently, a (named) tuple or vector of such pairs, producing each a single separate column
+5. a function which will be called with a `SubDataFrame` corresponding to each group; this form should be avoided due to its poor performance
 
 In all of these cases, the function can return either a single row or multiple rows, with a single or multiple columns:
 - a single value produces a single row and column per group
@@ -14,6 +15,10 @@ In all of these cases, the function can return either a single row or multiple r
 - a vector produces a single column with one row per entry
 - a named tuple of vectors produces one column per field with one row per entry in the vectors
 - a `DataFrame` or a matrix produces as many rows and columns as it contains; note that returning a `DataFrame` should be avoided due to its poor performance when the number of groups is large
+
+The kind of return value and the number and names of columns must be the same for all groups.
+
+As a special case, if a tuple or vector of pairs is passed (form 3 above), each function is required to return a single value or vector, which will produce each a separate column.
 
 The name for the resulting column can be chosen either by passing a named tuple of pairs, or by returning a named tuple or a data frame. If no name is provided, it is generated automatically. For functions taking a single column (first form), the input column name is concatenated with the function name: for standard functions like `mean` this will produce columns with names like `SepalLength_mean`; for anonymous functions like `x -> sqrt(x)^e`, the produced columns will be `SepalLength_function`. For functions taking multiple columns (second form), names are `x1`, `x2`, etc.
 

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -2,7 +2,20 @@
 
 Many data analysis tasks involve splitting a data set into groups, applying some functions to each of the groups and then combining the results. A standardized framework for handling this sort of computation is described in the paper "[The Split-Apply-Combine Strategy for Data Analysis](http://www.jstatsoft.org/v40/i01)", written by Hadley Wickham.
 
-The DataFrames package supports the Split-Apply-Combine strategy through the `by` function, which takes in three arguments: (1) a DataFrame, (2) one or more columns to split the DataFrame on, and (3) a function or expression to apply to each subset of the DataFrame.
+The DataFrames package supports the Split-Apply-Combine strategy through the `by` function, which takes in three arguments: (1) a `DataFrame`, (2) one or more columns to split the `DataFrame` on, and (3) a specification of one or more functions to apply to each subset of the `DataFrame`. This specification can be of the following forms:
+- a `col => function` pair indicating that `function` should be called with the vector of values for column `col`, which can be a column name or index
+- a `cols => function` pair indicating that `function` should be called with a named tuple holding columns `cols`, which can be a tuple or vector of names or indices
+- a (named) tuple or vector of such pairs, producing each a single separate column
+- a function which will be called with a `SubDataFrame` corresponding to each group; this form should be avoided due to its poor performance
+
+In all of these cases, the function can return either a single row or multiple rows, with a single or multiple columns:
+- a single value produces a single row and column per group
+- a named tuple or `DataFrameRow` produces a single row and one column per field
+- a vector produces a single column with one row per entry
+- a named tuple of vectors produces one column per field with one row per entry in the vectors
+- a `DataFrame` produces as many rows and columns as it contains; this return value should be avoided due to its poor performance
+
+The name for the resulting column can be chosen either by passing a named tuple of pairs, or by returning a named tuple or a data frame. If no name is provided, it is generated automatically. For functions taking a single column (first form), the input column name is concatenated with the function name: for standard functions like `mean` this will produce columns with names like `SepalLength_mean`; for anonymous functions like `x -> sqrt(x)^e`, the produced columns will be `SepalLength_function`. For functions taking multiple columns (second form), names are `x1`, `x2`, etc.
 
 We show several examples of the `by` function applied to the `iris` dataset below:
 
@@ -35,25 +48,16 @@ julia> tail(iris)
 │ 5   │ 6.2         │ 3.4        │ 5.4         │ 2.3        │ virginica     │
 │ 6   │ 5.9         │ 3.0        │ 5.1         │ 1.8        │ virginica     │
 
-julia> by(iris, :Species, size)
+julia> by(iris, :Species, :PetalLength => mean)
 3×2 DataFrame
-│ Row │ Species       │ x1      │
-│     │ Categorical…⍰ │ Tuple…  │
-├─────┼───────────────┼─────────┤
-│ 1   │ setosa        │ (50, 5) │
-│ 2   │ versicolor    │ (50, 5) │
-│ 3   │ virginica     │ (50, 5) │
+│ Row │ Species    │ PetalLength_mean │
+│     │ String⍰    │ Float64          │
+├─────┼────────────┼──────────────────┤
+│ 1   │ setosa     │ 1.462            │
+│ 2   │ versicolor │ 4.26             │
+│ 3   │ virginica  │ 5.552            │
 
-julia> by(iris, :Species, df -> mean(df.PetalLength))
-3×2 DataFrame
-│ Row │ Species       │ x1      │
-│     │ Categorical…⍰ │ Float64 │
-├─────┼───────────────┼─────────┤
-│ 1   │ setosa        │ 1.462   │
-│ 2   │ versicolor    │ 4.26    │
-│ 3   │ virginica     │ 5.552   │
-
-julia> by(iris, :Species, df -> DataFrame(N = size(df, 1)))
+julia> by(iris, :Species, (N = :Species => length,)) # Chosen column is arbitrary
 3×2 DataFrame
 │ Row │ Species       │ N     │
 │     │ Categorical…⍰ │ Int64 │
@@ -63,11 +67,31 @@ julia> by(iris, :Species, df -> DataFrame(N = size(df, 1)))
 │ 3   │ virginica     │ 50    │
 ```
 
-The `by` function also support the `do` block form:
+julia> by(iris, :Species, (N = :Species => length, mean = :PetalLength => mean)) # Chosen column is arbitrary
+3×3 DataFrame
+│ Row │ Species    │ N     │ mean    │
+│     │ String⍰    │ Int64 │ Float64 │
+├─────┼────────────┼───────┼─────────┤
+│ 1   │ setosa     │ 50    │ 1.462   │
+│ 2   │ versicolor │ 50    │ 4.26    │
+│ 3   │ virginica  │ 50    │ 5.552   │
+
+julia> by(iris, :Species, [:PetalLength, :SepalLength] =>
+              x -> (a=mean(x.PetalLength)/mean(x.SepalLength), b=sum(x.PetalLength)))
+3×3 DataFrame
+│ Row │ Species    │ a        │ b       │
+│     │ String⍰    │ Float64  │ Float64 │
+├─────┼────────────┼──────────┼─────────┤
+│ 1   │ setosa     │ 0.29205  │ 73.1    │
+│ 2   │ versicolor │ 0.717655 │ 213.0   │
+│ 3   │ virginica  │ 0.842744 │ 277.6   │
+```
+
+The `by` function also support the `do` block form. However, as noted above, this form is slow and should therefore be avoided when performance matters.
 
 ```jldoctest sac
 julia> by(iris, :Species) do df
-          DataFrame(m = mean(df.PetalLength), s² = var(df.PetalLength))
+          (m = mean(df.PetalLength), s² = var(df.PetalLength))
        end
 3×3 DataFrame
 │ Row │ Species       │ m       │ s²        │
@@ -78,7 +102,7 @@ julia> by(iris, :Species) do df
 │ 3   │ virginica     │ 5.552   │ 0.304588  │
 ```
 
-A second approach to the Split-Apply-Combine strategy is implemented in the `aggregate` function, which also takes three arguments: (1) a DataFrame, (2) one or more columns to split the DataFrame on, and (3) one or more functions that are used to compute a summary of each subset of the DataFrame. Each function is applied to each column that was not used to split the DataFrame, creating new columns of the form `$name_$function`. For named functions like `mean` this will produce columns with names like `SepalLength_mean`. For anonymous functions like `x -> sqrt(x)^e`, which Julia tracks and references by a numerical identifier e.g. `#12`, the produced columns will be `SepalLength_#12`. We show several examples of the `aggregate` function applied to the `iris` dataset below:
+A second approach to the Split-Apply-Combine strategy is implemented in the `aggregate` function, which also takes three arguments: (1) a DataFrame, (2) one or more columns to split the DataFrame on, and (3) one or more functions that are used to compute a summary of each subset of the DataFrame. Each function is applied to each column that was not used to split the DataFrame, creating new columns of the form `$name_$function` like with `by` (see above). We show several examples of the `aggregate` function applied to the `iris` dataset below:
 
 ```jldoctest sac
 julia> aggregate(iris, :Species, length)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1430,6 +1430,12 @@ function Base.getindex(itr::DataFrameColumns{<:SubDataFrame,AbstractVector}, j)
     itr.df[:, j]
 end
 
+function Base.getindex(itr::DataFrameColumns{<:SubDataFrame,AbstractVector}, j::Int)
+    Base.depwarn("Indexing into a return value of columns on SubDataFrame will return a" *
+                 " view of column value", :getindex)
+    itr.df[:, j]
+end
+
 function Base.iterate(itr::DataFrameColumns{<:SubDataFrame,
                                             Pair{Symbol, AbstractVector}}, j=1)
     Base.depwarn("iterating over value of eachcol on SubDataFrame will return a" *

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -241,7 +241,7 @@ Transform a `GroupedDataFrame` into a `DataFrame`.
 If the last argument(s) consist(s) in one or more `cols => f` pair(s), or if
 `colname = cols => f` keyword arguments are provided, `cols` must be
 a column name or index, or a vector or tuple thereof, and `f` must be a callable.
-A tuple or a named tuple of pairs can also be provided as the first or last argument.
+A pair or a (named) tuple of pairs can also be provided as the first or last argument.
 If `cols` is a single column index, `f` is called with a `SubArray` view into that
 column for each group; else, `f` is called with a named tuple holding `SubArray`
 views into these columns.
@@ -664,7 +664,7 @@ based on grouping columns `keys`, and return a `DataFrame`.
 If the last argument(s) consist(s) in one or more `cols => f` pair(s), or if
 `colname = cols => f` keyword arguments are provided, `cols` must be
 a column name or index, or a vector or tuple thereof, and `f` must be a callable.
-A tuple or a named tuple of pairs can also be provided as the first or last argument.
+A pair or a (named) tuple of pairs can also be provided as the first or last argument.
 If `cols` is a single column index, `f` is called with a `SubArray` view into that
 column for each group; else, `f` is called with a named tuple holding `SubArray`
 views into these columns.

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -744,13 +744,8 @@ by(d::AbstractDataFrame, cols::Any, f::Pair; sort::Bool = false) =
     combine(f, groupby(d, cols, sort = sort))
 by(d::AbstractDataFrame, cols::Any, f::Pair...; sort::Bool = false) =
     combine(f, groupby(d, cols, sort = sort))
-if VERSION < v"1.0"
-    by(d::AbstractDataFrame, cols::Any; sort::Bool = false, f...) =
-        combine(values(f), groupby(d, cols, sort = sort))
-else
-    by(d::AbstractDataFrame, cols::Any; sort::Bool = false, f...) =
-        combine(f.iter, groupby(d, cols, sort = sort))
-end
+by(d::AbstractDataFrame, cols::Any; sort::Bool = false, f...) =
+    combine(values(f), groupby(d, cols, sort = sort))
 
 #
 # Aggregate convenience functions

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -269,10 +269,6 @@ In all cases, the resulting data frame contains all the grouping columns in addi
 to those listed above. Column names are automatically generated when necessary: for functions
 operating on a single column and returning a single value or vector, the function name is
 appended to the input column name; for other functions, columns are called `x1`, `x2`
-and so on.In all cases, the resulting data frame contains all the grouping columns in addition
-to those listed above. Column names are automatically generated when necessary: for functions
-operating on a single column and returning a single value or vector, the function name is
-appended to the input colummn name; for other functions, columns are called `x1`, `x2`
 and so on.
 
 Note that `f` must always return the same type of object for

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -161,11 +161,11 @@ Note that this second form is much slower than the first one due to type instabi
 determines the shape of the resulting data frame:
 - A single value gives a data frame with a single column and one row per group.
 - A named tuple of single values or a `DataFrameRow` gives a data frame with one column
-for each field and one row per group.
+  for each field and one row per group.
 - A vector gives a data frame with a single column and as many rows
   for each group as the length of the returned vector for that group.
 - A data frame, a named tuple of vectors or a matrix gives a data frame
-with the same columns and as many rows for each group as the rows returned for that group.
+  with the same columns and as many rows for each group as the rows returned for that group.
 
 In all cases, the resulting `GroupedDataFrame` contains all the grouping columns in addition
 to those listed above. Note that `f` must always return the same type of object for
@@ -265,11 +265,11 @@ Note that this second form is much slower than the first one due to type instabi
 determines the shape of the resulting data frame:
 - A single value gives a data frame with a single column and one row per group.
 - A named tuple of single values or a `DataFrameRow` gives a data frame with one column
-for each field and one row per group.
+  for each field and one row per group.
 - A vector gives a data frame with a single column and as many rows
   for each group as the length of the returned vector for that group.
 - A data frame, a named tuple of vectors or a matrix gives a data frame
-with the same columns and as many rows for each group as the rows returned for that group.
+  with the same columns and as many rows for each group as the rows returned for that group.
 
 In all cases, the resulting data frame contains all the grouping columns in addition
 to those listed above. Note that `f` must always return the same type of object for
@@ -425,7 +425,7 @@ function _combine!(first::Union{NamedTuple, DataFrameRow}, outcols::NTuple{N, Ab
         if j !== nothing # Need to widen column type
             local newcols
             let i = i, j = j, outcols=outcols, row=row # Workaround for julia#15276
-                newcols = ntuple(_ncol(first)) do k
+                newcols = ntuple(length(outcols)) do k
                     S = typeof(row[k])
                     T = eltype(outcols[k])
                     U = promote_type(S, T)
@@ -575,11 +575,11 @@ Note that this second form is much slower than the first one due to type instabi
 determines the shape of the resulting data frame:
 - A single value gives a data frame with a single column and one row per group.
 - A named tuple of single values or a `DataFrameRow` gives a data frame with one column
-for each field and one row per group.
+  for each field and one row per group.
 - A vector gives a data frame with a single column and as many rows
   for each group as the length of the returned vector for that group.
 - A data frame, a named tuple of vectors or a matrix gives a data frame
-with the same columns and as many rows for each group as the rows returned for that group.
+  with the same columns and as many rows for each group as the rows returned for that group.
 
 In all cases, the resulting data frame contains all the grouping columns in addition
 to those listed above. Note that `f` must always return the same type of object for
@@ -606,7 +606,7 @@ julia> df = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
                       b = repeat([2, 1], outer=[4]),
                       c = 1:8);
 
-julia> by(df, :a, :c => sum)
+julia> by(:c => sum, df, :a)
 4×2 DataFrame
 │ Row │ a     │ c_sum │
 │     │ Int64 │ Int64 │
@@ -616,7 +616,7 @@ julia> by(df, :a, :c => sum)
 │ 3   │ 3     │ 10    │
 │ 4   │ 4     │ 12    │
 
-julia> by(df, :a, d -> sum(d.c)) # Slower variant
+julia> by(d -> sum(d.c), df, :a) # Slower variant
 4×2 DataFrame
 │ Row │ a     │ x1    │
 │     │ Int64 │ Int64 │
@@ -638,7 +638,7 @@ julia> by(df, :a) do d # do syntax for the slower variant
 │ 3   │ 3     │ 10    │
 │ 4   │ 4     │ 12    │
 
-julia> by(df, :a, :c => x -> 2 .* x)
+julia> by(:c => x -> 2 .* x, df, :a)
 8×2 DataFrame
 │ Row │ a     │ c_function │
 │     │ Int64 │ Int64      │
@@ -652,7 +652,7 @@ julia> by(df, :a, :c => x -> 2 .* x)
 │ 7   │ 4     │ 8          │
 │ 8   │ 4     │ 16         │
 
-julia> by(df, :a, :c => x -> (c_sum = sum(x), c_sum2 = sum(x.^2)))
+julia> by(:c => x -> (c_sum = sum(x), c_sum2 = sum(x.^2)), df, :a)
 4×3 DataFrame
 │ Row │ a     │ c_sum │ c_sum2 │
 │     │ Int64 │ Int64 │ Int64  │
@@ -662,20 +662,7 @@ julia> by(df, :a, :c => x -> (c_sum = sum(x), c_sum2 = sum(x.^2)))
 │ 3   │ 3     │ 10    │ 58     │
 │ 4   │ 4     │ 12    │ 80     │
 
-8×2 DataFrame
-│ Row │ a     │ minusx │
-│     │ Int64 │ Int64  │
-├─────┼───────┼────────┤
-│ 1   │ 1     │ -1     │
-│ 2   │ 1     │ -5     │
-│ 3   │ 2     │ -2     │
-│ 4   │ 2     │ -6     │
-│ 5   │ 3     │ -3     │
-│ 6   │ 3     │ -7     │
-│ 7   │ 4     │ -4     │
-│ 8   │ 4     │ -8     │
-
-julia> by(df, :a, (:b, :c) => x -> (minb = minimum(x.b), sumc = sum(x.c)))
+julia> by((:b, :c) => x -> (minb = minimum(x.b), sumc = sum(x.c)), df, :a)
 4×3 DataFrame
 │ Row │ a     │ minb  │ sumc  │
 │     │ Int64 │ Int64 │ Int64 │

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -343,8 +343,8 @@ function combine(f::Any, gd::GroupedDataFrame)
 end
 combine(gd::GroupedDataFrame, f::Any) = combine(f, gd)
 combine(gd::GroupedDataFrame, f::Pair...) = combine(f, gd)
-combine(gd::GroupedDataFrame; f...) = combine(values(f), gd)
-combine(gd::GroupedDataFrame) = combine(identity, gd)
+combine(gd::GroupedDataFrame; f...) =
+    isempty(f) ? combine(identity, gd) : combine(values(f), gd)
 
 # Wrapping automatically adds column names when the value returned
 # by the user-provided function lacks them

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -99,6 +99,8 @@ module TestGrouping
         f4(df) = [maximum(df[:, :c]), minimum(df[:, :c])]
         f5(df) = reshape([maximum(df[:, :c]), minimum(df[:, :c])], 2, 1)
         f6(df) = [maximum(df[:, :c]) minimum(df[:, :c])]
+        f7(df) = (c2 = df[:, :c].^2,)
+        f8(df) = DataFrame(c2 = df[:, :c].^2)
         #TODO: enable lines below after getindex deprecation
         # f1(df) = DataFrame(cmax = maximum(df[:c]))
         # f2(df) = (cmax = maximum(df[:c]),)
@@ -106,6 +108,8 @@ module TestGrouping
         # f4(df) = [maximum(df[:c]), minimum(df[:c])]
         # f5(df) = reshape([maximum(df[:c]), minimum(df[:c])], 2, 1)
         # f6(df) = [maximum(df[:c]) minimum(df[:c])]
+        # f7(df) = (c2 = df[:c].^2,)
+        # f8(df) = DataFrame(c2 = df[:c].^2)
 
         res = unique(df[cols])
         res.cmax = [maximum(df[(df.a .== a) .& (df.b .== b), :c])
@@ -119,9 +123,12 @@ module TestGrouping
                    for (a, b) in zip(res.a, res.b)]
         res3.x2 = [minimum(df[(df.a .== a) .& (df.b .== b), :c])
                    for (a, b) in zip(res.a, res.b)]
+        res4 = df[cols]
+        res4.c2 = df.c.^2
         sres = sort(res, cols)
         sres2 = sort(res2, cols)
         sres3 = sort(res3, cols)
+        sres4 = sort(res4, cols)
 
         # by() without groups sorting
         @test sort(by(df, cols, identity)) ==
@@ -134,6 +141,8 @@ module TestGrouping
         @test by(df, cols, f4) == res2
         @test by(df, cols, f5) == res2
         @test by(df, cols, f6) == res3
+        @test sort(by(df, cols, f7)) == sort(res4)
+        @test sort(by(df, cols, f8)) == sort(res4)
 
         # by() with groups sorting
         @test by(df, cols, identity, sort=true) ==
@@ -146,6 +155,8 @@ module TestGrouping
         @test by(df, cols, f4, sort=true) == sres2
         @test by(df, cols, f5, sort=true) == sres2
         @test by(df, cols, f6, sort=true) == sres3
+        @test by(df, cols, f7, sort=true) == sres4
+        @test by(df, cols, f8, sort=true) == sres4
 
         @test by(df, [:a], f1) == by(df, :a, f1)
         @test by(df, [:a], f1, sort=true) == by(df, :a, f1, sort=true)
@@ -160,6 +171,8 @@ module TestGrouping
         @test combine(f4, gd) == res2
         @test combine(f5, gd) == res2
         @test combine(f6, gd) == res3
+        @test sort(combine(f7, gd)) == sort(res4)
+        @test sort(combine(f8, gd)) == sort(res4)
 
         # groupby() with groups sorting
         gd = groupby(df, cols, sort=true)
@@ -175,27 +188,33 @@ module TestGrouping
         @test combine(f4, gd) == sres2
         @test combine(f5, gd) == sres2
         @test combine(f6, gd) == sres3
+        @test combine(f7, gd) == sres4
+        @test combine(f8, gd) == sres4
 
         # map() without and with groups sorting
         for sort in (false, true)
-            gd = groupby(df, cols)
+            gd = groupby(df, cols, sort=sort)
             v = map(d -> d[[:c]], gd)
             @test length(gd) == length(v)
             @test v[1] == gd[1] && v[2] == gd[2] && v[3] == gd[3] && v[4] == gd[4]
-            v = map(f1, groupby(df, cols, sort=sort))
+            v = map(f1, gd)
             @test vcat(v[1], v[2], v[3], v[4]) == by(f1, df, cols, sort=sort)
-            v = map(f2, groupby(df, cols, sort=sort))
+            v = map(f2, gd)
             @test vcat(v[1], v[2], v[3], v[4]) == by(f2, df, cols, sort=sort)
-            v = map(f3, groupby(df, cols, sort=sort))
+            v = map(f3, gd)
             @test vcat(v[1], v[2], v[3], v[4]) == by(f3, df, cols, sort=sort)
-            v = map(f4, groupby(df, cols, sort=sort))
+            v = map(f4, gd)
             @test vcat(v[1], v[2], v[3], v[4]) == by(f4, df, cols, sort=sort)
-            v = map(f5, groupby(df, cols, sort=sort))
+            v = map(f5, gd)
             @test vcat(v[1], v[2], v[3], v[4]) == by(f5, df, cols, sort=sort)
-            v = map(f5, groupby(df, cols, sort=sort))
+            v = map(f5, gd)
             @test vcat(v[1], v[2], v[3], v[4]) == by(f5, df, cols, sort=sort)
-            v = map(f6, groupby(df, cols, sort=sort))
+            v = map(f6, gd)
             @test vcat(v[1], v[2], v[3], v[4]) == by(f6, df, cols, sort=sort)
+            v = map(f7, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f7, df, cols, sort=sort)
+            v = map(f8, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f8, df, cols, sort=sort)
         end
 
         # testing pool overflow

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -528,9 +528,10 @@ module TestGrouping
                         f(d -> (xyz=sum(d.b), xzz=sum(d.b)), gd)
                     @test f((xyz = cols2[1] => sum, xzz = cols2[2] => x -> first(x)), gd) ==
                         f(d -> (xyz=sum(d.b), xzz=first(d.c)), gd)
+                    @test_throws ArgumentError f((xyz = cols2[1] => x -> exp.(x), xzz = cols2[2] => identity), gd)
+                    @test_throws ArgumentError f((xyz = cols2[1] => x -> exp.(x), xzz = cols2[2] => sum), gd)
                 end
-                @test_throws ArgumentError f((xyz = cols2[1] => x -> exp.(x), xzz = cols2[2] => identity), gd)
-                @test_throws ArgumentError f((xyz = cols2[1] => x -> exp.(x), xzz = cols2[2] => sum), gd)
+
                 @test_throws ArgumentError f((xyz = cols2 => x -> DataFrame(y=exp.(x.b), z=sum(x.c)),), gd)
                 @test_throws ArgumentError f((xyz = cols2 => x -> [exp.(x.b) x.c],), gd)
 
@@ -550,10 +551,10 @@ module TestGrouping
                             f(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), gd)
                         @test f(wrap(cols[1] => sum, cols[2] => x -> first(x)), gd) ==
                             f(d -> (b_sum=sum(d.b), c_function=first(d.c)), gd)
+                        @test_throws ArgumentError f(wrap(cols2[1] => x -> exp.(x), cols2[2] => identity), gd)
+                        @test_throws ArgumentError f(wrap(cols2[1] => x -> exp.(x), cols2[2] => sum), gd)
                     end
 
-                    @test_throws ArgumentError f(wrap(cols2[1] => x -> exp.(x), cols2[2] => identity), gd)
-                    @test_throws ArgumentError f(wrap(cols2[1] => x -> exp.(x), cols2[2] => sum), gd)
                     @test_throws ArgumentError f(wrap(cols => x -> DataFrame(y=exp.(x.b), z=sum(x.c))), gd)
                     @test_throws ArgumentError f(wrap(cols => x -> [exp.(x.b) x.c]), gd)
                 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -448,7 +448,7 @@ module TestGrouping
         end
     end
 
-    @testset "by, combine and map with (::Pair, ::GroupedDataFrame)" begin
+    @testset "by, combine and map with pair interface" begin
         Random.seed!(1)
         df = DataFrame(a = repeat([1, 3, 2, 4], outer=[2]),
                        b = repeat([2, 1], outer=[4]),

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -455,35 +455,43 @@ module TestGrouping
                        c = randn(8))
 
 
-        @test by(:c => sum, df, :a) == by(d -> (c_sum=sum(d.c),), df, :a)
-        @test by(:c => x -> sum(x), df, :a) == by(d -> (c_function=sum(d.c),), df, :a)
-        @test by(:c => x -> (z=sum(x),), df, :a) == by(d -> (z=sum(d.c),), df, :a)
-        @test by(:c => x -> DataFrame(z=sum(x),), df, :a) == by(d -> (z=sum(d.c),), df, :a)
-        @test by(:c => identity, df, :a) == by(d -> (c_identity=d.c,), df, :a)
-        @test by(:c => x -> (z=x,), df, :a) == by(d -> (z=d.c,), df, :a)
-        @test by((:b, :c) => x -> (y=exp.(x.b), z=x.c), df, :a) ==
-            by(d -> (y=exp.(d.b), z=d.c), df, :a)
-        @test by((:b, :c) => x -> (y=exp.(x.b), z=sum(x.c)), df, :a) ==
-            by(d -> (y=exp.(d.b), z=sum(d.c)), df, :a)
-        @test by((:b, :c) => x -> DataFrame(y=exp.(x.b), z=sum(x.c)), df, :a) ==
-            by(d -> DataFrame(y=exp.(d.b), z=sum(d.c)), df, :a)
-        @test by((:b, :c) => x -> [exp.(x.b) x.c], df, :a) ==
-            by(d -> [exp.(d.b) d.c], df, :a)
+        for col in (:c, 3)
+            @test by(col => sum, df, :a) == by(d -> (c_sum=sum(d.c),), df, :a)
+            @test by(col => x -> sum(x), df, :a) == by(d -> (c_function=sum(d.c),), df, :a)
+            @test by(col => x -> (z=sum(x),), df, :a) == by(d -> (z=sum(d.c),), df, :a)
+            @test by(col => x -> DataFrame(z=sum(x),), df, :a) == by(d -> (z=sum(d.c),), df, :a)
+            @test by(col => identity, df, :a) == by(d -> (c_identity=d.c,), df, :a)
+            @test by(col => x -> (z=x,), df, :a) == by(d -> (z=d.c,), df, :a)
+        end
+        for cols in ((:b, :c), [:b, :c], (2, 3), 2:3, [2, 3], [false, true, true])
+            @test by(cols => x -> (y=exp.(x.b), z=x.c), df, :a) ==
+                by(d -> (y=exp.(d.b), z=d.c), df, :a)
+            @test by(cols => x -> (y=exp.(x.b), z=sum(x.c)), df, :a) ==
+                by(d -> (y=exp.(d.b), z=sum(d.c)), df, :a)
+            @test by(cols => x -> DataFrame(y=exp.(x.b), z=sum(x.c)), df, :a) ==
+                by(d -> DataFrame(y=exp.(d.b), z=sum(d.c)), df, :a)
+            @test by(cols => x -> [exp.(x.b) x.c], df, :a) ==
+                by(d -> [exp.(d.b) d.c], df, :a)
+        end
 
         gd = groupby(df, :a)
         for f in (map, combine)
-            @test f(:c => sum, gd) == f(d -> (c_sum=sum(d.c),), gd)
-            @test f(:c => x -> sum(x), gd) == f(d -> (c_function=sum(d.c),), gd)
-            @test f(:c => x -> (z=sum(x),), gd) == f(d -> (z=sum(d.c),), gd)
-            @test f(:c => x -> DataFrame(z=sum(x),), gd) == f(d -> (z=sum(d.c),), gd)
-            @test f(:c => identity, gd) == f(d -> (c_identity=d.c,), gd)
-            @test f(:c => x -> (z=x,), gd) == f(d -> (z=d.c,), gd)
-            @test f((:b, :c) => x -> (y=exp.(x.b), z=x.c), gd) ==
-                f(d -> (y=exp.(d.b), z=d.c), gd)
-            @test f((:b, :c) => x -> (y=exp.(x.b), z=sum(x.c)), gd) ==
-                f(d -> (y=exp.(d.b), z=sum(d.c)), gd)
-            @test f((:b, :c) => x -> [exp.(x.b) x.c], gd) ==
-                f(d -> [exp.(d.b) d.c], gd)
+            for col in (:c, 3)
+                @test f(col => sum, gd) == f(d -> (c_sum=sum(d.c),), gd)
+                @test f(col => x -> sum(x), gd) == f(d -> (c_function=sum(d.c),), gd)
+                @test f(col => x -> (z=sum(x),), gd) == f(d -> (z=sum(d.c),), gd)
+                @test f(col => x -> DataFrame(z=sum(x),), gd) == f(d -> (z=sum(d.c),), gd)
+                @test f(col => identity, gd) == f(d -> (c_identity=d.c,), gd)
+                @test f(col => x -> (z=x,), gd) == f(d -> (z=d.c,), gd)
+            end
+            for cols in ((:b, :c), [:b, :c], (2, 3), 2:3, [2, 3], [false, true, true])
+                @test f(cols => x -> (y=exp.(x.b), z=x.c), gd) ==
+                    f(d -> (y=exp.(d.b), z=d.c), gd)
+                @test f(cols => x -> (y=exp.(x.b), z=sum(x.c)), gd) ==
+                    f(d -> (y=exp.(d.b), z=sum(d.c)), gd)
+                @test f(cols => x -> [exp.(x.b) x.c], gd) ==
+                    f(d -> [exp.(d.b) d.c], gd)
+            end
         end
     end
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -164,6 +164,7 @@ module TestGrouping
         # groupby() without groups sorting
         gd = groupby(df, cols)
         @test sort(combine(identity, gd)) ==
+            sort(combine(gd)) ==
             sort(hcat(df, df[cols], makeunique=true))[[:a, :b, :a_1, :b_1, :c]]
         @test combine(f1, gd) == res
         @test combine(f2, gd) == res
@@ -181,6 +182,7 @@ module TestGrouping
             @test all(gd[i].b .== sres.b[i])
         end
         @test combine(identity, gd) ==
+            combine(gd) ==
             sort(hcat(df, df[cols], makeunique=true), cols)[[:a, :b, :a_1, :b_1, :c]]
         @test combine(f1, gd) == sres
         @test combine(f2, gd) == sres

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -460,14 +460,16 @@ module TestGrouping
             by(df, :a, :c => sum) ==
             by(df, :a, (:c => sum,)) ==
             by(df, :a, [:c => sum]) ==
-            by(df, :a, c_sum => :c => sum) ==
+            by(df, :a, c_sum = :c => sum) ==
             by(d -> (c_sum=sum(d.c),), df, :a)
+            by(df, :a, d -> (c_sum=sum(d.c),))
 
         @test by(df, :a, :b => sum, :c => sum) ==
             by(df, :a, (:b => sum, :c => sum,)) ==
             by(df, :a, [:b => sum, :c => sum]) ==
             by(df, :a, b_sum = :b => sum, c_sum = :c => sum) ==
-            by(d -> (b=sum=sum(d.b), c_sum=sum(d.c)), df, :a)
+            by(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), df, :a)
+            by(df, :a, d -> (b_sum=sum(d.b), c_sum=sum(d.c)))
 
         gd = groupby(df, :a)
         for f in (map, combine)


### PR DESCRIPTION
This is inspired by the [JuliaDB API](http://juliadb.org/latest/api/aggregation.html#IndexedTables.groupby). When columns are specified via `select`, the user-provided function is passed column vectors (as `SubArray`s) rather than a `SubDataFrame`. This gives fully type-stable code and dramatically improves performance.

This relatively limited change allows taking full advantage of the recent refactoring (https://github.com/JuliaData/DataFrames.jl/pull/1520). The performance gain is really incredible: about 200× for a simple sum after compilation.
```julia
using DataFrames, BenchmarkTools
df = DataFrame(a = repeat(1:40000, outer=[20]),
               b = randn(800000))
gd = groupby(df, :a)

julia> @time combine(d -> sum(d.b), gd);
  4.657727 seconds (7.39 M allocations: 640.692 MiB, 2.92% gc time)

julia> @btime combine(d -> sum(d.b), gd);
  3.129 s (4399077 allocations: 494.68 MiB)

julia> @time combine(:b => sum, gd);
  0.545264 seconds (1.65 M allocations: 80.211 MiB, 3.91% gc time)

julia> @btime combine(:b => sum, gd);
  10.395 ms (399620 allocations: 16.78 MiB)
```

I still need to write tests, but otherwise the main question is the API. The discussion has already been started [on Discourse](https://discourse.julialang.org/t/dataframes-obtaining-the-subset-of-rows-by-a-set-of-values/15923/24?u=nalimilan). To sum up: while the `select` API illustrated above is reasonable, the slow variant is a bit shorter and more intuitive, in particular because it avoids repeating the column names in two different places. Yet we *really* don't want people to use the slow variant unless they really need to (for complex operations or when the number of columns isn't known in advance), since its terribly slow.

The solution I proposed to that problem is to detect whether the user-provided function expects a `SubDataFrame` or columns, assuming the argument names are those of columns. This would allow writing the example above as simply `combine(b -> sum(b), gd)`. Implementation-wise, it is actually quite easy to extract the argument names and match them to column names. The main problem is that when the function takes a single argument, we don't know whether it's supposed to be a `SubDataFrame` or a column. So far I haven't found a good solution to that, except writing `combine((b, args...) -> sum(b), gd)` or something silly like this.

Anyway, we don't necessarily need to decide this right now, as the `select` approach could be complementary to another more convenient approach: `select` can be useful to choose programmatically which column(s) to operate on, and a convenience syntax could be based on that for its implementation.

Cc: @bkamins, @piever, @pdeffebach 