### PR TITLE
avoid depwarn in eachcol

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -36,8 +36,6 @@ export AbstractDataFrame,
        disallowmissing!,
        dropmissing,
        dropmissing!,
-       eachcol,
-       eachrow,
        eltypes,
        groupby,
        insertcols!,
@@ -58,6 +56,11 @@ export AbstractDataFrame,
        unstack,
        permutecols!
 
+if VERSION >= v"1.1.0-DEV.792"
+    import Base.eachcol, Base.eachrow
+else
+    export eachcol, eachrow
+end
 
 ##############################################################################
 ##

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -346,7 +346,7 @@ dump(df)
 function Base.dump(io::IO, df::AbstractDataFrame, n::Int, indent)
     println(io, typeof(df), "  $(nrow(df)) observations of $(ncol(df)) variables")
     if n > 0
-        for (name, col) in eachcol(df)
+        for (name, col) in eachcol(df, true)
             print(io, indent, "  ", name, ": ")
             dump(io, col, n - 1, string(indent, "  "))
         end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -102,7 +102,7 @@ function getmaxwidths(df::AbstractDataFrame,
     undefstrwidth = ourstrwidth(Base.undef_ref_str)
 
     j = 1
-    for (name, col) in eachcol(df)
+    for (name, col) in eachcol(df, true)
         # (1) Consider length of column name
         maxwidth = ourstrwidth(name)
 


### PR DESCRIPTION
@nalimilan This is a pretty urgent PR to merge and tag a minor release. It avoids pringing deprecation warning on eachcol when using `dump` or showing a data frame (which calls `getmaxwidths`).