### PR TITLE
correctly handle ranges in deletecols!

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -788,7 +788,7 @@ julia> deletecols!(d, 1)
 ```
 
 """
-function deletecols!(df::DataFrame, inds::Vector{Int})
+function deletecols!(df::DataFrame, inds::AbstractVector{Int})
     sorted_inds = sort(inds, rev=true)
     for i in 2:length(sorted_inds)
         if sorted_inds[i] == sorted_inds[i-1]

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -346,6 +346,10 @@ module TestDataFrame
         @test names(d) == [:a, :d]
         deletecols!(d, 2)
         @test d == DataFrame(a=1)
+
+        d = copy(df)
+        deletecols!(d, 2:3)
+        @test d == DataFrame(a=1, d=4, e=5)
     end
 
     @testset "deleterows!" begin


### PR DESCRIPTION
Fixes a bug when indexing `deletecols!` with a range caused StackOverflow.