### PR TITLE
Conversion of SubDataFrame to a DataFrame

### DIFF
--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -143,3 +143,7 @@ function without(df::SubDataFrame, icols::Vector{<:Integer})
 end
 deleterows!(df::SubDataFrame, ind) =
     throw(ArgumentError("SubDataFrame does not support deleting rows"))
+
+DataFrame(sdf::SubDataFrame) = sdf[:, :]
+
+Base.convert(::Type{DataFrame}, sdf::SubDataFrame) = DataFrame(sdf)

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -196,4 +196,17 @@ module TestSubDataFrame
         @test df.x3[3] == 333
         @test_throws KeyError sdf.x1
     end
+
+    @testset "conversion to DataFrame" begin
+        df = DataFrame([11:16 21:26 31:36 41:46])
+        sdf = view(df, [3,1,4], [3,2,1])
+        df2 = DataFrame(sdf)
+        @test df2 isa DataFrame
+        @test df2 == df[[3,1,4], [3,2,1]]
+        @test all(x -> x isa Vector{Int}, eachcol(df2, false))
+        df2 = convert(DataFrame, sdf)
+        @test df2 isa DataFrame
+        @test df2 == df[[3,1,4], [3,2,1]]
+        @test all(x -> x isa Vector{Int}, eachcol(df2, false))
+    end
 end


### PR DESCRIPTION
Replaces the need for #840.

I did not implement `promote_rule` as I do not see why `Base.promote_rule(::Type{DataFrame}, ::Type{SubDataFrame}) = AbstractDataFrame` is needed. Can someone please explain?

Promotion refers to converting values of mixed types to a single common type. and `SubDataFrame` is already `AbstractDataFrame` which is an abstract type anyway.