### PR TITLE
Sanitize haskey and column inserting against Bool column index

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -334,7 +334,7 @@ function insert_single_column!(df::DataFrame,
         throw(ArgumentError("New columns must have the same length as old columns"))
     end
     if col_ind isa Bool
-        throw(ArgumentError("invalid column index: $idx of type Bool"))
+        throw(ArgumentError("invalid column index: $col_ind of type Bool"))
     end
     dv = isa(v, AbstractRange) ? collect(v) : v
     if haskey(index(df), col_ind)
@@ -358,7 +358,7 @@ end
 
 function insert_single_entry!(df::DataFrame, v::Any, row_ind::Integer, col_ind::ColumnIndex)
     if col_ind isa Bool
-        throw(ArgumentError("invalid column index: $idx of type Bool"))
+        throw(ArgumentError("invalid column index: $col_ind of type Bool"))
     end
     if haskey(index(df), col_ind)
         _columns(df)[index(df)[col_ind]][row_ind] = v
@@ -372,8 +372,8 @@ function insert_multiple_entries!(df::DataFrame,
                                   v::Any,
                                   row_inds::AbstractVector{<:Integer},
                                   col_ind::ColumnIndex)
-    if colind isa Bool
-        throw(ArgumentError("invalid column index: $idx of type Bool"))
+    if col_ind isa Bool
+        throw(ArgumentError("invalid column index: $col_ind of type Bool"))
     end
     if haskey(index(df), col_ind)
         _columns(df)[index(df)[col_ind]][row_inds] .= v

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -333,6 +333,9 @@ function insert_single_column!(df::DataFrame,
     if ncol(df) != 0 && nrow(df) != length(v)
         throw(ArgumentError("New columns must have the same length as old columns"))
     end
+    if col_ind isa Bool
+        throw(ArgumentError("invalid column index: $idx of type Bool"))
+    end
     dv = isa(v, AbstractRange) ? collect(v) : v
     if haskey(index(df), col_ind)
         j = index(df)[col_ind]
@@ -353,7 +356,10 @@ function insert_single_column!(df::DataFrame,
     return dv
 end
 
-function insert_single_entry!(df::DataFrame, v::Any, row_ind::Real, col_ind::ColumnIndex)
+function insert_single_entry!(df::DataFrame, v::Any, row_ind::Integer, col_ind::ColumnIndex)
+    if col_ind isa Bool
+        throw(ArgumentError("invalid column index: $idx of type Bool"))
+    end
     if haskey(index(df), col_ind)
         _columns(df)[index(df)[col_ind]][row_ind] = v
         return v
@@ -364,8 +370,11 @@ end
 
 function insert_multiple_entries!(df::DataFrame,
                                   v::Any,
-                                  row_inds::AbstractVector{<:Real},
+                                  row_inds::AbstractVector{<:Integer},
                                   col_ind::ColumnIndex)
+    if colind isa Bool
+        throw(ArgumentError("invalid column index: $idx of type Bool"))
+    end
     if haskey(index(df), col_ind)
         _columns(df)[index(df)[col_ind]][row_inds] .= v
         return v

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -76,7 +76,9 @@ rename(f::Function, x::Index) = rename!(f, copy(x))
 end
 
 Base.haskey(x::Index, key::Symbol) = haskey(x.lookup, key)
-Base.haskey(x::Index, key::Real) = 1 <= key <= length(x.names)
+Base.haskey(x::Index, key::Integer) = 1 <= key <= length(x.names)
+Base.haskey(x::Index, key::Bool) =
+    throw(ArgumentError("invalid key: $key of type Bool"))
 Base.keys(x::Index) = names(x)
 
 # TODO: If this should stay 'unsafe', perhaps make unexported

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -81,6 +81,8 @@ module TestDataFrame
         df = DataFrame(a=[1, 2], b=[3.0, 4.0])
         @test haskey(df, :a)
         @test !haskey(df, :c)
+        @test haskey(df, 1)
+        @test_throws ArgumentError haskey(df, true)
         @test get(df, :a, -1) === columns(df)[1]
         @test get(df, :c, -1) == -1
         @test !isempty(df)
@@ -779,6 +781,8 @@ module TestDataFrame
         df[3] = [1,2,3]
         df[4] = [1,2,3]
         @test names(df) == [:x3, :x3_1, :x3_2, :x4]
+        df = DataFrame()
+        @test_throws ArgumentError df[true] = 1
     end
 
     @testset "passing range to a DataFrame" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -82,6 +82,7 @@ module TestDataFrame
         @test haskey(df, :a)
         @test !haskey(df, :c)
         @test haskey(df, 1)
+        @test_throws MethodError haskey(df, 1.5)
         @test_throws ArgumentError haskey(df, true)
         @test get(df, :a, -1) === columns(df)[1]
         @test get(df, :c, -1) == -1

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -784,6 +784,9 @@ module TestDataFrame
         @test names(df) == [:x3, :x3_1, :x3_2, :x4]
         df = DataFrame()
         @test_throws ArgumentError df[true] = 1
+        @test_throws ArgumentError df[true] = [1,2,3]
+        @test_throws ArgumentError df[1:2, true] = [1,2]
+        @test_throws ArgumentError df[1, true] = 1
     end
 
     @testset "passing range to a DataFrame" begin


### PR DESCRIPTION
A small PR that is a pre `setindex!` review clean up. It makes sure that we do not allow `Bool` for column indexing and cleans up method signatures (the signature changes are not breaking).

Disallowing `Bool` is a bit breaking, but I would merge it without deprecation as this is what we have warned against in `getindex` and it is disallowed in Base.