### PR TITLE
Add summary option to HTML and LaTeX show methods

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -92,7 +92,7 @@ function html_escape(cell::AbstractString)
     return cell
 end
 
-function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame; summary=true)
+function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame; summary::Bool=true)
     cnames = _names(df)
     write(io, "<table class=\"data-frame\">")
     write(io, "<thead>")

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -92,7 +92,7 @@ function html_escape(cell::AbstractString)
     return cell
 end
 
-function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame)
+function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame; summary=true)
     cnames = _names(df)
     write(io, "<table class=\"data-frame\">")
     write(io, "<thead>")
@@ -119,7 +119,9 @@ function Base.show(io::IO, ::MIME"text/html", df::AbstractDataFrame)
     else
         mxrow = n
     end
-    write(io, "<p>$(digitsep(n)) rows × $(digitsep(ncol(df))) columns</p>")
+    if summary
+        write(io, "<p>$(digitsep(n)) rows × $(digitsep(ncol(df))) columns</p>")
+    end
     for row in 1:mxrow
         write(io, "<tr>")
         write(io, "<th>$row</th>")
@@ -165,7 +167,7 @@ function latex_escape(cell::AbstractString)
     replace(cell, ['\\','~','#','$','%','&','_','^','{','}']=>latex_char_escape)
 end
 
-function Base.show(io::IO, ::MIME"text/latex", df::AbstractDataFrame)
+function Base.show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; summary=true)
     nrows = size(df, 1)
     ncols = size(df, 2)
 

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -167,7 +167,7 @@ function latex_escape(cell::AbstractString)
     replace(cell, ['\\','~','#','$','%','&','_','^','{','}']=>latex_char_escape)
 end
 
-function Base.show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; summary=true)
+function Base.show(io::IO, ::MIME"text/latex", df::AbstractDataFrame)
     nrows = size(df, 1)
     ncols = size(df, 2)
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -55,7 +55,16 @@ module TestIO
         @test str == "<table class=\"data-frame\"><thead><tr><th>" *
                     "</th><th>Fish</th><th>Mass</th></tr>" *
                     "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
-                    "<p>2 rows × 2 columns</p>" * 
+                    "<p>2 rows × 2 columns</p>" *
+                    "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
+                    "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
+
+        io = IOBuffer()
+        show(io, MIME"text/html"(), df, summary=false)
+        str = String(take!(io))
+        @test str == "<table class=\"data-frame\"><thead><tr><th>" *
+                    "</th><th>Fish</th><th>Mass</th></tr>" *
+                    "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
                     "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
                     "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
     end


### PR DESCRIPTION
This PR adds the option to not print the number of rows and columns in HTML and LaTeX output. This is useful in custom DataFrame types that have their own headers.