### PR TITLE
add proper fallbacks for dump, getmaxwidths and mapcols to avoid depwarns

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -861,12 +861,16 @@ if isdefined(Base, :unique!)
 end
 
 unique!(df::AbstractDataFrame) = deleterows!(df, findall(nonunique(df)))
-unique!(df::AbstractDataFrame, cols::Union{Integer, Symbol, AbstractVector, Colon}) =
+unique!(df::AbstractDataFrame, cols::AbstractVector) =
+    deleterows!(df, findall(nonunique(df, cols)))
+unique!(df::AbstractDataFrame, cols::Union{Integer, Symbol, Colon}) =
     deleterows!(df, findall(nonunique(df, cols)))
 
 # Unique rows of an AbstractDataFrame.
 Base.unique(df::AbstractDataFrame) = df[(!).(nonunique(df)), :]
-Base.unique(df::AbstractDataFrame, cols::Union{Integer, Symbol, AbstractVector, Colon}) =
+Base.unique(df::AbstractDataFrame, cols::AbstractVector) =
+    df[(!).(nonunique(df, cols)), :]
+Base.unique(df::AbstractDataFrame, cols::Union{Integer, Symbol, Colon}) =
     df[(!).(nonunique(df, cols)), :]
 
 """

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -853,7 +853,7 @@ function nonunique(df::AbstractDataFrame)
     return res
 end
 
-nonunique(df::AbstractDataFrame, cols::Union{Real, Symbol}) = nonunique(df[[cols]])
+nonunique(df::AbstractDataFrame, cols::Union{Integer, Symbol}) = nonunique(df[[cols]])
 nonunique(df::AbstractDataFrame, cols::Any) = nonunique(df[cols])
 
 if isdefined(Base, :unique!)
@@ -861,11 +861,13 @@ if isdefined(Base, :unique!)
 end
 
 unique!(df::AbstractDataFrame) = deleterows!(df, findall(nonunique(df)))
-unique!(df::AbstractDataFrame, cols::Any) = deleterows!(df, findall(nonunique(df, cols)))
+unique!(df::AbstractDataFrame, cols::Union{Integer, Symbol, AbstractVector}) =
+    deleterows!(df, findall(nonunique(df, cols)))
 
 # Unique rows of an AbstractDataFrame.
 Base.unique(df::AbstractDataFrame) = df[(!).(nonunique(df)), :]
-Base.unique(df::AbstractDataFrame, cols::Any) = df[(!).(nonunique(df, cols)), :]
+Base.unique(df::AbstractDataFrame, cols::Union{Integer, Symbol, AbstractVector}) =
+    df[(!).(nonunique(df, cols)), :]
 
 """
 Delete duplicate rows

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -861,12 +861,12 @@ if isdefined(Base, :unique!)
 end
 
 unique!(df::AbstractDataFrame) = deleterows!(df, findall(nonunique(df)))
-unique!(df::AbstractDataFrame, cols::Union{Integer, Symbol, AbstractVector}) =
+unique!(df::AbstractDataFrame, cols::Union{Integer, Symbol, AbstractVector, Colon}) =
     deleterows!(df, findall(nonunique(df, cols)))
 
 # Unique rows of an AbstractDataFrame.
 Base.unique(df::AbstractDataFrame) = df[(!).(nonunique(df)), :]
-Base.unique(df::AbstractDataFrame, cols::Union{Integer, Symbol, AbstractVector}) =
+Base.unique(df::AbstractDataFrame, cols::Union{Integer, Symbol, AbstractVector, Colon}) =
     df[(!).(nonunique(df, cols)), :]
 
 """

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -178,7 +178,7 @@ julia> mapcols(x -> x.^2, df)
 function mapcols(f::Union{Function,Type}, df::AbstractDataFrame)
     # note: `f` must return a consistent length
     res = DataFrame()
-    for (n, v) in eachcol(df)
+    for (n, v) in eachcol(df, true)
         res[n] = f(v)
     end
     res


### PR DESCRIPTION
Avoid depwarn messages when using `SubDataFrame`