### PR TITLE
Add parentindices and parent

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1142,7 +1142,7 @@ function Base.hash(df::AbstractDataFrame, h::UInt)
 end
 
 Base.parent(adf::AbstractDataFrame) = adf
-Base.parentindices(adf::AbstractDataFrame) = map(Base.OneTo, size(adf))
+Base.parentindices(adf::AbstractDataFrame) = axes(adf)
 
 ## Documentation for methods defined elsewhere
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1141,6 +1141,8 @@ function Base.hash(df::AbstractDataFrame, h::UInt)
     return h
 end
 
+Base.parent(adf::AbstractDataFrame) = adf
+Base.parantindices(adf::AbstractDataFrame) = map(Base.OneTo, size(adf))
 
 ## Documentation for methods defined elsewhere
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1142,7 +1142,7 @@ function Base.hash(df::AbstractDataFrame, h::UInt)
 end
 
 Base.parent(adf::AbstractDataFrame) = adf
-Base.parantindices(adf::AbstractDataFrame) = map(Base.OneTo, size(adf))
+Base.parentindices(adf::AbstractDataFrame) = map(Base.OneTo, size(adf))
 
 ## Documentation for methods defined elsewhere
 

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -22,12 +22,8 @@ end
 @inline DataFrameRow(df::T, row::Integer) where {T<:AbstractDataFrame} =
     DataFrameRow{T}(df, row)
 
-"""
-    parent(r::DataFrameRow)
-
-Return the parent data frame of `r`.
-"""
 Base.parent(r::DataFrameRow) = getfield(r, :df)
+Base.parantindices(r::DataFrameRow) = (row(r), Base.OneTo(ncol(parent(r))))
 row(r::DataFrameRow) = getfield(r, :row)
 
 Base.view(adf::AbstractDataFrame, rowind::Integer, ::Colon) =

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -23,7 +23,7 @@ end
     DataFrameRow{T}(df, row)
 
 Base.parent(r::DataFrameRow) = getfield(r, :df)
-Base.parantindices(r::DataFrameRow) = (row(r), Base.OneTo(ncol(parent(r))))
+Base.parentindices(r::DataFrameRow) = (row(r), axes(parent(r), 2))
 row(r::DataFrameRow) = getfield(r, :row)
 
 Base.view(adf::AbstractDataFrame, rowind::Integer, ::Colon) =

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -98,7 +98,7 @@ end
 SubDataFrame(sdf::SubDataFrame, rowinds::Colon) = sdf
 
 Base.parent(sdf::SubDataFrame) = getfield(sdf, :parent)
-Base.parentindices(sdf::AbstractDataFrame) = (rows(sdf), axes(parent(r), 2))
+Base.parentindices(sdf::AbstractDataFrame) = (rows(sdf), axes(parent(sdf), 2))
 rows(sdf::SubDataFrame) = getfield(sdf, :rows)
 
 Base.view(adf::AbstractDataFrame, colinds) = view(adf, :, colinds)

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -98,7 +98,7 @@ end
 SubDataFrame(sdf::SubDataFrame, rowinds::Colon) = sdf
 
 Base.parent(sdf::SubDataFrame) = getfield(sdf, :parent)
-Base.parentindices(sdf::AbstractDataFrame) = (rows(sdf), axes(parent(sdf), 2))
+Base.parentindices(sdf::SubDataFrame) = (rows(sdf), axes(parent(sdf), 2))
 rows(sdf::SubDataFrame) = getfield(sdf, :rows)
 
 Base.view(adf::AbstractDataFrame, colinds) = view(adf, :, colinds)

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -97,13 +97,9 @@ end
 
 SubDataFrame(sdf::SubDataFrame, rowinds::Colon) = sdf
 
-"""
-    parent(sdf::SubDataFrame)
-
-Return the parent data frame of `sdf`.
-"""
 Base.parent(sdf::SubDataFrame) = getfield(sdf, :parent)
-
+Base.parantindices(sdf::AbstractDataFrame) =
+    (rows(sdf), Base.OneTo(ncol(parent(sdf))))
 rows(sdf::SubDataFrame) = getfield(sdf, :rows)
 
 Base.view(adf::AbstractDataFrame, colinds) = view(adf, :, colinds)

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -98,8 +98,7 @@ end
 SubDataFrame(sdf::SubDataFrame, rowinds::Colon) = sdf
 
 Base.parent(sdf::SubDataFrame) = getfield(sdf, :parent)
-Base.parantindices(sdf::AbstractDataFrame) =
-    (rows(sdf), Base.OneTo(ncol(parent(sdf))))
+Base.parentindices(sdf::AbstractDataFrame) = (rows(sdf), axes(parent(r), 2))
 rows(sdf::SubDataFrame) = getfield(sdf, :rows)
 
 Base.view(adf::AbstractDataFrame, colinds) = view(adf, :, colinds)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -967,4 +967,10 @@ module TestDataFrame
         @test_throws ArgumentError z[:, [1, 1, 2]]
         @test_throws ArgumentError z[[1, 1, 2]]
     end
+
+    @testset "parent" begin
+        x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])
+        @test parent(x) === x
+        @test parentindices(x) === (Base.OneTo(3), Base.OneTo(2))
+    end
 end

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -116,4 +116,8 @@ module TestDataFrameRow
                    c=["A", "B", "C", "A", "B", missing])
     @test copy(DataFrameRow(df, 1)) == (a = 1, b = 2.0, c = "A")
     @test isequal(copy(DataFrameRow(df, 2)), (a = 2, b = missing, c = "B"))
+    @test parent(df[1, :]) === df
+    @test parentindices(df[1, :]) == (1, Base.OneTo(3))
+    @test parent(df[1, 1:3]) !== df
+    @test parentindices(df[1, 1:3]) == (1, Base.OneTo(3))
 end

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -146,4 +146,14 @@ module TestSubDataFrame
         df = view(DataFrame(y=y), 2:6, :)
         @test_throws ArgumentError deleterows!(df, 1)
     end
+
+    @testset "parent" begin
+        df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                       b=[2.0, missing, 1.2, 2.0, missing, missing],
+                       c=["A", "B", "C", "A", "B", missing])
+        @test parent(view(df, [4, 2], :)) === df
+        @test parentindices(view(df, [4, 2], :)) == ([4,2], Base.OneTo(3))
+        @test parent(view(df, [4, 2], 1:3)) !== df
+        @test parentindices(view(df, [4, 2], 1:3)) == ([4, 2], Base.OneTo(3))
+    end
 end


### PR DESCRIPTION
In this PR:
* add `parent` to `AbstractDataFrame` as identity (similarly to `parent` for arrays that are not views)
* add `parentindices` to `AbstractDataFrame`, `SubDataFrame` and `DataFrameRow` - this is a standard function and we can avoid users calling `DataFrames.row` or `DataFrames.rows`; see e.g. https://discourse.julialang.org/t/dataframerow-row-number/18692
* remove docstrings for `parent` as I think they are not needed (it is clear that `SubDataFrame` and `DataFrameRow` are views)