### PR TITLE
Fix grouping column after map on GroupedDataFrame

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -238,9 +238,11 @@ function Base.map(f::Any, gd::GroupedDataFrame)
         resize!(starts, j-1)
         resize!(ends, j-1)
         ends[end] = length(idx)
-        return GroupedDataFrame(parent, gd.cols, idx, collect(1:length(idx)), starts, ends)
+        return GroupedDataFrame(parent, collect(1:length(gd.cols)), idx,
+                                collect(1:length(idx)), starts, ends)
     else
-        return GroupedDataFrame(gd.parent[1:0, gd.cols], gd.cols, Int[], Int[], Int[], Int[])
+        return GroupedDataFrame(gd.parent[1:0, gd.cols], collect(1:length(gd.cols)),
+                                Int[], Int[], Int[], Int[])
     end
 end
 


### PR DESCRIPTION
Column indices referred to the original data frame but did not necessarily point to the right column in the new parent. Add tests to cover this situation and more.

(Hide whitespace changes to review.)