### PR TITLE
Add bindrows(), which appends DataFrames regardless of column order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,34 @@
+name = "DataFrames"
+uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+repo = "https://github.com/JuliaData/DataFrames.jl.git"
+
+[deps]
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+DataStreams = "9a8bc11e-79be-5b39-94d7-1ccc349a1a85"
+IteratorInterfaceExtensions = "82899510-4779-5014-852e-03e436cf321d"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+SortingAlgorithms = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+
+[extras]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+DataValues = "e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["DataStructures", "DataValues", "Dates", "InteractiveUtils", "LaTeXStrings", "LinearAlgebra", "Random", "Test"]

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -25,6 +25,7 @@ export AbstractDataFrame,
 
        allowmissing!,
        aggregate,
+       bindrows,
        by,
        categorical!,
        colwise,


### PR DESCRIPTION
Hello! I've added a `bind_rows()` function to `src/dataframe.jl`, which takes an array of `DataFrames` and appends them to the first in the array. This is accomplished by iterating through the array, reordering columns, casting the proper types to `Union{Missing,eltype(c)}`, and filling the missing data with `missing`. I have also added appropriate unit tests to `test/dataframe.jl`.

I have read the contributing guidelines, and did my best to follow them, but there are a few lines that push past 79 characters. I did notice other definitions that weren't my own that did the same, however.

You will also notice that this PR adds a v1.0-canonical `Project.toml` file. I am developing on Julia v1.0.3, and in order to get tests to run cleanly, I needed to use the v1.0+ `Pkg`, or Julia fails due to "missing dependencies". If this file is undesired for some reason, please let me know, but I would like to know why, for my own knowledge. I have left the `REQUIRE` files untouched.

Please let me know if you have any questions. Thank you!