### PR TITLE
improve row-removal functions

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -658,15 +658,15 @@ julia> dropmissing(df, [:x, :y])
 ```
 
 """
-dropmissing(df::AbstractDataFrame,
-            cols::Union{Integer, Symbol, AbstractVector}=1:size(df, 2);
-            keepeltype::Bool) =
-    dropmissing!(copy(df), cols, keepeltype=keepeltype)
+function dropmissing(df::AbstractDataFrame,
+                     cols::Union{Integer, Symbol, AbstractVector}=1:size(df, 2);
+                     keepeltype::Bool=true)
+    if keepeltype
+        Base.depwarn("dropmissing will change eltype of cols to disallow Missing by default. " *
+             "use dropmissing(df, cols, keepeltype=true) to retain Missing.", :dropmissing)
 
-function dropmissing(df, cols)
-    Base.depwarn("dropmissing will change eltype of cols to disallow Missing. " *
-                 "use dropmissing(df, cols, keepeltype=true) to retain Missing.", :dropmissing)
-    dropmissing(df, cols, keepeltype=true)
+    end
+    dropmissing!(copy(df), cols, keepeltype=keepeltype)
 end
 
 """

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -33,7 +33,7 @@ The following are normally implemented for AbstractDataFrames:
 * [`unique!`](@ref) : remove duplicate rows (`DataFrame` only)
 * `similar` : a DataFrame with similar columns as `d`
 * `filter` : remove rows
-* `filter` : remove rows in-place (`DataFrame` only)
+* `filter!` : remove rows in-place (`DataFrame` only)
 
 **Indexing**
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -872,16 +872,15 @@ julia> df3
 """
 function dropmissing!(df::DataFrame,
                      cols::Union{Integer, Symbol, AbstractVector}=1:size(df, 2);
-                     keepeltype::Bool)
+                     keepeltype::Bool=true)
     deleterows!(df, (!).(completecases(df, cols)))
-    keepeltype || disallowmissing!(df, cols)
+    if keepeltype
+        Base.depwarn("dropmissing! will change eltype of cols to disallow Missing by default. " *
+                     "use dropmissing(df, cols, keepeltype=true) to retain Missing.", :dropmissing!)
+    else
+        disallowmissing!(df, cols)
+    end
     df
-end
-
-function dropmissing!(df, cols)
-    Base.depwarn("dropmissing! will change eltype of cols to disallow Missing. " *
-                 "use dropmissing(df, cols, keepeltype=true) to retain Missing.", :dropmissing!)
-    dropmissing!(df, cols, keepeltype=true)
 end
 
 """

--- a/test/data.jl
+++ b/test/data.jl
@@ -73,6 +73,18 @@ module TestData
             @test df4b == df4
         end
 
+        df = DataFrame(a=[1, missing, 3])
+        sdf = view(df, :, :)
+        @test dropmissing(sdf) == DataFrame(a=[1, 3])
+        @test eltype(dropmissing(sdf, keepeltype=true)[:a]) == Union{Int, Missing}
+        @test eltype(dropmissing(sdf, keepeltype=false)[:a]) == Int
+
+        df2 = copy(df)
+        dropmissing!(df, keepeltype=false)
+        dropmissing!(df2, keepeltype=true)
+        @test eltype(df.a) == Union{Int, Missing}
+        @test eltype(df2.a) == Int
+
         #test_context("SubDataFrames")
 
         #test_group("constructors")

--- a/test/data.jl
+++ b/test/data.jl
@@ -82,8 +82,8 @@ module TestData
         df2 = copy(df)
         dropmissing!(df, keepeltype=false)
         dropmissing!(df2, keepeltype=true)
-        @test eltype(df.a) == Union{Int, Missing}
-        @test eltype(df2.a) == Int
+        @test eltype(df.a) == Int
+        @test eltype(df2.a) == Union{Int, Missing}
 
         #test_context("SubDataFrames")
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -383,11 +383,11 @@ module TestDataFrame
 
         df = DataFrame()
         @test_throws BoundsError deleterows!(df, 10)
-        @test_throws IndexactError deleterows!(df, [10])
+        @test_throws InexactError deleterows!(df, [10])
 
         df = DataFrame(a=[])
         @test_throws BoundsError deleterows!(df, 10)
-        @test_throws IndexactError deleterows!(df, [10])
+        @test_throws InexactError deleterows!(df, [10])
 
         df = DataFrame(a=[1, 2, 3], b=[3, 2, 1])
         @test_throws ArgumentError deleterows!(df, [3,2])

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -380,6 +380,40 @@ module TestDataFrame
         df = DataFrame(a=Union{Int, Missing}[1, 2, 3], b=Union{Float64, Missing}[3.0, 4.0, 5.0])
         @test deleterows!(df, [2, 3]) === df
         @test df == DataFrame(a=[1], b=[3.0])
+
+        df = DataFrame()
+        @test_throws BoundsError deleterows!(df, 10)
+        @test_throws BoundsError deleterows!(df, [10])
+
+        df = DataFrame(a=[])
+        @test_throws BoundsError deleterows!(df, 10)
+        @test_throws BoundsError deleterows!(df, [10])
+
+        df = DataFrame(a=[1, 2, 3], b=[3, 2, 1])
+        @test_throws ArgumentError deleterows!(df, [3,2])
+        @test_throws ArgumentError deleterows!(df, [2,2])
+        @test deleterows!(df, [false, true, false]) === df
+        @test df == DataFrame(a=[1, 3], b=[3, 1])
+
+        x = [1, 2, 3]
+        df = DataFrame(x=x)
+        @test deleterows!(x, 1) == DataFrame(x=[2, 3])
+        @test x == [1, 2, 3]
+ 
+        x = [1, 2, 3]
+        df = DataFrame(x=x)
+        @test deleterows!(x, [1]) == DataFrame(x=[2, 3])
+        @test x == [1, 2, 3]
+ 
+        x = [1, 2, 3]
+        df = DataFrame(x=x)
+        @test deleterows!(x, 1:1) == DataFrame(x=[2, 3])
+        @test x == [1, 2, 3]
+ 
+        x = [1, 2, 3]
+        df = DataFrame(x=x)
+        @test deleterows!(x, [true, false, false]) == DataFrame(x=[2, 3])
+        @test x == [1, 2, 3]
     end
 
     @testset "describe" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -383,11 +383,11 @@ module TestDataFrame
 
         df = DataFrame()
         @test_throws BoundsError deleterows!(df, 10)
-        @test_throws BoundsError deleterows!(df, [10])
+        @test_throws IndexactError deleterows!(df, [10])
 
         df = DataFrame(a=[])
         @test_throws BoundsError deleterows!(df, 10)
-        @test_throws BoundsError deleterows!(df, [10])
+        @test_throws IndexactError deleterows!(df, [10])
 
         df = DataFrame(a=[1, 2, 3], b=[3, 2, 1])
         @test_throws ArgumentError deleterows!(df, [3,2])
@@ -397,22 +397,22 @@ module TestDataFrame
 
         x = [1, 2, 3]
         df = DataFrame(x=x)
-        @test deleterows!(x, 1) == DataFrame(x=[2, 3])
+        @test deleterows!(df, 1) == DataFrame(x=[2, 3])
         @test x == [1, 2, 3]
  
         x = [1, 2, 3]
         df = DataFrame(x=x)
-        @test deleterows!(x, [1]) == DataFrame(x=[2, 3])
+        @test deleterows!(df, [1]) == DataFrame(x=[2, 3])
         @test x == [1, 2, 3]
  
         x = [1, 2, 3]
         df = DataFrame(x=x)
-        @test deleterows!(x, 1:1) == DataFrame(x=[2, 3])
+        @test deleterows!(df, 1:1) == DataFrame(x=[2, 3])
         @test x == [1, 2, 3]
  
         x = [1, 2, 3]
         df = DataFrame(x=x)
-        @test deleterows!(x, [true, false, false]) == DataFrame(x=[2, 3])
+        @test deleterows!(df, [true, false, false]) == DataFrame(x=[2, 3])
         @test x == [1, 2, 3]
     end
 


### PR DESCRIPTION
This PR relates to #1441 and #1617. It depends on https://github.com/JuliaLang/julia/pull/30287 for correctly handling some corner cases (but it is OK to merge it without that PR as those are obscure cases).

What it changes:
* change signature of `unique!` and `filter!`, `dropmissing!` functions as they allow only `DataFrame`
* `dropmissing!` and `dropmissing` get a keyword argument `keepeltype` stating if we want to keep eltype of the original columns or change them to disallow `Missing`
* fix `deleterows!` to always create a new vector instead of modifying the source (note: we could do it the other way around - i.e. always update the source; please comment what would be a preferred solution)
* make `deleterows!` work consistently with `deleteat!` in base (in particular allow boolean indexing and expect that the rows to be deleted are sorted - in the past this requirement was not present so this is a bit breaking - I can add sorting or I can add depwarn, but now an error on unsorted data is thrown so I think it is OK go go forward as proposed)