### PR TITLE
Add dropmissing mention in missing.md docs

### DIFF
--- a/docs/src/man/missing.md
+++ b/docs/src/man/missing.md
@@ -78,18 +78,8 @@ julia> dropmissing(df)
 │ 1   │ 4     │ 2      │ d       │
 │ 2   │ 5     │ 1      │ e       │
 ```
-By default the `dropmissing` and `dropmissing!` functions keep the `Union{Type,Missing}` element type in columns selected for row removal. To remove the `Missing` part, if present, set the `disallowmissing` option to `true` (it will become the default behavior in the future).
 
-```jldoctest missings
-julia> dropmissing(df, disallowmissing=true)
-2×3 DataFrame
-│ Row │ i     │ x     │ y      │
-│     │ Int64 │ Int64 │ String │
-├─────┼───────┼───────┼────────┤
-│ 1   │ 4     │ 2     │ d      │
-│ 2   │ 5     │ 1     │ e      │
-```
-You can define the column or the list of columns where to search for the rows containing `missing` values to be removed.
+One can specify the column(s) in which to search for rows containing `missing` values to be removed.
 
 ```jldoctest missings
 julia> dropmissing(df, :x)
@@ -100,6 +90,18 @@ julia> dropmissing(df, :x)
 │ 1   │ 2     │ 4      │ missing │
 │ 2   │ 4     │ 2      │ d       │
 │ 3   │ 5     │ 1      │ e       │
+```
+
+By default the `dropmissing` and `dropmissing!` functions keep the `Union{T,Missing}` element type in columns selected for row removal. To remove the `Missing` part, if present, set the `disallowmissing` option to `true` (it will become the default behavior in the future).
+
+```jldoctest missings
+julia> dropmissing(df, disallowmissing=true)
+2×3 DataFrame
+│ Row │ i     │ x     │ y      │
+│     │ Int64 │ Int64 │ String │
+├─────┼───────┼───────┼────────┤
+│ 1   │ 4     │ 2     │ d      │
+│ 2   │ 5     │ 1     │ e      │
 ```
 
 

--- a/docs/src/man/missing.md
+++ b/docs/src/man/missing.md
@@ -63,7 +63,7 @@ julia> coalesce.(x, 0)
 
 ```
 
-The function `dropmissing` or `dropmissing!` can be used to remove the rows with incomplete data from a DataFrame and either create a new DataFrame or mutate the original in-place. 
+The functions `dropmissing` and `dropmissing!` can be used to remove the rows containing `missing` values from a `DataFrame` and either create a new `DataFrame` or mutate the original in-place respectively.
 
 ```jldoctest missings
 julia> df = DataFrame(i = 1:5,
@@ -78,7 +78,7 @@ julia> dropmissing(df)
 │ 1   │ 4     │ 2      │ d       │
 │ 2   │ 5     │ 1      │ e       │
 ```
-By default dropmissing keep the `Union{Type,Missing}` type. To remove the Missing part, set the `disallowmissing` option to true (it should become the default in the future).
+By default the `dropmissing` and `dropmissing!` functions keep the `Union{Type,Missing}` element type in columns selected for row removal. To remove the `Missing` part, if present, set the `disallowmissing` option to `true` (it will become the default behavior in the future).
 
 ```jldoctest missings
 julia> dropmissing(df, disallowmissing=true)
@@ -89,7 +89,7 @@ julia> dropmissing(df, disallowmissing=true)
 │ 1   │ 4     │ 2     │ d      │
 │ 2   │ 5     │ 1     │ e      │
 ```
-You can define the column or the list of columns where to search for the missing rows to be removed.
+You can define the column or the list of columns where to search for the rows containing `missing` values to be removed.
 
 ```jldoctest missings
 julia> dropmissing(df, :x)

--- a/docs/src/man/missing.md
+++ b/docs/src/man/missing.md
@@ -63,6 +63,46 @@ julia> coalesce.(x, 0)
 
 ```
 
+The function `dropmissing` or `dropmissing!` can be used to remove the rows with incomplete data from a DataFrame and either create a new DataFrame or mutate the original in-place. 
+
+```jldoctest missings
+julia> df = DataFrame(i = 1:5,
+                      x = [missing, 4, missing, 2, 1],
+                      y = [missing, missing, "c", "d", "e"])
+
+julia> dropmissing(df)
+2×3 DataFrame
+│ Row │ i     │ x      │ y       │
+│     │ Int64 │ Int64⍰ │ String⍰ │
+├─────┼───────┼────────┼─────────┤
+│ 1   │ 4     │ 2      │ d       │
+│ 2   │ 5     │ 1      │ e       │
+```
+By default dropmissing keep the `Union{Type,Missing}` type. To remove the Missing part, set the `disallowmissing` option to true (it should become the default in the future).
+
+```jldoctest missings
+julia> dropmissing(df, disallowmissing=true)
+2×3 DataFrame
+│ Row │ i     │ x     │ y      │
+│     │ Int64 │ Int64 │ String │
+├─────┼───────┼───────┼────────┤
+│ 1   │ 4     │ 2     │ d      │
+│ 2   │ 5     │ 1     │ e      │
+```
+You can define the column or the list of columns where to search for the missing rows to be removed.
+
+```jldoctest missings
+julia> dropmissing(df, :x)
+3×3 DataFrame
+│ Row │ i     │ x      │ y       │
+│     │ Int64 │ Int64⍰ │ String⍰ │
+├─────┼───────┼────────┼─────────┤
+│ 1   │ 2     │ 4      │ missing │
+│ 2   │ 4     │ 2      │ d       │
+│ 3   │ 5     │ 1      │ e       │
+```
+
+
 The [Missings.jl](https://github.com/JuliaData/Missings.jl) package provides a few convenience functions to work with missing values.
 
 The function `Missings.replace` returns an iterator which replaces `missing` elements with another value:


### PR DESCRIPTION
Add description of dropmissing in missing.md docs. The function is already described in the API but it seems useful to mention it in the missing handling part as it should most of the time be more useful that skipmissing to keep alignment between column vectors.