### PR TITLE
Add optimized methods to compute grouped reductions

### DIFF
--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -90,7 +90,7 @@ end
 function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
                          hash::Val = Val(true),
                          groups::Union{Vector{Int}, Nothing} = nothing,
-                         skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool, Bool}
+                         skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
     @assert groups === nothing || length(groups) == length(cols[1])
     rhashes, missings = hashrows(cols, skipmissing)
     # inspired by Dict code from base cf. https://github.com/JuliaData/DataTables.jl/pull/17#discussion_r102481481
@@ -130,13 +130,13 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
             groups[i] = gix
         end
     end
-    return ngroups, rhashes, gslots, false, false
+    return ngroups, rhashes, gslots, false
 end
 
 function row_group_slots(cols::Tuple{CategoricalVector},
                          hash::Val{false},
                          groups::Union{Vector{Int}, Nothing} = nothing,
-                         skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool, Bool}
+                         skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
     col = cols[1]
     @assert groups === nothing || length(groups) == length(col)
 
@@ -149,16 +149,36 @@ function row_group_slots(cols::Tuple{CategoricalVector},
         # we could simply copy refs to groups, but the performance gain is negligible,
         # so always sort groups in the order of levels
         refmap = [0; CategoricalArrays.order(col.pool)]
+        seen = fill(false, length(refmap))
         if skipmissing
             refmap .+= 1
+            seen[1] = true
         else
             refmap[1] = ngroups
         end
         @inbounds for i in eachindex(groups)
-            groups[i] = refmap[col.refs[i]+1]
+            j = refmap[col.refs[i]+1]
+            groups[i] = j
+            seen[j] |= true
+        end
+        if !all(seen)
+            if skipmissing # Always keep first group even if empty
+                ngroups = 1
+                start = 2
+            else
+                ngroups = 0
+                start = 1
+            end
+            @inbounds for i in start:length(refmap)
+                ngroups += seen[i]
+                refmap[i] = ngroups
+            end
+            @inbounds for i in eachindex(groups)
+                groups[i] = refmap[groups[i]]
+            end
         end
     end
-    return ngroups, UInt[], Int[], true, true
+    return ngroups, UInt[], Int[], true
 end
 
 # Builds RowGroupDict for a given DataFrame.
@@ -171,7 +191,7 @@ end
 function group_rows(df::AbstractDataFrame, hash::Bool = true, sort::Bool = false,
                     skipmissing::Bool = false)
     groups = Vector{Int}(undef, nrow(df))
-    ngroups, rhashes, gslots, sorted, empty =
+    ngroups, rhashes, gslots, sorted =
         row_group_slots(ntuple(i -> df[i], ncol(df)), Val(hash), groups, skipmissing)
 
     # count elements in each group
@@ -203,25 +223,6 @@ function group_rows(df::AbstractDataFrame, hash::Bool = true, sort::Bool = false
         popfirst!(starts)
         popfirst!(stops)
         ngroups -= 1
-    end
-
-    # if row_group_slots can return empty groups, remove them
-    if empty
-        i = 0
-        j = 0
-        @inbounds while j < ngroups
-            j += 1
-            while stops[j] < starts[j]
-                j < ngroups || @goto done
-                j += 1
-            end
-            i += 1
-            starts[i] = starts[j]
-            stops[i] = stops[j]
-        end
-        @label done
-        resize!(starts, i)
-        resize!(stops, i)
     end
 
     # sort groups if row_group_slots hasn't already done that

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -85,7 +85,6 @@ end
 # 3) slot array for a hash map, non-zero values are
 #    the indices of the first row in a group
 # 4) whether groups are already sorted
-# 5) whether some groups might be empty (index isn't used in `groups`)
 # Optional `groups` vector is set to the group indices of each row
 function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
                          hash::Val = Val(true),
@@ -159,7 +158,7 @@ function row_group_slots(cols::Tuple{CategoricalVector},
         @inbounds for i in eachindex(groups)
             j = refmap[col.refs[i]+1]
             groups[i] = j
-            seen[j] |= true
+            seen[j] = true
         end
         if !all(seen)
             if skipmissing # Always keep first group even if empty

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -232,7 +232,7 @@ function Base.map(f::Any, gd::GroupedDataFrame)
         ends[end] = length(idx)
         return GroupedDataFrame(parent, gd.cols, idx, collect(1:length(idx)), starts, ends)
     else
-        return GroupedDataFrame(parent, gd.cols, idx, Int[], Int[], Int[])
+        return GroupedDataFrame(gd.parent[1:0, gd.cols], gd.cols, Int[], Int[], Int[], Int[])
     end
 end
 
@@ -346,7 +346,7 @@ function combine(f::Any, gd::GroupedDataFrame)
         idx, valscat = _combine(f, gd)
         return hcat!(gd.parent[idx, gd.cols], valscat, makeunique=true)
     else
-        return similar(gd.parent[gd.cols], 0)
+        return gd.parent[1:0, gd.cols]
     end
 end
 combine(gd::GroupedDataFrame, f::Any) = combine(f, gd)

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -160,8 +160,9 @@ all groups, and (if a named tuple or data frame) with the same fields or columns
 Due to type instability, returning a single value or a named tuple is dramatically
 faster than returning a data frame.
 
-Optimized methods are used when standard reduction functions (`sum`, `prod`,
-`minimum`, `maximum` and `mean`) are specified using the pair syntax (e.g. `col => sum`).
+Optimized methods are used when standard summary functions (`sum`, `prod`,
+`minimum`, `maximum`, `mean`, `var`, `std`, `first`, `last` and `length)
+are specified using the pair syntax (e.g. `col => sum`).
 When computing the `sum` or `mean` over floating point columns, results will be less
 accurate than the standard [`sum`](@ref) function (which uses pairwise summation). Use
 `col => x -> sum(x)` to avoid the optimized method and use the slower, more accurate one.
@@ -285,8 +286,9 @@ all groups, and (if a named tuple or data frame) with the same fields or columns
 Due to type instability, returning a single value or a named tuple is dramatically
 faster than returning a data frame.
 
-Optimized methods are used when standard reduction functions (`sum`, `prod`,
-`minimum`, `maximum` and `mean`) are specified using the pair syntax (e.g. `col => sum`).
+Optimized methods are used when standard summary functions (`sum`, `prod`,
+`minimum`, `maximum`, `mean`, `var`, `std`, `first`, `last` and `length)
+are specified using the pair syntax (e.g. `col => sum`).
 When computing the `sum` or `mean` over floating point columns, results will be less
 accurate than the standard [`sum`](@ref) function (which uses pairwise summation). Use
 `col => x -> sum(x)` to avoid the optimized method and use the slower, more accurate one.
@@ -424,7 +426,6 @@ for f in (:sum, :prod, :maximum, :minimum, :mean, :var, :std, :first, :last)
         funname(::typeof(check_aggregate($f∘skipmissing))) = :function
     end
 end
-funname(::typeof(length)) = :length
 
 # Find first value matching condition for each group
 # Optimized for situations where a matching value is typically encountered
@@ -445,7 +446,7 @@ function fillfirst!(condf, outcol::AbstractVector, incol::AbstractVector,
         end
     end
     if nfilled < length(outcol)
-        throw(ArgumentError("cannot compute maximum or minimum for groups with only missing values"))
+        throw(ArgumentError("some groups contain only missing values"))
     end
     outcol
 end
@@ -920,8 +921,9 @@ all groups, and (if a named tuple or data frame) with the same fields or columns
 Due to type instability, returning a single value or a named tuple is dramatically
 faster than returning a data frame.
 
-Optimized methods are used when standard reduction functions (`sum`, `prod`,
-`minimum`, `maximum` and `mean`) are specified using the pair syntax (e.g. `col => sum`).
+Optimized methods are used when standard summary functions (`sum`, `prod`,
+`minimum`, `maximum`, `mean`, `var`, `std`, `first`, `last` and `length)
+are specified using the pair syntax (e.g. `col => sum`).
 When computing the `sum` or `mean` over floating point columns, results will be less
 accurate than the standard [`sum`](@ref) function (which uses pairwise summation). Use
 `col => x -> sum(x)` to avoid the optimized method and use the slower, more accurate one.

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -496,7 +496,7 @@ function groupreduce(op, adjust, incol::AbstractVector{T}, gd::GroupedDataFrame)
                   eltype(outcol) >: Missing ? Missing : Union{}}
         outcol = CategoricalArray{U, 1}(outcol.refs, incol.pool)
     end
-    if isconcretetype(T)
+    if isconcretetype(eltype(outcol))
         return outcol
     else
         copyto_widen!(Tables.allocatecolumn(typeof(first(outcol)), n), outcol)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -503,7 +503,9 @@ module TestGrouping
             combine(gd, (:c => sum,)) ==
             combine(gd, [:c => sum]) ==
             combine(gd, c_sum = :c => sum) ==
-            combine(d -> (c_sum=sum(d.c),), gd)
+            combine(:c => x -> (c_sum=sum(x),), gd) ==
+            combine(gd, :c => x -> (c_sum=sum(x),)) ==
+            combine(d -> (c_sum=sum(d.c),), gd) ==
             combine(gd, d -> (c_sum=sum(d.c),))
 
         @test combine(:c => vexp, gd) ==
@@ -511,6 +513,8 @@ module TestGrouping
             combine(gd, (:c => vexp,)) ==
             combine(gd, [:c => vexp]) ==
             combine(gd, c_function = :c => vexp) ==
+            combine(:c => x -> (c_function=exp.(x),), gd) ==
+            combine(gd, :c => x -> (c_function=exp.(x),)) ==
             combine(d -> (c_function=exp.(d.c),), gd)
             combine(gd, d -> (c_function=exp.(d.c),))
 
@@ -518,14 +522,18 @@ module TestGrouping
             combine(gd, (:b => sum, :c => sum,)) ==
             combine(gd, [:b => sum, :c => sum]) ==
             combine(gd, b_sum = :b => sum, c_sum = :c => sum) ==
-            combine(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), gd)
+            combine((:b, :c) => x -> (b_sum=sum(x.b), c_sum=sum(x.c)), gd) ==
+            combine(gd, (:b, :c) => x -> (b_sum=sum(x.b), c_sum=sum(x.c))) ==
+            combine(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), gd) ==
             combine(gd, d -> (b_sum=sum(d.b), c_sum=sum(d.c)))
 
         @test combine(gd, :b => vexp, :c => identity) ==
             combine(gd, (:b => vexp, :c => identity,)) ==
             combine(gd, [:b => vexp, :c => identity]) ==
             combine(gd, b_function = :b => vexp, c_identity = :c => identity) ==
-            combine(d -> (b_function=vexp(d.b), c_identity=d.c), gd)
+            combine((:b, :c) => x -> (b_function=vexp(x.b), c_identity=x.c), gd) ==
+            combine(gd, (:b, :c) => x -> (b_function=vexp(x.b), c_identity=x.c)) ==
+            combine(d -> (b_function=vexp(d.b), c_identity=d.c), gd) ==
             combine(gd, d -> (b_function=vexp(d.b), c_identity=d.c))
 
         for f in (map, combine)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -368,6 +368,14 @@ module TestGrouping
         res = by(d -> 1, df, :x)
         @test size(res) == (0, 1)
         @test res.x isa Vector{Int}
+
+        # Test with empty data frame
+        df = DataFrame(x=[], y=[])
+        gd = groupby(df, :x)
+        @test combine(df -> sum(df.x), gd) == DataFrame(x=[])
+        res = map(df -> sum(df.x), gd)
+        @test length(res) == 0
+        @test res.parent == DataFrame(x=[])
     end
 
     @testset "grouping with missings" for df in
@@ -628,7 +636,6 @@ module TestGrouping
     Base.isless(::Int, ::TestType) = false
     Base.isless(::TestType, ::TestType) = false
 
-    # TODO: and map?
     @testset "combine with aggregation functions" begin
         Random.seed!(1)
         df = DataFrame(a = rand(1:5, 20), x1 = rand(Int, 20), x2 = rand(Complex{Int}, 20))
@@ -658,7 +665,7 @@ module TestGrouping
             @test res ≅ expected
             @test typeof(res.y) == typeof(expected.y)
             res = combine(gd, y = :x3 => f∘skipmissing)
-            expected =  combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
+            expected = combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
             @test res ≅ expected
             @test typeof(res.y) == typeof(expected.y)
         end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -587,9 +587,9 @@ module TestGrouping
                     f(d -> (xyz=sum(d.b) + sum(d.c),), gd)
                 if eltype(cols) === Bool
                     cols2 = [[false, true, false], [false, false, true]]
-                    @test_throws ArgumentError f((xyz = cols[1] => sum, xzz = cols2[2] => sum), gd)
-                    @test_throws ArgumentError f((xyz = cols[1] => sum, xzz = cols2[1] => sum), gd)
-                    @test_throws ArgumentError f((xyz = cols[1] => sum, xzz = cols2[2] => x -> first(x)), gd)
+                    @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[2] => sum), gd)
+                    @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[1] => sum), gd)
+                    @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[2] => x -> first(x)), gd)
                 else
                     cols2 = cols
                     @test f((xyz = cols2[1] => sum, xzz = cols2[2] => sum), gd) ==

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -628,11 +628,11 @@ module TestGrouping
     Base.isless(::Int, ::TestType) = false
     Base.isless(::TestType, ::TestType) = false
 
-    @testset "combine with reductions" begin
+    @testset "combine with aggregation functions" begin
         Random.seed!(1)
         df = DataFrame(a = rand(1:5, 20), x1 = rand(Int, 20), x2 = rand(Int, 20))
 
-        for f in (sum, prod, maximum, minimum, mean)
+        for f in (sum, prod, maximum, minimum, mean, var, std)
             gd = groupby(df, :a)
             @test combine(gd, y = :x1 => f) == combine(gd, y = :x1 => x -> f(x))
             @test combine(gd, y = :x1 => f) == combine(gd, y = :x1 => x -> f(x))
@@ -643,7 +643,7 @@ module TestGrouping
                 gd = groupby(df, :a)
                 res = combine(gd, y = :x3 => f)
                 @test res == combine(gd, y = :x3 => x -> f(x))
-                @test res.y isa Vector{f === mean ? Float64 : Int}
+                @test res.y isa Vector{f in (mean, var, std) ? Float64 : Int}
             end
 
             df.x3 = allowmissing(df.x1)
@@ -651,10 +651,10 @@ module TestGrouping
             gd = groupby(df, :a)
             res = combine(gd, y = :x3 => f)
             @test isequal(res, combine(gd, y = :x3 => x -> f(x)))
-            @test res.y isa Vector{Union{Missing, f === mean ? Float64 : Int}}
+            @test res.y isa Vector{Union{Missing, f in (mean, var, std) ? Float64 : Int}}
             res = combine(gd, y = :x3 => f∘skipmissing)
             @test res == combine(gd, y = :x3 => x -> (f∘skipmissing)(x))
-            @test res.y isa Vector{f === mean ? Float64 : Int}
+            @test res.y isa Vector{f in (mean, var, std) ? Float64 : Int}
         end
         for f in (maximum, minimum),
             (T, m) in ((Int, false),

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -635,7 +635,7 @@ module TestGrouping
                 gd = groupby(df, :a)
                 res = combine(gd, y = :x3 => f)
                 @test res == combine(gd, y = :x3 => x -> f(x))
-                @test res.y isa Vector{Int}
+                @test res.y isa Vector{f === mean ? Float64 : Int}
             end
 
             df.x3 = allowmissing(df.x1)
@@ -643,7 +643,7 @@ module TestGrouping
             gd = groupby(df, :a)
             res = combine(gd, y = :x3 => f)
             @test isequal(res, combine(gd, y = :x3 => x -> f(x)))
-            @test res.y isa Vector{Union{Missing, Int}}
+            @test res.y isa Vector{Union{Missing, f === mean ? Float64 : Int}}
         end
         for f in (maximum, minimum),
             (T, m) in ((Int, false),


### PR DESCRIPTION
```julia
df = DataFrame(a = repeat(1:40000, outer=[20]),
               b = repeat(20000:-1:1, outer=[40]),
               c = randn(800000))
gd = groupby(df, :a)
using BenchmarkTools, Statistics

# Master
julia> @btime combine(gd, :c => sum);
  10.473 ms (439181 allocations: 17.39 MiB)

julia> @btime combine(gd, :c => sum, :b => mean);
  19.515 ms (719227 allocations: 26.24 MiB)

# This PR
julia> @btime combine(gd, :c => sum);
  1.578 ms (154 allocations: 946.95 KiB)

julia> @btime combine(gd, :c => sum, :b => mean);
  3.046 ms (186 allocations: 1.54 MiB)
```