### PR TITLE
Generalize optimized categorical grouping method to multiple keys

### DIFF
--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -260,14 +260,20 @@ function group_rows(df::AbstractDataFrame, hash::Bool = true, sort::Bool = false
     if skipmissing
         popfirst!(starts)
         popfirst!(stops)
+        groups .-= 1
         ngroups -= 1
     end
 
     # sort groups if row_group_slots hasn't already done that
     if sort && !sorted
         group_perm = sortperm(view(df, rperm[starts], :))
+        group_invperm = invperm(group_perm)
         permute!(starts, group_perm)
         Base.permute!!(stops, group_perm)
+        for i in eachindex(groups)
+            gix = groups[i]
+            groups[i] = gix == 0 ? 0 : group_invperm[gix]
+        end
     end
 
     return RowGroupDict(df, rhashes, gslots, groups, rperm, starts, stops)

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -106,6 +106,7 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     @assert groups === nothing || length(groups) == length(cols[1])
     rhashes, missings = hashrows(cols, skipmissing)
     # inspired by Dict code from base cf. https://github.com/JuliaData/DataTables.jl/pull/17#discussion_r102481481
+    # but using open addressing with a table with as many slots as rows
     sz = Base._tablesz(length(rhashes))
     @assert sz >= length(rhashes)
     szm1 = sz-1
@@ -145,50 +146,75 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     return ngroups, rhashes, gslots, false
 end
 
-function row_group_slots(cols::Tuple{CategoricalVector},
+function row_group_slots(cols::NTuple{N,<:CategoricalVector},
                          hash::Val{false},
                          groups::Union{Vector{Int}, Nothing} = nothing,
-                         skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
-    col = cols[1]
-    @assert groups === nothing || length(groups) == length(col)
+                         skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool} where N
+    # Computing neither hashes nor groups isn't very useful,
+    # and this method needs to allocate a groups vector anyway
+    @assert groups !== nothing && all(col -> length(col) == length(groups), cols)
 
     # If missings are to be skipped, they will all go to group 1,
     # which will be removed by group_rows
-    ngroups = length(levels(col)) + (eltype(col) >: Missing)
+    ngroupstup = map(cols) do c
+        length(levels(c)) + (!skipmissing && eltype(c) >: Missing)
+    end
+    ngroups = prod(ngroupstup) + skipmissing
 
-    if groups !== nothing
+    # Fall back to hashing if there would be too many empty combinations.
+    # The first check ensures the computation of ngroups did not overflow.
+    # The rationale for the 2 threshold is that while the fallback method is always slower,
+    # it allocates a hash table of size length(groups) instead of the remap vector
+    # of size ngroups (i.e. the number of possible combinations) in this method:
+    # so it makes sense to allocate more memory for better performance,
+    # but it needs to remain reasonable compared with the size of the data frame.
+    if prod(Int128.(ngroupstup)) > typemax(Int) || ngroups > 2 * length(groups)
+        return invoke(row_group_slots,
+                      Tuple{Tuple{Vararg{AbstractVector}}, Val,
+                            Union{Vector{Int}, Nothing}, Bool},
+                      cols, hash, groups, skipmissing)
+    end
+
+    seen = fill(false, ngroups)
+    # If skipmissing=true, missings will all go to group 1,
+    # which will be removed by group_rows
+    seen[1] = skipmissing
+    refmaps = map(cols) do col
         # When levels are in the same order as the index and there are no missing values,
-        # we could simply copy refs to groups, but the performance gain is negligible,
+        # we could simply use refs, but the performance gain is negligible,
         # so always sort groups in the order of levels
-        refmap = [0; CategoricalArrays.order(col.pool)]
-        seen = fill(false, length(refmap))
+        nlevels = length(levels(col))
+        refmap = Vector{Int}(undef, nlevels + 1)
+        refmap[1] = nlevels
+        refmap[2:end] .= CategoricalArrays.order(col.pool) .- 1
+        refmap
+    end
+    strides = (cumprod(collect(reverse(ngroupstup)))[end-1:-1:1]..., 1)::NTuple{N,Int}
+    @inbounds for i in eachindex(groups)
+        local refs
+        let i=i # Workaround for julia#15276
+            refs = map(c -> c.refs[i], cols)
+        end
+        j = sum(map((m, r, s) -> m[r+1] * s, refmaps, refs, strides)) + 1
         if skipmissing
-            refmap .+= 1
-            seen[1] = true
-        else
-            refmap[1] = ngroups
+            j = any(iszero, refs) ? 1 : j + 1
+        end
+        groups[i] = j
+        seen[j] = true
+    end
+    if !all(seen) # Compress group indices to remove unused ones
+        oldngroups = ngroups
+        remap = zeros(Int, ngroups)
+        ngroups = 0
+        @inbounds for i in eachindex(remap, seen)
+            ngroups += seen[i]
+            remap[i] = ngroups
         end
         @inbounds for i in eachindex(groups)
-            j = refmap[col.refs[i]+1]
-            groups[i] = j
-            seen[j] = true
+            groups[i] = remap[groups[i]]
         end
-        if !all(seen)
-            if skipmissing # Always keep first group even if empty
-                ngroups = 1
-                start = 2
-            else
-                ngroups = 0
-                start = 1
-            end
-            @inbounds for i in start:length(refmap)
-                ngroups += seen[i]
-                refmap[i] = ngroups
-            end
-            @inbounds for i in eachindex(groups)
-                groups[i] = refmap[groups[i]]
-            end
-        end
+        # To catch potential bugs inducing unnecessary computations
+        @assert oldngroups != ngroups
     end
     return ngroups, UInt[], Int[], true
 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2,9 +2,15 @@ module TestGrouping
     using Test, DataFrames, Random, Statistics
     const ≅ = isequal
 
-    # Needed since == doesn't check groups as it is redundant with other fields
-    isequal_internal(gd1::GroupedDataFrame, gd2::GroupedDataFrame) =
-        isequal(gd1, gd2) && gd1.groups == gd2.groups
+    # Call groupby, checking that groups field is consistent with other fields
+    # (since == and isequal do not use it)
+    function groupby_checked(df::AbstractDataFrame, keys, args...; kwargs...)
+        gd = groupby(df, keys, args...; kwargs...)
+        for i in 1:length(gd)
+            @assert findall(==(i), gd.groups) == gd.idx[gd.starts[i]:gd.ends[i]]
+        end
+        gd
+    end
 
     @testset "parent" begin
         df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8])
@@ -35,7 +41,7 @@ module TestGrouping
         end
 
         @testset "::Function, ::GroupedDataFrame" begin
-            gd = groupby(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+            gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
             @test colwise(length, gd) == [[2,2], [2,2]]
         end
 
@@ -62,7 +68,7 @@ module TestGrouping
         end
 
         @testset "::Vector, ::GroupedDataFrame" begin
-            gd = groupby(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+            gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
             @test colwise([length], gd) == [[2 2], [2 2]]
         end
 
@@ -90,7 +96,7 @@ module TestGrouping
         end
 
         @testset "::Tuple, ::GroupedDataFrame" begin
-            gd = groupby(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+            gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
             @test colwise((length), gd) == [[2,2],[2,2]]
         end
     end
@@ -163,7 +169,7 @@ module TestGrouping
         @test by(df, [:a], f1, sort=true) == by(df, :a, f1, sort=true)
 
         # groupby() without groups sorting
-        gd = groupby(df, cols)
+        gd = groupby_checked(df, cols)
         @test sort(combine(identity, gd)) ==
             sort(combine(gd)) ==
             sort(hcat(df, df[cols], makeunique=true))[[:a, :b, :a_1, :b_1, :c]]
@@ -177,7 +183,7 @@ module TestGrouping
         @test sort(combine(f8, gd)) == sort(res4)
 
         # groupby() with groups sorting
-        gd = groupby(df, cols, sort=true)
+        gd = groupby_checked(df, cols, sort=true)
         for i in 1:length(gd)
             @test all(gd[i].a .== sres.a[i])
             @test all(gd[i].b .== sres.b[i])
@@ -196,7 +202,7 @@ module TestGrouping
 
         # map() without and with groups sorting
         for sort in (false, true)
-            gd = groupby(df, cols, sort=sort)
+            gd = groupby_checked(df, cols, sort=sort)
             v = map(d -> d[[:c]], gd)
             @test length(gd) == length(v)
             @test v[1] == gd[1] && v[2] == gd[2] && v[3] == gd[3] && v[4] == gd[4]
@@ -226,18 +232,18 @@ module TestGrouping
                         v2 = levels!(categorical(rand(1:N, 100)), collect(1:N)),
                         v3 = levels!(categorical(rand(1:N, 100)), collect(1:N)))
         df2b = mapcols(Vector{Int}, df2)
-        @test isequal_internal(groupby(df2, [:v1, :v2, :v3]),
-                               groupby(df2b, [:v1, :v2, :v3]))
+        @test groupby_checked(df2, [:v1, :v2, :v3]) ==
+            groupby_checked(df2b, [:v1, :v2, :v3])
 
         # grouping empty table
-        @test groupby(DataFrame(A=Int[]), :A).starts == Int[]
+        @test groupby_checked(DataFrame(A=Int[]), :A).starts == Int[]
         # grouping single row
-        @test groupby(DataFrame(A=Int[1]), :A).starts == Int[1]
+        @test groupby_checked(DataFrame(A=Int[1]), :A).starts == Int[1]
 
         # issue #960
         x = CategoricalArray(collect(1:20))
         df = DataFrame(v1=x, v2=x)
-        groupby(df, [:v1, :v2])
+        groupby_checked(df, [:v1, :v2])
 
         df2 = by(e->1, DataFrame(x=Int64[]), :x)
         @test size(df2) == (0, 1)
@@ -247,11 +253,11 @@ module TestGrouping
         df = DataFrame(Key1 = CategoricalArray(["A", "A", "B", "B", "B", "A"]),
                        Key2 = CategoricalArray(["A", "B", "A", "B", "B", "A"]),
                        Value = 1:6)
-        gd = groupby(df, :Key1)
+        gd = groupby_checked(df, :Key1)
         @test length(gd) == 2
         @test gd[1] == DataFrame(Key1="A", Key2=["A", "B", "A"], Value=[1, 2, 6])
         @test gd[2] == DataFrame(Key1="B", Key2=["A", "B", "B"], Value=[3, 4, 5])
-        gd = groupby(df, [:Key1, :Key2])
+        gd = groupby_checked(df, [:Key1, :Key2])
         @test length(gd) == 4
         @test gd[1] == DataFrame(Key1="A", Key2="A", Value=[1, 6])
         @test gd[2] == DataFrame(Key1="A", Key2="B", Value=2)
@@ -260,13 +266,13 @@ module TestGrouping
         # Reorder levels, add unused level
         levels!(df[:Key1], ["Z", "B", "A"])
         levels!(df[:Key2], ["Z", "B", "A"])
-        gd = groupby(df, :Key1)
-        @test isequal_internal(gd, groupby(df, :Key1, skipmissing=true))
+        gd = groupby_checked(df, :Key1)
+        @test gd == groupby_checked(df, :Key1, skipmissing=true)
         @test length(gd) == 2
         @test gd[1] == DataFrame(Key1="B", Key2=["A", "B", "B"], Value=[3, 4, 5])
         @test gd[2] == DataFrame(Key1="A", Key2=["A", "B", "A"], Value=[1, 2, 6])
-        gd = groupby(df, [:Key1, :Key2])
-        @test isequal_internal(gd, groupby(df, [:Key1, :Key2], skipmissing=true))
+        gd = groupby_checked(df, [:Key1, :Key2])
+        @test gd == groupby_checked(df, [:Key1, :Key2], skipmissing=true)
         @test length(gd) == 4
         @test gd[1] == DataFrame(Key1="B", Key2="B", Value=[4, 5])
         @test gd[2] == DataFrame(Key1="B", Key2="A", Value=3)
@@ -274,37 +280,37 @@ module TestGrouping
         @test gd[4] == DataFrame(Key1="A", Key2="A", Value=[1, 6])
         # Make first level unused too
         replace!(df.Key1, "A"=>"B")
-        gd = groupby(df, :Key1)
+        gd = groupby_checked(df, :Key1)
         @test length(gd) == 1
         @test gd[1] == DataFrame(Key1="B", Key2=["A", "B", "A", "B", "B", "A"], Value=1:6)
-        gd = groupby(df, [:Key1, :Key2])
-        @test isequal_internal(gd, groupby(df, [:Key1, :Key2]))
+        gd = groupby_checked(df, [:Key1, :Key2])
+        @test gd == groupby_checked(df, [:Key1, :Key2])
         @test length(gd) == 2
         @test gd[1] == DataFrame(Key1="B", Key2="B", Value=[2, 4, 5])
         @test gd[2] == DataFrame(Key1="B", Key2="A", Value=[1, 3, 6])
 
         # Check that CategoricalArray column is preserved when returning a value...
-        res = combine(d -> DataFrame(x=d[1, :Key2]), groupby(df, :Key1))
+        res = combine(d -> DataFrame(x=d[1, :Key2]), groupby_checked(df, :Key1))
         @test res.x isa CategoricalVector{String}
-        res = combine(d -> (x=d[1, :Key2],), groupby(df, :Key1))
+        res = combine(d -> (x=d[1, :Key2],), groupby_checked(df, :Key1))
         @test res.x isa CategoricalVector{String}
         # ...and when returning an array
-        res = combine(d -> DataFrame(x=d[:Key1]), groupby(df, :Key1))
+        res = combine(d -> DataFrame(x=d[:Key1]), groupby_checked(df, :Key1))
         @test res.x isa CategoricalVector{String}
 
         # Check that CategoricalArray and String give a String...
         res = combine(d -> d.Key1 == ["A", "A"] ? DataFrame(x=d[1, :Key1]) : DataFrame(x="C"),
-                     groupby(df, :Key1))
+                     groupby_checked(df, :Key1))
         @test res.x isa Vector{String}
         res = combine(d -> d.Key1 == ["A", "A"] ? (x=d[1, :Key1],) : (x="C",),
-                      groupby(df, :Key1))
+                      groupby_checked(df, :Key1))
         @test res.x isa Vector{String}
         # ...even when CategoricalString comes second
         res = combine(d -> d.Key1 == ["B", "B"] ? DataFrame(x=d[1, :Key1]) : DataFrame(x="C"),
-                      groupby(df, :Key1))
+                      groupby_checked(df, :Key1))
         @test res.x isa Vector{String}
         res = combine(d -> d.Key1 == ["B", "B"] ? (x=d[1, :Key1],) : (x="C",),
-                      groupby(df, :Key1))
+                      groupby_checked(df, :Key1))
         @test res.x isa Vector{String}
 
         df = DataFrame(x = [1, 2, 3], y = [2, 3, 1])
@@ -320,7 +326,7 @@ module TestGrouping
         # Test with some groups returning empty data frames
         @test by(d -> d.x == [1] ? DataFrame(z=[]) : DataFrame(z=1), df, :x) ==
             DataFrame(x=[2, 3], z=[1, 1])
-        v = map(d -> d.x == [1] ? DataFrame(z=[]) : DataFrame(z=1), groupby(df, :x))
+        v = map(d -> d.x == [1] ? DataFrame(z=[]) : DataFrame(z=1), groupby_checked(df, :x))
         @test length(v) == 2
         @test vcat(v[1], v[2]) == DataFrame(x=[2, 3], z=[1, 1])
 
@@ -385,7 +391,7 @@ module TestGrouping
 
         # Test with empty data frame
         df = DataFrame(x=[], y=[])
-        gd = groupby(df, :x)
+        gd = groupby_checked(df, :x)
         @test combine(df -> sum(df.x), gd) == DataFrame(x=[])
         res = map(df -> sum(df.x), gd)
         @test length(res) == 0
@@ -405,7 +411,7 @@ module TestGrouping
         df = DataFrame(Key1 = x, Key2 = y, Value = 1:8)
 
         @testset "sort=false, skipmissing=false" begin
-            gd = groupby(df, :Key1)
+            gd = groupby_checked(df, :Key1)
             @test length(gd) == 3
             if df.Key1 isa CategoricalVector # Order of missing changes
                 @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
@@ -417,7 +423,7 @@ module TestGrouping
                 @test gd[3] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
             end
 
-            gd = groupby(df, [:Key1, :Key2])
+            gd = groupby_checked(df, [:Key1, :Key2])
             @test length(gd) == 5
             if df.Key1 isa CategoricalVector && df.Key2 isa CategoricalVector
                 @test gd[1] ≅ DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
@@ -435,12 +441,12 @@ module TestGrouping
         end
 
         @testset "sort=false, skipmissing=true" begin
-            gd = groupby(df, :Key1, skipmissing=true)
+            gd = groupby_checked(df, :Key1, skipmissing=true)
             @test length(gd) == 2
             @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
             @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
 
-            gd = groupby(df, [:Key1, :Key2], skipmissing=true)
+            gd = groupby_checked(df, [:Key1, :Key2], skipmissing=true)
             @test length(gd) == 3
             if df.Key1 isa CategoricalVector && df.Key2 isa CategoricalVector
                 @test gd[1] == DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
@@ -454,13 +460,13 @@ module TestGrouping
         end
 
         @testset "sort=true, skipmissing=false" begin
-            gd = groupby(df, :Key1, sort=true)
+            gd = groupby_checked(df, :Key1, sort=true)
             @test length(gd) == 3
             @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
             @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
             @test gd[3] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
 
-            gd = groupby(df, [:Key1, :Key2], sort=true)
+            gd = groupby_checked(df, [:Key1, :Key2], sort=true)
             @test length(gd) == 5
             @test gd[1] ≅ DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
             @test gd[2] == DataFrame(Key1="A", Key2="B", Value=1)
@@ -470,12 +476,12 @@ module TestGrouping
         end
 
         @testset "sort=true, skipmissing=true" begin
-            gd = groupby(df, :Key1, sort=true, skipmissing=true)
+            gd = groupby_checked(df, :Key1, sort=true, skipmissing=true)
             @test length(gd) == 2
             @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
             @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
 
-            gd = groupby(df, [:Key1, :Key2], sort=true, skipmissing=true)
+            gd = groupby_checked(df, [:Key1, :Key2], sort=true, skipmissing=true)
             @test length(gd) == 3
             @test gd[1] == DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
             @test gd[2] == DataFrame(Key1="A", Key2="B", Value=1)
@@ -502,22 +508,18 @@ module TestGrouping
         df = DataFrame(Key1 = x, Key2 = y, Key3 = z, Value = string.(1:100))
         dfb = mapcols(Vector{Union{String, Missing}}, df)
 
-        @test isequal_internal(groupby(df, [:Key1, :Key2, :Key3], sort=true),
-                               groupby(dfb, [:Key1, :Key2, :Key3], sort=true))
-        @test isequal_internal(groupby(df, [:Key1, :Key2, :Key3],
-                                       sort=true, skipmissing=true),
-                               groupby(dfb, [:Key1, :Key2, :Key3],
-                                       sort=true, skipmissing=true))
+        @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true) ≅
+            groupby_checked(dfb, [:Key1, :Key2, :Key3], sort=true)
+        @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true, skipmissing=true) ≅
+              groupby_checked(dfb, [:Key1, :Key2, :Key3], sort=true, skipmissing=true)
 
         if df.Key1 isa CategoricalVector &&
            df.Key2 isa CategoricalVector &&
            df.Key3 isa CategoricalVector
-            @test isequal_internal(groupby(df, [:Key1, :Key2, :Key3], sort=true),
-                                   groupby(df, [:Key1, :Key2, :Key3], sort=false))
-            @test isequal_internal(groupby(df, [:Key1, :Key2, :Key3],
-                                           sort=true, skipmissing=true),
-                                   groupby(df, [:Key1, :Key2, :Key3],
-                                           sort=false, skipmissing=true))
+            @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true) ≅
+                groupby_checked(df, [:Key1, :Key2, :Key3], sort=false)
+            @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true, skipmissing=true) ≅
+                groupby_checked(df, [:Key1, :Key2, :Key3], sort=false, skipmissing=true)
         end
     end
 
@@ -699,7 +701,7 @@ module TestGrouping
         df = DataFrame(a = rand(1:5, 20), x1 = rand(Int, 20), x2 = rand(Complex{Int}, 20))
 
         for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length)
-            gd = groupby(df, :a)
+            gd = groupby_checked(df, :a)
 
             res = combine(gd, y = :x1 => f)
             expected = combine(gd, y = :x1 => x -> f(x))
@@ -709,7 +711,7 @@ module TestGrouping
             for T in (Union{Missing, Int}, Union{Int, Int8},
                       Union{Missing, Int, Int8})
                 df.x3 = Vector{T}(df.x1)
-                gd = groupby(df, :a)
+                gd = groupby_checked(df, :a)
                 res = combine(gd, y = :x3 => f)
                 expected = combine(gd, y = :x3 => x -> f(x))
                 @test res ≅ expected
@@ -720,7 +722,7 @@ module TestGrouping
 
             df.x3 = allowmissing(df.x1)
             df.x3[1] = missing
-            gd = groupby(df, :a)
+            gd = groupby_checked(df, :a)
             res = combine(gd, y = :x3 => f)
             expected = combine(gd, y = :x3 => x -> f(x))
             @test res ≅ expected
@@ -732,7 +734,7 @@ module TestGrouping
         end
         # Test complex numbers
         for f in (sum, prod, mean, var, std, first, last, length)
-            gd = groupby(df, :a)
+            gd = groupby_checked(df, :a)
 
             res = combine(gd, y = :x2 => f)
             expected = combine(gd, y = :x2 => x -> f(x))
@@ -745,7 +747,7 @@ module TestGrouping
                        (Union{Missing, Int}, false), (Union{Missing, Int}, true))
             df.x3 = CategoricalVector{T}(df.x1)
             m && (df.x3[1] = missing)
-            gd = groupby(df, :a)
+            gd = groupby_checked(df, :a)
             res = combine(gd, y = :x3 => f)
             expected = combine(gd, y = :x3 => x -> f(x))
             @test res ≅ expected
@@ -771,7 +773,7 @@ module TestGrouping
         for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length),
             sort in (false, true),
             skip in (false, true)
-            gd = groupby(df, :a, sort=sort, skipmissing=skip)
+            gd = groupby_checked(df, :a, sort=sort, skipmissing=skip)
 
             res = combine(gd, y = :x1 => f)
             expected = combine(gd, y = :x1 => x -> f(x))
@@ -782,7 +784,7 @@ module TestGrouping
 
             df.x3 = allowmissing(df.x1)
             df.x3[1] = missing
-            gd = groupby(df, :a, sort=sort, skipmissing=skip)
+            gd = groupby_checked(df, :a, sort=sort, skipmissing=skip)
             res = combine(gd, y = :x3 => f)
             expected = combine(gd, y = :x3 => x -> f(x))
             @test res ≅ expected
@@ -800,7 +802,7 @@ module TestGrouping
 
         # Test maximum when no promotion rule exists
         df = DataFrame(x = [1, 1, 2, 2], y = [1, TestType(), TestType(), TestType()])
-        gd = groupby(df, :x)
+        gd = groupby_checked(df, :x)
         for f in (maximum, minimum)
             res = combine(gd, z = :y => maximum)
             @test res.z isa Vector{Any}
@@ -809,7 +811,7 @@ module TestGrouping
     end
 
     @testset "iteration protocol" begin
-        gd = groupby(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+        gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
         for v in gd
             @test size(v) == (2,2)
         end
@@ -818,7 +820,7 @@ module TestGrouping
     @testset "getindex" begin
         df = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
                        b = 1:8)
-        gd = groupby(df, :a)
+        gd = groupby_checked(df, :a)
         @test gd[1] isa SubDataFrame
         @test gd[1] == view(df, [1, 5], :)
         @test_throws BoundsError gd[5]
@@ -853,8 +855,8 @@ module TestGrouping
                         b = 1:8)
         df2 = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
                         b = [1:7;missing])
-        gd1 = groupby(df1, :a)
-        gd2 = groupby(df2, :a)
+        gd1 = groupby_checked(df1, :a)
+        gd2 = groupby_checked(df2, :a)
         @test gd1 == gd1
         @test isequal(gd1, gd1)
         @test ismissing(gd1 == gd2)
@@ -863,19 +865,19 @@ module TestGrouping
         @test isequal(gd2, gd2)
         df1.c = df1.a
         df2.c = df2.a
-        @test gd1 != groupby(df2, :c)
+        @test gd1 != groupby_checked(df2, :c)
         df2[7, :b] = 10
         @test gd1 != gd2
         df3 = DataFrame(a = repeat([1, 2, 3, missing], outer=[2]),
                         b = 1:8)
         df4 = DataFrame(a = repeat([1, 2, 3, missing], outer=[2]),
                         b = [1:7;missing])
-        gd3 = groupby(df3, :a)
-        gd4 = groupby(df4, :a)
+        gd3 = groupby_checked(df3, :a)
+        gd4 = groupby_checked(df4, :a)
         @test ismissing(gd3 == gd4)
         @test !isequal(gd3, gd4)
-        gd3 = groupby(df3, :a, skipmissing = true)
-        gd4 = groupby(df4, :a, skipmissing = true)
+        gd3 = groupby_checked(df3, :a, skipmissing = true)
+        gd4 = groupby_checked(df4, :a, skipmissing = true)
         @test gd3 == gd4
         @test isequal(gd3, gd4)
     end
@@ -895,7 +897,7 @@ module TestGrouping
 
         df = DataFrame(A = Int64[1:4;], B = ["x\"", "∀ε>0: x+ε>x", "z\$", "A\nC"],
                        C = Float32[1.0, 2.0, 3.0, 4.0])
-        gd = groupby(df, :A)
+        gd = groupby_checked(df, :A)
         io = IOContext(IOBuffer(), :limit=>true)
         show(io, gd)
         str = String(take!(io.io))


### PR DESCRIPTION
The compiler is still able to generate efficient code specialized on the number of keys. Also require `groups !== nothing` for this method since we never call it without groups and it cannot compute the actual number of nonempty groups without doing all the work anyway.

```julia
using DataFrames, BenchmarkTools
df1 = DataFrame(key1=categorical(string.(rand(1:10, 500_000))),
                key2=categorical(string.(rand(1:10, 500_000))));
df2 = DataFrame(key1=categorical(string.(rand(1:1000, 500_000))),
                key2=categorical(string.(rand(1:1000, 500_000))));

# Master
julia> @btime groupby(df1, :key1);
  2.807 ms (66 allocations: 7.63 MiB)

julia> @btime groupby(df2, :key1);
  4.727 ms (68 allocations: 7.66 MiB)

julia> @btime groupby(df1, [:key1, :key2]);
  21.069 ms (499949 allocations: 23.08 MiB)

julia> @btime groupby(df2, [:key1, :key2]);
  57.993 ms (106682 allocations: 23.08 MiB)

# This PR
julia> @btime groupby(df1, :key1);
  2.324 ms (50 allocations: 7.63 MiB)

julia> @btime groupby(df2, :key1);
  4.241 ms (50 allocations: 7.66 MiB)

julia> @btime groupby(df1, [:key1, :key2]);
  3.381 ms (52 allocations: 7.63 MiB)

julia> @btime groupby(df2, [:key1, :key2]);
  38.733 ms (58 allocations: 22.23 MiB)
```