### PR TITLE
DataFrameRow: fix iterate, ndims, iterate

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -81,7 +81,7 @@ Base.size(r::DataFrameRow) = (size(parent(r), 2),)
 Base.size(r::DataFrameRow, i) = size(r)[i]
 Base.length(r::DataFrameRow) = size(parent(r), 2)
 Base.ndims(r::DataFrameRow) = 1
-Base.ndims(::Type{DataFrameRow{T}}) where {T<:AbstractDataFrame} = 1
+Base.ndims(::Type{<:DataFrameRow}) = 1
 
 Base.lastindex(r::DataFrameRow) = size(parent(r), 2)
 

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -91,6 +91,8 @@ function Base.iterate(r::DataFrameRow, st)
     return (r[st], st + 1)
 end
 
+Base.eltype(r::DataFrameRow) = reduce(typejoin, eltypes(parent(r)))
+
 Base.convert(::Type{Array}, dfr::DataFrameRow) =
     [dfr[i] for j in 1:1, i in 1:length(dfr)]
 Base.convert(::Type{Vector}, dfr::DataFrameRow) =
@@ -99,7 +101,6 @@ Base.convert(::Type{Vector{T}}, dfr::DataFrameRow) where T =
     T[dfr[i] for i in 1:length(dfr)]
 Base.Vector(dfr::DataFrameRow) = convert(Vector, dfr)
 Base.Vector{T}(dfr::DataFrameRow) where T = convert(Vector{T}, dfr)
-
 
 Base.keys(r::DataFrameRow) = names(parent(r))
 Base.values(r::DataFrameRow) = ntuple(col -> parent(r)[col][row(r)], length(r))

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -80,15 +80,11 @@ index(r::DataFrameRow) = index(parent(r))
 Base.size(r::DataFrameRow) = (size(parent(r), 2),)
 Base.size(r::DataFrameRow, i) = size(r)[i]
 Base.length(r::DataFrameRow) = size(parent(r), 2)
+Base.ndims(r::DataFrameRow) = 1
 
-Compat.lastindex(r::DataFrameRow) = size(parent(r), 2)
+Base.lastindex(r::DataFrameRow) = size(parent(r), 2)
 
-function Base.iterate(r::DataFrameRow)
-    Base.depwarn("iteration over DataFrameRow will return values in the future:" *
-                 "use pairs(r::DataFrameRow) to get the current behavior",
-                 :start)
-    iterate(r, 1)
-end
+Base.iterate(r::DataFrameRow) = iterate(r, 1)
 
 function Base.iterate(r::DataFrameRow, st)
     st > length(r) && return nothing

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -81,6 +81,7 @@ Base.size(r::DataFrameRow) = (size(parent(r), 2),)
 Base.size(r::DataFrameRow, i) = size(r)[i]
 Base.length(r::DataFrameRow) = size(parent(r), 2)
 Base.ndims(r::DataFrameRow) = 1
+Base.ndims(::Type{DataFrameRow{T}}) where {T<:AbstractDataFrame} = 1
 
 Base.lastindex(r::DataFrameRow) = size(parent(r), 2)
 

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -88,6 +88,8 @@ function Base.iterate(r::DataFrameRow, st)
     return (r[st], st + 1)
 end
 
+# Computing the element type requires going over all columns,
+# so better let collect() do it only if necessary (widening)
 Base.IteratorEltype(::DataFrameRow) = Base.EltypeUnknown()
 
 Base.convert(::Type{Array}, dfr::DataFrameRow) =

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -92,7 +92,7 @@ function Base.iterate(r::DataFrameRow, st)
     return (r[st], st + 1)
 end
 
-Base.eltype(r::DataFrameRow) = reduce(typejoin, eltypes(parent(r)))
+Base.IteratorEltype(::DataFrameRow) = Base.EltypeUnknown()
 
 Base.convert(::Type{Array}, dfr::DataFrameRow) =
     [dfr[i] for j in 1:1, i in 1:length(dfr)]

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1328,9 +1328,6 @@ import Base: vcat
 @deprecate showcols(df::AbstractDataFrame, all::Bool=false, values::Bool=true) describe(df, stats = [:eltype, :nmissing, :first, :last])
 @deprecate showcols(io::IO, df::AbstractDataFrame, all::Bool=false, values::Bool=true) show(io, describe(df, stats = [:eltype, :nmissing, :first, :last]), all)
 
-import Base: collect
-@deprecate collect(r::DataFrameRow) collect(pairs(r))
-
 import Base: show
 @deprecate show(io::IO, df::AbstractDataFrame, allcols::Bool, rowlabel::Symbol, summary::Bool) show(io, df, allcols=allcols, rowlabel=rowlabel, summary=summary)
 @deprecate show(io::IO, df::AbstractDataFrame, allcols::Bool, rowlabel::Symbol) show(io, df, allcols=allcols, rowlabel=rowlabel)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -89,13 +89,19 @@ module TestDataFrameRow
     r = DataFrameRow(df, 1)
     @test r[:] == r
 
-    # keys, values and iteration
+    # keys, values and iteration, size
     @test keys(r) == names(df)
     @test values(r) == (df[1, 1], df[1, 2], df[1, 3], df[1, 4])
     @test collect(pairs(r)) == [:a=>df[1, 1], :b=>df[1, 2], :c=>df[1, 3], :d=>df[1, 4]]
 
     @test haskey(r, :a)
     @test !haskey(r, :zzz)
+
+    @test length(r) == 4
+    @test ndims(r) == 1
+    @test size(r) == (4,)
+    @test size(r, 1) == 4
+    @test_throws BoundsError size(r, 2)
 
     df = DataFrame(a=nothing, b=1)
     io = IOBuffer()
@@ -116,4 +122,16 @@ module TestDataFrameRow
                    c=["A", "B", "C", "A", "B", missing])
     @test copy(DataFrameRow(df, 1)) == (a = 1, b = 2.0, c = "A")
     @test isequal(copy(DataFrameRow(df, 2)), (a = 2, b = missing, c = "B"))
+
+    # iteration and collect
+    ref = ["a", "b", "c"]
+    df = DataFrame(permutedims(ref))
+    dfr = df[1, :]
+    @test collect(dfr) == ref
+    for (v1, v2) in zip(ref, dfr)
+        @test v1 == v2
+    end
+    for (i, v) in enumerate(dfr)
+        @test v == ref[i]
+    end
 end

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -99,6 +99,7 @@ module TestDataFrameRow
 
     @test length(r) == 4
     @test ndims(r) == 1
+    @test ndims(typeof(r)) == 1
     @test size(r) == (4,)
     @test size(r, 1) == 4
     @test_throws BoundsError size(r, 2)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -128,10 +128,13 @@ module TestDataFrameRow
     df = DataFrame(permutedims(ref))
     dfr = df[1, :]
     @test collect(dfr) == ref
+    @test eltype(collect(dfr)) === String
     for (v1, v2) in zip(ref, dfr)
         @test v1 == v2
     end
     for (i, v) in enumerate(dfr)
         @test v == ref[i]
     end
+    dfr = DataFrame(a=1, b=true, c=1.0)[1,:]
+    @test eltype(collect(dfr)) === Real
 end


### PR DESCRIPTION
Clean-up of `DataFrameRow` API.

Notice that `collect(dfr)` will have `eltype` set to `Any` (this is the standard mechanics), while `Vector(dfr)` does `promote_type` (and possibly makes a conversion - this is a behavior inherited from eralier implementation of `convert` to `Array` for `DataFrame`).