### PR TITLE
improve dropmissing and deleterows!

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.7.0
 Missings 0.2.3
-CategoricalArrays 0.3.14
+CategoricalArrays 0.5.2
 StatsBase 0.11.0
 SortingAlgorithms
 Reexport

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -30,6 +30,8 @@ meltdf
 ```@docs
 allowmissing!
 completecases
+deletecols!
+deleterows!
 describe
 disallowmissing!
 dropmissing

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -854,6 +854,9 @@ julia> deleterows!(d, 2)
 
 """
 function deleterows!(df::DataFrame, ind)
+    if !isempty(ind) && size(df, 2) == 0
+        throw(BoundsError(summary(df), ind))
+    end
     # we require ind to be stored and unique like in Base
     foreach(col -> deleteat!(col, ind), _columns(df))
     df

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -766,18 +766,11 @@ end
 """
     deletecols!(df::DataFrame, ind)
 
-Delete columns from a data frame in place.
+Delete columns specified by `ind` from a `DataFrame` df in place.
+Returns the modified `DataFrame`.
 
-
-### Arguments
-
-* `df` : the DataFrame from which we want to remove a column
-
-* `ind` : a position from which we want to remove a column
-
-### Result
-
-* `::DataFrame` : a `DataFrame` with removed columns.
+Argument `ind` can be any index that is allowed for column indexing of
+a `DataFrame` provided that the columns requested to be removed are unique.
 
 ### Examples
 
@@ -803,7 +796,14 @@ julia> deletecols!(d, 1)
 
 """
 function deletecols!(df::DataFrame, inds::Vector{Int})
-    for ind in sort(inds, rev = true)
+    sorted_inds = sort(inds, rev=true)
+    for i in 2:length(sorted_inds)
+        if sorted_inds[i] == sorted_inds[i-1]
+            throw(ArgumentError("Duplicate values in inds found at positions" *
+                                " $(i-1) and $i."))
+        end
+    end
+    for ind in sorted_inds
         if 1 <= ind <= ncol(df)
             splice!(_columns(df), ind)
             delete!(index(df), ind)
@@ -819,17 +819,11 @@ deletecols!(df::DataFrame, c::Any) = deletecols!(df, index(df)[c])
 """
     deleterows!(df::DataFrame, ind)
 
-Delete rows from a data frame in place.
+Delete rows specified by `ind` from a `DataFrame` df in place.
+Returns the modified `DataFrame`.
 
-### Arguments
-
-* `df` : the DataFrame from which we want to remove rows
-
-* `ind` : a position from which we want to remove rows
-
-### Result
-
-* `::DataFrame` : a `DataFrame` with removed rows. Original will be updated.
+Internally `deleteat!` is called for all columns so `ind` must
+be: a vector of sorted and unique integers, a boolean vector or an integer.
 
 ### Examples
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -766,8 +766,7 @@ end
 """
     deletecols!(df::DataFrame, ind)
 
-Delete columns specified by `ind` from a `DataFrame` df in place.
-Returns the modified `DataFrame`.
+Delete columns specified by `ind` from a `DataFrame` `df` in place and return it.
 
 Argument `ind` can be any index that is allowed for column indexing of
 a `DataFrame` provided that the columns requested to be removed are unique.
@@ -819,8 +818,7 @@ deletecols!(df::DataFrame, c::Any) = deletecols!(df, index(df)[c])
 """
     deleterows!(df::DataFrame, ind)
 
-Delete rows specified by `ind` from a `DataFrame` df in place.
-Returns the modified `DataFrame`.
+Delete rows specified by `ind` from a `DataFrame` `df` in place and return it.
 
 Internally `deleteat!` is called for all columns so `ind` must
 be: a vector of sorted and unique integers, a boolean vector or an integer.

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -849,7 +849,7 @@ julia> deleterows!(d, 2)
 """
 function deleterows!(df::DataFrame, ind)
     if !isempty(ind) && size(df, 2) == 0
-        throw(BoundsError(summary(df), ind))
+        throw(BoundsError())
     end
     # we require ind to be stored and unique like in Base
     foreach(col -> deleteat!(col, ind), _columns(df))
@@ -858,7 +858,7 @@ end
 
 function deleterows!(df::DataFrame, ind::AbstractVector{Bool})
     if length(ind) != size(df, 1)
-        throw(BoundsError(summary(df), ind))
+        throw(BoundsError())
     end
     drop = findall(ind)
     foreach(col -> deleteat!(col, drop), _columns(df))

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -763,6 +763,45 @@ end
 ##
 ##############################################################################
 
+"""
+    deletecols!(df::DataFrame, ind)
+
+Delete columns from a data frame in place.
+
+
+### Arguments
+
+* `df` : the DataFrame from which we want to remove a column
+
+* `ind` : a position from which we want to remove a column
+
+### Result
+
+* `::DataFrame` : a `DataFrame` with removed columns.
+
+### Examples
+
+```jldoctest
+julia> d = DataFrame(a=1:3, b=4:6)
+3×2 DataFrame
+│ Row │ a     │ b     │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 1     │ 4     │
+│ 2   │ 2     │ 5     │
+│ 3   │ 3     │ 6     │
+
+julia> deletecols!(d, 1)
+3×1 DataFrame
+│ Row │ b     │
+│     │ Int64 │
+├─────┼───────┤
+│ 1   │ 4     │
+│ 2   │ 5     │
+│ 3   │ 6     │
+```
+
+"""
 function deletecols!(df::DataFrame, inds::Vector{Int})
     for ind in sort(inds, rev = true)
         if 1 <= ind <= ncol(df)
@@ -777,36 +816,55 @@ end
 deletecols!(df::DataFrame, c::Int) = deletecols!(df, [c])
 deletecols!(df::DataFrame, c::Any) = deletecols!(df, index(df)[c])
 
-function deleterows!(df::DataFrame, ind::Union{Integer, UnitRange{Int}})
-    for i in 1:ncol(df)
-        _columns(df)[i] = deleteat!(_columns(df)[i], ind)
-    end
+"""
+    deleterows!(df::DataFrame, ind)
+
+Delete rows from a data frame in place.
+
+### Arguments
+
+* `df` : the DataFrame from which we want to remove rows
+
+* `ind` : a position from which we want to remove rows
+
+### Result
+
+* `::DataFrame` : a `DataFrame` with removed rows. Original will be updated.
+
+### Examples
+
+```jldoctest
+julia> d = DataFrame(a=1:3, b=4:6)
+3×2 DataFrame
+│ Row │ a     │ b     │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 1     │ 4     │
+│ 2   │ 2     │ 5     │
+│ 3   │ 3     │ 6     │
+
+julia> deleterows!(d, 2)
+2×2 DataFrame
+│ Row │ a     │ b     │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 1     │ 4     │
+│ 2   │ 3     │ 6     │
+```
+
+"""
+function deleterows!(df::DataFrame, ind)
+    # we require ind to be stored and unique like in Base
+    foreach(col -> deleteat!(col, ind), _columns(df))
     df
 end
 
-function deleterows!(df::DataFrame, ind::AbstractVector{Int})
-    ind2 = sort(ind)
-    n = size(df, 1)
-
-    idf = 1
-    iind = 1
-    ikeep = 1
-    keep = Vector{Int}(undef, n-length(ind2))
-    while idf <= n && iind <= length(ind2)
-        1 <= ind2[iind] <= n || error(BoundsError())
-        if idf == ind2[iind]
-            iind += 1
-        else
-            keep[ikeep] = idf
-            ikeep += 1
-        end
-        idf += 1
+function deleterows!(df::DataFrame, ind::AbstractVector{Bool})
+    if length(ind) != size(df, 1)
+        throw(BoundsError(summary(df), ind))
     end
-    keep[ikeep:end] = idf:n
-
-    for i in 1:ncol(df)
-        _columns(df)[i] = _columns(df)[i][keep]
-    end
+    drop = findall(ind)
+    foreach(col -> deleteat!(col, drop), _columns(df))
     df
 end
 

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -220,3 +220,6 @@ Base.copy(sdf::SubDataFrame) = parent(sdf)[rows(sdf), :]
 without(sdf::SubDataFrame, c) = view(without(parent(sdf), c), rows(sdf), :)
 # Resolve a method ambiguity
 without(sdf::SubDataFrame, c::Vector{<:Integer}) = view(without(parent(sdf), c), rows(sdf), :)
+
+deleterows!(df::SubDataFrame, ind) =
+    throw(ArgumentError("SubDataFrame does not support deleting rows"))

--- a/test/data.jl
+++ b/test/data.jl
@@ -73,6 +73,17 @@ module TestData
             @test df4b == df4
         end
 
+        df = DataFrame(a=[1, missing, 3])
+        sdf = view(df, :, :)
+        @test dropmissing(sdf) == DataFrame(a=[1, 3])
+        @test eltype(dropmissing(sdf, disallowmissing=false)[:a]) == Union{Int, Missing}
+        @test eltype(dropmissing(sdf, disallowmissing=true)[:a]) == Int
+         df2 = copy(df)
+        dropmissing!(df, disallowmissing=true)
+        dropmissing!(df2, disallowmissing=false)
+        @test eltype(df.a) == Int
+        @test eltype(df2.a) == Union{Int, Missing}
+
         #test_context("SubDataFrames")
 
         #test_group("constructors")

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -380,6 +380,40 @@ module TestDataFrame
         df = DataFrame(a=Union{Int, Missing}[1, 2, 3], b=Union{Float64, Missing}[3.0, 4.0, 5.0])
         @test deleterows!(df, [2, 3]) === df
         @test df == DataFrame(a=[1], b=[3.0])
+
+        df = DataFrame()
+        @test_throws BoundsError deleterows!(df, 10)
+        @test_throws InexactError deleterows!(df, [10])
+
+        df = DataFrame(a=[])
+        @test_throws BoundsError deleterows!(df, 10)
+        @test_throws InexactError deleterows!(df, [10])
+
+        df = DataFrame(a=[1, 2, 3], b=[3, 2, 1])
+        @test_throws ArgumentError deleterows!(df, [3,2])
+        @test_throws ArgumentError deleterows!(df, [2,2])
+        @test deleterows!(df, [false, true, false]) === df
+        @test df == DataFrame(a=[1, 3], b=[3, 1])
+
+        x = [1, 2, 3]
+        df = DataFrame(x=x)
+        @test deleterows!(df, 1) == DataFrame(x=[2, 3])
+        @test x == [2, 3]
+
+        x = [1, 2, 3]
+        df = DataFrame(x=x)
+        @test deleterows!(df, [1]) == DataFrame(x=[2, 3])
+        @test x == [2, 3]
+
+        x = [1, 2, 3]
+        df = DataFrame(x=x)
+        @test deleterows!(df, 1:1) == DataFrame(x=[2, 3])
+        @test x == [2, 3]
+
+        x = [1, 2, 3]
+        df = DataFrame(x=x)
+        @test deleterows!(df, [true, false, false]) == DataFrame(x=[2, 3])
+        @test x == [2, 3]
     end
 
     @testset "describe" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -387,7 +387,9 @@ module TestDataFrame
 
         df = DataFrame(a=[])
         @test_throws BoundsError deleterows!(df, 10)
-        @test_throws InexactError deleterows!(df, [10])
+        # the exception type changed between Julia 1.0.2 and Julia 1.1
+        # so we use their supertype below
+        @test_throws Exception deleterows!(df, [10])
 
         df = DataFrame(a=[1, 2, 3], b=[3, 2, 1])
         @test_throws ArgumentError deleterows!(df, [3,2])

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -333,6 +333,7 @@ module TestDataFrame
         df = DataFrame(a=1, b=2, c=3, d=4, e=5)
         @test_throws ArgumentError deletecols!(df, 0)
         @test_throws ArgumentError deletecols!(df, 6)
+        @test_throws ArgumentError deletecols!(df, [1, 1])
         @test_throws KeyError deletecols!(df, :f)
 
         d = copy(df)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -383,7 +383,7 @@ module TestDataFrame
 
         df = DataFrame()
         @test_throws BoundsError deleterows!(df, 10)
-        @test_throws InexactError deleterows!(df, [10])
+        @test_throws BoundsError deleterows!(df, [10])
 
         df = DataFrame(a=[])
         @test_throws BoundsError deleterows!(df, 10)

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -96,8 +96,8 @@ module TestSubDataFrame
     end
 
     @testset "getproperty, setproperty! and propertynames" begin
-        x = 1:10
-        y = 1.0:10.0
+        x = collect(1:10)
+        y = collect(1.0:10.0)
         df = view(DataFrame(x = x, y = y), 2:6, :)
 
         @test Base.propertynames(df) == names(df)
@@ -118,7 +118,7 @@ module TestSubDataFrame
 
     @testset "dump" begin
         y = 1.0:10.0
-        df = view(DataFrame(y = y), 2:6, :)
+        df = view(DataFrame(y=y), 2:6, :)
         @test sprint(dump, df) == """
                                   SubDataFrame{UnitRange{$Int}}  5 observations of 1 variables
                                     y: Array{Float64}((5,)) [2.0, 3.0, 4.0, 5.0, 6.0]
@@ -127,7 +127,7 @@ module TestSubDataFrame
 
     @testset "deleterows!" begin
         y = 1.0:10.0
-        df = view(DataFrame(y = y), 2:6, :)
+        df = view(DataFrame(y=y), 2:6, :)
         @test_throws ArgumentError deleterows!(df, 1)
     end
 end

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -96,8 +96,8 @@ module TestSubDataFrame
     end
 
     @testset "getproperty, setproperty! and propertynames" begin
-        x = collect(1:10)
-        y = collect(1.0:10.0)
+        x = 1:10
+        y = 1.0:10.0
         df = view(DataFrame(x = x, y = y), 2:6, :)
 
         @test Base.propertynames(df) == names(df)
@@ -117,7 +117,7 @@ module TestSubDataFrame
     end
 
     @testset "dump" begin
-        y = collect(1.0:10.0)
+        y = 1.0:10.0
         df = view(DataFrame(y = y), 2:6, :)
         @test sprint(dump, df) == """
                                   SubDataFrame{UnitRange{$Int}}  5 observations of 1 variables
@@ -126,7 +126,7 @@ module TestSubDataFrame
     end
 
     @testset "deleterows!" begin
-        y = collect(1.0:10.0)
+        y = 1.0:10.0
         df = view(DataFrame(y = y), 2:6, :)
         @test_throws ArgumentError deleterows!(df, 1)
     end

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -124,4 +124,10 @@ module TestSubDataFrame
                                     y: Array{Float64}((5,)) [2.0, 3.0, 4.0, 5.0, 6.0]
                                   """
     end
+
+    @testset "deleterows!" begin
+        y = collect(1.0:10.0)
+        df = view(DataFrame(y = y), 2:6, :)
+        @test_throws ArgumentError deleterows!(df, 1)
+    end
 end


### PR DESCRIPTION
I opened a new PR instead of #1618 as there were too many changes and this way is cleaner.

What it changes:
* add `disallowmissing` kwarg for `dropmissing` and `dropmissing!`
* add documentation for `deletecols!` and `deleterows!`
* `deleterows!` manipulates columns "in-place" (I did not do not in-place modification as it can be achieved by `getindex` so it would duplicate)
* `deleterows!` for `SubDataFrame` has a nicer error as it could be accidentally called