### PR TITLE
Update URL to the stable version of Julia manual

### DIFF
--- a/docs/src/man/missing.md
+++ b/docs/src/man/missing.md
@@ -160,4 +160,4 @@ julia> missings(Int, 1, 3)
 
 ```
 
-See the [Julia manual](https://docs.julialang.org/en/stable/manual/missing/) for more information about missing values.
+See the [Julia manual](https://docs.julialang.org/en/v1/manual/missing/) for more information about missing values.


### PR DESCRIPTION
The URL to the stable version of Julia manual website, https://docs.julialang.org/en/stable/manual/, is not generated any more. Instead, use the new URL, https://docs.julialang.org/en/v1/manual/.

Discussed at JuliaLang/julia#30524