### PR TITLE
clean up ndims

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -222,6 +222,7 @@ Base.lastindex(df::AbstractDataFrame, i::Integer) = last(axes(df, i))
 Base.axes(df::AbstractDataFrame, i::Integer) = axes(df)[i]
 
 Base.ndims(::AbstractDataFrame) = 2
+Base.ndims(::Type{T}) where {T<AbstractDataFrame} = 2
 
 Base.getproperty(df::AbstractDataFrame, col_ind::Symbol) = getindex(df, col_ind)
 Base.setproperty!(df::AbstractDataFrame, col_ind::Symbol, x) = setindex!(df, x, col_ind)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -380,7 +380,6 @@ end
 Base.IndexStyle(::Type{StackedVector}) = Base.IndexLinear()
 Base.size(v::StackedVector) = (length(v),)
 Base.length(v::StackedVector) = sum(map(length, v.components))
-Base.ndims(v::StackedVector) = 1
 Base.eltype(v::StackedVector) = promote_type(map(eltype, v.components)...)
 Base.similar(v::StackedVector, T::Type, dims::Union{Integer, AbstractUnitRange}...) =
     similar(v.components[1], T, dims...)
@@ -436,7 +435,6 @@ end
 Base.IndexStyle(::Type{<:RepeatedVector}) = Base.IndexLinear()
 Base.size(v::RepeatedVector) = (length(v),)
 Base.length(v::RepeatedVector) = v.inner * v.outer * length(v.parent)
-Base.ndims(v::RepeatedVector) = 1
 Base.eltype(v::RepeatedVector{T}) where {T} = T
 Base.reverse(v::RepeatedVector) = RepeatedVector(reverse(v.parent), v.inner, v.outer)
 Base.similar(v::RepeatedVector, T::Type, dims::Dims) = similar(v.parent, T, dims)

--- a/test/data.jl
+++ b/test/data.jl
@@ -229,6 +229,12 @@ module TestData
 
         # Tests of RepeatedVector and StackedVector indexing
         d1s = stackdf(d1, [:a, :b])
+        @test d1s[1] isa DataFrames.RepeatedVector
+        @test ndims(d1s[1]) == 1
+        @test ndims(typeof(d1s[1])) == 1
+        @test d1s[1] isa DataFrames.StackedVector
+        @test ndims(d1s[2]) == 1
+        @test ndims(typeof(d1s[2])) == 1
         @test d1s[1][[1,24]] == [:a, :b]
         @test d1s[2][[1,24]] == [1, 4]
         if VERSION >= v"1" # this was silently accepted pre Julia 1.0

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -690,6 +690,7 @@ module TestDataFrame
         df = DataFrame(A = 1:3, B = 'A':'C')
         @test_throws ArgumentError size(df, 3)
         @test ndims(df) == 2
+        @test ndims(typeof(df)) == 2
         @test (nrow(df), ncol(df)) == (3, 2)
         @test size(df) == (3, 2)
         @inferred nrow(df)


### PR DESCRIPTION
`ndims` should be also defined for types not only for objects. Additionally for `StackedVector` and `RepeatedVector` it is not required to define it as they are subtypes of `AbstractVector`.