### PR TITLE
better AbstractDataFrame conversion

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -801,7 +801,7 @@ Base.filter!(f, df::AbstractDataFrame) =
     deleterows!(df, findall(collect(!f(r)::Bool for r in eachrow(df))))
 
 function Base.convert(::Type{Matrix}, df::AbstractDataFrame)
-    T = reduce(typejoin, eltypes(df))
+    T = reduce(promote_type, eltypes(df))
     convert(Matrix{T}, df)
 end
 function Base.convert(::Type{Matrix{T}}, df::AbstractDataFrame) where T

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1371,3 +1371,11 @@ import Base: length
 @deprecate tail(df::AbstractDataFrame) last(df, 6)
 @deprecate head(df::AbstractDataFrame, n::Integer) first(df, n)
 @deprecate tail(df::AbstractDataFrame, n::Integer) last(df, n)
+
+import Base: convert
+function convert(::Type{Array}, df::AbstractDataFrame)
+    convert(Matrix, df)
+end
+function convert(::Type{Array{T}}, df::AbstractDataFrame) where T
+    convert(Matrix{T}, df)
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1373,9 +1373,5 @@ import Base: length
 @deprecate tail(df::AbstractDataFrame, n::Integer) last(df, n)
 
 import Base: convert
-function convert(::Type{Array}, df::AbstractDataFrame)
-    convert(Matrix, df)
-end
-function convert(::Type{Array{T}}, df::AbstractDataFrame) where T
-    convert(Matrix{T}, df)
-end
+@deprecate convert(::Type{Array}, df::AbstractDataFrame) convert(Matrix, df)
+@deprecate convert(::Type{Array{T}}, df::AbstractDataFrame) where {T} convert(Matrix{T}, df)

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -12,10 +12,10 @@ module TestConversions
     df = DataFrame()
     df[:A] = 1:5
     df[:B] = 1.0:5.0
-    @test isa(convert(Array, df), Matrix{Float64})
+    @test isa(convert(Array, df), Matrix{Real})
     @test isa(convert(Array{Any}, df), Matrix{Any})
     @test isa(convert(Array{Float64}, df), Matrix{Float64})
-    @test isa(Matrix(df), Matrix{Float64})
+    @test isa(Matrix(df), Matrix{Real})
     @test isa(Matrix{Any}(df), Matrix{Any})
     @test isa(Matrix{Float64}(df), Matrix{Float64})
 

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -12,10 +12,10 @@ module TestConversions
     df = DataFrame()
     df[:A] = 1:5
     df[:B] = 1.0:5.0
-    @test isa(convert(Array, df), Matrix{Real})
+    @test isa(convert(Array, df), Matrix{Float64})
     @test isa(convert(Array{Any}, df), Matrix{Any})
     @test isa(convert(Array{Float64}, df), Matrix{Float64})
-    @test isa(Matrix(df), Matrix{Real})
+    @test isa(Matrix(df), Matrix{Float64})
     @test isa(Matrix{Any}(df), Matrix{Any})
     @test isa(Matrix{Float64}(df), Matrix{Float64})
 


### PR DESCRIPTION
1. Make conversion to Matrix use `typejoin` not `propote_type`
2. Remove internal function `promote_col_type` that is not used anywhere (@nalimilan - do you know its use?)
3. Deprecate `convert(Arraty, ::AbstractDataFrame)` as I do not understand its value.