### PR TITLE
improve show of GroupedDataFrame

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -168,7 +168,7 @@ function Base.show(io::IO, mime::MIME"text/html", gd::GroupedDataFrame)
     N = length(gd)
     keynames = names(gd.parent)[gd.cols]
     parent_names = names(gd.parent)
-    keys = join(':' .* string.(keynames), ", ")
+    keys = html_escape(join(':' .* string.(keynames), ", "))
     keystr = length(gd.cols) > 1 ? "keys" : "key"
     groupstr = N > 1 ? "groups" : "group"
     write(io, "<p><b>$(typeof(gd).name) with $N $groupstr based on $keystr: $keys</b></p>")
@@ -176,7 +176,7 @@ function Base.show(io::IO, mime::MIME"text/html", gd::GroupedDataFrame)
         nrows = size(gd[1], 1)
         rows = nrows > 1 ? "rows" : "row"
 
-        identified_groups = [':' * string(parent_names[col], " = ", first(gd[1][col]))
+        identified_groups = [html_escape(':' * string(parent_names[col], " = ", repr(first(gd[1][col]))))
                              for col in gd.cols]
 
         write(io, "<p><i>First Group ($nrows $rows): ")
@@ -188,7 +188,7 @@ function Base.show(io::IO, mime::MIME"text/html", gd::GroupedDataFrame)
         nrows = size(gd[N], 1)
         rows = nrows > 1 ? "rows" : "row"
 
-        identified_groups = [':' * string(parent_names[col], " = ", first(gd[N][col]))
+        identified_groups = [html_escape(':' * string(parent_names[col], " = ", repr(first(gd[N][col]))))
                              for col in gd.cols]
 
         write(io, "<p>&vellip;</p>")
@@ -297,7 +297,7 @@ function Base.show(io::IO, mime::MIME"text/latex", gd::GroupedDataFrame)
         rows = nrows > 1 ? "rows" : "row"
 
         identified_groups = [latex_escape(':' * string(parent_names[col], " = ",
-                                                       first(gd[1][col])))
+                                                       repr(first(gd[1][col]))))
                              for col in gd.cols]
 
         write(io, "First Group ($nrows $rows): ")
@@ -310,7 +310,7 @@ function Base.show(io::IO, mime::MIME"text/latex", gd::GroupedDataFrame)
         rows = nrows > 1 ? "rows" : "row"
 
         identified_groups = [latex_escape(':' * string(parent_names[col], " = ",
-                                                       first(gd[N][col])))
+                                                       repr(first(gd[N][col]))))
                              for col in gd.cols]
 
         write(io, "\n\$\\dots\$\n\n")

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -168,7 +168,7 @@ function Base.show(io::IO, mime::MIME"text/html", gd::GroupedDataFrame)
     N = length(gd)
     keynames = names(gd.parent)[gd.cols]
     parent_names = names(gd.parent)
-    keys = html_escape(join(':' .* string.(keynames), ", "))
+    keys = html_escape(join(string.(keynames), ", "))
     keystr = length(gd.cols) > 1 ? "keys" : "key"
     groupstr = N > 1 ? "groups" : "group"
     write(io, "<p><b>$(typeof(gd).name) with $N $groupstr based on $keystr: $keys</b></p>")
@@ -176,7 +176,7 @@ function Base.show(io::IO, mime::MIME"text/html", gd::GroupedDataFrame)
         nrows = size(gd[1], 1)
         rows = nrows > 1 ? "rows" : "row"
 
-        identified_groups = [html_escape(':' * string(parent_names[col], " = ", repr(first(gd[1][col]))))
+        identified_groups = [html_escape(string(parent_names[col], " = ", repr(first(gd[1][col]))))
                              for col in gd.cols]
 
         write(io, "<p><i>First Group ($nrows $rows): ")
@@ -188,7 +188,7 @@ function Base.show(io::IO, mime::MIME"text/html", gd::GroupedDataFrame)
         nrows = size(gd[N], 1)
         rows = nrows > 1 ? "rows" : "row"
 
-        identified_groups = [html_escape(':' * string(parent_names[col], " = ", repr(first(gd[N][col]))))
+        identified_groups = [html_escape(string(parent_names[col], " = ", repr(first(gd[N][col]))))
                              for col in gd.cols]
 
         write(io, "<p>&vellip;</p>")
@@ -288,7 +288,7 @@ function Base.show(io::IO, mime::MIME"text/latex", gd::GroupedDataFrame)
     N = length(gd)
     keynames = names(gd.parent)[gd.cols]
     parent_names = names(gd.parent)
-    keys = join(latex_escape.(':' .* string.(keynames)), ", ")
+    keys = join(latex_escape.(string.(keynames)), ", ")
     keystr = length(gd.cols) > 1 ? "keys" : "key"
     groupstr = N > 1 ? "groups" : "group"
     write(io, "$(typeof(gd).name) with $N $groupstr based on $keystr: $keys\n\n")
@@ -296,8 +296,8 @@ function Base.show(io::IO, mime::MIME"text/latex", gd::GroupedDataFrame)
         nrows = size(gd[1], 1)
         rows = nrows > 1 ? "rows" : "row"
 
-        identified_groups = [latex_escape(':' * string(parent_names[col], " = ",
-                                                       repr(first(gd[1][col]))))
+        identified_groups = [latex_escape(string(parent_names[col], " = ",
+                                                 repr(first(gd[1][col]))))
                              for col in gd.cols]
 
         write(io, "First Group ($nrows $rows): ")
@@ -309,8 +309,8 @@ function Base.show(io::IO, mime::MIME"text/latex", gd::GroupedDataFrame)
         nrows = size(gd[N], 1)
         rows = nrows > 1 ? "rows" : "row"
 
-        identified_groups = [latex_escape(':' * string(parent_names[col], " = ",
-                                                       repr(first(gd[N][col]))))
+        identified_groups = [latex_escape(string(parent_names[col], " = ",
+                                                 repr(first(gd[N][col]))))
                              for col in gd.cols]
 
         write(io, "\n\$\\dots\$\n\n")

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -8,7 +8,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
     N = length(gd)
     keynames = names(gd.parent)[gd.cols]
     parent_names = names(gd.parent)
-    keys = join(':' .* string.(keynames), ", ")
+    keys = join(string.(keynames), ", ")
 
     keystr = length(gd.cols) > 1 ? "keys" : "key"
     groupstr = N > 1 ? "groups" : "group"
@@ -18,7 +18,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
             nrows = size(gd[i], 1)
             rows = nrows > 1 ? "rows" : "row"
 
-            identified_groups = [':' * string(parent_names[col], " = ", repr(first(gd[i][col])))
+            identified_groups = [string(parent_names[col], " = ", repr(first(gd[i][col])))
                                  for col in gd.cols]
 
             print(io, "\nGroup $i ($nrows $rows): ")
@@ -32,7 +32,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
             nrows = size(gd[1], 1)
             rows = nrows > 1 ? "rows" : "row"
 
-            identified_groups = [':' * string(parent_names[col], " = ", repr(first(gd[1][col])))
+            identified_groups = [string(parent_names[col], " = ", repr(first(gd[1][col])))
                                  for col in gd.cols]
 
             print(io, "\nFirst Group ($nrows $rows): ")
@@ -45,7 +45,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
             nrows = size(gd[N], 1)
             rows = nrows > 1 ? "rows" : "row"
 
-            identified_groups = [':' * string(parent_names[col], " = ", repr(first(gd[N][col])))
+            identified_groups = [string(parent_names[col], " = ", repr(first(gd[N][col])))
                                  for col in gd.cols]
             print(io, "\n⋮")
             print(io, "\nLast Group ($nrows $rows): ")

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -18,12 +18,12 @@ function Base.show(io::IO, gd::GroupedDataFrame;
             nrows = size(gd[i], 1)
             rows = nrows > 1 ? "rows" : "row"
 
-            identified_groups = [':' * string(parent_names[col], " = ", first(gd[i][col])) 
+            identified_groups = [':' * string(parent_names[col], " = ", repr(first(gd[i][col])))
                                  for col in gd.cols]
 
             print(io, "\nGroup $i ($nrows $rows): ")
             join(io, identified_groups, ", ")
-            
+
             show(io, gd[i], summary=false,
                  allrows=allrows, allcols=allcols, rowlabel=rowlabel)
         end
@@ -31,8 +31,8 @@ function Base.show(io::IO, gd::GroupedDataFrame;
         if N > 0
             nrows = size(gd[1], 1)
             rows = nrows > 1 ? "rows" : "row"
-                        
-            identified_groups = [':' * string(parent_names[col], " = ", first(gd[1][col])) 
+
+            identified_groups = [':' * string(parent_names[col], " = ", repr(first(gd[1][col])))
                                  for col in gd.cols]
 
             print(io, "\nFirst Group ($nrows $rows): ")
@@ -44,8 +44,8 @@ function Base.show(io::IO, gd::GroupedDataFrame;
         if N > 1
             nrows = size(gd[N], 1)
             rows = nrows > 1 ? "rows" : "row"
-            
-            identified_groups = [':' * string(parent_names[col], " = ", first(gd[N][col])) 
+
+            identified_groups = [':' * string(parent_names[col], " = ", repr(first(gd[N][col])))
                                  for col in gd.cols]
             print(io, "\n⋮")
             print(io, "\nLast Group ($nrows $rows): ")

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -985,5 +985,35 @@ module TestGrouping
             \t1 & 4 & A\\textbackslash{}nC & 4.0 \\\\
             \\end{tabular}
             """
+
+        gd = groupby(DataFrame(a=[Symbol("&")], b=["&"]), [1,2])
+        @test sprint(show, gd) === """
+            GroupedDataFrame with 1 group based on keys: :a, :b
+            Group 1 (1 row): :a = :&, :b = "&"
+            │ Row │ a      │ b      │
+            │     │ Symbol │ String │
+            ├─────┼────────┼────────┤
+            │ 1   │ &      │ &      │"""
+
+        @test sprint(show, "text/html", gd) ==
+            "<p><b>GroupedDataFrame with 1 group based on keys: :a, :b</b></p><p><i>" *
+            "First Group (1 row): :a = :&amp;, :b = \"&amp;\"</i></p>" *
+            "<table class=\"data-frame\"><thead><tr><th></th><th>a</th><th>b</th></tr>" *
+            "<tr><th></th><th>Symbol</th><th>String</th></tr></thead><tbody><tr><th>1</th>" *
+            "<td>&amp;</td><td>&amp;</td></tr></tbody></table>"
+
+        @test sprint(show, "text/latex", gd) == """
+            GroupedDataFrame with 1 group based on keys: :a, :b
+
+            First Group (1 row): :a = :\\&, :b = "\\&"
+
+            \\begin{tabular}{r|cc}
+            \t& a & b\\\\
+            \t\\hline
+            \t& Symbol & String\\\\
+            \t\\hline
+            \t1 & \\& & \\& \\\\
+            \\end{tabular}
+            """
     end
 end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -902,14 +902,14 @@ module TestGrouping
         show(io, gd)
         str = String(take!(io.io))
         @test str == """
-        GroupedDataFrame with 4 groups based on key: :A
-        First Group (1 row): :A = 1
+        GroupedDataFrame with 4 groups based on key: A
+        First Group (1 row): A = 1
         │ Row │ A     │ B      │ C       │
         │     │ Int64 │ String │ Float32 │
         ├─────┼───────┼────────┼─────────┤
         │ 1   │ 1     │ x"     │ 1.0     │
         ⋮
-        Last Group (1 row): :A = 4
+        Last Group (1 row): A = 4
         │ Row │ A     │ B      │ C       │
         │     │ Int64 │ String │ Float32 │
         ├─────┼───────┼────────┼─────────┤
@@ -917,23 +917,23 @@ module TestGrouping
         show(io, gd, allgroups=true)
         str = String(take!(io.io))
         @test str == """
-        GroupedDataFrame with 4 groups based on key: :A
-        Group 1 (1 row): :A = 1
+        GroupedDataFrame with 4 groups based on key: A
+        Group 1 (1 row): A = 1
         │ Row │ A     │ B      │ C       │
         │     │ Int64 │ String │ Float32 │
         ├─────┼───────┼────────┼─────────┤
         │ 1   │ 1     │ x\"     │ 1.0     │
-        Group 2 (1 row): :A = 2
+        Group 2 (1 row): A = 2
         │ Row │ A     │ B           │ C       │
         │     │ Int64 │ String      │ Float32 │
         ├─────┼───────┼─────────────┼─────────┤
         │ 1   │ 2     │ ∀ε>0: x+ε>x │ 2.0     │
-        Group 3 (1 row): :A = 3
+        Group 3 (1 row): A = 3
         │ Row │ A     │ B      │ C       │
         │     │ Int64 │ String │ Float32 │
         ├─────┼───────┼────────┼─────────┤
         │ 1   │ 3     │ z\$     │ 3.0     │
-        Group 4 (1 row): :A = 4
+        Group 4 (1 row): A = 4
         │ Row │ A     │ B      │ C       │
         │     │ Int64 │ String │ Float32 │
         ├─────┼───────┼────────┼─────────┤
@@ -950,20 +950,20 @@ module TestGrouping
 
 
         @test sprint(show, "text/html", gd) ==
-            "<p><b>GroupedDataFrame with 4 groups based on key: :A</b></p>" *
-            "<p><i>First Group (1 row): :A = 1</i></p><table class=\"data-frame\">" *
+            "<p><b>GroupedDataFrame with 4 groups based on key: A</b></p>" *
+            "<p><i>First Group (1 row): A = 1</i></p><table class=\"data-frame\">" *
             "<thead><tr><th></th><th>A</th><th>B</th><th>C</th></tr><tr><th></th>" *
             "<th>Int64</th><th>String</th><th>Float32</th></tr></thead>" *
             "<tbody><tr><th>1</th><td>1</td><td>x\"</td><td>1.0</td></tr></tbody>" *
-            "</table><p>&vellip;</p><p><i>Last Group (1 row): :A = 4</i></p>" *
+            "</table><p>&vellip;</p><p><i>Last Group (1 row): A = 4</i></p>" *
             "<table class=\"data-frame\"><thead><tr><th></th><th>A</th><th>B</th><th>C</th></tr>" *
             "<tr><th></th><th>Int64</th><th>String</th><th>Float32</th></tr></thead>" *
             "<tbody><tr><th>1</th><td>4</td><td>A\\nC</td><td>4.0</td></tr></tbody></table>"
 
         @test sprint(show, "text/latex", gd) == """
-            GroupedDataFrame with 4 groups based on key: :A
+            GroupedDataFrame with 4 groups based on key: A
 
-            First Group (1 row): :A = 1
+            First Group (1 row): A = 1
 
             \\begin{tabular}{r|ccc}
             \t& A & B & C\\\\
@@ -975,7 +975,7 @@ module TestGrouping
 
             \$\\dots\$
 
-            Last Group (1 row): :A = 4
+            Last Group (1 row): A = 4
 
             \\begin{tabular}{r|ccc}
             \t& A & B & C\\\\
@@ -988,24 +988,24 @@ module TestGrouping
 
         gd = groupby(DataFrame(a=[Symbol("&")], b=["&"]), [1,2])
         @test sprint(show, gd) === """
-            GroupedDataFrame with 1 group based on keys: :a, :b
-            Group 1 (1 row): :a = :&, :b = "&"
+            GroupedDataFrame with 1 group based on keys: a, b
+            Group 1 (1 row): a = :&, b = "&"
             │ Row │ a      │ b      │
             │     │ Symbol │ String │
             ├─────┼────────┼────────┤
             │ 1   │ &      │ &      │"""
 
         @test sprint(show, "text/html", gd) ==
-            "<p><b>GroupedDataFrame with 1 group based on keys: :a, :b</b></p><p><i>" *
-            "First Group (1 row): :a = :&amp;, :b = \"&amp;\"</i></p>" *
+            "<p><b>GroupedDataFrame with 1 group based on keys: a, b</b></p><p><i>" *
+            "First Group (1 row): a = :&amp;, b = \"&amp;\"</i></p>" *
             "<table class=\"data-frame\"><thead><tr><th></th><th>a</th><th>b</th></tr>" *
             "<tr><th></th><th>Symbol</th><th>String</th></tr></thead><tbody><tr><th>1</th>" *
             "<td>&amp;</td><td>&amp;</td></tr></tbody></table>"
 
         @test sprint(show, "text/latex", gd) == """
-            GroupedDataFrame with 1 group based on keys: :a, :b
+            GroupedDataFrame with 1 group based on keys: a, b
 
-            First Group (1 row): :a = :\\&, :b = "\\&"
+            First Group (1 row): a = :\\&, b = "\\&"
 
             \\begin{tabular}{r|cc}
             \t& a & b\\\\


### PR DESCRIPTION
Use `repr` to show grouping column values and improve escaping in HTML and LaTeX output.