### PR TITLE
Improve push! and DataFrame for DataFrameRow

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1016,20 +1016,11 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple})
     i = 1
     for nm in _names(df)
         try
-            val = get(row, nm) do
-                v = row[string(nm)]
-                Base.depwarn("push!(::DataFrame, ::AbstractDict) with " *
-                             "AbstractDict keys other than Symbol is deprecated",
-                             :push!)
-                v
-            end
-            # after deprecation replace above call by
-            # val = row[nm]
-            push!(df[nm], val)
+            push!(df[i], row[nm])
         catch
             #clean up partial row
             for j in 1:(i - 1)
-                pop!(df[_names(df)[j]])
+                pop!(df[j])
             end
             msg = "Error adding value to column :$nm."
             throw(ArgumentError(msg))

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -216,6 +216,7 @@ function Base.push!(df::DataFrame, dfr::DataFrameRow)
         # in this case we are sure that all we do is safe
         r = row(dfr)
         for col in _columns(df)
+            # use a barrier function to improve performance
             pushhelper!(col, r)
         end
     else

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -209,7 +209,7 @@ function DataFrame(dfr::DataFrameRow)
     parent(dfr)[row:row, cols]
 end
 
-pushhelper!(x, r) = push!(x, x[r])
+@noinline pushhelper!(x, r) = push!(x, x[r])
 
 function Base.push!(df::DataFrame, dfr::DataFrameRow)
     if parent(dfr) === df && index(dfr) isa Index

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -326,6 +326,10 @@ module TestDataFrame
         df = DataFrame(x=1, y=2)
         push!(df, [3, 4], [5, 6])
         @test df[:x] == [1, 3, 5] && df[:y] == [2, 4, 6]
+
+        df = DataFrame(x=1, y=2)
+        @test_throws ArgumentError push!(df, Dict(:x=>1, "y"=>2))
+        @test df == DataFrame(x=1, y=2)
     end
 
     @testset "deletecols!" begin

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -244,6 +244,27 @@ module TestDataFrameRow
         @test_throws KeyError dfr2.x2
     end
 
+    @testset "conversion and push!" begin
+            df = DataFrame(x=1, y=2)
+
+            @test df == DataFrame(df[1, :])
+            @test df[1:1, [2,1]] == DataFrame(df[1, [2,1]])
+            @test df[1:1, 1:1] == DataFrame(df[1, 1:1])
+            @test_throws ArgumentError DataFrame(df[1, [1,1]])
+
+            @test_throws ArgumentError push!(df, df[1, 1:1])
+            @test df == DataFrame(x=1, y=2)
+
+            @test_throws ArgumentError push!(df, df[1, [2,2]])
+            @test df == DataFrame(x=1, y=2)
+
+            @test_throws ArgumentError push!(df, df[1, [2,1,2]])
+            @test df == DataFrame(x=1, y=2)
+
+            @test push!(df, df[1, :]) == DataFrame(x=[1, 1], y=[2, 2])
+            @test push!(df, df[1, [2,1]]) == DataFrame(x=[1, 1, 1], y=[2, 2, 2])
+    end
+
     @testset "show" begin
         df = DataFrame(a=nothing, b=1)
 


### PR DESCRIPTION
Changes in this PR:
* add `push!` for `DataFrameRow`
* add `DataFrame` constructor for `DataFrameRow` (it is inconsistent with `NamedTuple`, but we cannot guarantee consistency here anyway so it does not hurt to allow it)
* finish deprecation period for `push!` with string keys; now we do not allow it
* small performance improvements in column lookup

This replaces https://github.com/JuliaData/DataFrames.jl/pull/1439 and fixes https://github.com/JuliaData/DataFrames.jl/issues/1675.