### PR TITLE
deprecate convert(Array, ::DataFrameRow)

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -95,8 +95,6 @@ function Base.iterate(r::DataFrameRow, st)
     return (r[st], st + 1)
 end
 
-Base.convert(::Type{Array}, dfr::DataFrameRow) =
-    [dfr[i] for j in 1:1, i in 1:length(dfr)]
 Base.convert(::Type{Vector}, dfr::DataFrameRow) =
     [dfr[i] for i in 1:length(dfr)]
 Base.convert(::Type{Vector{T}}, dfr::DataFrameRow) where T =

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -95,8 +95,10 @@ function Base.iterate(r::DataFrameRow, st)
     return (r[st], st + 1)
 end
 
-Base.convert(::Type{Vector}, dfr::DataFrameRow) =
-    [dfr[i] for i in 1:length(dfr)]
+function Base.convert(::Type{Vector}, dfr::DataFrameRow)
+    T = reduce(promote_type, eltypes(parent(dfr)))
+    convert(Vector{T}, dfr)
+end
 Base.convert(::Type{Vector{T}}, dfr::DataFrameRow) where T =
     T[dfr[i] for i in 1:length(dfr)]
 Base.Vector(dfr::DataFrameRow) = convert(Vector, dfr)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1371,3 +1371,6 @@ import Base: length
 @deprecate tail(df::AbstractDataFrame) last(df, 6)
 @deprecate head(df::AbstractDataFrame, n::Integer) first(df, n)
 @deprecate tail(df::AbstractDataFrame, n::Integer) last(df, n)
+
+import Base: convert
+@deprecate convert(::Type{Array}, dfr::DataFrameRow) permutedims(Vector(dfr))

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -105,7 +105,7 @@ module TestDataFrameRow
     # convert
     df = DataFrame(a=[1, missing], b=[2.0, 3.0])
     dfr = DataFrameRow(df, 1)
-    @test convert(Vector, dfr)::Vector{Float64} == [1.0, 2.0]
+    @test convert(Vector, dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
     @test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]
     @test Vector(dfr)::Vector{Float64} == [1.0, 2.0]
     @test Vector{Int}(dfr)::Vector{Int} == [1, 2]

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -107,7 +107,7 @@ module TestDataFrameRow
     dfr = DataFrameRow(df, 1)
     @test convert(Vector, dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
     @test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]
-    @test Vector(dfr)::Vector{Float64} == [1.0, 2.0]
+    @test Vector(dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
     @test Vector{Int}(dfr)::Vector{Int} == [1, 2]
 
     # copy

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -105,9 +105,9 @@ module TestDataFrameRow
     # convert
     df = DataFrame(a=[1, missing], b=[2.0, 3.0])
     dfr = DataFrameRow(df, 1)
-    @test convert(Vector, dfr)::Vector{Real} == Real[1, 2.0]
+    @test convert(Vector, dfr)::Vector{Float64} == [1.0, 2.0]
     @test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]
-    @test Vector(dfr)::Vector{Real} == Real[1, 2.0]
+    @test Vector(dfr)::Vector{Float64} == [1.0, 2.0]
     @test Vector{Int}(dfr)::Vector{Int} == [1, 2]
 
     # copy


### PR DESCRIPTION
I propose to deprecate `convert(Array, ::DataFrameRow)` as it is easy enough to get this functionality with other means and it is not consistent with anything I am aware of since we treat `DataFrameRow` as 1-dimensional object.