### PR TITLE
Clean up test files

### DIFF
--- a/test/cat.jl
+++ b/test/cat.jl
@@ -1,288 +1,290 @@
 module TestCat
-    using Test, Random, DataFrames
-    using DataFrames: columns
-    const ≅ = isequal
 
-    #
-    # hcat
-    #
-    @testset "hcat" begin
-        nvint = [1, 2, missing, 4]
-        nvstr = ["one", "two", missing, "four"]
+using Test, Random, DataFrames
+using DataFrames: columns
+const ≅ = isequal
 
-        df2 = DataFrame([nvint, nvstr])
-        df3 = DataFrame([nvint])
-        df4 = convert(DataFrame, [1:4 1:4])
-        df5 = DataFrame([Union{Int, Missing}[1,2,3,4], nvstr])
+#
+# hcat
+#
+@testset "hcat" begin
+    nvint = [1, 2, missing, 4]
+    nvstr = ["one", "two", missing, "four"]
 
-        ref_df = copy(df3)
-        dfh = hcat(df3, df4, makeunique=true)
-        @test ref_df ≅ df3 # make sure that df3 is not mutated by hcat
-        @test size(dfh, 2) == 3
-        @test names(dfh) ≅ [:x1, :x1_1, :x2]
-        @test dfh[:x1] ≅ df3[:x1]
-        @test dfh ≅ DataFrames.hcat!(DataFrame(), df3, df4, makeunique=true)
+    df2 = DataFrame([nvint, nvstr])
+    df3 = DataFrame([nvint])
+    df4 = convert(DataFrame, [1:4 1:4])
+    df5 = DataFrame([Union{Int, Missing}[1,2,3,4], nvstr])
 
-        dfa = DataFrame(a=[1,2])
-        dfb = DataFrame(b=[3,missing])
-        @test hcat(dfa, dfb) ≅ [dfa dfb]
+    ref_df = copy(df3)
+    dfh = hcat(df3, df4, makeunique=true)
+    @test ref_df ≅ df3 # make sure that df3 is not mutated by hcat
+    @test size(dfh, 2) == 3
+    @test names(dfh) ≅ [:x1, :x1_1, :x2]
+    @test dfh[:x1] ≅ df3[:x1]
+    @test dfh ≅ DataFrames.hcat!(DataFrame(), df3, df4, makeunique=true)
 
-        dfh3 = hcat(df3, df4, df5, makeunique=true)
-        @test names(dfh3) == [:x1, :x1_1, :x2, :x1_2, :x2_1]
-        @test dfh3 ≅ hcat(dfh, df5, makeunique=true)
-        @test dfh3 ≅ DataFrames.hcat!(DataFrame(), df3, df4, df5, makeunique=true)
+    dfa = DataFrame(a=[1,2])
+    dfb = DataFrame(b=[3,missing])
+    @test hcat(dfa, dfb) ≅ [dfa dfb]
 
-        @test df2 ≅ DataFrames.hcat!(df2, makeunique=true)
-    end
+    dfh3 = hcat(df3, df4, df5, makeunique=true)
+    @test names(dfh3) == [:x1, :x1_1, :x2, :x1_2, :x2_1]
+    @test dfh3 ≅ hcat(dfh, df5, makeunique=true)
+    @test dfh3 ≅ DataFrames.hcat!(DataFrame(), df3, df4, df5, makeunique=true)
 
-    @testset "hcat ::AbstractDataFrame" begin
-        df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)
-        gd = groupby(df, :A)
-        answer = DataFrame(A = fill('A', 4), B = 1:4, A_1 = 'B', B_1 = 5:8, A_2 = 'C', B_2 = 9:12)
-        @test hcat(gd..., makeunique=true) == answer
-        answer = answer[1:4]
-        @test hcat(gd[1], gd[2], makeunique=true) == answer
-    end
-
-    @testset "hcat ::AbstractDataFrame" begin
-        df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)
-        gd = groupby(df, :A)
-        answer = DataFrame(A = fill('A', 4), B = 1:4, A_1 = 'B', B_1 = 5:8, A_2 = 'C', B_2 = 9:12)
-        @test hcat(gd..., makeunique=true) == answer
-        answer = answer[1:4]
-        @test hcat(gd[1], gd[2], makeunique=true) == answer
-    end
-
-    @testset "hcat ::AbstractVectors" begin
-        df = DataFrame()
-        DataFrames.hcat!(df, CategoricalVector{Union{Int,Missing}}(1:10), makeunique=true)
-        @test df[1] == CategoricalVector(1:10)
-        DataFrames.hcat!(df, 1:10, makeunique=true)
-        @test df[2] == collect(1:10)
-        DataFrames.hcat!(df, collect(1:10), makeunique=true)
-        @test df[3] == collect(1:10)
-
-        df = DataFrame()
-        df2 = hcat(CategoricalVector{Union{Int,Missing}}(1:10), df, makeunique=true)
-        @test isempty(df)
-        @test df2[1] == collect(1:10)
-        @test names(df2) == [:x1]
-        ref_df = copy(df2)
-        df3 = hcat(11:20, df2, makeunique=true)
-        @test df2 == ref_df
-        @test df3[1] == collect(11:20)
-        @test names(df3) == [:x1, :x1_1]
-
-        @test_throws ArgumentError hcat("a", df, makeunique=true)
-        @test_throws ArgumentError hcat(df, "a", makeunique=true)
-    end
-    #
-    # vcat
-    #
-
-    @testset "vcat" begin
-        missing_df = DataFrame(Int, 0, 0)
-        df = DataFrame(Int, 4, 3)
-
-        # Assignment of rows
-        # TODO: re-enable when we fix setindex! to handle DataFrameRow on RHS
-        # df[1, :] = df[1, :]
-        df[1, :] = df[1:1, :]
-        df[1:2, :] = df[1:2, :]
-        df[[true,false,false,true], :] = df[2:3, :]
-
-        # Scalar broadcasting assignment of rows
-        df[1, :] = 1
-        df[1:2, :] = 1
-        df[[true,false,false,true], :] = 3
-
-        # Vector broadcasting assignment of rows
-        df[1:2, :] = [2,3]
-        df[[true,false,false,true], :] = [2,3]
-
-        # Assignment of columns
-        df[1] = zeros(4)
-        df[:, 2] = ones(4)
-
-        # Broadcasting assignment of columns
-        df[:, 1] = 1
-        df[1] = 3
-        df[:x3] = 2
-
-        # assignment of subtables
-        # TODO: re-enable when we fix setindex! to handle DataFrameRow on RHS
-        # df[1, 1:2] = df[2, 2:3]
-        df[1, 1:2] = df[2:2, 2:3]
-        df[1:2, 1:2] = df[2:3, 2:3]
-        df[[true,false,false,true], 2:3] = df[1:2,1:2]
-
-        # scalar broadcasting assignment of subtables
-        df[1, 1:2] = 3
-        df[1:2, 1:2] = 3
-        df[[true,false,false,true], 2:3] = 3
-
-        # vector broadcasting assignment of subtables
-        df[1:2, 1:2] = [3,2]
-        df[[true,false,false,true], 2:3] = [2,3]
-
-        @test vcat(missing_df) == DataFrame()
-        @test vcat(missing_df, missing_df) == DataFrame()
-        @test_throws ArgumentError vcat(missing_df, df)
-        @test_throws ArgumentError vcat(df, missing_df)
-        @test eltypes(vcat(df, df)) == Type[Float64, Float64, Int]
-        @test size(vcat(df, df)) == (size(df, 1) * 2, size(df, 2))
-        res = vcat(df, df)
-        @test res[1:size(df, 1), :] == df
-        @test res[1+size(df, 1):end, :] == df
-        @test eltypes(vcat(df, df, df)) == Type[Float64, Float64, Int]
-        @test size(vcat(df, df, df)) == (size(df, 1) * 3, size(df, 2))
-        res = vcat(df, df, df)
-        s = size(df, 1)
-        for i in 1:3
-            @test res[1+(i-1)*s:i*s, :] == df
-        end
-
-        alt_df = deepcopy(df)
-        @test vcat(df, alt_df) == DataFrame([[3.0,2.0,3.0,3.0,3.0,2.0,3.0,3.0],
-                                             [2.0,2.0,1.0,3.0,2.0,2.0,1.0,3.0],
-                                             [2,2,2,3,2,2,2,3]])
-
-        # Don't fail on non-matching types
-        df[1] = zeros(Int, nrow(df))
-        @test vcat(df, alt_df) == DataFrame([[0.0,0.0,0.0,0.0,3.0,2.0,3.0,3.0],
-                                             [2.0,2.0,1.0,3.0,2.0,2.0,1.0,3.0],
-                                             [2,2,2,3,2,2,2,3]])
-    end
-
-    @testset "vcat >2 args" begin
-        @test vcat(DataFrame(), DataFrame(), DataFrame()) == DataFrame()
-        df = DataFrame(x = trues(1), y = falses(1))
-        @test vcat(df, df, df) == DataFrame(x = trues(3), y = falses(3))
-    end
-
-    @testset "vcat mixed coltypes" begin
-        df = vcat(DataFrame([[1]], [:x]), DataFrame([[1.0]], [:x]))
-        @test df == DataFrame([[1.0, 1.0]], [:x])
-        @test typeof.(columns(df)) == [Vector{Float64}]
-        df = vcat(DataFrame([[1]], [:x]), DataFrame([["1"]], [:x]))
-        @test df == DataFrame([[1, "1"]], [:x])
-        @test typeof.(columns(df)) == [Vector{Any}]
-        df = vcat(DataFrame([Union{Missing, Int}[1]], [:x]), DataFrame([[1]], [:x]))
-        @test df == DataFrame([[1, 1]], [:x])
-        @test typeof.(columns(df)) == [Vector{Union{Missing, Int}}]
-        df = vcat(DataFrame([CategoricalArray([1])], [:x]), DataFrame([[1]], [:x]))
-        @test df == DataFrame([[1, 1]], [:x])
-        @test df[:x] isa Vector{Int}
-        df = vcat(DataFrame([CategoricalArray([1])], [:x]),
-                  DataFrame([Union{Missing, Int}[1]], [:x]))
-        @test df == DataFrame([[1, 1]], [:x])
-        @test df[:x] isa Vector{Union{Int, Missing}}
-        df = vcat(DataFrame([CategoricalArray([1])], [:x]),
-                  DataFrame([CategoricalArray{Union{Int, Missing}}([1])], [:x]))
-        @test df == DataFrame([[1, 1]], [:x])
-        @test df[:x] isa CategoricalVector{Union{Int, Missing}}
-        df = vcat(DataFrame([Union{Int, Missing}[1]], [:x]),
-                  DataFrame([["1"]], [:x]))
-        @test df == DataFrame([[1, "1"]], [:x])
-        @test typeof.(columns(df)) == [Vector{Any}]
-        df = vcat(DataFrame([CategoricalArray([1])], [:x]),
-                  DataFrame([CategoricalArray(["1"])], [:x]))
-        @test df == DataFrame([[1, "1"]], [:x])
-        @test df[:x] isa CategoricalVector{Any}
-        df = vcat(DataFrame([trues(1)], [:x]), DataFrame([[false]], [:x]))
-        @test df == DataFrame([[true, false]], [:x])
-        @test typeof.(columns(df)) == [Vector{Bool}]
-    end
-
-    @testset "vcat out of order" begin
-        df1 = DataFrame(A = 1:3, B = 4:6, C = 7:9)
-        df2 = DataFrame(colwise(x->2x, df1), reverse(names(df1)))
-        @test vcat(df1, df2) == DataFrame([[1, 2, 3, 14, 16, 18],
-                                           [4, 5, 6, 8, 10, 12],
-                                           [7, 8, 9, 2, 4, 6]], [:A, :B, :C])
-        @test vcat(df1, df1, df2) == DataFrame([[1, 2, 3, 1, 2, 3, 14, 16, 18],
-                                                [4, 5, 6, 4, 5, 6, 8, 10, 12],
-                                                [7, 8, 9, 7, 8, 9, 2, 4, 6]], [:A, :B, :C])
-        @test vcat(df1, df2, df2) == DataFrame([[1, 2, 3, 14, 16, 18, 14, 16, 18],
-                                                [4, 5, 6, 8, 10, 12, 8, 10, 12],
-                                                [7, 8, 9, 2, 4, 6, 2, 4, 6]], [:A, :B, :C])
-        @test vcat(df2, df1, df2) == DataFrame([[2, 4, 6, 7, 8, 9, 2, 4, 6],
-                                                [8, 10, 12, 4, 5, 6, 8, 10, 12],
-                                                [14, 16, 18, 1, 2, 3, 14, 16, 18]] ,[:C, :B, :A]) 
-        @test size(vcat(df1, df1, df1, df2, df2, df2)) == (18, 3)
-        df3 = df1[[1, 3, 2]]
-        res = vcat(df1, df1, df1, df2, df2, df2, df3, df3, df3, df3)
-        @test size(res) == (30, 3)
-        @test res[1:3,:] == df1
-        @test res[4:6,:] == df1
-        @test res[7:9,:] == df1
-        @test res[10:12,:] == df2[names(res)]
-        @test res[13:15,:] == df2[names(res)]
-        @test res[16:18,:] == df2[names(res)]
-        @test res[19:21,:] == df3[names(res)]
-        @test res[22:24,:] == df3[names(res)]
-        @test res[25:27,:] == df3[names(res)]
-        df1 = DataFrame(A = 1, B = 2)
-        df2 = DataFrame(B = 12, A = 11)
-        df3 = DataFrame(A = [1, 11], B = [2, 12])
-        @test [df1; df2] == df3
-    end
-
-    @testset "vcat errors" begin
-        err = @test_throws ArgumentError vcat(DataFrame(), DataFrame(), DataFrame(x=[]))
-        @test err.value.msg == "column(s) x are missing from argument(s) 1 and 2"
-        err = @test_throws ArgumentError vcat(DataFrame(), DataFrame(), DataFrame(x=[1]))
-        @test err.value.msg == "column(s) x are missing from argument(s) 1 and 2"
-        df1 = DataFrame(A = 1:3, B = 1:3)
-        df2 = DataFrame(A = 1:3)
-        # right missing 1 column
-        err = @test_throws ArgumentError vcat(df1, df2)
-        @test err.value.msg == "column(s) B are missing from argument(s) 2"
-        # left missing 1 column
-        err = @test_throws ArgumentError vcat(df2, df1)
-        @test err.value.msg == "column(s) B are missing from argument(s) 1"
-        # multiple missing 1 column
-        err = @test_throws ArgumentError vcat(df1, df2, df2, df2, df2, df2)
-        @test err.value.msg == "column(s) B are missing from argument(s) 2, 3, 4, 5 and 6"
-        # argument missing >1 columns
-        df1 = DataFrame(A = 1:3, B = 1:3, C = 1:3, D = 1:3, E = 1:3)
-        err = @test_throws ArgumentError vcat(df1, df2)
-        @test err.value.msg == "column(s) B, C, D and E are missing from argument(s) 2"
-        # >1 arguments missing >1 columns
-        err = @test_throws ArgumentError vcat(df1, df2, df2, df2, df2)
-        @test err.value.msg == "column(s) B, C, D and E are missing from argument(s) 2, 3, 4 and 5"
-        # missing columns throws error
-        df1 = DataFrame(A = 1, B = 1)
-        df2 = DataFrame(A = 1)
-        df3 = DataFrame(B = 1, A = 1)
-        err = @test_throws ArgumentError vcat(df1, df2, df3)
-        @test err.value.msg == "column(s) B are missing from argument(s) 2"
-        # unique columns for both sides
-        df1 = DataFrame(A = 1, B = 1, C = 1, D = 1)
-        df2 = DataFrame(A = 1, C = 1, D = 1, E = 1, F = 1)
-        err = @test_throws ArgumentError vcat(df1, df2)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1, and column(s) B are missing from argument(s) 2"
-        err = @test_throws ArgumentError vcat(df1, df1, df2, df2)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1 and 2, and column(s) B are missing from argument(s) 3 and 4"
-        df3 = DataFrame(A = 1, B = 1, C = 1, D = 1, E = 1)
-        err = @test_throws ArgumentError vcat(df1, df2, df3)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1, column(s) B are missing from argument(s) 2, and column(s) F are missing from argument(s) 3"
-        err = @test_throws ArgumentError vcat(df1, df1, df2, df2, df3, df3)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1 and 2, column(s) B are missing from argument(s) 3 and 4, and column(s) F are missing from argument(s) 5 and 6"
-        err = @test_throws ArgumentError vcat(df1, df1, df1, df2, df2, df2, df3, df3, df3)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 2 and 3, column(s) B are missing from argument(s) 4, 5 and 6, and column(s) F are missing from argument(s) 7, 8 and 9"
-        # df4 is a superset of names found in all other DataFrames and won't be shown in error
-        df4 = DataFrame(A = 1, B = 1, C = 1, D = 1, E = 1, F = 1)
-        err = @test_throws ArgumentError vcat(df1, df2, df3, df4)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1, column(s) B are missing from argument(s) 2, and column(s) F are missing from argument(s) 3"
-        err = @test_throws ArgumentError vcat(df1, df1, df2, df2, df3, df3, df4, df4)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1 and 2, column(s) B are missing from argument(s) 3 and 4, and column(s) F are missing from argument(s) 5 and 6"
-        err = @test_throws ArgumentError vcat(df1, df1, df1, df2, df2, df2, df3, df3, df3, df4, df4, df4)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 2 and 3, column(s) B are missing from argument(s) 4, 5 and 6, and column(s) F are missing from argument(s) 7, 8 and 9"
-        err = @test_throws ArgumentError vcat(df1, df2, df3, df4, df1, df2, df3, df4, df1, df2, df3, df4)
-        @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 5 and 9, column(s) B are missing from argument(s) 2, 6 and 10, and column(s) F are missing from argument(s) 3, 7 and 11"
-    end
-    x = view(DataFrame(A = Vector{Union{Missing, Int}}(1:3)), 2:2, :)
-    y = DataFrame(A = 4:5)
-    @test vcat(x, y) == DataFrame(A = [2, 4, 5])
+    @test df2 ≅ DataFrames.hcat!(df2, makeunique=true)
 end
+
+@testset "hcat ::AbstractDataFrame" begin
+    df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)
+    gd = groupby(df, :A)
+    answer = DataFrame(A = fill('A', 4), B = 1:4, A_1 = 'B', B_1 = 5:8, A_2 = 'C', B_2 = 9:12)
+    @test hcat(gd..., makeunique=true) == answer
+    answer = answer[1:4]
+    @test hcat(gd[1], gd[2], makeunique=true) == answer
+end
+
+@testset "hcat ::AbstractDataFrame" begin
+    df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)
+    gd = groupby(df, :A)
+    answer = DataFrame(A = fill('A', 4), B = 1:4, A_1 = 'B', B_1 = 5:8, A_2 = 'C', B_2 = 9:12)
+    @test hcat(gd..., makeunique=true) == answer
+    answer = answer[1:4]
+    @test hcat(gd[1], gd[2], makeunique=true) == answer
+end
+
+@testset "hcat ::AbstractVectors" begin
+    df = DataFrame()
+    DataFrames.hcat!(df, CategoricalVector{Union{Int,Missing}}(1:10), makeunique=true)
+    @test df[1] == CategoricalVector(1:10)
+    DataFrames.hcat!(df, 1:10, makeunique=true)
+    @test df[2] == collect(1:10)
+    DataFrames.hcat!(df, collect(1:10), makeunique=true)
+    @test df[3] == collect(1:10)
+
+    df = DataFrame()
+    df2 = hcat(CategoricalVector{Union{Int,Missing}}(1:10), df, makeunique=true)
+    @test isempty(df)
+    @test df2[1] == collect(1:10)
+    @test names(df2) == [:x1]
+    ref_df = copy(df2)
+    df3 = hcat(11:20, df2, makeunique=true)
+    @test df2 == ref_df
+    @test df3[1] == collect(11:20)
+    @test names(df3) == [:x1, :x1_1]
+
+    @test_throws ArgumentError hcat("a", df, makeunique=true)
+    @test_throws ArgumentError hcat(df, "a", makeunique=true)
+end
+#
+# vcat
+#
+
+@testset "vcat" begin
+    missing_df = DataFrame(Int, 0, 0)
+    df = DataFrame(Int, 4, 3)
+
+    # Assignment of rows
+    # TODO: re-enable when we fix setindex! to handle DataFrameRow on RHS
+    # df[1, :] = df[1, :]
+    df[1, :] = df[1:1, :]
+    df[1:2, :] = df[1:2, :]
+    df[[true,false,false,true], :] = df[2:3, :]
+
+    # Scalar broadcasting assignment of rows
+    df[1, :] = 1
+    df[1:2, :] = 1
+    df[[true,false,false,true], :] = 3
+
+    # Vector broadcasting assignment of rows
+    df[1:2, :] = [2,3]
+    df[[true,false,false,true], :] = [2,3]
+
+    # Assignment of columns
+    df[1] = zeros(4)
+    df[:, 2] = ones(4)
+
+    # Broadcasting assignment of columns
+    df[:, 1] = 1
+    df[1] = 3
+    df[:x3] = 2
+
+    # assignment of subtables
+    # TODO: re-enable when we fix setindex! to handle DataFrameRow on RHS
+    # df[1, 1:2] = df[2, 2:3]
+    df[1, 1:2] = df[2:2, 2:3]
+    df[1:2, 1:2] = df[2:3, 2:3]
+    df[[true,false,false,true], 2:3] = df[1:2,1:2]
+
+    # scalar broadcasting assignment of subtables
+    df[1, 1:2] = 3
+    df[1:2, 1:2] = 3
+    df[[true,false,false,true], 2:3] = 3
+
+    # vector broadcasting assignment of subtables
+    df[1:2, 1:2] = [3,2]
+    df[[true,false,false,true], 2:3] = [2,3]
+
+    @test vcat(missing_df) == DataFrame()
+    @test vcat(missing_df, missing_df) == DataFrame()
+    @test_throws ArgumentError vcat(missing_df, df)
+    @test_throws ArgumentError vcat(df, missing_df)
+    @test eltypes(vcat(df, df)) == Type[Float64, Float64, Int]
+    @test size(vcat(df, df)) == (size(df, 1) * 2, size(df, 2))
+    res = vcat(df, df)
+    @test res[1:size(df, 1), :] == df
+    @test res[1+size(df, 1):end, :] == df
+    @test eltypes(vcat(df, df, df)) == Type[Float64, Float64, Int]
+    @test size(vcat(df, df, df)) == (size(df, 1) * 3, size(df, 2))
+    res = vcat(df, df, df)
+    s = size(df, 1)
+    for i in 1:3
+        @test res[1+(i-1)*s:i*s, :] == df
+    end
+
+    alt_df = deepcopy(df)
+    @test vcat(df, alt_df) == DataFrame([[3.0,2.0,3.0,3.0,3.0,2.0,3.0,3.0],
+                                         [2.0,2.0,1.0,3.0,2.0,2.0,1.0,3.0],
+                                         [2,2,2,3,2,2,2,3]])
+
+    # Don't fail on non-matching types
+    df[1] = zeros(Int, nrow(df))
+    @test vcat(df, alt_df) == DataFrame([[0.0,0.0,0.0,0.0,3.0,2.0,3.0,3.0],
+                                         [2.0,2.0,1.0,3.0,2.0,2.0,1.0,3.0],
+                                         [2,2,2,3,2,2,2,3]])
+end
+
+@testset "vcat >2 args" begin
+    @test vcat(DataFrame(), DataFrame(), DataFrame()) == DataFrame()
+    df = DataFrame(x = trues(1), y = falses(1))
+    @test vcat(df, df, df) == DataFrame(x = trues(3), y = falses(3))
+end
+
+@testset "vcat mixed coltypes" begin
+    df = vcat(DataFrame([[1]], [:x]), DataFrame([[1.0]], [:x]))
+    @test df == DataFrame([[1.0, 1.0]], [:x])
+    @test typeof.(columns(df)) == [Vector{Float64}]
+    df = vcat(DataFrame([[1]], [:x]), DataFrame([["1"]], [:x]))
+    @test df == DataFrame([[1, "1"]], [:x])
+    @test typeof.(columns(df)) == [Vector{Any}]
+    df = vcat(DataFrame([Union{Missing, Int}[1]], [:x]), DataFrame([[1]], [:x]))
+    @test df == DataFrame([[1, 1]], [:x])
+    @test typeof.(columns(df)) == [Vector{Union{Missing, Int}}]
+    df = vcat(DataFrame([CategoricalArray([1])], [:x]), DataFrame([[1]], [:x]))
+    @test df == DataFrame([[1, 1]], [:x])
+    @test df[:x] isa Vector{Int}
+    df = vcat(DataFrame([CategoricalArray([1])], [:x]),
+              DataFrame([Union{Missing, Int}[1]], [:x]))
+    @test df == DataFrame([[1, 1]], [:x])
+    @test df[:x] isa Vector{Union{Int, Missing}}
+    df = vcat(DataFrame([CategoricalArray([1])], [:x]),
+              DataFrame([CategoricalArray{Union{Int, Missing}}([1])], [:x]))
+    @test df == DataFrame([[1, 1]], [:x])
+    @test df[:x] isa CategoricalVector{Union{Int, Missing}}
+    df = vcat(DataFrame([Union{Int, Missing}[1]], [:x]),
+              DataFrame([["1"]], [:x]))
+    @test df == DataFrame([[1, "1"]], [:x])
+    @test typeof.(columns(df)) == [Vector{Any}]
+    df = vcat(DataFrame([CategoricalArray([1])], [:x]),
+              DataFrame([CategoricalArray(["1"])], [:x]))
+    @test df == DataFrame([[1, "1"]], [:x])
+    @test df[:x] isa CategoricalVector{Any}
+    df = vcat(DataFrame([trues(1)], [:x]), DataFrame([[false]], [:x]))
+    @test df == DataFrame([[true, false]], [:x])
+    @test typeof.(columns(df)) == [Vector{Bool}]
+end
+
+@testset "vcat out of order" begin
+    df1 = DataFrame(A = 1:3, B = 4:6, C = 7:9)
+    df2 = DataFrame(colwise(x->2x, df1), reverse(names(df1)))
+    @test vcat(df1, df2) == DataFrame([[1, 2, 3, 14, 16, 18],
+                                       [4, 5, 6, 8, 10, 12],
+                                       [7, 8, 9, 2, 4, 6]], [:A, :B, :C])
+    @test vcat(df1, df1, df2) == DataFrame([[1, 2, 3, 1, 2, 3, 14, 16, 18],
+                                            [4, 5, 6, 4, 5, 6, 8, 10, 12],
+                                            [7, 8, 9, 7, 8, 9, 2, 4, 6]], [:A, :B, :C])
+    @test vcat(df1, df2, df2) == DataFrame([[1, 2, 3, 14, 16, 18, 14, 16, 18],
+                                            [4, 5, 6, 8, 10, 12, 8, 10, 12],
+                                            [7, 8, 9, 2, 4, 6, 2, 4, 6]], [:A, :B, :C])
+    @test vcat(df2, df1, df2) == DataFrame([[2, 4, 6, 7, 8, 9, 2, 4, 6],
+                                            [8, 10, 12, 4, 5, 6, 8, 10, 12],
+                                            [14, 16, 18, 1, 2, 3, 14, 16, 18]] ,[:C, :B, :A])
+    @test size(vcat(df1, df1, df1, df2, df2, df2)) == (18, 3)
+    df3 = df1[[1, 3, 2]]
+    res = vcat(df1, df1, df1, df2, df2, df2, df3, df3, df3, df3)
+    @test size(res) == (30, 3)
+    @test res[1:3,:] == df1
+    @test res[4:6,:] == df1
+    @test res[7:9,:] == df1
+    @test res[10:12,:] == df2[names(res)]
+    @test res[13:15,:] == df2[names(res)]
+    @test res[16:18,:] == df2[names(res)]
+    @test res[19:21,:] == df3[names(res)]
+    @test res[22:24,:] == df3[names(res)]
+    @test res[25:27,:] == df3[names(res)]
+    df1 = DataFrame(A = 1, B = 2)
+    df2 = DataFrame(B = 12, A = 11)
+    df3 = DataFrame(A = [1, 11], B = [2, 12])
+    @test [df1; df2] == df3
+end
+
+@testset "vcat errors" begin
+    err = @test_throws ArgumentError vcat(DataFrame(), DataFrame(), DataFrame(x=[]))
+    @test err.value.msg == "column(s) x are missing from argument(s) 1 and 2"
+    err = @test_throws ArgumentError vcat(DataFrame(), DataFrame(), DataFrame(x=[1]))
+    @test err.value.msg == "column(s) x are missing from argument(s) 1 and 2"
+    df1 = DataFrame(A = 1:3, B = 1:3)
+    df2 = DataFrame(A = 1:3)
+    # right missing 1 column
+    err = @test_throws ArgumentError vcat(df1, df2)
+    @test err.value.msg == "column(s) B are missing from argument(s) 2"
+    # left missing 1 column
+    err = @test_throws ArgumentError vcat(df2, df1)
+    @test err.value.msg == "column(s) B are missing from argument(s) 1"
+    # multiple missing 1 column
+    err = @test_throws ArgumentError vcat(df1, df2, df2, df2, df2, df2)
+    @test err.value.msg == "column(s) B are missing from argument(s) 2, 3, 4, 5 and 6"
+    # argument missing >1 columns
+    df1 = DataFrame(A = 1:3, B = 1:3, C = 1:3, D = 1:3, E = 1:3)
+    err = @test_throws ArgumentError vcat(df1, df2)
+    @test err.value.msg == "column(s) B, C, D and E are missing from argument(s) 2"
+    # >1 arguments missing >1 columns
+    err = @test_throws ArgumentError vcat(df1, df2, df2, df2, df2)
+    @test err.value.msg == "column(s) B, C, D and E are missing from argument(s) 2, 3, 4 and 5"
+    # missing columns throws error
+    df1 = DataFrame(A = 1, B = 1)
+    df2 = DataFrame(A = 1)
+    df3 = DataFrame(B = 1, A = 1)
+    err = @test_throws ArgumentError vcat(df1, df2, df3)
+    @test err.value.msg == "column(s) B are missing from argument(s) 2"
+    # unique columns for both sides
+    df1 = DataFrame(A = 1, B = 1, C = 1, D = 1)
+    df2 = DataFrame(A = 1, C = 1, D = 1, E = 1, F = 1)
+    err = @test_throws ArgumentError vcat(df1, df2)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1, and column(s) B are missing from argument(s) 2"
+    err = @test_throws ArgumentError vcat(df1, df1, df2, df2)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1 and 2, and column(s) B are missing from argument(s) 3 and 4"
+    df3 = DataFrame(A = 1, B = 1, C = 1, D = 1, E = 1)
+    err = @test_throws ArgumentError vcat(df1, df2, df3)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1, column(s) B are missing from argument(s) 2, and column(s) F are missing from argument(s) 3"
+    err = @test_throws ArgumentError vcat(df1, df1, df2, df2, df3, df3)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1 and 2, column(s) B are missing from argument(s) 3 and 4, and column(s) F are missing from argument(s) 5 and 6"
+    err = @test_throws ArgumentError vcat(df1, df1, df1, df2, df2, df2, df3, df3, df3)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 2 and 3, column(s) B are missing from argument(s) 4, 5 and 6, and column(s) F are missing from argument(s) 7, 8 and 9"
+    # df4 is a superset of names found in all other DataFrames and won't be shown in error
+    df4 = DataFrame(A = 1, B = 1, C = 1, D = 1, E = 1, F = 1)
+    err = @test_throws ArgumentError vcat(df1, df2, df3, df4)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1, column(s) B are missing from argument(s) 2, and column(s) F are missing from argument(s) 3"
+    err = @test_throws ArgumentError vcat(df1, df1, df2, df2, df3, df3, df4, df4)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1 and 2, column(s) B are missing from argument(s) 3 and 4, and column(s) F are missing from argument(s) 5 and 6"
+    err = @test_throws ArgumentError vcat(df1, df1, df1, df2, df2, df2, df3, df3, df3, df4, df4, df4)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 2 and 3, column(s) B are missing from argument(s) 4, 5 and 6, and column(s) F are missing from argument(s) 7, 8 and 9"
+    err = @test_throws ArgumentError vcat(df1, df2, df3, df4, df1, df2, df3, df4, df1, df2, df3, df4)
+    @test err.value.msg == "column(s) E and F are missing from argument(s) 1, 5 and 9, column(s) B are missing from argument(s) 2, 6 and 10, and column(s) F are missing from argument(s) 3, 7 and 11"
+end
+x = view(DataFrame(A = Vector{Union{Missing, Int}}(1:3)), 2:2, :)
+y = DataFrame(A = 4:5)
+@test vcat(x, y) == DataFrame(A = [2, 4, 5])
+
+end # module

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -1,134 +1,136 @@
 module TestConstructors
-    using Test, DataFrames
-    using DataFrames: Index, _columns, index
-    using DataFrames: columns
-    const ≅ = isequal
 
-    #
-    # DataFrame
-    #
-    @testset "constructors" begin
-        df = DataFrame()
-        @test isempty(_columns(df))
-        @test _columns(df) isa Vector{AbstractVector}
-        @test index(df) == Index()
+using Test, DataFrames
+using DataFrames: Index, _columns, index
+using DataFrames: columns
+const ≅ = isequal
 
-        df = DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
-                       CategoricalVector{Union{Float64, Missing}}(ones(3))],
-                       Index([:x1, :x2]))
-        @test size(df, 1) == 3
-        @test size(df, 2) == 2
+#
+# DataFrame
+#
+@testset "constructors" begin
+    df = DataFrame()
+    @test isempty(_columns(df))
+    @test _columns(df) isa Vector{AbstractVector}
+    @test index(df) == Index()
 
-        @test df == DataFrame([CategoricalVector{Union{Float64, Missing}}(zeros(3)),
-                               CategoricalVector{Union{Float64, Missing}}(ones(3))])
-        @test df == DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
-                                  CategoricalVector{Union{Float64, Missing}}(ones(3))])
-        @test df == DataFrame(AbstractVector[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
-                                             CategoricalVector{Union{Float64, Missing}}(ones(3))])
-        @test df == DataFrame(x1 = Union{Int, Missing}[0.0, 0.0, 0.0],
-                              x2 = Union{Int, Missing}[1.0, 1.0, 1.0])
+    df = DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+                   CategoricalVector{Union{Float64, Missing}}(ones(3))],
+                   Index([:x1, :x2]))
+    @test size(df, 1) == 3
+    @test size(df, 2) == 2
 
-        @test (DataFrame([1:3, 1:3]) == DataFrame(Any[1:3, 1:3]) ==
-               DataFrame(UnitRange[1:3, 1:3]) == DataFrame(AbstractVector[1:3, 1:3]) ==
-               DataFrame([[1,2,3], [1,2,3]]) == DataFrame(Any[[1,2,3], [1,2,3]]))
+    @test df == DataFrame([CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+                           CategoricalVector{Union{Float64, Missing}}(ones(3))])
+    @test df == DataFrame(Any[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+                              CategoricalVector{Union{Float64, Missing}}(ones(3))])
+    @test df == DataFrame(AbstractVector[CategoricalVector{Union{Float64, Missing}}(zeros(3)),
+                                         CategoricalVector{Union{Float64, Missing}}(ones(3))])
+    @test df == DataFrame(x1 = Union{Int, Missing}[0.0, 0.0, 0.0],
+                          x2 = Union{Int, Missing}[1.0, 1.0, 1.0])
 
-        @test df !== DataFrame(df)
-        @test df == DataFrame(df)
+    @test (DataFrame([1:3, 1:3]) == DataFrame(Any[1:3, 1:3]) ==
+           DataFrame(UnitRange[1:3, 1:3]) == DataFrame(AbstractVector[1:3, 1:3]) ==
+           DataFrame([[1,2,3], [1,2,3]]) == DataFrame(Any[[1,2,3], [1,2,3]]))
 
-        df2 = convert(DataFrame, Union{Float64, Missing}[0.0 1.0;
-                                                         0.0 1.0;
-                                                         0.0 1.0])
-        names!(df2, [:x1, :x2])
-        @test df[:x1] == df2[:x1]
-        @test df[:x2] == df2[:x2]
+    @test df !== DataFrame(df)
+    @test df == DataFrame(df)
 
-        df2 = DataFrame([0.0 1.0;
-                         0.0 1.0;
-                         0.0 1.0])
-        names!(df2, [:x1, :x2])
-        @test df[:x1] == df2[:x1]
-        @test df[:x2] == df2[:x2]
+    df2 = convert(DataFrame, Union{Float64, Missing}[0.0 1.0;
+                                                     0.0 1.0;
+                                                     0.0 1.0])
+    names!(df2, [:x1, :x2])
+    @test df[:x1] == df2[:x1]
+    @test df[:x2] == df2[:x2]
 
-        df2 = DataFrame([0.0 1.0;
-                         0.0 1.0;
-                         0.0 1.0], [:a, :b])
-        names!(df2, [:a, :b])
-        @test df[:x1] == df2[:a]
-        @test df[:x2] == df2[:b]
+    df2 = DataFrame([0.0 1.0;
+                     0.0 1.0;
+                     0.0 1.0])
+    names!(df2, [:x1, :x2])
+    @test df[:x1] == df2[:x1]
+    @test df[:x2] == df2[:x2]
 
-        @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],
-                              x2 = Union{Float64, Missing}[1.0, 1.0, 1.0])
-        @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],
-                              x2 = Union{Float64, Missing}[1.0, 1.0, 1.0],
-                              x3 = Union{Float64, Missing}[2.0, 2.0, 2.0])[[:x1, :x2]]
+    df2 = DataFrame([0.0 1.0;
+                     0.0 1.0;
+                     0.0 1.0], [:a, :b])
+    names!(df2, [:a, :b])
+    @test df[:x1] == df2[:a]
+    @test df[:x2] == df2[:b]
 
-        df = DataFrame(Union{Int, Missing}, 2, 2)
-        @test size(df) == (2, 2)
-        @test eltypes(df) == [Union{Int, Missing}, Union{Int, Missing}]
+    @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],
+                          x2 = Union{Float64, Missing}[1.0, 1.0, 1.0])
+    @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],
+                          x2 = Union{Float64, Missing}[1.0, 1.0, 1.0],
+                          x3 = Union{Float64, Missing}[2.0, 2.0, 2.0])[[:x1, :x2]]
 
-        df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}], [:x1, :x2], 2)
-        @test size(df) == (2, 2)
-        @test eltypes(df) == [Union{Int, Missing}, Union{Float64, Missing}]
+    df = DataFrame(Union{Int, Missing}, 2, 2)
+    @test size(df) == (2, 2)
+    @test eltypes(df) == [Union{Int, Missing}, Union{Int, Missing}]
 
-        @test df ≅ DataFrame([Union{Int, Missing}, Union{Float64, Missing}], 2)
+    df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}], [:x1, :x2], 2)
+    @test size(df) == (2, 2)
+    @test eltypes(df) == [Union{Int, Missing}, Union{Float64, Missing}]
 
-        @test_throws BoundsError SubDataFrame(DataFrame(A=1), 0:0, :)
-        @test_throws ArgumentError SubDataFrame(DataFrame(A=1), 0, :)
-        @test_throws BoundsError DataFrame(A=1)[0, :]
-        @test_throws BoundsError DataFrame(A=1)[0, 1:1]
-        @test SubDataFrame(DataFrame(A=1), 1:1, :) == DataFrame(A=1)
-        @test SubDataFrame(DataFrame(A=1:10), 1:4, :) == DataFrame(A=1:4)
-        @test view(SubDataFrame(DataFrame(A=1:10), 1:4, :), 2:2, :) == DataFrame(A=2)
-        @test view(SubDataFrame(DataFrame(A=1:10), 1:4, :), [true, true, false, false], :) == DataFrame(A=1:2)
+    @test df ≅ DataFrame([Union{Int, Missing}, Union{Float64, Missing}], 2)
 
-        @test DataFrame(a=1, b=1:2) == DataFrame(a=[1,1], b=[1,2])
-    end
+    @test_throws BoundsError SubDataFrame(DataFrame(A=1), 0:0, :)
+    @test_throws ArgumentError SubDataFrame(DataFrame(A=1), 0, :)
+    @test_throws BoundsError DataFrame(A=1)[0, :]
+    @test_throws BoundsError DataFrame(A=1)[0, 1:1]
+    @test SubDataFrame(DataFrame(A=1), 1:1, :) == DataFrame(A=1)
+    @test SubDataFrame(DataFrame(A=1:10), 1:4, :) == DataFrame(A=1:4)
+    @test view(SubDataFrame(DataFrame(A=1:10), 1:4, :), 2:2, :) == DataFrame(A=2)
+    @test view(SubDataFrame(DataFrame(A=1:10), 1:4, :), [true, true, false, false], :) == DataFrame(A=1:2)
 
-    @testset "pair constructor" begin
-        df = DataFrame(:x1 => zeros(3), :x2 => ones(3))
-        @test size(df, 1) == 3
-        @test size(df, 2) == 2
-        @test isequal(df, DataFrame(x1 = [0.0, 0.0, 0.0], x2 = [1.0, 1.0, 1.0]))
-
-        df = DataFrame(:type => [], :begin => [])
-        @test names(df) == [:type, :begin]
-    end
-
-    @testset "associative" begin
-        df = DataFrame(Dict(:A => 1:3, :B => 4:6))
-        @test df == DataFrame(A = 1:3, B = 4:6)
-        @test eltypes(df) == [Int, Int]
-    end
-
-    @testset "recyclers" begin
-        @test DataFrame(a = 1:5, b = 1) == DataFrame(a = collect(1:5), b = fill(1, 5))
-        @test DataFrame(a = 1, b = 1:5) == DataFrame(a = fill(1, 5), b = collect(1:5))
-    end
-
-    @testset "constructor errors" begin
-        @test_throws DimensionMismatch DataFrame(a=1, b=[])
-        @test_throws DimensionMismatch DataFrame(Any[collect(1:10)], DataFrames.Index([:A, :B]))
-        @test_throws DimensionMismatch DataFrame(A = rand(2,2))
-        @test_throws DimensionMismatch DataFrame(A = rand(2,1))
-        @test_throws ArgumentError DataFrame([1, 2, 3])
-    end
-
-    @testset "column types" begin
-        df = DataFrame(A = 1:3, B = 2:4, C = 3:5)
-        answer = [Array{Int,1}, Array{Int,1}, Array{Int,1}]
-        @test map(typeof, columns(df)) == answer
-        df[:D] = [4, 5, missing]
-        push!(answer, Vector{Union{Int, Missing}})
-        @test map(typeof, columns(df)) == answer
-        df[:E] = 'c'
-        push!(answer, Vector{Char})
-        @test map(typeof, columns(df)) == answer
-    end
-
-    @testset "categorical constructor" begin
-        df = DataFrame([Int, String], [:a, :b], [false, true], 3)
-        @test !(df[:a] isa CategoricalVector)
-        @test df[:b] isa CategoricalVector
-        @test_throws DimensionMismatch DataFrame([Int, String], [:a, :b], [true], 3)
-    end
+    @test DataFrame(a=1, b=1:2) == DataFrame(a=[1,1], b=[1,2])
 end
+
+@testset "pair constructor" begin
+    df = DataFrame(:x1 => zeros(3), :x2 => ones(3))
+    @test size(df, 1) == 3
+    @test size(df, 2) == 2
+    @test isequal(df, DataFrame(x1 = [0.0, 0.0, 0.0], x2 = [1.0, 1.0, 1.0]))
+
+    df = DataFrame(:type => [], :begin => [])
+    @test names(df) == [:type, :begin]
+end
+
+@testset "associative" begin
+    df = DataFrame(Dict(:A => 1:3, :B => 4:6))
+    @test df == DataFrame(A = 1:3, B = 4:6)
+    @test eltypes(df) == [Int, Int]
+end
+
+@testset "recyclers" begin
+    @test DataFrame(a = 1:5, b = 1) == DataFrame(a = collect(1:5), b = fill(1, 5))
+    @test DataFrame(a = 1, b = 1:5) == DataFrame(a = fill(1, 5), b = collect(1:5))
+end
+
+@testset "constructor errors" begin
+    @test_throws DimensionMismatch DataFrame(a=1, b=[])
+    @test_throws DimensionMismatch DataFrame(Any[collect(1:10)], DataFrames.Index([:A, :B]))
+    @test_throws DimensionMismatch DataFrame(A = rand(2,2))
+    @test_throws DimensionMismatch DataFrame(A = rand(2,1))
+    @test_throws ArgumentError DataFrame([1, 2, 3])
+end
+
+@testset "column types" begin
+    df = DataFrame(A = 1:3, B = 2:4, C = 3:5)
+    answer = [Array{Int,1}, Array{Int,1}, Array{Int,1}]
+    @test map(typeof, columns(df)) == answer
+    df[:D] = [4, 5, missing]
+    push!(answer, Vector{Union{Int, Missing}})
+    @test map(typeof, columns(df)) == answer
+    df[:E] = 'c'
+    push!(answer, Vector{Char})
+    @test map(typeof, columns(df)) == answer
+end
+
+@testset "categorical constructor" begin
+    df = DataFrame([Int, String], [:a, :b], [false, true], 3)
+    @test !(df[:a] isa CategoricalVector)
+    @test df[:b] isa CategoricalVector
+    @test_throws DimensionMismatch DataFrame([Int, String], [:a, :b], [true], 3)
+end
+
+end # module

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,86 +1,87 @@
 module TestConversions
-    using Test, DataFrames, InteractiveUtils
-    using DataStructures: OrderedDict, SortedDict
-    const ≅ = isequal
 
-    df = DataFrame()
-    df[:A] = 1:5
-    df[:B] = [:A, :B, :C, :D, :E]
-    @test isa(convert(Array, df), Matrix{Any})
-    @test isa(convert(Array{Any}, df), Matrix{Any})
+using Test, DataFrames, InteractiveUtils
+using DataStructures: OrderedDict, SortedDict
+const ≅ = isequal
 
-    df = DataFrame()
-    df[:A] = 1:5
-    df[:B] = 1.0:5.0
-    @test isa(convert(Array, df), Matrix{Float64})
-    @test isa(convert(Array{Any}, df), Matrix{Any})
-    @test isa(convert(Array{Float64}, df), Matrix{Float64})
-    @test isa(Matrix(df), Matrix{Float64})
-    @test isa(Matrix{Any}(df), Matrix{Any})
-    @test isa(Matrix{Float64}(df), Matrix{Float64})
+df = DataFrame()
+df[:A] = 1:5
+df[:B] = [:A, :B, :C, :D, :E]
+@test isa(convert(Array, df), Matrix{Any})
+@test isa(convert(Array{Any}, df), Matrix{Any})
 
-    df = DataFrame()
-    df[:A] = Vector{Union{Float64, Missing}}(1.0:5.0)
-    df[:B] = Vector{Union{Float64, Missing}}(1.0:5.0)
-    a = convert(Array, df)
-    aa = convert(Array{Any}, df)
-    ai = convert(Array{Int}, df)
-    @test isa(a, Matrix{Union{Float64, Missing}})
-    @test a == convert(Array, convert(Array{Union{Float64, Missing}}, df))
-    @test a == convert(Matrix, df)
-    @test a == Matrix(df)
-    @test isa(aa, Matrix{Any})
-    @test aa == convert(Matrix{Any}, df)
-    @test aa == Matrix{Any}(df)
-    @test isa(ai, Matrix{Int})
-    @test ai == convert(Matrix{Int}, df)
-    @test ai == Matrix{Int}(df)
+df = DataFrame()
+df[:A] = 1:5
+df[:B] = 1.0:5.0
+@test isa(convert(Array, df), Matrix{Float64})
+@test isa(convert(Array{Any}, df), Matrix{Any})
+@test isa(convert(Array{Float64}, df), Matrix{Float64})
+@test isa(Matrix(df), Matrix{Float64})
+@test isa(Matrix{Any}(df), Matrix{Any})
+@test isa(Matrix{Float64}(df), Matrix{Float64})
 
-    df[1,1] = missing
-    @test_throws ErrorException convert(Array{Float64}, df)
-    na = convert(Array{Union{Float64, Missing}}, df)
-    naa = convert(Array{Any}, df)
-    nai = convert(Array{Union{Int, Missing}}, df)
-    @test isa(na, Matrix{Union{Float64, Missing}})
-    @test na ≅ convert(Matrix, df)
-    @test na ≅ Matrix(df)
-    @test isa(naa, Matrix{Union{Any, Missing}})
-    @test naa ≅ convert(Matrix{Any}, df)
-    @test naa ≅ Matrix{Any}(df)
-    @test isa(nai, Matrix{Union{Int, Missing}})
-    @test nai ≅ convert(Matrix{Union{Int, Missing}}, df)
-    @test nai ≅ Matrix{Union{Int, Missing}}(df)
+df = DataFrame()
+df[:A] = Vector{Union{Float64, Missing}}(1.0:5.0)
+df[:B] = Vector{Union{Float64, Missing}}(1.0:5.0)
+a = convert(Array, df)
+aa = convert(Array{Any}, df)
+ai = convert(Array{Int}, df)
+@test isa(a, Matrix{Union{Float64, Missing}})
+@test a == convert(Array, convert(Array{Union{Float64, Missing}}, df))
+@test a == convert(Matrix, df)
+@test a == Matrix(df)
+@test isa(aa, Matrix{Any})
+@test aa == convert(Matrix{Any}, df)
+@test aa == Matrix{Any}(df)
+@test isa(ai, Matrix{Int})
+@test ai == convert(Matrix{Int}, df)
+@test ai == Matrix{Int}(df)
 
-    a = Union{Float64, Missing}[1.0,2.0]
-    b = Union{Float64, Missing}[-0.1,3]
-    c = Union{Float64, Missing}[-3.1,7]
-    di = Dict("a"=>a, "b"=>b, "c"=>c)
+df[1,1] = missing
+@test_throws ErrorException convert(Array{Float64}, df)
+na = convert(Array{Union{Float64, Missing}}, df)
+naa = convert(Array{Any}, df)
+nai = convert(Array{Union{Int, Missing}}, df)
+@test isa(na, Matrix{Union{Float64, Missing}})
+@test na ≅ convert(Matrix, df)
+@test na ≅ Matrix(df)
+@test isa(naa, Matrix{Union{Any, Missing}})
+@test naa ≅ convert(Matrix{Any}, df)
+@test naa ≅ Matrix{Any}(df)
+@test isa(nai, Matrix{Union{Int, Missing}})
+@test nai ≅ convert(Matrix{Union{Int, Missing}}, df)
+@test nai ≅ Matrix{Union{Int, Missing}}(df)
 
-    df = convert(DataFrame, di)
-    @test isa(df, DataFrame)
-    @test names(df) == [Symbol(x) for x in sort(collect(keys(di)))]
-    @test df[:a] == a
-    @test df[:b] == b
-    @test df[:c] == c
+a = Union{Float64, Missing}[1.0,2.0]
+b = Union{Float64, Missing}[-0.1,3]
+c = Union{Float64, Missing}[-3.1,7]
+di = Dict("a"=>a, "b"=>b, "c"=>c)
 
-    od = OrderedDict("c"=>c, "a"=>a, "b"=>b)
-    df = convert(DataFrame,od)
-    @test isa(df, DataFrame)
-    @test names(df) == [Symbol(x) for x in keys(od)]
-    @test df[:a] == a
-    @test df[:b] == b
-    @test df[:c] == c
+df = convert(DataFrame, di)
+@test isa(df, DataFrame)
+@test names(df) == [Symbol(x) for x in sort(collect(keys(di)))]
+@test df[:a] == a
+@test df[:b] == b
+@test df[:c] == c
 
-    sd = SortedDict("c"=>c, "a"=>a, "b"=>b)
-    df = convert(DataFrame,sd)
-    @test isa(df, DataFrame)
-    @test names(df) == [Symbol(x) for x in keys(sd)]
-    @test df[:a] == a
-    @test df[:b] == b
-    @test df[:c] == c
+od = OrderedDict("c"=>c, "a"=>a, "b"=>b)
+df = convert(DataFrame,od)
+@test isa(df, DataFrame)
+@test names(df) == [Symbol(x) for x in keys(od)]
+@test df[:a] == a
+@test df[:b] == b
+@test df[:c] == c
 
-    a = [1.0]
-    di = Dict("a"=>a, "b"=>b, "c"=>c)
-    @test_throws DimensionMismatch convert(DataFrame,di)
+sd = SortedDict("c"=>c, "a"=>a, "b"=>b)
+df = convert(DataFrame,sd)
+@test isa(df, DataFrame)
+@test names(df) == [Symbol(x) for x in keys(sd)]
+@test df[:a] == a
+@test df[:b] == b
+@test df[:c] == c
 
-end
+a = [1.0]
+di = Dict("a"=>a, "b"=>b, "c"=>c)
+@test_throws DimensionMismatch convert(DataFrame,di)
+
+end # module

--- a/test/data.jl
+++ b/test/data.jl
@@ -1,427 +1,429 @@
 module TestData
-    using Test, DataFrames, Random, Statistics
-    const ≅ = isequal
 
-    @testset "constructors" begin
-        df1 = DataFrame([[1, 2, missing, 4], ["one", "two", missing, "four"]], [:Ints, :Strs])
-        df2 = DataFrame([[1, 2, missing, 4], ["one", "two", missing, "four"]])
-        df3 = DataFrame([[1, 2, missing, 4]])
-        df4 = DataFrame([Vector{Union{Int, Missing}}(1:4), Vector{Union{Int, Missing}}(1:4)])
-        df5 = DataFrame([Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]])
-        df6 = DataFrame([[1, 2, missing, 4], [1, 2, missing, 4], ["one", "two", missing, "four"]],
-                        [:A, :B, :C])
-        df7 = DataFrame(x = [1, 2, missing, 4], y = ["one", "two", missing, "four"])
-        @test size(df7) == (4, 2)
-        @test df7[:x] ≅ [1, 2, missing, 4]
+using Test, DataFrames, Random, Statistics
+const ≅ = isequal
 
-        #test_group("description functions")
-        @test size(df6, 1) == 4
-        @test size(df6, 2) == 3
-        @test names(df6) == [:A, :B, :C]
-        @test names(df2) == [:x1, :x2]
-        @test names(df7) == [:x, :y]
+@testset "constructors" begin
+    df1 = DataFrame([[1, 2, missing, 4], ["one", "two", missing, "four"]], [:Ints, :Strs])
+    df2 = DataFrame([[1, 2, missing, 4], ["one", "two", missing, "four"]])
+    df3 = DataFrame([[1, 2, missing, 4]])
+    df4 = DataFrame([Vector{Union{Int, Missing}}(1:4), Vector{Union{Int, Missing}}(1:4)])
+    df5 = DataFrame([Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]])
+    df6 = DataFrame([[1, 2, missing, 4], [1, 2, missing, 4], ["one", "two", missing, "four"]],
+                    [:A, :B, :C])
+    df7 = DataFrame(x = [1, 2, missing, 4], y = ["one", "two", missing, "four"])
+    @test size(df7) == (4, 2)
+    @test df7[:x] ≅ [1, 2, missing, 4]
 
-        #test_group("ref")
-        @test df6[2, 3] == "two"
-        @test ismissing(df6[3, 3])
-        @test df6[2, :C] == "two"
-        @test df6[:B] ≅ [1, 2, missing, 4]
-        @test size(df6[[2,3]], 2) == 2
-        @test size(df6[2,:], 1) == ncol(df6) # this is a DataFrameRow
-        @test size(df6[2:2,:], 1) == 1
-        @test size(df6[[1, 3], [1, 3]]) == (2, 2)
-        @test size(df6[1:2, 1:2]) == (2, 2)
-        @test size(first(df6,2)) == (2, 3)
-        # lots more to do
+    #test_group("description functions")
+    @test size(df6, 1) == 4
+    @test size(df6, 2) == 3
+    @test names(df6) == [:A, :B, :C]
+    @test names(df2) == [:x1, :x2]
+    @test names(df7) == [:x, :y]
 
-        #test_group("assign")
-        df6[3] = ["un", "deux", "trois", "quatre"]
-        @test df6[1, 3] == "un"
-        df6[:B] = [4, 3, 2, 1]
-        @test df6[1,2] == 4
-        df6[:D] = [true, false, true, false]
-        @test df6[1,4]
-        deletecols!(df6, :D)
-        @test names(df6) == [:A, :B, :C]
-        @test size(df6, 2) == 3
+    #test_group("ref")
+    @test df6[2, 3] == "two"
+    @test ismissing(df6[3, 3])
+    @test df6[2, :C] == "two"
+    @test df6[:B] ≅ [1, 2, missing, 4]
+    @test size(df6[[2,3]], 2) == 2
+    @test size(df6[2,:], 1) == ncol(df6) # this is a DataFrameRow
+    @test size(df6[2:2,:], 1) == 1
+    @test size(df6[[1, 3], [1, 3]]) == (2, 2)
+    @test size(df6[1:2, 1:2]) == (2, 2)
+    @test size(first(df6,2)) == (2, 3)
+    # lots more to do
 
-        #test_group("missing handling")
-        @test df5[completecases(df5), :] == df5[[1, 2, 4], :]
-        @test dropmissing(df5) == df5[[1, 2, 4], :]
-        returned = dropmissing(df4)
+    #test_group("assign")
+    df6[3] = ["un", "deux", "trois", "quatre"]
+    @test df6[1, 3] == "un"
+    df6[:B] = [4, 3, 2, 1]
+    @test df6[1,2] == 4
+    df6[:D] = [true, false, true, false]
+    @test df6[1,4]
+    deletecols!(df6, :D)
+    @test names(df6) == [:A, :B, :C]
+    @test size(df6, 2) == 3
+
+    #test_group("missing handling")
+    @test df5[completecases(df5), :] == df5[[1, 2, 4], :]
+    @test dropmissing(df5) == df5[[1, 2, 4], :]
+    returned = dropmissing(df4)
+    @test df4 == returned && df4 !== returned
+    df5b = deepcopy(df5)
+    @test dropmissing!(df5b) === df5b
+    @test df5b == df5[[1, 2, 4], :]
+    df4b = deepcopy(df4)
+    @test dropmissing!(df4b) === df4b
+    @test df4b == df4
+
+    for cols in (:x2, [:x2], [:x1, :x2], 2, [2], 1:2, [true, true], [false, true])
+        @test df5[completecases(df5, cols), :] == df5[[1, 2, 4], :]
+        @test dropmissing(df5, cols) == df5[[1, 2, 4], :]
+        returned = dropmissing(df4, cols)
         @test df4 == returned && df4 !== returned
         df5b = deepcopy(df5)
-        @test dropmissing!(df5b) === df5b
+        @test dropmissing!(df5b, cols) === df5b
         @test df5b == df5[[1, 2, 4], :]
+        @test dropmissing(df5, cols) == df5b
+        @test df5 != df5b
         df4b = deepcopy(df4)
-        @test dropmissing!(df4b) === df4b
+        @test dropmissing!(df4b, cols) === df4b
         @test df4b == df4
-
-        for cols in (:x2, [:x2], [:x1, :x2], 2, [2], 1:2, [true, true], [false, true])
-            @test df5[completecases(df5, cols), :] == df5[[1, 2, 4], :]
-            @test dropmissing(df5, cols) == df5[[1, 2, 4], :]
-            returned = dropmissing(df4, cols)
-            @test df4 == returned && df4 !== returned
-            df5b = deepcopy(df5)
-            @test dropmissing!(df5b, cols) === df5b
-            @test df5b == df5[[1, 2, 4], :]
-            @test dropmissing(df5, cols) == df5b
-            @test df5 != df5b
-            df4b = deepcopy(df4)
-            @test dropmissing!(df4b, cols) === df4b
-            @test df4b == df4
-        end
-
-        df = DataFrame(a=[1, missing, 3])
-        sdf = view(df, :, :)
-        @test dropmissing(sdf) == DataFrame(a=[1, 3])
-        @test eltype(dropmissing(sdf, disallowmissing=false)[:a]) == Union{Int, Missing}
-        @test eltype(dropmissing(sdf, disallowmissing=true)[:a]) == Int
-         df2 = copy(df)
-        dropmissing!(df, disallowmissing=true)
-        dropmissing!(df2, disallowmissing=false)
-        @test eltype(df.a) == Int
-        @test eltype(df2.a) == Union{Int, Missing}
-
-        #test_context("SubDataFrames")
-
-        #test_group("constructors")
-        # single index is rows
-        sdf6a = view(df6, 1:1, :)
-        sdf6b = view(df6, 2:3, :)
-        sdf6c = view(df6, [true, false, true, false], :)
-        @test size(sdf6a) == (1,3)
-        sdf6d = view(df6, [1,3], [:B])
-        @test size(sdf6d) == (2,1)
-        sdf6e = view(df6, [0x01], :)
-        @test size(sdf6e) == (1,3)
-        sdf6f = view(df6, UInt64[1, 2], :)
-        @test size(sdf6f) == (2,3)
-        sdf6g = view(df6, [1,3], :B)
-        sdf6h = view(df6, 1, :B)
-        sdf6i = view(df6, 1, [:B])
-
-        #test_group("ref")
-        @test sdf6a[1,2] == 4
-
-        #test_context("Within")
-        #test_group("Associative")
-
-        #test_group("DataFrame")
-        Random.seed!(1)
-        N = 20
-        d1 = Vector{Union{Int64, Missing}}(rand(1:2, N))
-        d2 = CategoricalArray(["A", "B", missing])[rand(1:3, N)]
-        d3 = randn(N)
-        d4 = randn(N)
-        df7 = DataFrame([d1, d2, d3], [:d1, :d2, :d3])
-
-        #test_group("groupby")
-        gd = groupby(df7, :d1)
-        @test length(gd) == 2
-        @test gd[1][:, :d2] ≅ d2[d1 .== 1]
-        @test gd[2][:, :d2] ≅ d2[d1 .== 2]
-        @test gd[1][:, :d3] == d3[d1 .== 1]
-        @test gd[2][:, :d3] == d3[d1 .== 2]
-
-        g1 = groupby(df7, [:d1, :d2])
-        g2 = groupby(df7, [:d2, :d1])
-        @test g1[1][:, :d3] == g2[1][:, :d3]
-
-        res = 0.0
-        for x in g1
-            res += sum(x[:, :d1])
-        end
-        @test res == sum(df7[:d1])
-
-        @test aggregate(DataFrame(a=1), identity) == DataFrame(a_identity=1)
-
-        df8 = aggregate(df7[[1, 3]], sum)
-        @test df8[1, :d1_sum] == sum(df7[:d1])
-
-        df8 = aggregate(df7, :d2, [sum, length], sort=true)
-        @test df8[1:2, :d2] == ["A", "B"]
-        @test size(df8, 1) == 3
-        @test size(df8, 2) == 5
-        @test sum(df8[:d1_length]) == N
-        @test all(df8[:d1_length] .> 0)
-        @test df8[:d1_length] == [sum(isequal.(d2, "A")), sum(isequal.(d2, "B")), sum(ismissing.(d2))]
-        df8′ = aggregate(df7, 2, [sum, length], sort=true)
-        @test df8 ≅ df8′
-        adf = aggregate(groupby(df7, :d2, sort=true), [sum, length])
-        @test df8 ≅ adf
-        adf′ = aggregate(groupby(df7, 2, sort=true), [sum, length])
-        @test df8 ≅ adf′
-        adf = aggregate(groupby(df7, :d2), [sum, length], sort=true)
-        @test sort(df8, [:d1_sum, :d3_sum, :d1_length, :d3_length]) ≅ adf
-        adf′ = aggregate(groupby(df7, 2), [sum, length], sort=true)
-        @test adf ≅ adf′
-
-        # Check column names
-        anonf = x -> sum(x)
-        adf = aggregate(df7, :d2, [mean, anonf])
-        @test names(adf) == [:d2, :d1_mean, :d3_mean,
-                             :d1_function, :d3_function]
-        adf = aggregate(df7, :d2, [mean, mean, anonf, anonf])
-        @test names(adf) == [:d2, :d1_mean, :d3_mean, :d1_mean_1, :d3_mean_1,
-                             :d1_function, :d3_function, :d1_function_1, :d3_function_1]
-
-        df9 = aggregate(df7, :d2, [sum, length], sort=true)
-        @test df9 ≅ df8
-        df9′ = aggregate(df7, 2, [sum, length], sort=true)
-        @test df9′ ≅ df8
-
-        df10 = DataFrame([[1:4;], [2:5;],
-                          ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],
-                         [:d1, :d2, :d3, :d4])
-
-        gd = groupby(df10, [:d3], sort=true)
-        ggd = groupby(gd[1], [:d3, :d4], sort=true) # make sure we can groupby SubDataFrames
-        @test ggd[1][1, :d3] == "a"
-        @test ggd[1][1, :d4] == "c"
-        @test ggd[1][2, :d3] == "a"
-        @test ggd[1][2, :d4] == "c"
-        @test ggd[2][1, :d3] == "a"
-        @test ggd[2][1, :d4] == "d"
     end
 
-    @testset "reshape" begin
-        d1 = DataFrame(a = Array{Union{Int, Missing}}(repeat([1:3;], inner = [4])),
-                    b = Array{Union{Int, Missing}}(repeat([1:4;], inner = [3])),
-                    c = Array{Union{Float64, Missing}}(randn(12)),
-                    d = Array{Union{Float64, Missing}}(randn(12)),
-                    e = Array{Union{String, Missing}}(map(string, 'a':'l')))
+    df = DataFrame(a=[1, missing, 3])
+    sdf = view(df, :, :)
+    @test dropmissing(sdf) == DataFrame(a=[1, 3])
+    @test eltype(dropmissing(sdf, disallowmissing=false)[:a]) == Union{Int, Missing}
+    @test eltype(dropmissing(sdf, disallowmissing=true)[:a]) == Int
+     df2 = copy(df)
+    dropmissing!(df, disallowmissing=true)
+    dropmissing!(df2, disallowmissing=false)
+    @test eltype(df.a) == Int
+    @test eltype(df2.a) == Union{Int, Missing}
 
-        stack(d1, :a)
-        d1s = stack(d1, [:a, :b])
-        d1s2 = stack(d1, [:c, :d])
-        d1s3 = stack(d1)
-        d1m = melt(d1, [:c, :d, :e])
-        @test d1s[1:12, :c] == d1[:c]
-        @test d1s[13:24, :c] == d1[:c]
-        @test d1s2 == d1s3
-        @test names(d1s) == [:variable, :value, :c, :d, :e]
-        @test d1s == d1m
-        d1m = melt(d1[[1,3,4]], :a)
-        @test names(d1m) == [:variable, :value, :a]
+    #test_context("SubDataFrames")
 
-        # Test naming of measure/value columns
-        d1s_named = stack(d1, [:a, :b], variable_name=:letter, value_name=:someval)
-        @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
-        d1m_named = melt(d1[[1,3,4]], :a, variable_name=:letter, value_name=:someval)
-        @test names(d1m_named) == [:letter, :someval, :a]
+    #test_group("constructors")
+    # single index is rows
+    sdf6a = view(df6, 1:1, :)
+    sdf6b = view(df6, 2:3, :)
+    sdf6c = view(df6, [true, false, true, false], :)
+    @test size(sdf6a) == (1,3)
+    sdf6d = view(df6, [1,3], [:B])
+    @test size(sdf6d) == (2,1)
+    sdf6e = view(df6, [0x01], :)
+    @test size(sdf6e) == (1,3)
+    sdf6f = view(df6, UInt64[1, 2], :)
+    @test size(sdf6f) == (2,3)
+    sdf6g = view(df6, [1,3], :B)
+    sdf6h = view(df6, 1, :B)
+    sdf6i = view(df6, 1, [:B])
 
-        # test empty measures or ids
-        dx = stack(d1, [], [:a])
-        @test size(dx) == (0, 3)
-        @test names(dx) == [:variable, :value, :a]
-        dx = stack(d1, :a, [])
-        @test size(dx) == (12, 2)
-        @test names(dx) == [:variable, :value]
-        dx = melt(d1, [], [:a])
-        @test size(dx) == (12, 2)
-        @test names(dx) == [:variable, :value]
-        dx = melt(d1, :a, [])
-        @test size(dx) == (0, 3)
-        @test names(dx) == [:variable, :value, :a]
+    #test_group("ref")
+    @test sdf6a[1,2] == 4
 
-        @test stackdf(d1, :a) == stackdf(d1, [:a])
+    #test_context("Within")
+    #test_group("Associative")
 
-        # Tests of RepeatedVector and StackedVector indexing
-        d1s = stackdf(d1, [:a, :b])
-        @test d1s[1] isa DataFrames.RepeatedVector
-        @test ndims(d1s[1]) == 1
-        @test ndims(typeof(d1s[1])) == 1
-        @test d1s[2] isa DataFrames.StackedVector
-        @test ndims(d1s[2]) == 1
-        @test ndims(typeof(d1s[2])) == 1
-        @test d1s[1][[1,24]] == [:a, :b]
-        @test d1s[2][[1,24]] == [1, 4]
-        if VERSION >= v"1" # this was silently accepted pre Julia 1.0
-            @test_throws ArgumentError d1s[1][true]
-            @test_throws ArgumentError d1s[2][true]
-        end
-        @test_throws ArgumentError d1s[1][1.0]
-        @test_throws ArgumentError d1s[2][1.0]
-
-        # Those tests check indexing RepeatedVector/StackedVector by a vector
-        @test d1s[1][trues(24)] == d1s[1]
-        @test d1s[2][trues(24)] == d1s[2]
-        @test d1s[1][:] == d1s[1]
-        @test d1s[2][:] == d1s[2]
-        @test d1s[1][1:24] == d1s[1]
-        @test d1s[2][1:24] == d1s[2]
-        @test [d1s[1][1:12]; d1s[1][13:24]] == d1s[1]
-        @test [d1s[2][1:12]; d1s[2][13:24]] == d1s[2]
-
-        d1s2 = stackdf(d1, [:c, :d])
-        d1s3 = stackdf(d1)
-        d1m = meltdf(d1, [:c, :d, :e])
-        @test d1s[1:12, :c] == d1[:c]
-        @test d1s[13:24, :c] == d1[:c]
-        @test d1s2 == d1s3
-        @test names(d1s) == [:variable, :value, :c, :d, :e]
-        @test d1s == d1m
-        d1m = meltdf(d1[[1,3,4]], :a)
-        @test names(d1m) == [:variable, :value, :a]
-
-        d1s_named = stackdf(d1, [:a, :b], variable_name=:letter, value_name=:someval)
-        @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
-        d1m_named = meltdf(d1, [:c, :d, :e], variable_name=:letter, value_name=:someval)
-        @test names(d1m_named) == [:letter, :someval, :c, :d, :e]
-
-        d1s[:id] = Union{Int, Missing}[1:12; 1:12]
-        d1s2[:id] =  Union{Int, Missing}[1:12; 1:12]
-        d1us = unstack(d1s, :id, :variable, :value)
-        d1us2 = unstack(d1s2, :id, :variable, :value)
-        d1us3 = unstack(d1s2, :variable, :value)
-        @test d1us[:a] == d1[:a]
-        @test d1us2[:d] == d1[:d]
-        @test d1us2[3] == d1[:d]
-        @test d1us3[:d] == d1[:d]
-        @test d1us3 == unstack(d1s2)
-
-        # test unstack with exactly one key column that is not passed
-        df1 = melt(DataFrame(rand(10,10)))
-        df1[:id] = 1:100
-        @test size(unstack(df1, :variable, :value)) == (100, 11)
-        @test unstack(df1, :variable, :value) ≅ unstack(df1)
-
-        # test empty keycol
-        @test_throws ArgumentError unstack(melt(DataFrame(rand(3,2))), :variable, :value)
-    end
-
-    @testset "merge" begin
-        Random.seed!(1)
-        df1 = DataFrame(a = shuffle!(Vector{Union{Int, Missing}}(1:10)),
-                        b = rand(Union{Symbol, Missing}[:A,:B], 10),
-                        v1 = Vector{Union{Float64, Missing}}(randn(10)))
-
-        df2 = DataFrame(a = shuffle!(Vector{Union{Int, Missing}}(1:5)),
-                        b2 = rand(Union{Symbol, Missing}[:A,:B,:C], 5),
-                        v2 = Vector{Union{Float64, Missing}}(randn(5)))
-
-        m1 = join(df1, df2, on = :a, kind=:inner)
-        @test m1[:a] == df1[:a][df1[:a] .<= 5] # preserves df1 order
-        m2 = join(df1, df2, on = :a, kind = :outer)
-        @test m2[:a] == df1[:a] # preserves df1 order
-        @test m2[:b] == df1[:b] # preserves df1 order
-        @test m2[indexin(df1[:a], m2[:a]), :b] == df1[:b]
-        @test m2[indexin(df2[:a], m2[:a]), :b2] == df2[:b2]
-        @test m2[indexin(df1[:a], m2[:a]), :v1] == df1[:v1]
-        @test m2[indexin(df2[:a], m2[:a]), :v2] == df2[:v2]
-        @test all(ismissing, m2[map(x -> !in(x, df2[:a]), m2[:a]), :b2])
-        @test all(ismissing, m2[map(x -> !in(x, df2[:a]), m2[:a]), :v2])
-
-        df1 = DataFrame(a = Union{Int, Missing}[1, 2, 3],
-                        b = Union{String, Missing}["America", "Europe", "Africa"])
-        df2 = DataFrame(a = Union{Int, Missing}[1, 2, 4],
-                        c = Union{String, Missing}["New World", "Old World", "New World"])
-
-        m1 = join(df1, df2, on = :a, kind = :inner)
-        @test m1[:a] == [1, 2]
-
-        m2 = join(df1, df2, on = :a, kind = :left)
-        @test m2[:a] == [1, 2, 3]
-
-        m3 = join(df1, df2, on = :a, kind = :right)
-        @test m3[:a] == [1, 2, 4]
-
-        m4 = join(df1, df2, on = :a, kind = :outer)
-        @test m4[:a] == [1, 2, 3, 4]
-
-        # test with missings (issue #185)
-        df1 = DataFrame()
-        df1[:A] = ["a", "b", "a", missing]
-        df1[:B] = Union{Int, Missing}[1, 2, 1, 3]
-
-        df2 = DataFrame()
-        df2[:A] = ["a", missing, "c"]
-        df2[:C] = Union{Int, Missing}[1, 2, 4]
-
-        m1 = join(df1, df2, on = :A)
-        @test size(m1) == (3,3)
-        @test m1[:A] ≅ ["a","a", missing]
-
-        m2 = join(df1, df2, on = :A, kind = :outer)
-        @test size(m2) == (5,3)
-        @test m2[:A] ≅ ["a", "b", "a", missing, "c"]
-    end
-
+    #test_group("DataFrame")
     Random.seed!(1)
-    df1 = DataFrame(
-        a = rand(Union{Symbol, Missing}[:x,:y], 10),
-        b = rand(Union{Symbol, Missing}[:A,:B], 10),
-        v1 = Vector{Union{Float64, Missing}}(randn(10))
-    )
+    N = 20
+    d1 = Vector{Union{Int64, Missing}}(rand(1:2, N))
+    d2 = CategoricalArray(["A", "B", missing])[rand(1:3, N)]
+    d3 = randn(N)
+    d4 = randn(N)
+    df7 = DataFrame([d1, d2, d3], [:d1, :d2, :d3])
 
-    df2 = DataFrame(
-        a = Union{Symbol, Missing}[:x,:y][[1,2,1,1,2]],
-        b = Union{Symbol, Missing}[:A,:B,:C][[1,1,1,2,3]],
-        v2 = Vector{Union{Float64, Missing}}(randn(5))
-    )
-    df2[1,:a] = missing
+    #test_group("groupby")
+    gd = groupby(df7, :d1)
+    @test length(gd) == 2
+    @test gd[1][:, :d2] ≅ d2[d1 .== 1]
+    @test gd[2][:, :d2] ≅ d2[d1 .== 2]
+    @test gd[1][:, :d3] == d3[d1 .== 1]
+    @test gd[2][:, :d3] == d3[d1 .== 2]
 
-    m1 = join(df1, df2, on = [:a,:b])
-    @test m1[:a] == Union{Missing, Symbol}[:x, :x, :y, :y, :y, :x, :x, :x]
-    m2 = join(df1, df2, on = [:a,:b], kind = :outer)
-    @test ismissing(m2[10,:v2])
-    @test m2[:a] ≅ [:x, :x, :y, :y, :y, :x, :x, :y, :x, :y, missing, :y]
+    g1 = groupby(df7, [:d1, :d2])
+    g2 = groupby(df7, [:d2, :d1])
+    @test g1[1][:, :d3] == g2[1][:, :d3]
 
-    Random.seed!(1)
-    function spltdf(d)
-        d[:x1] = map(x -> x[1], d[:a])
-        d[:x2] = map(x -> x[2], d[:a])
-        d[:x3] = map(x -> x[3], d[:a])
-        d
+    res = 0.0
+    for x in g1
+        res += sum(x[:, :d1])
     end
-    df1 = DataFrame(
-        a = ["abc", "abx", "axz", "def", "dfr"],
-        v1 = randn(5)
-    )
-    df1 = spltdf(df1)
-    df2 = DataFrame(
-        a = ["def", "abc","abx", "axz", "xyz"],
-        v2 = randn(5)
-    )
-    df2 = spltdf(df2)
+    @test res == sum(df7[:d1])
 
-    m1 = join(df1, df2, on = :a, makeunique=true)
-    m2 = join(df1, df2, on = [:x1, :x2, :x3], makeunique=true)
-    @test sort(m1[:a]) == sort(m2[:a])
+    @test aggregate(DataFrame(a=1), identity) == DataFrame(a_identity=1)
 
-    # test nonunique() with extra argument
-    df1 = DataFrame(a = Union{String, Missing}["a", "b", "a", "b", "a", "b"],
-                    b = Vector{Union{Int, Missing}}(1:6),
-                    c = Union{Int, Missing}[1:3;1:3])
-    df = vcat(df1, df1)
-    @test findall(nonunique(df)) == collect(7:12)
-    @test findall(nonunique(df, :)) == collect(7:12)
-    @test findall(nonunique(df, Colon())) == collect(7:12)
-    @test findall(nonunique(df, :a)) == collect(3:12)
-    @test findall(nonunique(df, [:a, :c])) == collect(7:12)
-    @test findall(nonunique(df, [1, 3])) == collect(7:12)
-    @test findall(nonunique(df, 1)) == collect(3:12)
+    df8 = aggregate(df7[[1, 3]], sum)
+    @test df8[1, :d1_sum] == sum(df7[:d1])
 
-    # Test unique() with extra argument
-    @test unique(df) == df1
-    @test unique(df, :) == df1
-    @test unique(df, Colon()) == df1
-    @test unique(df, 2:3) == df1
-    @test unique(df, 3) == df1[1:3,:]
-    @test unique(df, [1, 3]) == df1
-    @test unique(df, [:a, :c]) == df1
-    @test unique(df, :a) == df1[1:2,:]
+    df8 = aggregate(df7, :d2, [sum, length], sort=true)
+    @test df8[1:2, :d2] == ["A", "B"]
+    @test size(df8, 1) == 3
+    @test size(df8, 2) == 5
+    @test sum(df8[:d1_length]) == N
+    @test all(df8[:d1_length] .> 0)
+    @test df8[:d1_length] == [sum(isequal.(d2, "A")), sum(isequal.(d2, "B")), sum(ismissing.(d2))]
+    df8′ = aggregate(df7, 2, [sum, length], sort=true)
+    @test df8 ≅ df8′
+    adf = aggregate(groupby(df7, :d2, sort=true), [sum, length])
+    @test df8 ≅ adf
+    adf′ = aggregate(groupby(df7, 2, sort=true), [sum, length])
+    @test df8 ≅ adf′
+    adf = aggregate(groupby(df7, :d2), [sum, length], sort=true)
+    @test sort(df8, [:d1_sum, :d3_sum, :d1_length, :d3_length]) ≅ adf
+    adf′ = aggregate(groupby(df7, 2), [sum, length], sort=true)
+    @test adf ≅ adf′
 
-    #test unique!() with extra argument
-    unique!(df, [1, 3])
-    @test df == df1
+    # Check column names
+    anonf = x -> sum(x)
+    adf = aggregate(df7, :d2, [mean, anonf])
+    @test names(adf) == [:d2, :d1_mean, :d3_mean,
+                         :d1_function, :d3_function]
+    adf = aggregate(df7, :d2, [mean, mean, anonf, anonf])
+    @test names(adf) == [:d2, :d1_mean, :d3_mean, :d1_mean_1, :d3_mean_1,
+                         :d1_function, :d3_function, :d1_function_1, :d3_function_1]
 
-    #test filter() and filter!()
-    df = DataFrame(x = [3, 1, 2, 1], y = ["b", "c", "a", "b"])
-    @test filter(r -> r[:x] > 1, df) == DataFrame(x = [3, 2], y = ["b", "a"])
-    @test filter!(r -> r[:x] > 1, df) === df == DataFrame(x = [3, 2], y = ["b", "a"])
-    df = DataFrame(x = [3, 1, 2, 1, missing], y = ["b", "c", "a", "b", "c"])
-    @test_throws TypeError filter(r -> r[:x] > 1, df)
-    @test_throws TypeError filter!(r -> r[:x] > 1, df)
+    df9 = aggregate(df7, :d2, [sum, length], sort=true)
+    @test df9 ≅ df8
+    df9′ = aggregate(df7, 2, [sum, length], sort=true)
+    @test df9′ ≅ df8
+
+    df10 = DataFrame([[1:4;], [2:5;],
+                      ["a", "a", "a", "b" ], ["c", "d", "c", "d"]],
+                     [:d1, :d2, :d3, :d4])
+
+    gd = groupby(df10, [:d3], sort=true)
+    ggd = groupby(gd[1], [:d3, :d4], sort=true) # make sure we can groupby SubDataFrames
+    @test ggd[1][1, :d3] == "a"
+    @test ggd[1][1, :d4] == "c"
+    @test ggd[1][2, :d3] == "a"
+    @test ggd[1][2, :d4] == "c"
+    @test ggd[2][1, :d3] == "a"
+    @test ggd[2][1, :d4] == "d"
 end
+
+@testset "reshape" begin
+    d1 = DataFrame(a = Array{Union{Int, Missing}}(repeat([1:3;], inner = [4])),
+                b = Array{Union{Int, Missing}}(repeat([1:4;], inner = [3])),
+                c = Array{Union{Float64, Missing}}(randn(12)),
+                d = Array{Union{Float64, Missing}}(randn(12)),
+                e = Array{Union{String, Missing}}(map(string, 'a':'l')))
+
+    stack(d1, :a)
+    d1s = stack(d1, [:a, :b])
+    d1s2 = stack(d1, [:c, :d])
+    d1s3 = stack(d1)
+    d1m = melt(d1, [:c, :d, :e])
+    @test d1s[1:12, :c] == d1[:c]
+    @test d1s[13:24, :c] == d1[:c]
+    @test d1s2 == d1s3
+    @test names(d1s) == [:variable, :value, :c, :d, :e]
+    @test d1s == d1m
+    d1m = melt(d1[[1,3,4]], :a)
+    @test names(d1m) == [:variable, :value, :a]
+
+    # Test naming of measure/value columns
+    d1s_named = stack(d1, [:a, :b], variable_name=:letter, value_name=:someval)
+    @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
+    d1m_named = melt(d1[[1,3,4]], :a, variable_name=:letter, value_name=:someval)
+    @test names(d1m_named) == [:letter, :someval, :a]
+
+    # test empty measures or ids
+    dx = stack(d1, [], [:a])
+    @test size(dx) == (0, 3)
+    @test names(dx) == [:variable, :value, :a]
+    dx = stack(d1, :a, [])
+    @test size(dx) == (12, 2)
+    @test names(dx) == [:variable, :value]
+    dx = melt(d1, [], [:a])
+    @test size(dx) == (12, 2)
+    @test names(dx) == [:variable, :value]
+    dx = melt(d1, :a, [])
+    @test size(dx) == (0, 3)
+    @test names(dx) == [:variable, :value, :a]
+
+    @test stackdf(d1, :a) == stackdf(d1, [:a])
+
+    # Tests of RepeatedVector and StackedVector indexing
+    d1s = stackdf(d1, [:a, :b])
+    @test d1s[1] isa DataFrames.RepeatedVector
+    @test ndims(d1s[1]) == 1
+    @test ndims(typeof(d1s[1])) == 1
+    @test d1s[2] isa DataFrames.StackedVector
+    @test ndims(d1s[2]) == 1
+    @test ndims(typeof(d1s[2])) == 1
+    @test d1s[1][[1,24]] == [:a, :b]
+    @test d1s[2][[1,24]] == [1, 4]
+    if VERSION >= v"1" # this was silently accepted pre Julia 1.0
+        @test_throws ArgumentError d1s[1][true]
+        @test_throws ArgumentError d1s[2][true]
+    end
+    @test_throws ArgumentError d1s[1][1.0]
+    @test_throws ArgumentError d1s[2][1.0]
+
+    # Those tests check indexing RepeatedVector/StackedVector by a vector
+    @test d1s[1][trues(24)] == d1s[1]
+    @test d1s[2][trues(24)] == d1s[2]
+    @test d1s[1][:] == d1s[1]
+    @test d1s[2][:] == d1s[2]
+    @test d1s[1][1:24] == d1s[1]
+    @test d1s[2][1:24] == d1s[2]
+    @test [d1s[1][1:12]; d1s[1][13:24]] == d1s[1]
+    @test [d1s[2][1:12]; d1s[2][13:24]] == d1s[2]
+
+    d1s2 = stackdf(d1, [:c, :d])
+    d1s3 = stackdf(d1)
+    d1m = meltdf(d1, [:c, :d, :e])
+    @test d1s[1:12, :c] == d1[:c]
+    @test d1s[13:24, :c] == d1[:c]
+    @test d1s2 == d1s3
+    @test names(d1s) == [:variable, :value, :c, :d, :e]
+    @test d1s == d1m
+    d1m = meltdf(d1[[1,3,4]], :a)
+    @test names(d1m) == [:variable, :value, :a]
+
+    d1s_named = stackdf(d1, [:a, :b], variable_name=:letter, value_name=:someval)
+    @test names(d1s_named) == [:letter, :someval, :c, :d, :e]
+    d1m_named = meltdf(d1, [:c, :d, :e], variable_name=:letter, value_name=:someval)
+    @test names(d1m_named) == [:letter, :someval, :c, :d, :e]
+
+    d1s[:id] = Union{Int, Missing}[1:12; 1:12]
+    d1s2[:id] =  Union{Int, Missing}[1:12; 1:12]
+    d1us = unstack(d1s, :id, :variable, :value)
+    d1us2 = unstack(d1s2, :id, :variable, :value)
+    d1us3 = unstack(d1s2, :variable, :value)
+    @test d1us[:a] == d1[:a]
+    @test d1us2[:d] == d1[:d]
+    @test d1us2[3] == d1[:d]
+    @test d1us3[:d] == d1[:d]
+    @test d1us3 == unstack(d1s2)
+
+    # test unstack with exactly one key column that is not passed
+    df1 = melt(DataFrame(rand(10,10)))
+    df1[:id] = 1:100
+    @test size(unstack(df1, :variable, :value)) == (100, 11)
+    @test unstack(df1, :variable, :value) ≅ unstack(df1)
+
+    # test empty keycol
+    @test_throws ArgumentError unstack(melt(DataFrame(rand(3,2))), :variable, :value)
+end
+
+@testset "merge" begin
+    Random.seed!(1)
+    df1 = DataFrame(a = shuffle!(Vector{Union{Int, Missing}}(1:10)),
+                    b = rand(Union{Symbol, Missing}[:A,:B], 10),
+                    v1 = Vector{Union{Float64, Missing}}(randn(10)))
+
+    df2 = DataFrame(a = shuffle!(Vector{Union{Int, Missing}}(1:5)),
+                    b2 = rand(Union{Symbol, Missing}[:A,:B,:C], 5),
+                    v2 = Vector{Union{Float64, Missing}}(randn(5)))
+
+    m1 = join(df1, df2, on = :a, kind=:inner)
+    @test m1[:a] == df1[:a][df1[:a] .<= 5] # preserves df1 order
+    m2 = join(df1, df2, on = :a, kind = :outer)
+    @test m2[:a] == df1[:a] # preserves df1 order
+    @test m2[:b] == df1[:b] # preserves df1 order
+    @test m2[indexin(df1[:a], m2[:a]), :b] == df1[:b]
+    @test m2[indexin(df2[:a], m2[:a]), :b2] == df2[:b2]
+    @test m2[indexin(df1[:a], m2[:a]), :v1] == df1[:v1]
+    @test m2[indexin(df2[:a], m2[:a]), :v2] == df2[:v2]
+    @test all(ismissing, m2[map(x -> !in(x, df2[:a]), m2[:a]), :b2])
+    @test all(ismissing, m2[map(x -> !in(x, df2[:a]), m2[:a]), :v2])
+
+    df1 = DataFrame(a = Union{Int, Missing}[1, 2, 3],
+                    b = Union{String, Missing}["America", "Europe", "Africa"])
+    df2 = DataFrame(a = Union{Int, Missing}[1, 2, 4],
+                    c = Union{String, Missing}["New World", "Old World", "New World"])
+
+    m1 = join(df1, df2, on = :a, kind = :inner)
+    @test m1[:a] == [1, 2]
+
+    m2 = join(df1, df2, on = :a, kind = :left)
+    @test m2[:a] == [1, 2, 3]
+
+    m3 = join(df1, df2, on = :a, kind = :right)
+    @test m3[:a] == [1, 2, 4]
+
+    m4 = join(df1, df2, on = :a, kind = :outer)
+    @test m4[:a] == [1, 2, 3, 4]
+
+    # test with missings (issue #185)
+    df1 = DataFrame()
+    df1[:A] = ["a", "b", "a", missing]
+    df1[:B] = Union{Int, Missing}[1, 2, 1, 3]
+
+    df2 = DataFrame()
+    df2[:A] = ["a", missing, "c"]
+    df2[:C] = Union{Int, Missing}[1, 2, 4]
+
+    m1 = join(df1, df2, on = :A)
+    @test size(m1) == (3,3)
+    @test m1[:A] ≅ ["a","a", missing]
+
+    m2 = join(df1, df2, on = :A, kind = :outer)
+    @test size(m2) == (5,3)
+    @test m2[:A] ≅ ["a", "b", "a", missing, "c"]
+end
+
+Random.seed!(1)
+df1 = DataFrame(
+    a = rand(Union{Symbol, Missing}[:x,:y], 10),
+    b = rand(Union{Symbol, Missing}[:A,:B], 10),
+    v1 = Vector{Union{Float64, Missing}}(randn(10))
+)
+
+df2 = DataFrame(
+    a = Union{Symbol, Missing}[:x,:y][[1,2,1,1,2]],
+    b = Union{Symbol, Missing}[:A,:B,:C][[1,1,1,2,3]],
+    v2 = Vector{Union{Float64, Missing}}(randn(5))
+)
+df2[1,:a] = missing
+
+m1 = join(df1, df2, on = [:a,:b])
+@test m1[:a] == Union{Missing, Symbol}[:x, :x, :y, :y, :y, :x, :x, :x]
+m2 = join(df1, df2, on = [:a,:b], kind = :outer)
+@test ismissing(m2[10,:v2])
+@test m2[:a] ≅ [:x, :x, :y, :y, :y, :x, :x, :y, :x, :y, missing, :y]
+
+Random.seed!(1)
+function spltdf(d)
+    d[:x1] = map(x -> x[1], d[:a])
+    d[:x2] = map(x -> x[2], d[:a])
+    d[:x3] = map(x -> x[3], d[:a])
+    d
+end
+df1 = DataFrame(
+    a = ["abc", "abx", "axz", "def", "dfr"],
+    v1 = randn(5)
+)
+df1 = spltdf(df1)
+df2 = DataFrame(
+    a = ["def", "abc","abx", "axz", "xyz"],
+    v2 = randn(5)
+)
+df2 = spltdf(df2)
+
+m1 = join(df1, df2, on = :a, makeunique=true)
+m2 = join(df1, df2, on = [:x1, :x2, :x3], makeunique=true)
+@test sort(m1[:a]) == sort(m2[:a])
+
+# test nonunique() with extra argument
+df1 = DataFrame(a = Union{String, Missing}["a", "b", "a", "b", "a", "b"],
+                b = Vector{Union{Int, Missing}}(1:6),
+                c = Union{Int, Missing}[1:3;1:3])
+df = vcat(df1, df1)
+@test findall(nonunique(df)) == collect(7:12)
+@test findall(nonunique(df, :)) == collect(7:12)
+@test findall(nonunique(df, Colon())) == collect(7:12)
+@test findall(nonunique(df, :a)) == collect(3:12)
+@test findall(nonunique(df, [:a, :c])) == collect(7:12)
+@test findall(nonunique(df, [1, 3])) == collect(7:12)
+@test findall(nonunique(df, 1)) == collect(3:12)
+
+# Test unique() with extra argument
+@test unique(df) == df1
+@test unique(df, :) == df1
+@test unique(df, Colon()) == df1
+@test unique(df, 2:3) == df1
+@test unique(df, 3) == df1[1:3,:]
+@test unique(df, [1, 3]) == df1
+@test unique(df, [:a, :c]) == df1
+@test unique(df, :a) == df1[1:2,:]
+
+#test unique!() with extra argument
+unique!(df, [1, 3])
+@test df == df1
+
+#test filter() and filter!()
+df = DataFrame(x = [3, 1, 2, 1], y = ["b", "c", "a", "b"])
+@test filter(r -> r[:x] > 1, df) == DataFrame(x = [3, 2], y = ["b", "a"])
+@test filter!(r -> r[:x] > 1, df) === df == DataFrame(x = [3, 2], y = ["b", "a"])
+df = DataFrame(x = [3, 1, 2, 1, missing], y = ["b", "c", "a", "b", "c"])
+@test_throws TypeError filter(r -> r[:x] > 1, df)
+@test_throws TypeError filter!(r -> r[:x] > 1, df)
+
+end # module

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1,999 +1,1001 @@
 module TestDataFrame
-    using Dates, DataFrames, LinearAlgebra, Statistics, Random, Test
-    using DataFrames: _columns
-    using DataFrames: columns
-    const ≅ = isequal
-    const ≇ = !isequal
 
-    @testset "equality" begin
-        @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) == DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-        @test DataFrame(a=[1, 2], b=[4, 5]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-        @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3])
-        @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], c=[4, 5, 6])
-        @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(b=[4, 5, 6], a=[1, 2, 3])
-        @test DataFrame(a=[1, 2, 2], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-        @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≅
-                    DataFrame(a=[1, 2, missing], b=[4, 5, 6])
+using Dates, DataFrames, LinearAlgebra, Statistics, Random, Test
+using DataFrames: _columns
+using DataFrames: columns
+const ≅ = isequal
+const ≇ = !isequal
 
-        @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) == DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-        @test DataFrame(a=[1, 2], b=[4, 5]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-        @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3])
-        @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], c=[4, 5, 6])
-        @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(b=[4, 5, 6], a=[1, 2, 3])
-        @test DataFrame(a=[1, 2, 2], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-        @test DataFrame(a=[1, 3, missing], b=[4, 5, 6]) !=
+@testset "equality" begin
+    @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) == DataFrame(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2], b=[4, 5]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3])
+    @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], c=[4, 5, 6])
+    @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(b=[4, 5, 6], a=[1, 2, 3])
+    @test DataFrame(a=[1, 2, 2], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≅
                 DataFrame(a=[1, 2, missing], b=[4, 5, 6])
-        @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≅
-                    DataFrame(a=[1, 2, missing], b=[4, 5, 6])
-        @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≇
-                    DataFrame(a=[1, 2, 3], b=[4, 5, 6])
-    end
-
-    @testset "copying" begin
-        df = DataFrame(a = Union{Int, Missing}[2, 3],
-                    b = Union{DataFrame, Missing}[DataFrame(c = 1), DataFrame(d = 2)])
-        dfc = copy(df)
-        dfdc = deepcopy(df)
-
-        df[1, :a] = 4
-        df[1, :b][:e] = 5
-        names!(df, [:f, :g])
-
-        @test names(dfc) == [:a, :b]
-        @test names(dfdc) == [:a, :b]
-
-        @test dfc[1, :a] === 4
-        @test dfdc[1, :a] === 2
-
-        @test names(dfc[1, :b]) == [:c, :e]
-        @test names(dfdc[1, :b]) == [:c]
-
-        x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])
-
-        #test_group("DataFrame assignment")
-        # Insert single column
-        x0 = x[Int[], :]
-        @test_throws ArgumentError x0[:d] = [1]
-        @test_throws ArgumentError x0[:d] = 1:3
-
-        # Insert single value
-        x[:d] = 3
-        @test x[:d] == [3, 3, 3]
-
-        x0[:d] = 3
-        @test x0[:d] == Int[]
-    end
-
-    @testset "similar / missings" begin
-        df = DataFrame(a = Union{Int, Missing}[1],
-                    b = Union{String, Missing}["b"],
-                    c = CategoricalArray{Union{Float64, Missing}}([3.3]))
-        missingdf = DataFrame(a = missings(Int, 2),
-                            b = missings(String, 2),
-                            c = CategoricalArray{Union{Float64, Missing}}(undef, 2))
-        # https://github.com/JuliaData/Missings.jl/issues/66
-        # @test missingdf ≅ similar(df, 2)
-        @test typeof.(columns(similar(df, 2))) == typeof.(columns(missingdf))
-        @test size(similar(df, 2)) == size(missingdf)
-    end
-
-    @testset "Associative methods" begin
-        df = DataFrame(a=[1, 2], b=[3.0, 4.0])
-        @test haskey(df, :a)
-        @test !haskey(df, :c)
-        @test haskey(df, 1)
-        @test_throws MethodError haskey(df, 1.5)
-        @test_throws ArgumentError haskey(df, true)
-        @test get(df, :a, -1) === columns(df)[1]
-        @test get(df, :c, -1) == -1
-        @test !isempty(df)
-
-        dfv = view(df, 1:2, 1:2)
-        @test get(df, :a, -1) === columns(df)[1]
-
-        @test empty!(df) === df
-        @test isempty(columns(df))
-        @test isempty(df)
-        @test isempty(DataFrame(a=[], b=[]))
-
-        df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
-        @test_throws BoundsError insertcols!(df, 5, :newcol => ["a", "b"], )
-        @test_throws ErrorException insertcols!(df, 1, :newcol => ["a"])
-        @test insertcols!(df, 1, :newcol => ["a", "b"]) == df
-        @test names(df) == [:newcol, :a, :b]
-        @test df[:a] == [1, 2]
-        @test df[:b] == [3.0, 4.0]
-        @test df[:newcol] == ["a", "b"]
-
-        @test insertcols!(df, 1, :newcol => ["a1", "b1"], makeunique=true) == df
-        @test names(df) == [:newcol_1, :newcol, :a, :b]
-        @test df[:a] == [1, 2]
-        @test df[:b] == [3.0, 4.0]
-        @test df[:newcol] == ["a", "b"]
-        @test df[:newcol_1] == ["a1", "b1"]
-
-        df = DataFrame(a=[1,2], a_1=[3,4])
-        @test_throws ArgumentError insertcols!(df, 1, :a => [11,12])
-        df = DataFrame(a=[1,2], a_1=[3,4])
-        insertcols!(df, 1, :a => [11,12], makeunique=true)
-        @test names(df) == [:a_2, :a, :a_1]
-        insertcols!(df, 4, :a => [11,12], makeunique=true)
-        @test names(df) == [:a_2, :a, :a_1, :a_3]
-        @test_throws BoundsError insertcols!(df, 10, :a => [11,12], makeunique=true)
-        df = DataFrame(a=[1,2], a_1=[3,4])
-        insertcols!(df, 1, :a => 11, makeunique=true)
-        @test names(df) == [:a_2, :a, :a_1]
-        insertcols!(df, 4, :a => 11, makeunique=true)
-        @test names(df) == [:a_2, :a, :a_1, :a_3]
-        @test_throws BoundsError insertcols!(df, 10, :a => 11, makeunique=true)
-
-        df = DataFrame(x = 1:2)
-        @test insertcols!(df, 2, y=2:3) == DataFrame(x=1:2, y=2:3)
-        @test_throws ArgumentError insertcols!(df, 2)
-        @test_throws ArgumentError insertcols!(df, 2, a=1, b=2)
-
-        df = DataFrame()
-        @test insertcols!(df, 1, x=[1]) == DataFrame(x = [1])
-    end
-
-    @testset "DataFrame constructors" begin
-        df = DataFrame(Union{Int, Missing}, 10, 3)
-        @test size(df, 1) == 10
-        @test size(df, 2) == 3
-        @test typeof(df[1]) == Vector{Union{Int, Missing}}
-        @test typeof(df[2]) == Vector{Union{Int, Missing}}
-        @test typeof(df[3]) == Vector{Union{Int, Missing}}
-        @test all(ismissing, df[1])
-        @test all(ismissing, df[2])
-        @test all(ismissing, df[3])
-        @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
-        @test typeof(df[:, 2]) == Vector{Union{Int, Missing}}
-        @test typeof(df[:, 3]) == Vector{Union{Int, Missing}}
-        @test all(ismissing, df[:, 1])
-        @test all(ismissing, df[:, 2])
-        @test all(ismissing, df[:, 3])
-
-        df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}], 100)
-        @test size(df, 1) == 100
-        @test size(df, 2) == 3
-        @test typeof(df[1]) == Vector{Union{Int, Missing}}
-        @test typeof(df[2]) == Vector{Union{Float64, Missing}}
-        @test typeof(df[3]) == Vector{Union{String, Missing}}
-        @test all(ismissing, df[1])
-        @test all(ismissing, df[2])
-        @test all(ismissing, df[3])
-        @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
-        @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
-        @test typeof(df[:, 3]) == Vector{Union{String, Missing}}
-        @test all(ismissing, df[:, 1])
-        @test all(ismissing, df[:, 2])
-        @test all(ismissing, df[:, 3])
-
-        df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}],
-                    [:A, :B, :C], 100)
-        @test size(df, 1) == 100
-        @test size(df, 2) == 3
-        @test typeof(df[1]) == Vector{Union{Int, Missing}}
-        @test typeof(df[2]) == Vector{Union{Float64, Missing}}
-        @test typeof(df[3]) == Vector{Union{String, Missing}}
-        @test all(ismissing, df[1])
-        @test all(ismissing, df[2])
-        @test all(ismissing, df[3])
-        @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
-        @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
-        @test typeof(df[:, 3]) == Vector{Union{String, Missing}}
-        @test all(ismissing, df[:, 1])
-        @test all(ismissing, df[:, 2])
-        @test all(ismissing, df[:, 3])
-
-        df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}],
-                    [:A, :B, :C], [false, false, true], 100)
-        @test size(df, 1) == 100
-        @test size(df, 2) == 3
-        @test typeof(df[1]) == Vector{Union{Int, Missing}}
-        @test typeof(df[2]) == Vector{Union{Float64, Missing}}
-        @test typeof(df[3]) <: CategoricalVector{Union{String, Missing}}
-        @test all(ismissing, df[1])
-        @test all(ismissing, df[2])
-        @test all(ismissing, df[3])
-        @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
-        @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
-        @test typeof(df[:, 3]) <: CategoricalVector{Union{String, Missing}}
-        @test all(ismissing, df[:, 1])
-        @test all(ismissing, df[:, 2])
-        @test all(ismissing, df[:, 3])
-
-        df = convert(DataFrame, zeros(10, 5))
-        @test size(df, 1) == 10
-        @test size(df, 2) == 5
-        @test typeof(df[1]) == Vector{Float64}
-        @test typeof(df[:, 1]) == Vector{Float64}
-
-        df = convert(DataFrame, ones(10, 5))
-        @test size(df, 1) == 10
-        @test size(df, 2) == 5
-        @test typeof(df[1]) == Vector{Float64}
-        @test typeof(df[:, 1]) == Vector{Float64}
-
-        df = convert(DataFrame, Matrix{Float64}(undef, 10, 5))
-        @test size(df, 1) == 10
-        @test size(df, 2) == 5
-        @test typeof(df[1]) == Vector{Float64}
-        @test typeof(df[:, 1]) == Vector{Float64}
-
-        @test DataFrame([Union{Int, Missing}[1, 2, 3], Union{Float64, Missing}[2.5, 4.5, 6.5]],
-                        [:A, :B]) ==
-            DataFrame(A = Union{Int, Missing}[1, 2, 3], B = Union{Float64, Missing}[2.5, 4.5, 6.5])
-
-        # This assignment was missing before
-        df = DataFrame(Column = [:A])
-        df[1, :Column] = :Testing
-
-        # zero-row DataFrame and subDataFrame test
-        df = DataFrame(x=[], y=[])
-        @test nrow(df) == 0
-        df = DataFrame(x=[1:3;], y=[3:5;])
-        sdf = view(df, df[:x] .== 4, :)
-        @test size(sdf, 1) == 0
-
-        # Test that vector type is correctly determined from scalar type
-        df = DataFrame(x=categorical(["a"])[1])
-        @test df.x isa CategoricalVector{String}
-
-        @test hash(convert(DataFrame, [1 2; 3 4])) == hash(convert(DataFrame, [1 2; 3 4]))
-        @test hash(convert(DataFrame, [1 2; 3 4])) != hash(convert(DataFrame, [1 3; 2 4]))
-        @test hash(convert(DataFrame, [1 2; 3 4])) == hash(convert(DataFrame, [1 2; 3 4]), zero(UInt))
-    end
-
-    @testset "push!(df, row)" begin
-        df=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        dfc= DataFrame( first=[1,2], second=["apple","orange"] )
-        push!(dfb, Any[3,"pear"])
-        @test df == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        push!(dfb, (3,"pear"))
-        @test df == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        @test_throws ArgumentError push!(dfb, (33.33,"pear"))
-        @test dfc == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        @test_throws ArgumentError push!(dfb, (1,"2",3))
-        @test dfc == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        @test_throws ArgumentError push!(dfb, ("coconut",22))
-        @test dfc == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        @test_throws ArgumentError push!(dfb, (11,22))
-        @test dfc == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        push!(dfb, Dict(:first=>3, :second=>"pear"))
-        @test df == dfb
-
-        df=DataFrame( first=[1,2,3], second=["apple","orange","banana"] )
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        push!(dfb, Dict(:first=>3, :second=>"banana"))
-        @test df == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        push!(dfb, (first=3, second="banana"))
-        @test df == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        push!(dfb, (second="banana", first=3))
-        @test df == dfb
-
-        df0= DataFrame( first=[1,2], second=["apple","orange"] )
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        @test_throws ArgumentError push!(dfb, (second=3, first=3))
-        @test df0 == dfb
-
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        push!(dfb, (second="banana", first=3))
-        @test df == dfb
-
-        df0= DataFrame( first=[1,2], second=["apple","orange"] )
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        @test_throws ArgumentError push!(dfb, Dict(:first=>true, :second=>false))
-        @test df0 == dfb
-
-        df0= DataFrame( first=[1,2], second=["apple","orange"] )
-        dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-        @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>"stuff"))
-        @test df0 == dfb
-
-        df0=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
-        dfb=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
-        @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
-        @test df0 == dfb
-
-        df0=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
-        dfb=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
-        @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
-        @test df0 == dfb
-
-        df = DataFrame(x=1)
-        push!(df, Dict(:x=>2), Dict(:x=>3))
-        @test df[:x] == [1,2,3]
-
-        df = DataFrame(x=1, y=2)
-        push!(df, [3, 4], [5, 6])
-        @test df[:x] == [1, 3, 5] && df[:y] == [2, 4, 6]
-
-        df = DataFrame(x=1, y=2)
-        @test_throws ArgumentError push!(df, Dict(:x=>1, "y"=>2))
-        @test df == DataFrame(x=1, y=2)
-    end
-
-    @testset "deletecols!" begin
-        df = DataFrame(a=1, b=2, c=3, d=4, e=5)
-        @test_throws ArgumentError deletecols!(df, 0)
-        @test_throws ArgumentError deletecols!(df, 6)
-        @test_throws ArgumentError deletecols!(df, [1, 1])
-        @test_throws KeyError deletecols!(df, :f)
-
-        d = copy(df)
-        deletecols!(d, [:a, :e, :c])
-        @test names(d) == [:b, :d]
-        deletecols!(d, :b)
-        @test d == DataFrame(d=4)
-
-        d = copy(df)
-        deletecols!(d, [2, 5, 3])
-        @test names(d) == [:a, :d]
-        deletecols!(d, 2)
-        @test d == DataFrame(a=1)
-
-        d = copy(df)
-        deletecols!(d, 2:3)
-        @test d == DataFrame(a=1, d=4, e=5)
-    end
-
-    @testset "deleterows!" begin
-        df = DataFrame(a=[1, 2], b=[3.0, 4.0])
-        @test deleterows!(df, 1) === df
-        @test df == DataFrame(a=[2], b=[4.0])
-
-        df = DataFrame(a=[1, 2], b=[3.0, 4.0])
-        @test deleterows!(df, 2) === df
-        @test df == DataFrame(a=[1], b=[3.0])
-
-        df = DataFrame(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
-        @test deleterows!(df, 2:3) === df
-        @test df == DataFrame(a=[1], b=[3.0])
-
-        df = DataFrame(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
-        @test deleterows!(df, [2, 3]) === df
-        @test df == DataFrame(a=[1], b=[3.0])
-
-        df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
-        @test deleterows!(df, 1) === df
-        @test df == DataFrame(a=[2], b=[4.0])
-
-        df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
-        @test deleterows!(df, 2) === df
-        @test df == DataFrame(a=[1], b=[3.0])
-
-        df = DataFrame(a=Union{Int, Missing}[1, 2, 3], b=Union{Float64, Missing}[3.0, 4.0, 5.0])
-        @test deleterows!(df, 2:3) === df
-        @test df == DataFrame(a=[1], b=[3.0])
-
-        df = DataFrame(a=Union{Int, Missing}[1, 2, 3], b=Union{Float64, Missing}[3.0, 4.0, 5.0])
-        @test deleterows!(df, [2, 3]) === df
-        @test df == DataFrame(a=[1], b=[3.0])
-
-        df = DataFrame()
-        @test_throws BoundsError deleterows!(df, 10)
-        @test_throws BoundsError deleterows!(df, [10])
-
-        df = DataFrame(a=[])
-        @test_throws BoundsError deleterows!(df, 10)
-        # the exception type changed between Julia 1.0.2 and Julia 1.1
-        # so we use their supertype below
-        @test_throws Exception deleterows!(df, [10])
-
-        df = DataFrame(a=[1, 2, 3], b=[3, 2, 1])
-        @test_throws ArgumentError deleterows!(df, [3,2])
-        @test_throws ArgumentError deleterows!(df, [2,2])
-        @test deleterows!(df, [false, true, false]) === df
-        @test df == DataFrame(a=[1, 3], b=[3, 1])
-
-        x = [1, 2, 3]
-        df = DataFrame(x=x)
-        @test deleterows!(df, 1) == DataFrame(x=[2, 3])
-        @test x == [2, 3]
-
-        x = [1, 2, 3]
-        df = DataFrame(x=x)
-        @test deleterows!(df, [1]) == DataFrame(x=[2, 3])
-        @test x == [2, 3]
-
-        x = [1, 2, 3]
-        df = DataFrame(x=x)
-        @test deleterows!(df, 1:1) == DataFrame(x=[2, 3])
-        @test x == [2, 3]
-
-        x = [1, 2, 3]
-        df = DataFrame(x=x)
-        @test deleterows!(df, [true, false, false]) == DataFrame(x=[2, 3])
-        @test x == [2, 3]
-    end
-
-    @testset "describe" begin
-        # Construct the test dataframe
-        df = DataFrame(number = [1, 2, 3, 4],
-                       number_missing = [1,2, 3, missing],
-                       string = ["a", "b", "c", "d"],
-                       string_missing = ["a", "b", "c", missing],
-                       dates  = Date.([2000, 2001, 2003, 2004]),
-                       catarray = CategoricalArray([1,2,1,2]))
-
-        describe_output = DataFrame(variable = [:number, :number_missing, :string,
-                                                :string_missing, :dates, :catarray],
-                                    mean = [2.5, 2.0, nothing, nothing, nothing, nothing],
-                                    min = [1.0, 1.0, "a", "a", Date(2000), 1],
-                                    median = [2.5, 2.0, nothing, nothing, nothing, nothing],
-                                    max = [4.0, 3.0, "d", "c", Date(2004), 2],
-                                    nunique = [nothing, nothing, 4, 3, 4, 2],
-                                    nmissing = [nothing, 1, nothing, 1, nothing, nothing],
-                                    eltype = [Int, Int, String, String, Date, eltype(df[:catarray])])
-        describe_output_all_stats = DataFrame(variable = [:number, :number_missing,
-                                                          :string, :string_missing,
-                                                          :dates, :catarray],
-                                              mean = [2.5, 2.0, nothing, nothing, nothing, nothing],
-                                              std = [std(df[:number]), 1.0, nothing,
-                                                     nothing, nothing, nothing],
-                                              min = [1.0, 1.0, "a", "a", Date(2000), 1],
-                                              q25 = [1.75, 1.5, nothing, nothing, nothing, nothing],
-                                              median = [2.5, 2.0, nothing, nothing, nothing, nothing],
-                                              q75 = [3.25, 2.5, nothing, nothing, nothing, nothing],
-                                              max = [4.0, 3.0, "d", "c", Date(2004), 2],
-                                              nunique = [nothing, nothing, 4, 3, 4, 2],
-                                              nmissing = [nothing, 1, nothing, 1, nothing, nothing],
-                                              first = [1, 1, "a", "a", Date(2000), 1],
-                                              last = [4, missing, "d", missing, Date(2004), 2],
-                                              eltype = [Int, Int, String, String, Date,
-                                                        eltype(df[:catarray])])
-
-
-        # Test that it works as a whole, without keyword arguments
-        @test describe_output == describe(df)
-
-        # Test that it works with one stats argument
-        @test describe_output[[:variable, :mean]] == describe(df, stats = [:mean])
-
-        # Test that it works with all keyword arguments
-        @test describe_output_all_stats ≅ describe(df, stats = :all)
-
-        # Test that describe works with a dataframe with no observations
-        df = DataFrame(a = Int[], b = String[], c = [])
-        @test describe(df, stats = :mean) ≅ DataFrame(variable = [:a, :b, :c],
-                                                      mean = [NaN, nothing, nothing])
-    end
-
-    #Check the output of unstack
-    df = DataFrame(Fish = CategoricalArray{Union{String, Missing}}(["Bob", "Bob", "Batman", "Batman"]),
-                   Key = CategoricalArray{Union{String, Missing}}(["Mass", "Color", "Mass", "Color"]),
-                   Value = Union{String, Missing}["12 g", "Red", "18 g", "Grey"])
-    # Check that reordering levels does not confuse unstack
-    levels!(df[1], ["XXX", "Bob", "Batman"])
-    levels!(df[2], ["YYY", "Color", "Mass"])
-    #Unstack specifying a row column
-    df2 = unstack(df, :Fish, :Key, :Value)
-    @test levels(df[1]) == ["XXX", "Bob", "Batman"] # make sure we did not mess df[1] levels
-    @test levels(df[2]) == ["YYY", "Color", "Mass"] # make sure we did not mess df[2] levels
-    #Unstack without specifying a row column
-    df3 = unstack(df, :Key, :Value)
-    #The expected output, XXX level should be dropped as it has no rows with this key
-    df4 = DataFrame(Fish = Union{String, Missing}["Bob", "Batman"],
-                    Color = Union{String, Missing}["Red", "Grey"],
-                    Mass = Union{String, Missing}["12 g", "18 g"])
-    @test df2 ≅ df4
-    @test typeof(df2[:Fish]) <: CategoricalVector{Union{String, Missing}}
-    # first column stays as CategoricalArray in df3
-    @test df3 == df4
-    #Make sure unstack works with missing values at the start of the value column
-    df[1,:Value] = missing
-    df2 = unstack(df, :Fish, :Key, :Value)
-    #This changes the expected result
-    df4[1,:Mass] = missing
-    @test df2 ≅ df4
-
-    #The same as above but without CategoricalArray
-    df = DataFrame(Fish = ["Bob", "Bob", "Batman", "Batman"],
-                   Key = ["Mass", "Color", "Mass", "Color"],
-                   Value = ["12 g", "Red", "18 g", "Grey"])
-    #Unstack specifying a row column
-    df2 = unstack(df, :Fish, :Key, :Value)
-    #Unstack without specifying a row column
-    df3 = unstack(df, :Key, :Value)
-    #The expected output, XXX level should be dropped as it has no rows with this key
-    df4 = DataFrame(Fish = ["Batman", "Bob"],
-                    Color = ["Grey", "Red"],
-                    Mass = ["18 g", "12 g"])
-    @test df2 ≅ df4
-    @test typeof(df2[:Fish]) <: Vector{String}
-    # first column stays as CategoricalArray in df3
-    @test df3 == df4
-    #Make sure unstack works with missing values at the start of the value column
-    allowmissing!(df, :Value)
-    df[1,:Value] = missing
-    df2 = unstack(df, :Fish, :Key, :Value)
-    #This changes the expected result
-    allowmissing!(df4, :Mass)
-    df4[2,:Mass] = missing
-    @test df2 ≅ df4
-
-    # test empty set of grouping variables
-    @test_throws ArgumentError unstack(df, Int[], :Key, :Value)
-    @test_throws ArgumentError unstack(df, Symbol[], :Key, :Value)
-    @test_throws KeyError unstack(stack(DataFrame(rand(10, 10))),
-                                  :id, :variable, :value)
-
-    # test missing value in grouping variable
-    mdf = DataFrame(id=[missing,1,2,3], a=1:4, b=1:4)
-    @test unstack(melt(mdf, :id), :id, :variable, :value)[1:3,:] == sort(mdf)[1:3,:]
-    @test unstack(melt(mdf, :id), :id, :variable, :value)[2:3] == sort(mdf)[2:3]
-
-    # test more than one grouping column
-    wide = DataFrame(id = 1:12,
-                     a  = repeat([1:3;], inner = [4]),
-                     b  = repeat([1:4;], inner = [3]),
-                     c  = randn(12),
-                     d  = randn(12))
-
-    long = stack(wide)
-    wide3 = unstack(long, [:id, :a], :variable, :value)
-    @test wide3 == wide[[1, 2, 4, 5]]
-
-    df = DataFrame(A = 1:10, B = 'A':'J')
-    @test !(df[:] === df)
-    @test !(df[:,:] === df)
-
-    df = DataFrame(A = 1:2, B = 1:2)
-    df2 = DataFrame(A=1:4, B = 1:4)
-    @test append!(df, DataFrame(A = 3:4, B = [3.0, 4.0])) == df2
-    @test_throws InexactError append!(df, DataFrame(A = 3:4, B = [3.5, 4.5]))
-    @test df == df2
-    @test_throws MethodError append!(df, DataFrame(A = 3:4, B = ["a", "b"]))
-    @test df == df2
-
-    df = DataFrame(A = Vector{Union{Int, Missing}}(1:3), B = Vector{Union{Int, Missing}}(4:6))
-    DRT = CategoricalArrays.DefaultRefType
-    @test all(c -> isa(c, Vector{Union{Int, Missing}}), columns(categorical!(deepcopy(df))))
-    @test all(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
-              columns(categorical!(deepcopy(df), [1,2])))
-    @test all(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
-              columns(categorical!(deepcopy(df), [:A,:B])))
-    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
-                    _columns(categorical!(deepcopy(df), [:A]))) == 1
-    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
-                    _columns(categorical!(deepcopy(df), :A))) == 1
-    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
-                    _columns(categorical!(deepcopy(df), [1]))) == 1
-    @test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
-                    _columns(categorical!(deepcopy(df), 1))) == 1
-
-    @testset "categorical!" begin
-        df = DataFrame([["a", "b"], ['a', 'b'], [true, false], 1:2, ["x", "y"]])
-        @test all(map(<:, eltypes(categorical!(df)),
-                      [CategoricalArrays.CategoricalString,
-                       Char, Bool, Int,
-                       CategoricalArrays.CategoricalString]))
-        @test all(map(<:, eltypes(categorical!(df, names(df))),
-                      [CategoricalArrays.CategoricalString,
-                       CategoricalArrays.CategoricalValue{Char},
-                       CategoricalArrays.CategoricalValue{Bool},
-                       CategoricalArrays.CategoricalValue{Int},
-                       CategoricalArrays.CategoricalString]))
-    end
-
-    @testset "unstack promotion to support missing values" begin
-        df = DataFrame([repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
-                       [:id, :variable, :value])
-        udf = unstack(df, :variable, :value)
-        @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
-        @test udf == DataFrame([Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
-                                Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
-                                Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
-        @test isa(udf[1], Vector{Int})
-        @test all(isa.(columns(udf)[2:end], Vector{Union{Int, Missing}}))
-        df = DataFrame([categorical(repeat(1:2, inner=4)),
-                           categorical(repeat('a':'d', outer=2)), categorical(1:8)],
-                       [:id, :variable, :value])
-        udf = unstack(df, :variable, :value)
-        @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
-        @test udf == DataFrame([Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
-                                Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
-                                Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
-        @test isa(udf[1], CategoricalVector{Int})
-        @test all(isa.(columns(udf)[2:end], CategoricalVector{Union{Int, Missing}}))
-    end
-
-    @testset "duplicate entries in unstack warnings" begin
-        df = DataFrame(id=Union{Int, Missing}[1, 2, 1, 2],
-                       id2=Union{Int, Missing}[1, 2, 1, 2],
-                       variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
-        @test_logs (:warn, "Duplicate entries in unstack at row 3 for key 1 and variable a.") unstack(df, :id, :variable, :value)
-        @test_logs (:warn, "Duplicate entries in unstack at row 3 for key (1, 1) and variable a.") unstack(df, :variable, :value)
-        a = unstack(df, :id, :variable, :value)
-        @test a ≅ DataFrame(id = [1, 2], a = [5, missing], b = [missing, 6])
-        b = unstack(df, :variable, :value)
-        @test b ≅ DataFrame(id = [1, 2], id2 = [1, 2], a = [5, missing], b = [missing, 6])
-
-        df = DataFrame(id=1:2, variable=["a", "b"], value=3:4)
-        @test_nowarn unstack(df, :id, :variable, :value)
-        @test_nowarn unstack(df, :variable, :value)
-        a = unstack(df, :id, :variable, :value)
-        b = unstack(df, :variable, :value)
-        @test a ≅ b ≅ DataFrame(id = [1, 2], a = [3, missing], b = [missing, 4])
-
-        df = DataFrame(variable=["x", "x"], value=[missing, missing], id=[1,1])
-        @test_logs (:warn, "Duplicate entries in unstack at row 2 for key 1 and variable x.") unstack(df, :variable, :value)
-        @test_logs (:warn, "Duplicate entries in unstack at row 2 for key 1 and variable x.") unstack(df, :id, :variable, :value)
-    end
-
-    @testset "missing values in colkey" begin
-        df = DataFrame(id=[1, 1, 1, missing, missing, missing, 2, 2, 2],
-                       variable=["a", "b", missing, "a", "b", "missing", "a", "b", "missing"],
-                       value=[missing, 2.0, 3.0, 4.0, 5.0, missing, 7.0, missing, 9.0])
-        @test_logs (:warn, "Missing value in variable variable at row 3. Skipping.") unstack(df, :variable, :value)
-        udf = unstack(df, :variable, :value)
-        @test names(udf) == [:id, :a, :b, :missing]
-        @test udf[:missing] ≅ [missing, 9.0, missing]
-        df = DataFrame(id=[1, 1, 1, missing, missing, missing, 2, 2, 2],
-                       id2=[1, 1, 1, missing, missing, missing, 2, 2, 2],
-                       variable=["a", "b", missing, "a", "b", "missing", "a", "b", "missing"],
-                       value=[missing, 2.0, 3.0, 4.0, 5.0, missing, 7.0, missing, 9.0])
-        @test_logs (:warn, "Missing value in variable variable at row 3. Skipping.") unstack(df, 3, 4)
-        udf = unstack(df, 3, 4)
-        @test names(udf) == [:id, :id2, :a, :b, :missing]
-        @test udf[:missing] ≅ [missing, 9.0, missing]
-    end
-
-    @testset "stack-unstack correctness" begin
-        x = DataFrame(rand(100, 50))
-        x[:id] = [1:99; missing]
-        x[:id2] = string.("a", x[:id])
-        x[:s] = [i % 2 == 0 ? randstring() : missing for i in 1:100]
-        allowmissing!(x, :x1)
-        x[1, :x1] = missing
-        y = melt(x, [:id, :id2])
-        z = unstack(y, :id, :variable, :value)
-        @test all(isequal(z[n], x[n]) for n in names(z))
-        z = unstack(y, :variable, :value)
-        @test all(isequal(z[n], x[n]) for n in names(x))
-    end
-
-    @testset "rename" begin
-        df = DataFrame(A = 1:3, B = 'A':'C')
-        @test names(rename(df, :A => :A_1)) == [:A_1, :B]
-        @test names(df) == [:A, :B]
-        @test names(rename(df, :A => :A_1, :B => :B_1)) == [:A_1, :B_1]
-        @test names(df) == [:A, :B]
-        @test names(rename(df, [:A => :A_1, :B => :B_1])) == [:A_1, :B_1]
-        @test names(df) == [:A, :B]
-        @test names(rename(df, Dict(:A => :A_1, :B => :B_1))) == [:A_1, :B_1]
-        @test names(df) == [:A, :B]
-        @test names(rename(x->Symbol(lowercase(string(x))), df)) == [:a, :b]
-        @test names(df) == [:A, :B]
-
-        @test rename!(df, :A => :A_1) === df
-        @test names(df) == [:A_1, :B]
-        @test rename!(df, :A_1 => :A_2, :B => :B_2) === df
-        @test names(df) == [:A_2, :B_2]
-        @test rename!(df, [:A_2 => :A_3, :B_2 => :B_3]) === df
-        @test names(df) == [:A_3, :B_3]
-        @test rename!(df, Dict(:A_3 => :A_4, :B_3 => :B_4)) === df
-        @test names(df) == [:A_4, :B_4]
-        @test rename!(x->Symbol(lowercase(string(x))), df) === df
-        @test names(df) == [:a_4, :b_4]
-    end
-
-    @testset "size" begin
-        df = DataFrame(A = 1:3, B = 'A':'C')
-        @test_throws ArgumentError size(df, 3)
-        @test ndims(df) == 2
-        @test ndims(typeof(df)) == 2
-        @test (nrow(df), ncol(df)) == (3, 2)
-        @test size(df) == (3, 2)
-        @inferred nrow(df)
-        @inferred ncol(df)
-    end
-
-    @testset "description" begin
-        df = DataFrame(A = 1:10)
-
-        @test first(df) == df[1, :]
-        @test last(df) == df[end, :]
-        @test_throws BoundsError first(DataFrame(x=[]))
-        @test_throws BoundsError last(DataFrame(x=[]))
-
-        @test first(df, 6) == DataFrame(A = 1:6)
-        @test first(df, 1) == DataFrame(A = 1)
-        @test last(df, 6) == DataFrame(A = 5:10)
-        @test last(df, 1) == DataFrame(A = 10)
-    end
-
-    @testset "misc" begin
-        df = DataFrame([collect('A':'C')])
-        @test sprint(dump, df) == "DataFrame  3 observations of 1 variables\n  x1: ['A', 'B', 'C']\n\n"
-        df = DataFrame(A = 1:12, B = repeat('A':'C', inner=4))
-        # @test DataFrames.without(df, 1) == DataFrame(B = repeat('A':'C', inner=4))
-    end
-
-    @testset "column conversions" begin
-        df = DataFrame([collect(1:10), collect(1:10)])
-        @test !isa(df[1], Vector{Union{Int, Missing}})
-        allowmissing!(df, 1)
-        @test isa(df[1], Vector{Union{Int, Missing}})
-        @test !isa(df[2], Vector{Union{Int, Missing}})
-        df[1,1] = missing
-        @test_throws MethodError disallowmissing!(df, 1)
-        df[1,1] = 1
-        disallowmissing!(df, 1)
-        @test isa(df[1], Vector{Int})
-
-        df = DataFrame([collect(1:10), collect(1:10)])
-        allowmissing!(df, [1,2])
-        @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
-        disallowmissing!(df, [1,2])
-        @test isa(df[1], Vector{Int}) && isa(df[2], Vector{Int})
-
-        df = DataFrame([collect(1:10), collect(1:10)])
-        allowmissing!(df)
-        @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
-        disallowmissing!(df)
-        @test isa(df[1], Vector{Int}) && isa(df[2], Vector{Int})
-
-        df = DataFrame([CategoricalArray(1:10),
-                        CategoricalArray(string.('a':'j'))])
-        allowmissing!(df)
-        @test all(x->x <: CategoricalVector, typeof.(columns(df)))
-        @test eltypes(df)[1] <: Union{CategoricalValue{Int}, Missing}
-        @test eltypes(df)[2] <: Union{CategoricalString, Missing}
-        df[1,2] = missing
-        @test_throws MissingException disallowmissing!(df)
-        df[1,2] = "a"
-        disallowmissing!(df)
-        @test all(x->x <: CategoricalVector, typeof.(columns(df)))
-        @test eltypes(df)[1] <: CategoricalValue{Int}
-        @test eltypes(df)[2] <: CategoricalString
-    end
-
-    @testset "similar" begin
-        df = DataFrame(a = ["foo"],
-                       b = CategoricalArray(["foo"]),
-                       c = [0.0],
-                       d = CategoricalArray([0.0]))
-        @test eltypes(similar(df)) == eltypes(df)
-        @test size(similar(df)) == size(df)
-
-        rows = size(df, 1) + 5
-        @test size(similar(df, rows)) == (rows, size(df, 2))
-        @test eltypes(similar(df, rows)) == eltypes(df)
-
-        @test size(similar(df, 0)) == (0, size(df, 2))
-        @test eltypes(similar(df, 0)) == eltypes(df)
-
-        e = @test_throws ArgumentError similar(df, -1)
-        @test e.value.msg == "the number of rows must be positive"
-    end
-
-    @testset "setindex! special cases" begin
-        df = DataFrame(rand(3,2), [:x3, :x3_1])
-        @test_throws ArgumentError df[3] = [1, 2]
-        @test_throws ArgumentError df[4] = [1, 2, 3]
-        df[3] = [1,2,3]
-        df[4] = [1,2,3]
-        @test names(df) == [:x3, :x3_1, :x3_2, :x4]
-        df = DataFrame()
-        @test_throws MethodError df[true] = 1
-        @test_throws MethodError df[true] = [1,2,3]
-        @test_throws MethodError df[1:2, true] = [1,2]
-        @test_throws MethodError df[1, true] = 1
-        @test_throws ArgumentError df[1, 100] = 1
-        @test_throws ArgumentError df[1:2, 100] = [1,2]
-    end
-
-    @testset "passing range to a DataFrame" begin
-        df = DataFrame(a=1:3, b='a':'c')
-        df[:c] = 1:3
-        df[:d] = 'a':'c'
-        @test all(typeof(df[i]) <: Vector for i in 1:ncol(df))
-    end
-
-    @testset "test corner case of getindex" begin
-        df = DataFrame(x=[1], y=[1])
-        @test_throws MethodError df[true, 1:2]
-    end
-
-    @testset "empty data frame getindex" begin
-        @test_throws BoundsError DataFrame(x=[])[1, :]
-        @test_throws BoundsError DataFrame()[1, :]
-        @test_throws BoundsError DataFrame()[1:2, :]
-        @test_throws BoundsError DataFrame()[1, Bool[]]
-        @test_throws BoundsError DataFrame()[1:2, Bool[]]
-        @test_throws BoundsError DataFrame(x=[1])[1:2, [false]]
-        @test_throws BoundsError DataFrame(x=[1])[2, [false]]
-        #but this is OK:
-        @test DataFrame(x=[1])[1:1, [false]] == DataFrame()
-    end
-
-    @testset "handling of end in indexing" begin
-        z = DataFrame(rand(4,5))
-        for x in [z, view(z, 1:4, :)]
-            y = deepcopy(x)
-            @test x[end] == x[5]
-            @test x[end:end] == x[5:5]
-            @test x[end, :] == x[4, :]
-            @test x[end:end, :] == x[4:4, :]
-            @test x[end, end] == x[4,5]
-            @test x[2:end, 2:end] == x[2:4,2:5]
-            x[end] = 1:4
-            y[5] = 1:4
-            @test x == y
-            x[4:end] = DataFrame([11:14, 21:24])
-            y[4] = [11:14;]
-            y[5] = [21:24;]
-            @test x == y
-            x[end, :] = 111
-            y[4, :] = 111
-            @test x == y
-            x[end,end] = 1000
-            y[4,5] = 1000
-            @test x == y
-            x[2:end, 2:end] = 0
-            y[2:4, 2:5] = 0
-            @test x == y
-        end
-    end
-
-    @testset "aliasing in indexing" begin
-        # columns should not alias if scalar broadcasted
-        df = DataFrame(A=[0], B=[0])
-        df[1:end] = 0.0
-        df[1, :A] = 1.0
-        @test df[1, :B] === 0
-
-        df = DataFrame(A=[0], B=[0])
-        df[:, 1:end] = 0.0
-        df[1, :A] = 1.0
-        @test df[1, :B] === 0
-
-        # columns should not alias if vector assigned
-        df = DataFrame(A=[0], B=[0])
-        x = [0.0]
-        df[1:end] = x
-        x[1] = 1.0
-        @test df[1, :A] === 0.0
-        @test df[1, :B] === 0.0
-        df[1, :A] = 1.0
-        @test df[1, :B] === 0.0
-
-        df = DataFrame(A=[0], B=[0])
-        x = [0.0]
-        df[:, 1:end] = x
-        x[1] = 1.0
-        @test df[1, :A] === 0.0
-        @test df[1, :B] === 0.0
-        df[1, :A] = 1.0
-        @test df[1, :B] === 0.0
-    end
-
-    @testset "permutecols!" begin
-        a, b, c = 1:5, 2:6, 3:7
-        original = DataFrame(a=a, b=b, c=c)
-
-        df = deepcopy(original)
-        expected = deepcopy(original)
-        @test permutecols!(df, [:a, :b, :c]) === df
-        @test df == expected
-        @test permutecols!(df, 1:3) === df
-        @test df == expected
-
-        df = deepcopy(original)
-        expected = DataFrame(b=b, c=c, a=a)
-        permutecols!(df, [:b, :c, :a]) === df
-        @test df == expected
-        df = deepcopy(original)
-        permutecols!(df, [2, 3, 1]) === df
-        @test df == expected
-
-        df = deepcopy(original)
-        expected = DataFrame(c=c, a=a, b=b)
-        permutecols!(df, [:c, :a, :b]) === df
-        @test df == expected
-        df = deepcopy(original)
-        permutecols!(df, [3, 1, 2]) === df
-        @test df == expected
-
-        df = deepcopy(original)
-        expected = DataFrame(a=a, c=c, b=b)
-        permutecols!(df, [:a, :c, :b]) === df
-        @test df == expected
-        df = deepcopy(original)
-        permutecols!(df, [1, 3, 2]) === df
-        @test df == expected
-
-        df = deepcopy(original)
-        expected = DataFrame(b=b, a=a, c=c)
-        permutecols!(df, [:b, :a, :c]) === df
-        @test df == expected
-        df = deepcopy(original)
-        permutecols!(df, [2, 1, 3]) === df
-        @test df == expected
-
-        df = deepcopy(original)
-        expected = DataFrame(c=c, b=b, a=a)
-        permutecols!(df, [:c, :b, :a]) === df
-        @test df == expected
-        df = deepcopy(original)
-        permutecols!(df, [3, 2, 1]) === df
-        @test df == expected
-
-        # Invalid
-        df = DataFrame(a=a, b=b, c=c)
-        @test_throws ArgumentError permutecols!(df, [:a, :b])
-        @test_throws ArgumentError permutecols!(df, 1:4)
-        @test_throws KeyError permutecols!(df, [:a, :b, :c, :d])
-        @test_throws ArgumentError permutecols!(df, [1, 3])
-        @test_throws ArgumentError permutecols!(df, [:a, :c])
-        @test_throws ArgumentError permutecols!(df, [1, 2, 3, 1])
-        @test_throws ArgumentError permutecols!(df, [:a, :b, :c, :a])
-    end
-
-    @testset "getproperty, setproperty! and propertynames" begin
-        x = collect(1:10)
-        y = collect(1.0:10.0)
-        z = collect(10:-1:1)
-        df = DataFrame(x = x, y = y)
-
-        @test Base.propertynames(df) == names(df)
-
-        @test df.x === x
-        @test df.y === y
-        @test_throws KeyError df.z
-
-        df.x = 2:11
-        @test df.x == 2:11
-        @test x == 1:10
-        df.y = 1
-        @test df.y == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-        @test df.y === y
-        df.z = z
-        @test df.z === z
-        df.zz = 1
-        @test df.zz == df.y
-    end
-
-    @testset "duplicate column names" begin
-        x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])
-        v = DataFrame(a = [5, 6, 7], b = [8, 9, 10])
-        z = vcat(v, x)
-        @test_throws ArgumentError z[:, [1, 1, 2]]
-        @test_throws ArgumentError z[[1, 1, 2]]
-    end
-
-    @testset "parent, size and axes" begin
-        x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])
-        @test parent(x) === x
-        @test parentindices(x) === (Base.OneTo(3), Base.OneTo(2))
-        @test size(x) == (3,2)
-        @test size(x, 1) == 3
-        @test size(x, 2) == 2
-        @test_throws ArgumentError size(x, 3)
-        @test axes(x) === (Base.OneTo(3), Base.OneTo(2))
-        @test axes(x, 1) === Base.OneTo(3)
-        @test axes(x, 2) === Base.OneTo(2)
-        @test_throws ArgumentError axes(x, 3)
-        @test size(DataFrame()) == (0,0)
+
+    @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) == DataFrame(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2], b=[4, 5]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3])
+    @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], c=[4, 5, 6])
+    @test DataFrame(a=[1, 2, 3], b=[4, 5, 6]) != DataFrame(b=[4, 5, 6], a=[1, 2, 3])
+    @test DataFrame(a=[1, 2, 2], b=[4, 5, 6]) != DataFrame(a=[1, 2, 3], b=[4, 5, 6])
+    @test DataFrame(a=[1, 3, missing], b=[4, 5, 6]) !=
+            DataFrame(a=[1, 2, missing], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≅
+                DataFrame(a=[1, 2, missing], b=[4, 5, 6])
+    @test DataFrame(a=[1, 2, missing], b=[4, 5, 6]) ≇
+                DataFrame(a=[1, 2, 3], b=[4, 5, 6])
+end
+
+@testset "copying" begin
+    df = DataFrame(a = Union{Int, Missing}[2, 3],
+                b = Union{DataFrame, Missing}[DataFrame(c = 1), DataFrame(d = 2)])
+    dfc = copy(df)
+    dfdc = deepcopy(df)
+
+    df[1, :a] = 4
+    df[1, :b][:e] = 5
+    names!(df, [:f, :g])
+
+    @test names(dfc) == [:a, :b]
+    @test names(dfdc) == [:a, :b]
+
+    @test dfc[1, :a] === 4
+    @test dfdc[1, :a] === 2
+
+    @test names(dfc[1, :b]) == [:c, :e]
+    @test names(dfdc[1, :b]) == [:c]
+
+    x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])
+
+    #test_group("DataFrame assignment")
+    # Insert single column
+    x0 = x[Int[], :]
+    @test_throws ArgumentError x0[:d] = [1]
+    @test_throws ArgumentError x0[:d] = 1:3
+
+    # Insert single value
+    x[:d] = 3
+    @test x[:d] == [3, 3, 3]
+
+    x0[:d] = 3
+    @test x0[:d] == Int[]
+end
+
+@testset "similar / missings" begin
+    df = DataFrame(a = Union{Int, Missing}[1],
+                b = Union{String, Missing}["b"],
+                c = CategoricalArray{Union{Float64, Missing}}([3.3]))
+    missingdf = DataFrame(a = missings(Int, 2),
+                        b = missings(String, 2),
+                        c = CategoricalArray{Union{Float64, Missing}}(undef, 2))
+    # https://github.com/JuliaData/Missings.jl/issues/66
+    # @test missingdf ≅ similar(df, 2)
+    @test typeof.(columns(similar(df, 2))) == typeof.(columns(missingdf))
+    @test size(similar(df, 2)) == size(missingdf)
+end
+
+@testset "Associative methods" begin
+    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test haskey(df, :a)
+    @test !haskey(df, :c)
+    @test haskey(df, 1)
+    @test_throws MethodError haskey(df, 1.5)
+    @test_throws ArgumentError haskey(df, true)
+    @test get(df, :a, -1) === columns(df)[1]
+    @test get(df, :c, -1) == -1
+    @test !isempty(df)
+
+    dfv = view(df, 1:2, 1:2)
+    @test get(df, :a, -1) === columns(df)[1]
+
+    @test empty!(df) === df
+    @test isempty(columns(df))
+    @test isempty(df)
+    @test isempty(DataFrame(a=[], b=[]))
+
+    df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
+    @test_throws BoundsError insertcols!(df, 5, :newcol => ["a", "b"], )
+    @test_throws ErrorException insertcols!(df, 1, :newcol => ["a"])
+    @test insertcols!(df, 1, :newcol => ["a", "b"]) == df
+    @test names(df) == [:newcol, :a, :b]
+    @test df[:a] == [1, 2]
+    @test df[:b] == [3.0, 4.0]
+    @test df[:newcol] == ["a", "b"]
+
+    @test insertcols!(df, 1, :newcol => ["a1", "b1"], makeunique=true) == df
+    @test names(df) == [:newcol_1, :newcol, :a, :b]
+    @test df[:a] == [1, 2]
+    @test df[:b] == [3.0, 4.0]
+    @test df[:newcol] == ["a", "b"]
+    @test df[:newcol_1] == ["a1", "b1"]
+
+    df = DataFrame(a=[1,2], a_1=[3,4])
+    @test_throws ArgumentError insertcols!(df, 1, :a => [11,12])
+    df = DataFrame(a=[1,2], a_1=[3,4])
+    insertcols!(df, 1, :a => [11,12], makeunique=true)
+    @test names(df) == [:a_2, :a, :a_1]
+    insertcols!(df, 4, :a => [11,12], makeunique=true)
+    @test names(df) == [:a_2, :a, :a_1, :a_3]
+    @test_throws BoundsError insertcols!(df, 10, :a => [11,12], makeunique=true)
+    df = DataFrame(a=[1,2], a_1=[3,4])
+    insertcols!(df, 1, :a => 11, makeunique=true)
+    @test names(df) == [:a_2, :a, :a_1]
+    insertcols!(df, 4, :a => 11, makeunique=true)
+    @test names(df) == [:a_2, :a, :a_1, :a_3]
+    @test_throws BoundsError insertcols!(df, 10, :a => 11, makeunique=true)
+
+    df = DataFrame(x = 1:2)
+    @test insertcols!(df, 2, y=2:3) == DataFrame(x=1:2, y=2:3)
+    @test_throws ArgumentError insertcols!(df, 2)
+    @test_throws ArgumentError insertcols!(df, 2, a=1, b=2)
+
+    df = DataFrame()
+    @test insertcols!(df, 1, x=[1]) == DataFrame(x = [1])
+end
+
+@testset "DataFrame constructors" begin
+    df = DataFrame(Union{Int, Missing}, 10, 3)
+    @test size(df, 1) == 10
+    @test size(df, 2) == 3
+    @test typeof(df[1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[2]) == Vector{Union{Int, Missing}}
+    @test typeof(df[3]) == Vector{Union{Int, Missing}}
+    @test all(ismissing, df[1])
+    @test all(ismissing, df[2])
+    @test all(ismissing, df[3])
+    @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 2]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 3]) == Vector{Union{Int, Missing}}
+    @test all(ismissing, df[:, 1])
+    @test all(ismissing, df[:, 2])
+    @test all(ismissing, df[:, 3])
+
+    df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}], 100)
+    @test size(df, 1) == 100
+    @test size(df, 2) == 3
+    @test typeof(df[1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[3]) == Vector{Union{String, Missing}}
+    @test all(ismissing, df[1])
+    @test all(ismissing, df[2])
+    @test all(ismissing, df[3])
+    @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[:, 3]) == Vector{Union{String, Missing}}
+    @test all(ismissing, df[:, 1])
+    @test all(ismissing, df[:, 2])
+    @test all(ismissing, df[:, 3])
+
+    df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}],
+                [:A, :B, :C], 100)
+    @test size(df, 1) == 100
+    @test size(df, 2) == 3
+    @test typeof(df[1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[3]) == Vector{Union{String, Missing}}
+    @test all(ismissing, df[1])
+    @test all(ismissing, df[2])
+    @test all(ismissing, df[3])
+    @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[:, 3]) == Vector{Union{String, Missing}}
+    @test all(ismissing, df[:, 1])
+    @test all(ismissing, df[:, 2])
+    @test all(ismissing, df[:, 3])
+
+    df = DataFrame([Union{Int, Missing}, Union{Float64, Missing}, Union{String, Missing}],
+                [:A, :B, :C], [false, false, true], 100)
+    @test size(df, 1) == 100
+    @test size(df, 2) == 3
+    @test typeof(df[1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[3]) <: CategoricalVector{Union{String, Missing}}
+    @test all(ismissing, df[1])
+    @test all(ismissing, df[2])
+    @test all(ismissing, df[3])
+    @test typeof(df[:, 1]) == Vector{Union{Int, Missing}}
+    @test typeof(df[:, 2]) == Vector{Union{Float64, Missing}}
+    @test typeof(df[:, 3]) <: CategoricalVector{Union{String, Missing}}
+    @test all(ismissing, df[:, 1])
+    @test all(ismissing, df[:, 2])
+    @test all(ismissing, df[:, 3])
+
+    df = convert(DataFrame, zeros(10, 5))
+    @test size(df, 1) == 10
+    @test size(df, 2) == 5
+    @test typeof(df[1]) == Vector{Float64}
+    @test typeof(df[:, 1]) == Vector{Float64}
+
+    df = convert(DataFrame, ones(10, 5))
+    @test size(df, 1) == 10
+    @test size(df, 2) == 5
+    @test typeof(df[1]) == Vector{Float64}
+    @test typeof(df[:, 1]) == Vector{Float64}
+
+    df = convert(DataFrame, Matrix{Float64}(undef, 10, 5))
+    @test size(df, 1) == 10
+    @test size(df, 2) == 5
+    @test typeof(df[1]) == Vector{Float64}
+    @test typeof(df[:, 1]) == Vector{Float64}
+
+    @test DataFrame([Union{Int, Missing}[1, 2, 3], Union{Float64, Missing}[2.5, 4.5, 6.5]],
+                    [:A, :B]) ==
+        DataFrame(A = Union{Int, Missing}[1, 2, 3], B = Union{Float64, Missing}[2.5, 4.5, 6.5])
+
+    # This assignment was missing before
+    df = DataFrame(Column = [:A])
+    df[1, :Column] = :Testing
+
+    # zero-row DataFrame and subDataFrame test
+    df = DataFrame(x=[], y=[])
+    @test nrow(df) == 0
+    df = DataFrame(x=[1:3;], y=[3:5;])
+    sdf = view(df, df[:x] .== 4, :)
+    @test size(sdf, 1) == 0
+
+    # Test that vector type is correctly determined from scalar type
+    df = DataFrame(x=categorical(["a"])[1])
+    @test df.x isa CategoricalVector{String}
+
+    @test hash(convert(DataFrame, [1 2; 3 4])) == hash(convert(DataFrame, [1 2; 3 4]))
+    @test hash(convert(DataFrame, [1 2; 3 4])) != hash(convert(DataFrame, [1 3; 2 4]))
+    @test hash(convert(DataFrame, [1 2; 3 4])) == hash(convert(DataFrame, [1 2; 3 4]), zero(UInt))
+end
+
+@testset "push!(df, row)" begin
+    df=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    dfc= DataFrame( first=[1,2], second=["apple","orange"] )
+    push!(dfb, Any[3,"pear"])
+    @test df == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    push!(dfb, (3,"pear"))
+    @test df == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    @test_throws ArgumentError push!(dfb, (33.33,"pear"))
+    @test dfc == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    @test_throws ArgumentError push!(dfb, (1,"2",3))
+    @test dfc == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    @test_throws ArgumentError push!(dfb, ("coconut",22))
+    @test dfc == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    @test_throws ArgumentError push!(dfb, (11,22))
+    @test dfc == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    push!(dfb, Dict(:first=>3, :second=>"pear"))
+    @test df == dfb
+
+    df=DataFrame( first=[1,2,3], second=["apple","orange","banana"] )
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    push!(dfb, Dict(:first=>3, :second=>"banana"))
+    @test df == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    push!(dfb, (first=3, second="banana"))
+    @test df == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    push!(dfb, (second="banana", first=3))
+    @test df == dfb
+
+    df0= DataFrame( first=[1,2], second=["apple","orange"] )
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    @test_throws ArgumentError push!(dfb, (second=3, first=3))
+    @test df0 == dfb
+
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    push!(dfb, (second="banana", first=3))
+    @test df == dfb
+
+    df0= DataFrame( first=[1,2], second=["apple","orange"] )
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    @test_throws ArgumentError push!(dfb, Dict(:first=>true, :second=>false))
+    @test df0 == dfb
+
+    df0= DataFrame( first=[1,2], second=["apple","orange"] )
+    dfb= DataFrame( first=[1,2], second=["apple","orange"] )
+    @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>"stuff"))
+    @test df0 == dfb
+
+    df0=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
+    dfb=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
+    @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
+    @test df0 == dfb
+
+    df0=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
+    dfb=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
+    @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
+    @test df0 == dfb
+
+    df = DataFrame(x=1)
+    push!(df, Dict(:x=>2), Dict(:x=>3))
+    @test df[:x] == [1,2,3]
+
+    df = DataFrame(x=1, y=2)
+    push!(df, [3, 4], [5, 6])
+    @test df[:x] == [1, 3, 5] && df[:y] == [2, 4, 6]
+
+    df = DataFrame(x=1, y=2)
+    @test_throws ArgumentError push!(df, Dict(:x=>1, "y"=>2))
+    @test df == DataFrame(x=1, y=2)
+end
+
+@testset "deletecols!" begin
+    df = DataFrame(a=1, b=2, c=3, d=4, e=5)
+    @test_throws ArgumentError deletecols!(df, 0)
+    @test_throws ArgumentError deletecols!(df, 6)
+    @test_throws ArgumentError deletecols!(df, [1, 1])
+    @test_throws KeyError deletecols!(df, :f)
+
+    d = copy(df)
+    deletecols!(d, [:a, :e, :c])
+    @test names(d) == [:b, :d]
+    deletecols!(d, :b)
+    @test d == DataFrame(d=4)
+
+    d = copy(df)
+    deletecols!(d, [2, 5, 3])
+    @test names(d) == [:a, :d]
+    deletecols!(d, 2)
+    @test d == DataFrame(a=1)
+
+    d = copy(df)
+    deletecols!(d, 2:3)
+    @test d == DataFrame(a=1, d=4, e=5)
+end
+
+@testset "deleterows!" begin
+    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test deleterows!(df, 1) === df
+    @test df == DataFrame(a=[2], b=[4.0])
+
+    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test deleterows!(df, 2) === df
+    @test df == DataFrame(a=[1], b=[3.0])
+
+    df = DataFrame(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
+    @test deleterows!(df, 2:3) === df
+    @test df == DataFrame(a=[1], b=[3.0])
+
+    df = DataFrame(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
+    @test deleterows!(df, [2, 3]) === df
+    @test df == DataFrame(a=[1], b=[3.0])
+
+    df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
+    @test deleterows!(df, 1) === df
+    @test df == DataFrame(a=[2], b=[4.0])
+
+    df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
+    @test deleterows!(df, 2) === df
+    @test df == DataFrame(a=[1], b=[3.0])
+
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3], b=Union{Float64, Missing}[3.0, 4.0, 5.0])
+    @test deleterows!(df, 2:3) === df
+    @test df == DataFrame(a=[1], b=[3.0])
+
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3], b=Union{Float64, Missing}[3.0, 4.0, 5.0])
+    @test deleterows!(df, [2, 3]) === df
+    @test df == DataFrame(a=[1], b=[3.0])
+
+    df = DataFrame()
+    @test_throws BoundsError deleterows!(df, 10)
+    @test_throws BoundsError deleterows!(df, [10])
+
+    df = DataFrame(a=[])
+    @test_throws BoundsError deleterows!(df, 10)
+    # the exception type changed between Julia 1.0.2 and Julia 1.1
+    # so we use their supertype below
+    @test_throws Exception deleterows!(df, [10])
+
+    df = DataFrame(a=[1, 2, 3], b=[3, 2, 1])
+    @test_throws ArgumentError deleterows!(df, [3,2])
+    @test_throws ArgumentError deleterows!(df, [2,2])
+    @test deleterows!(df, [false, true, false]) === df
+    @test df == DataFrame(a=[1, 3], b=[3, 1])
+
+    x = [1, 2, 3]
+    df = DataFrame(x=x)
+    @test deleterows!(df, 1) == DataFrame(x=[2, 3])
+    @test x == [2, 3]
+
+    x = [1, 2, 3]
+    df = DataFrame(x=x)
+    @test deleterows!(df, [1]) == DataFrame(x=[2, 3])
+    @test x == [2, 3]
+
+    x = [1, 2, 3]
+    df = DataFrame(x=x)
+    @test deleterows!(df, 1:1) == DataFrame(x=[2, 3])
+    @test x == [2, 3]
+
+    x = [1, 2, 3]
+    df = DataFrame(x=x)
+    @test deleterows!(df, [true, false, false]) == DataFrame(x=[2, 3])
+    @test x == [2, 3]
+end
+
+@testset "describe" begin
+    # Construct the test dataframe
+    df = DataFrame(number = [1, 2, 3, 4],
+                   number_missing = [1,2, 3, missing],
+                   string = ["a", "b", "c", "d"],
+                   string_missing = ["a", "b", "c", missing],
+                   dates  = Date.([2000, 2001, 2003, 2004]),
+                   catarray = CategoricalArray([1,2,1,2]))
+
+    describe_output = DataFrame(variable = [:number, :number_missing, :string,
+                                            :string_missing, :dates, :catarray],
+                                mean = [2.5, 2.0, nothing, nothing, nothing, nothing],
+                                min = [1.0, 1.0, "a", "a", Date(2000), 1],
+                                median = [2.5, 2.0, nothing, nothing, nothing, nothing],
+                                max = [4.0, 3.0, "d", "c", Date(2004), 2],
+                                nunique = [nothing, nothing, 4, 3, 4, 2],
+                                nmissing = [nothing, 1, nothing, 1, nothing, nothing],
+                                eltype = [Int, Int, String, String, Date, eltype(df[:catarray])])
+    describe_output_all_stats = DataFrame(variable = [:number, :number_missing,
+                                                      :string, :string_missing,
+                                                      :dates, :catarray],
+                                          mean = [2.5, 2.0, nothing, nothing, nothing, nothing],
+                                          std = [std(df[:number]), 1.0, nothing,
+                                                 nothing, nothing, nothing],
+                                          min = [1.0, 1.0, "a", "a", Date(2000), 1],
+                                          q25 = [1.75, 1.5, nothing, nothing, nothing, nothing],
+                                          median = [2.5, 2.0, nothing, nothing, nothing, nothing],
+                                          q75 = [3.25, 2.5, nothing, nothing, nothing, nothing],
+                                          max = [4.0, 3.0, "d", "c", Date(2004), 2],
+                                          nunique = [nothing, nothing, 4, 3, 4, 2],
+                                          nmissing = [nothing, 1, nothing, 1, nothing, nothing],
+                                          first = [1, 1, "a", "a", Date(2000), 1],
+                                          last = [4, missing, "d", missing, Date(2004), 2],
+                                          eltype = [Int, Int, String, String, Date,
+                                                    eltype(df[:catarray])])
+
+
+    # Test that it works as a whole, without keyword arguments
+    @test describe_output == describe(df)
+
+    # Test that it works with one stats argument
+    @test describe_output[[:variable, :mean]] == describe(df, stats = [:mean])
+
+    # Test that it works with all keyword arguments
+    @test describe_output_all_stats ≅ describe(df, stats = :all)
+
+    # Test that describe works with a dataframe with no observations
+    df = DataFrame(a = Int[], b = String[], c = [])
+    @test describe(df, stats = :mean) ≅ DataFrame(variable = [:a, :b, :c],
+                                                  mean = [NaN, nothing, nothing])
+end
+
+#Check the output of unstack
+df = DataFrame(Fish = CategoricalArray{Union{String, Missing}}(["Bob", "Bob", "Batman", "Batman"]),
+               Key = CategoricalArray{Union{String, Missing}}(["Mass", "Color", "Mass", "Color"]),
+               Value = Union{String, Missing}["12 g", "Red", "18 g", "Grey"])
+# Check that reordering levels does not confuse unstack
+levels!(df[1], ["XXX", "Bob", "Batman"])
+levels!(df[2], ["YYY", "Color", "Mass"])
+#Unstack specifying a row column
+df2 = unstack(df, :Fish, :Key, :Value)
+@test levels(df[1]) == ["XXX", "Bob", "Batman"] # make sure we did not mess df[1] levels
+@test levels(df[2]) == ["YYY", "Color", "Mass"] # make sure we did not mess df[2] levels
+#Unstack without specifying a row column
+df3 = unstack(df, :Key, :Value)
+#The expected output, XXX level should be dropped as it has no rows with this key
+df4 = DataFrame(Fish = Union{String, Missing}["Bob", "Batman"],
+                Color = Union{String, Missing}["Red", "Grey"],
+                Mass = Union{String, Missing}["12 g", "18 g"])
+@test df2 ≅ df4
+@test typeof(df2[:Fish]) <: CategoricalVector{Union{String, Missing}}
+# first column stays as CategoricalArray in df3
+@test df3 == df4
+#Make sure unstack works with missing values at the start of the value column
+df[1,:Value] = missing
+df2 = unstack(df, :Fish, :Key, :Value)
+#This changes the expected result
+df4[1,:Mass] = missing
+@test df2 ≅ df4
+
+#The same as above but without CategoricalArray
+df = DataFrame(Fish = ["Bob", "Bob", "Batman", "Batman"],
+               Key = ["Mass", "Color", "Mass", "Color"],
+               Value = ["12 g", "Red", "18 g", "Grey"])
+#Unstack specifying a row column
+df2 = unstack(df, :Fish, :Key, :Value)
+#Unstack without specifying a row column
+df3 = unstack(df, :Key, :Value)
+#The expected output, XXX level should be dropped as it has no rows with this key
+df4 = DataFrame(Fish = ["Batman", "Bob"],
+                Color = ["Grey", "Red"],
+                Mass = ["18 g", "12 g"])
+@test df2 ≅ df4
+@test typeof(df2[:Fish]) <: Vector{String}
+# first column stays as CategoricalArray in df3
+@test df3 == df4
+#Make sure unstack works with missing values at the start of the value column
+allowmissing!(df, :Value)
+df[1,:Value] = missing
+df2 = unstack(df, :Fish, :Key, :Value)
+#This changes the expected result
+allowmissing!(df4, :Mass)
+df4[2,:Mass] = missing
+@test df2 ≅ df4
+
+# test empty set of grouping variables
+@test_throws ArgumentError unstack(df, Int[], :Key, :Value)
+@test_throws ArgumentError unstack(df, Symbol[], :Key, :Value)
+@test_throws KeyError unstack(stack(DataFrame(rand(10, 10))),
+                              :id, :variable, :value)
+
+# test missing value in grouping variable
+mdf = DataFrame(id=[missing,1,2,3], a=1:4, b=1:4)
+@test unstack(melt(mdf, :id), :id, :variable, :value)[1:3,:] == sort(mdf)[1:3,:]
+@test unstack(melt(mdf, :id), :id, :variable, :value)[2:3] == sort(mdf)[2:3]
+
+# test more than one grouping column
+wide = DataFrame(id = 1:12,
+                 a  = repeat([1:3;], inner = [4]),
+                 b  = repeat([1:4;], inner = [3]),
+                 c  = randn(12),
+                 d  = randn(12))
+
+long = stack(wide)
+wide3 = unstack(long, [:id, :a], :variable, :value)
+@test wide3 == wide[[1, 2, 4, 5]]
+
+df = DataFrame(A = 1:10, B = 'A':'J')
+@test !(df[:] === df)
+@test !(df[:,:] === df)
+
+df = DataFrame(A = 1:2, B = 1:2)
+df2 = DataFrame(A=1:4, B = 1:4)
+@test append!(df, DataFrame(A = 3:4, B = [3.0, 4.0])) == df2
+@test_throws InexactError append!(df, DataFrame(A = 3:4, B = [3.5, 4.5]))
+@test df == df2
+@test_throws MethodError append!(df, DataFrame(A = 3:4, B = ["a", "b"]))
+@test df == df2
+
+df = DataFrame(A = Vector{Union{Int, Missing}}(1:3), B = Vector{Union{Int, Missing}}(4:6))
+DRT = CategoricalArrays.DefaultRefType
+@test all(c -> isa(c, Vector{Union{Int, Missing}}), columns(categorical!(deepcopy(df))))
+@test all(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
+          columns(categorical!(deepcopy(df), [1,2])))
+@test all(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
+          columns(categorical!(deepcopy(df), [:A,:B])))
+@test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
+                _columns(categorical!(deepcopy(df), [:A]))) == 1
+@test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
+                _columns(categorical!(deepcopy(df), :A))) == 1
+@test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
+                _columns(categorical!(deepcopy(df), [1]))) == 1
+@test findfirst(c -> typeof(c) <: CategoricalVector{Union{Int, Missing}},
+                _columns(categorical!(deepcopy(df), 1))) == 1
+
+@testset "categorical!" begin
+    df = DataFrame([["a", "b"], ['a', 'b'], [true, false], 1:2, ["x", "y"]])
+    @test all(map(<:, eltypes(categorical!(df)),
+                  [CategoricalArrays.CategoricalString,
+                   Char, Bool, Int,
+                   CategoricalArrays.CategoricalString]))
+    @test all(map(<:, eltypes(categorical!(df, names(df))),
+                  [CategoricalArrays.CategoricalString,
+                   CategoricalArrays.CategoricalValue{Char},
+                   CategoricalArrays.CategoricalValue{Bool},
+                   CategoricalArrays.CategoricalValue{Int},
+                   CategoricalArrays.CategoricalString]))
+end
+
+@testset "unstack promotion to support missing values" begin
+    df = DataFrame([repeat(1:2, inner=4), repeat('a':'d', outer=2), collect(1:8)],
+                   [:id, :variable, :value])
+    udf = unstack(df, :variable, :value)
+    @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
+    @test udf == DataFrame([Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
+                            Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
+                            Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
+    @test isa(udf[1], Vector{Int})
+    @test all(isa.(columns(udf)[2:end], Vector{Union{Int, Missing}}))
+    df = DataFrame([categorical(repeat(1:2, inner=4)),
+                       categorical(repeat('a':'d', outer=2)), categorical(1:8)],
+                   [:id, :variable, :value])
+    udf = unstack(df, :variable, :value)
+    @test udf == unstack(df, :variable, :value) == unstack(df, :id, :variable, :value)
+    @test udf == DataFrame([Union{Int, Missing}[1, 2], Union{Int, Missing}[1, 5],
+                            Union{Int, Missing}[2, 6], Union{Int, Missing}[3, 7],
+                            Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
+    @test isa(udf[1], CategoricalVector{Int})
+    @test all(isa.(columns(udf)[2:end], CategoricalVector{Union{Int, Missing}}))
+end
+
+@testset "duplicate entries in unstack warnings" begin
+    df = DataFrame(id=Union{Int, Missing}[1, 2, 1, 2],
+                   id2=Union{Int, Missing}[1, 2, 1, 2],
+                   variable=["a", "b", "a", "b"], value=[3, 4, 5, 6])
+    @test_logs (:warn, "Duplicate entries in unstack at row 3 for key 1 and variable a.") unstack(df, :id, :variable, :value)
+    @test_logs (:warn, "Duplicate entries in unstack at row 3 for key (1, 1) and variable a.") unstack(df, :variable, :value)
+    a = unstack(df, :id, :variable, :value)
+    @test a ≅ DataFrame(id = [1, 2], a = [5, missing], b = [missing, 6])
+    b = unstack(df, :variable, :value)
+    @test b ≅ DataFrame(id = [1, 2], id2 = [1, 2], a = [5, missing], b = [missing, 6])
+
+    df = DataFrame(id=1:2, variable=["a", "b"], value=3:4)
+    @test_nowarn unstack(df, :id, :variable, :value)
+    @test_nowarn unstack(df, :variable, :value)
+    a = unstack(df, :id, :variable, :value)
+    b = unstack(df, :variable, :value)
+    @test a ≅ b ≅ DataFrame(id = [1, 2], a = [3, missing], b = [missing, 4])
+
+    df = DataFrame(variable=["x", "x"], value=[missing, missing], id=[1,1])
+    @test_logs (:warn, "Duplicate entries in unstack at row 2 for key 1 and variable x.") unstack(df, :variable, :value)
+    @test_logs (:warn, "Duplicate entries in unstack at row 2 for key 1 and variable x.") unstack(df, :id, :variable, :value)
+end
+
+@testset "missing values in colkey" begin
+    df = DataFrame(id=[1, 1, 1, missing, missing, missing, 2, 2, 2],
+                   variable=["a", "b", missing, "a", "b", "missing", "a", "b", "missing"],
+                   value=[missing, 2.0, 3.0, 4.0, 5.0, missing, 7.0, missing, 9.0])
+    @test_logs (:warn, "Missing value in variable variable at row 3. Skipping.") unstack(df, :variable, :value)
+    udf = unstack(df, :variable, :value)
+    @test names(udf) == [:id, :a, :b, :missing]
+    @test udf[:missing] ≅ [missing, 9.0, missing]
+    df = DataFrame(id=[1, 1, 1, missing, missing, missing, 2, 2, 2],
+                   id2=[1, 1, 1, missing, missing, missing, 2, 2, 2],
+                   variable=["a", "b", missing, "a", "b", "missing", "a", "b", "missing"],
+                   value=[missing, 2.0, 3.0, 4.0, 5.0, missing, 7.0, missing, 9.0])
+    @test_logs (:warn, "Missing value in variable variable at row 3. Skipping.") unstack(df, 3, 4)
+    udf = unstack(df, 3, 4)
+    @test names(udf) == [:id, :id2, :a, :b, :missing]
+    @test udf[:missing] ≅ [missing, 9.0, missing]
+end
+
+@testset "stack-unstack correctness" begin
+    x = DataFrame(rand(100, 50))
+    x[:id] = [1:99; missing]
+    x[:id2] = string.("a", x[:id])
+    x[:s] = [i % 2 == 0 ? randstring() : missing for i in 1:100]
+    allowmissing!(x, :x1)
+    x[1, :x1] = missing
+    y = melt(x, [:id, :id2])
+    z = unstack(y, :id, :variable, :value)
+    @test all(isequal(z[n], x[n]) for n in names(z))
+    z = unstack(y, :variable, :value)
+    @test all(isequal(z[n], x[n]) for n in names(x))
+end
+
+@testset "rename" begin
+    df = DataFrame(A = 1:3, B = 'A':'C')
+    @test names(rename(df, :A => :A_1)) == [:A_1, :B]
+    @test names(df) == [:A, :B]
+    @test names(rename(df, :A => :A_1, :B => :B_1)) == [:A_1, :B_1]
+    @test names(df) == [:A, :B]
+    @test names(rename(df, [:A => :A_1, :B => :B_1])) == [:A_1, :B_1]
+    @test names(df) == [:A, :B]
+    @test names(rename(df, Dict(:A => :A_1, :B => :B_1))) == [:A_1, :B_1]
+    @test names(df) == [:A, :B]
+    @test names(rename(x->Symbol(lowercase(string(x))), df)) == [:a, :b]
+    @test names(df) == [:A, :B]
+
+    @test rename!(df, :A => :A_1) === df
+    @test names(df) == [:A_1, :B]
+    @test rename!(df, :A_1 => :A_2, :B => :B_2) === df
+    @test names(df) == [:A_2, :B_2]
+    @test rename!(df, [:A_2 => :A_3, :B_2 => :B_3]) === df
+    @test names(df) == [:A_3, :B_3]
+    @test rename!(df, Dict(:A_3 => :A_4, :B_3 => :B_4)) === df
+    @test names(df) == [:A_4, :B_4]
+    @test rename!(x->Symbol(lowercase(string(x))), df) === df
+    @test names(df) == [:a_4, :b_4]
+end
+
+@testset "size" begin
+    df = DataFrame(A = 1:3, B = 'A':'C')
+    @test_throws ArgumentError size(df, 3)
+    @test ndims(df) == 2
+    @test ndims(typeof(df)) == 2
+    @test (nrow(df), ncol(df)) == (3, 2)
+    @test size(df) == (3, 2)
+    @inferred nrow(df)
+    @inferred ncol(df)
+end
+
+@testset "description" begin
+    df = DataFrame(A = 1:10)
+
+    @test first(df) == df[1, :]
+    @test last(df) == df[end, :]
+    @test_throws BoundsError first(DataFrame(x=[]))
+    @test_throws BoundsError last(DataFrame(x=[]))
+
+    @test first(df, 6) == DataFrame(A = 1:6)
+    @test first(df, 1) == DataFrame(A = 1)
+    @test last(df, 6) == DataFrame(A = 5:10)
+    @test last(df, 1) == DataFrame(A = 10)
+end
+
+@testset "misc" begin
+    df = DataFrame([collect('A':'C')])
+    @test sprint(dump, df) == "DataFrame  3 observations of 1 variables\n  x1: ['A', 'B', 'C']\n\n"
+    df = DataFrame(A = 1:12, B = repeat('A':'C', inner=4))
+    # @test DataFrames.without(df, 1) == DataFrame(B = repeat('A':'C', inner=4))
+end
+
+@testset "column conversions" begin
+    df = DataFrame([collect(1:10), collect(1:10)])
+    @test !isa(df[1], Vector{Union{Int, Missing}})
+    allowmissing!(df, 1)
+    @test isa(df[1], Vector{Union{Int, Missing}})
+    @test !isa(df[2], Vector{Union{Int, Missing}})
+    df[1,1] = missing
+    @test_throws MethodError disallowmissing!(df, 1)
+    df[1,1] = 1
+    disallowmissing!(df, 1)
+    @test isa(df[1], Vector{Int})
+
+    df = DataFrame([collect(1:10), collect(1:10)])
+    allowmissing!(df, [1,2])
+    @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
+    disallowmissing!(df, [1,2])
+    @test isa(df[1], Vector{Int}) && isa(df[2], Vector{Int})
+
+    df = DataFrame([collect(1:10), collect(1:10)])
+    allowmissing!(df)
+    @test isa(df[1], Vector{Union{Int, Missing}}) && isa(df[2], Vector{Union{Int, Missing}})
+    disallowmissing!(df)
+    @test isa(df[1], Vector{Int}) && isa(df[2], Vector{Int})
+
+    df = DataFrame([CategoricalArray(1:10),
+                    CategoricalArray(string.('a':'j'))])
+    allowmissing!(df)
+    @test all(x->x <: CategoricalVector, typeof.(columns(df)))
+    @test eltypes(df)[1] <: Union{CategoricalValue{Int}, Missing}
+    @test eltypes(df)[2] <: Union{CategoricalString, Missing}
+    df[1,2] = missing
+    @test_throws MissingException disallowmissing!(df)
+    df[1,2] = "a"
+    disallowmissing!(df)
+    @test all(x->x <: CategoricalVector, typeof.(columns(df)))
+    @test eltypes(df)[1] <: CategoricalValue{Int}
+    @test eltypes(df)[2] <: CategoricalString
+end
+
+@testset "similar" begin
+    df = DataFrame(a = ["foo"],
+                   b = CategoricalArray(["foo"]),
+                   c = [0.0],
+                   d = CategoricalArray([0.0]))
+    @test eltypes(similar(df)) == eltypes(df)
+    @test size(similar(df)) == size(df)
+
+    rows = size(df, 1) + 5
+    @test size(similar(df, rows)) == (rows, size(df, 2))
+    @test eltypes(similar(df, rows)) == eltypes(df)
+
+    @test size(similar(df, 0)) == (0, size(df, 2))
+    @test eltypes(similar(df, 0)) == eltypes(df)
+
+    e = @test_throws ArgumentError similar(df, -1)
+    @test e.value.msg == "the number of rows must be positive"
+end
+
+@testset "setindex! special cases" begin
+    df = DataFrame(rand(3,2), [:x3, :x3_1])
+    @test_throws ArgumentError df[3] = [1, 2]
+    @test_throws ArgumentError df[4] = [1, 2, 3]
+    df[3] = [1,2,3]
+    df[4] = [1,2,3]
+    @test names(df) == [:x3, :x3_1, :x3_2, :x4]
+    df = DataFrame()
+    @test_throws MethodError df[true] = 1
+    @test_throws MethodError df[true] = [1,2,3]
+    @test_throws MethodError df[1:2, true] = [1,2]
+    @test_throws MethodError df[1, true] = 1
+    @test_throws ArgumentError df[1, 100] = 1
+    @test_throws ArgumentError df[1:2, 100] = [1,2]
+end
+
+@testset "passing range to a DataFrame" begin
+    df = DataFrame(a=1:3, b='a':'c')
+    df[:c] = 1:3
+    df[:d] = 'a':'c'
+    @test all(typeof(df[i]) <: Vector for i in 1:ncol(df))
+end
+
+@testset "test corner case of getindex" begin
+    df = DataFrame(x=[1], y=[1])
+    @test_throws MethodError df[true, 1:2]
+end
+
+@testset "empty data frame getindex" begin
+    @test_throws BoundsError DataFrame(x=[])[1, :]
+    @test_throws BoundsError DataFrame()[1, :]
+    @test_throws BoundsError DataFrame()[1:2, :]
+    @test_throws BoundsError DataFrame()[1, Bool[]]
+    @test_throws BoundsError DataFrame()[1:2, Bool[]]
+    @test_throws BoundsError DataFrame(x=[1])[1:2, [false]]
+    @test_throws BoundsError DataFrame(x=[1])[2, [false]]
+    #but this is OK:
+    @test DataFrame(x=[1])[1:1, [false]] == DataFrame()
+end
+
+@testset "handling of end in indexing" begin
+    z = DataFrame(rand(4,5))
+    for x in [z, view(z, 1:4, :)]
+        y = deepcopy(x)
+        @test x[end] == x[5]
+        @test x[end:end] == x[5:5]
+        @test x[end, :] == x[4, :]
+        @test x[end:end, :] == x[4:4, :]
+        @test x[end, end] == x[4,5]
+        @test x[2:end, 2:end] == x[2:4,2:5]
+        x[end] = 1:4
+        y[5] = 1:4
+        @test x == y
+        x[4:end] = DataFrame([11:14, 21:24])
+        y[4] = [11:14;]
+        y[5] = [21:24;]
+        @test x == y
+        x[end, :] = 111
+        y[4, :] = 111
+        @test x == y
+        x[end,end] = 1000
+        y[4,5] = 1000
+        @test x == y
+        x[2:end, 2:end] = 0
+        y[2:4, 2:5] = 0
+        @test x == y
     end
 end
+
+@testset "aliasing in indexing" begin
+    # columns should not alias if scalar broadcasted
+    df = DataFrame(A=[0], B=[0])
+    df[1:end] = 0.0
+    df[1, :A] = 1.0
+    @test df[1, :B] === 0
+
+    df = DataFrame(A=[0], B=[0])
+    df[:, 1:end] = 0.0
+    df[1, :A] = 1.0
+    @test df[1, :B] === 0
+
+    # columns should not alias if vector assigned
+    df = DataFrame(A=[0], B=[0])
+    x = [0.0]
+    df[1:end] = x
+    x[1] = 1.0
+    @test df[1, :A] === 0.0
+    @test df[1, :B] === 0.0
+    df[1, :A] = 1.0
+    @test df[1, :B] === 0.0
+
+    df = DataFrame(A=[0], B=[0])
+    x = [0.0]
+    df[:, 1:end] = x
+    x[1] = 1.0
+    @test df[1, :A] === 0.0
+    @test df[1, :B] === 0.0
+    df[1, :A] = 1.0
+    @test df[1, :B] === 0.0
+end
+
+@testset "permutecols!" begin
+    a, b, c = 1:5, 2:6, 3:7
+    original = DataFrame(a=a, b=b, c=c)
+
+    df = deepcopy(original)
+    expected = deepcopy(original)
+    @test permutecols!(df, [:a, :b, :c]) === df
+    @test df == expected
+    @test permutecols!(df, 1:3) === df
+    @test df == expected
+
+    df = deepcopy(original)
+    expected = DataFrame(b=b, c=c, a=a)
+    permutecols!(df, [:b, :c, :a]) === df
+    @test df == expected
+    df = deepcopy(original)
+    permutecols!(df, [2, 3, 1]) === df
+    @test df == expected
+
+    df = deepcopy(original)
+    expected = DataFrame(c=c, a=a, b=b)
+    permutecols!(df, [:c, :a, :b]) === df
+    @test df == expected
+    df = deepcopy(original)
+    permutecols!(df, [3, 1, 2]) === df
+    @test df == expected
+
+    df = deepcopy(original)
+    expected = DataFrame(a=a, c=c, b=b)
+    permutecols!(df, [:a, :c, :b]) === df
+    @test df == expected
+    df = deepcopy(original)
+    permutecols!(df, [1, 3, 2]) === df
+    @test df == expected
+
+    df = deepcopy(original)
+    expected = DataFrame(b=b, a=a, c=c)
+    permutecols!(df, [:b, :a, :c]) === df
+    @test df == expected
+    df = deepcopy(original)
+    permutecols!(df, [2, 1, 3]) === df
+    @test df == expected
+
+    df = deepcopy(original)
+    expected = DataFrame(c=c, b=b, a=a)
+    permutecols!(df, [:c, :b, :a]) === df
+    @test df == expected
+    df = deepcopy(original)
+    permutecols!(df, [3, 2, 1]) === df
+    @test df == expected
+
+    # Invalid
+    df = DataFrame(a=a, b=b, c=c)
+    @test_throws ArgumentError permutecols!(df, [:a, :b])
+    @test_throws ArgumentError permutecols!(df, 1:4)
+    @test_throws KeyError permutecols!(df, [:a, :b, :c, :d])
+    @test_throws ArgumentError permutecols!(df, [1, 3])
+    @test_throws ArgumentError permutecols!(df, [:a, :c])
+    @test_throws ArgumentError permutecols!(df, [1, 2, 3, 1])
+    @test_throws ArgumentError permutecols!(df, [:a, :b, :c, :a])
+end
+
+@testset "getproperty, setproperty! and propertynames" begin
+    x = collect(1:10)
+    y = collect(1.0:10.0)
+    z = collect(10:-1:1)
+    df = DataFrame(x = x, y = y)
+
+    @test Base.propertynames(df) == names(df)
+
+    @test df.x === x
+    @test df.y === y
+    @test_throws KeyError df.z
+
+    df.x = 2:11
+    @test df.x == 2:11
+    @test x == 1:10
+    df.y = 1
+    @test df.y == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+    @test df.y === y
+    df.z = z
+    @test df.z === z
+    df.zz = 1
+    @test df.zz == df.y
+end
+
+@testset "duplicate column names" begin
+    x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])
+    v = DataFrame(a = [5, 6, 7], b = [8, 9, 10])
+    z = vcat(v, x)
+    @test_throws ArgumentError z[:, [1, 1, 2]]
+    @test_throws ArgumentError z[[1, 1, 2]]
+end
+
+@testset "parent, size and axes" begin
+    x = DataFrame(a = [1, 2, 3], b = [4, 5, 6])
+    @test parent(x) === x
+    @test parentindices(x) === (Base.OneTo(3), Base.OneTo(2))
+    @test size(x) == (3,2)
+    @test size(x, 1) == 3
+    @test size(x, 2) == 2
+    @test_throws ArgumentError size(x, 3)
+    @test axes(x) === (Base.OneTo(3), Base.OneTo(2))
+    @test axes(x, 1) === Base.OneTo(3)
+    @test axes(x, 2) === Base.OneTo(2)
+    @test_throws ArgumentError axes(x, 3)
+    @test size(DataFrame()) == (0,0)
+end
+
+end # module

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -1,315 +1,317 @@
 module TestDataFrameRow
-    using Test, DataFrames
-    using DataFrames: columns
 
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing],
-                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
-    df2 = DataFrame(a = [1, 2, 3])
-    sdf = view(df, [5, 3], [3, 1, 2])
+using Test, DataFrames
+using DataFrames: columns
 
-    @test names(DataFrameRow(df, 1, :)) == [:a, :b, :c, :d]
-    @test names(DataFrameRow(df, 3, [3, 2])) == [:c, :b]
-    @test copy(DataFrameRow(df, 3, [3, 2])) == (c = "C", b = 1.2)
-    @test copy(DataFrameRow(sdf, 2, [3, 2])) == (b = 1.2, a = 3)
-    @test copy(DataFrameRow(sdf, 2, :)) == (c = "C", a = 3, b = 1.2)
-    @test DataFrameRow(df, 3, [3, 2]) == df[3, [3, 2]] == view(df, 3, [3, 2])
-    @test DataFrameRow(sdf, 2, [3, 2]) == sdf[2, [3, 2]] == view(sdf, 2, [3, 2])
-    @test DataFrameRow(sdf, 2, :) == sdf[2, :] == view(sdf, 2, :)
-    @test DataFrameRow(df, 3, 2:3) === df[3, 2:3]
-    @test view(df, 3, 2:3) === df[3, 2:3]
-    @test_throws ArgumentError DataFrameRow(df, 1, :a)
-    @test_throws ArgumentError DataFrameRow(df, 1, 1)
-    @test_throws BoundsError DataFrameRow(df, 1, 1:10)
-    @test_throws BoundsError DataFrameRow(df, 1, [1:10;])
-    @test_throws BoundsError DataFrameRow(df, 100, 1:2)
-    @test_throws BoundsError DataFrameRow(df, 100, [1:2;])
-    @test_throws BoundsError DataFrameRow(df, 100, :)
-    @test_throws MethodError DataFrameRow(df, true, 1:2)
-    if VERSION ≥ v"1.0.0"
-        # this test throws a warning on Julia 0.7
-        @test_throws ArgumentError DataFrameRow(sdf, true, 1:2)
-    end
+df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+               b=[2.0, missing, 1.2, 2.0, missing, missing],
+               c=["A", "B", "C", "A", "B", missing],
+               d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+df2 = DataFrame(a = [1, 2, 3])
+sdf = view(df, [5, 3], [3, 1, 2])
 
-    # getindex
-    r = DataFrameRow(df, 2, :)
-    @test r[:] === r
-    @test view(r, :) === r
-    @test r[3] == "B"
-    @test_throws BoundsError r[5]
-    @test view(r, 3)[] == "B"
-    view(r, 3)[] = "BB"
-    @test df.c[2] == "BB"
-    @test_throws MethodError r[true]
-    @test_throws MethodError view(r, true)
-    @test copy(r[[:c,:a]]) == (c = "BB", a = 2)
-    @test copy(view(r, [:c,:a])) == (c = "BB", a = 2)
-    @test copy(r[[true, false, true, false]]) == (a = 2, c = "BB")
-    r.c = "B"
-    @test df.c[2] == "B"
-    @test_throws BoundsError copy(r[[true, false, true]])
-
-    r = DataFrameRow(sdf, 2, [3, 1])
-    @test r[:] == r
-    @test view(r, :) === r
-    @test r[2] == "C"
-    @test_throws BoundsError r[4]
-    @test view(r, 2)[] == "C"
-    view(r, 2)[] = "CC"
-    @test df.c[3] == "CC"
-    @test_throws MethodError r[true]
-    @test_throws MethodError view(r, true)
-    @test copy(r[[:c,:b]]) == (c = "CC", b = 1.2)
-    @test copy(view(r, [:c,:b])) == (c = "CC", b = 1.2)
-    @test copy(view(r, [:c,:b])) == (c = "CC", b = 1.2)
-    @test copy(r[[false, true]]) == (c = "CC",)
-    r.c = "C"
-    @test df.c[3] == "C"
-
-    #
-    # Equality
-    #
-    @test DataFrameRow(df, 1, :) != DataFrameRow(df2, 1, :)
-    @test DataFrameRow(df, 1, [:a]) == DataFrameRow(df2, 1, :)
-    @test DataFrameRow(df, 1, [:a]) == DataFrameRow(df2, big(1), :)
-    @test DataFrameRow(df, 1, :) != DataFrameRow(df, 2, :)
-    @test DataFrameRow(df, 1, :) != DataFrameRow(df, 3, :)
-    @test DataFrameRow(df, 1, :) == DataFrameRow(df, 4, :)
-    @test ismissing(DataFrameRow(df, 2, :) == DataFrameRow(df, 5, :))
-    @test isequal(DataFrameRow(df, 2, :), DataFrameRow(df, 5, :))
-    @test ismissing(DataFrameRow(df, 2, :) != DataFrameRow(df, 6, :))
-    @test !isequal(DataFrameRow(df, 2, :), DataFrameRow(df, 6, :))
-
-    # isless()
-    df4 = DataFrame(a=[1, 1, 2, 2, 2, 2, missing, missing],
-                    b=Union{Float64, Missing}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
-                    c=[:B, missing, :A, :C, :D, :D, :A, :A])
-    @test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 2, :))
-    @test !isless(DataFrameRow(df4, 2, :), DataFrameRow(df4, 1, :))
-    @test !isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 1, :))
-    @test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 3, :))
-    @test !isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 1, :))
-    @test isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 4, :))
-    @test !isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 3, :))
-    @test isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 5, :))
-    @test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 4, :))
-    @test !isless(DataFrameRow(df4, 6, :), DataFrameRow(df4, 5, :))
-    @test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 6, :))
-    @test isless(DataFrameRow(df4, 7, :), DataFrameRow(df4, 8, :))
-    @test !isless(DataFrameRow(df4, 8, :), DataFrameRow(df4, 7, :))
-
-    # hashing
-    @test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 2, :))
-    @test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 3, :))
-    @test hash(DataFrameRow(df, 1, :)) == hash(DataFrameRow(df, 4, :))
-    @test hash(DataFrameRow(df, 2, :)) == hash(DataFrameRow(df, 5, :))
-    @test hash(DataFrameRow(df, 2, :)) != hash(DataFrameRow(df, 6, :))
-
-    # check that hashrows() function generates the same hashes as DataFrameRow
-    df_rowhashes, _ = DataFrames.hashrows(Tuple(columns(df)), false)
-    @test df_rowhashes == [hash(dr) for dr in eachrow(df)]
-
-    # test incompatible frames
-    @test_throws UndefVarError DataFrameRow(df, 1, :) == DataFrameRow(df3, 1, :)
-
-    # test RowGroupDict
-    N = 20
-    d1 = rand(map(Int64, 1:2), N)
-    df5 = DataFrame([d1], [:d1])
-    df6 = DataFrame(d1 = [2,3])
-
-    # test_group("group_rows")
-    gd = DataFrames.group_rows(df5)
-    @test length(unique(gd.groups)) == 2
-
-    # getting groups for the rows of the other frames
-    @test length(gd[DataFrameRow(df6, 1, :)]) > 0
-    @test_throws KeyError gd[DataFrameRow(df6, 2, :)]
-    @test isempty(DataFrames.findrows(gd, df6, (gd.df[1],), (df6[1],), 2))
-
-    # grouping empty frame
-    gd = DataFrames.group_rows(DataFrame(x=Int[]))
-    @test length(unique(gd.groups)) == 0
-
-    # grouping single row
-    gd = DataFrames.group_rows(df5[1:1,:])
-    @test length(unique(gd.groups)) == 1
-
-    # getproperty, setproperty! and propertynames
-    r = DataFrameRow(df, 1, :)
-    @test Base.propertynames(r) == names(df)
-    @test r.a === 1
-    @test r.b === 2.0
-    @test copy(r[[:a,:b]]) === (a=1, b=2.0)
-
-    r.a = 2
-    @test r.a === 2
-    r.b = 1
-    @test r.b === 1.0
-
-    # keys, values and iteration, size
-    @test keys(r) == names(df)
-    @test values(r) == (df[1, 1], df[1, 2], df[1, 3], df[1, 4])
-    @test collect(pairs(r)) == [:a=>df[1, 1], :b=>df[1, 2], :c=>df[1, 3], :d=>df[1, 4]]
-
-    @test haskey(r, :a)
-    @test haskey(r, 1)
-    @test !haskey(r, :zzz)
-    @test !haskey(r, 0)
-    @test !haskey(r, 1000)
-    @test_throws ArgumentError haskey(r, true)
-
-    x = DataFrame(ones(5,4))
-    dfr = view(x, 2, 2:3)
-    @test names(dfr) == names(x)[2:3]
-    dfr = view(x, 2, [4,2])
-    @test names(dfr) == names(x)[[4,2]]
-
-    x = DataFrame(ones(10,10))
-    r = x[3, [8, 5, 1, 3]]
-    @test length(r) == 4
-    @test lastindex(r) == 4
-    @test ndims(r) == 1
-    @test ndims(typeof(r)) == 1
-    @test size(r) == (4,)
-    @test size(r, 1) == 4
-    @test_throws BoundsError size(r, 2)
-    @test keys(r) == [:x8, :x5, :x1, :x3]
-    r[:] = 0.0
-    r[1:2] = 2.0
-    @test values(r) == (2.0, 2.0, 0.0, 0.0)
-    @test collect(pairs(r)) == [:x8 => 2.0, :x5 => 2.0, :x1 => 0.0, :x3 => 0.0]
-
-    # convert
-    df = DataFrame(a=[1, missing], b=[2.0, 3.0])
-    dfr = DataFrameRow(df, 1, :)
-    @test convert(Vector, dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
-    @test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]
-    @test Vector(dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
-    @test Vector{Int}(dfr)::Vector{Int} == [1, 2]
-
-    # copy
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing])
-    @test copy(DataFrameRow(df, 1, :)) == (a = 1, b = 2.0, c = "A")
-    @test isequal(copy(DataFrameRow(df, 2, :)), (a = 2, b = missing, c = "B"))
-
-    # parent and parentindices
-    @test parent(df[2, :]) === df
-    @test parentindices(df[2, :]) == (2, Base.OneTo(3))
-    @test parent(df[1, 1:3]) === df
-    @test parentindices(df[1, [3,2]]) == (1, [3, 2])
-    sdf = view(df, [4,3], [:c, :a])
-    @test parent(sdf[2, :]) === df
-    @test parentindices(sdf[2, :]) == (3, [3, 1])
-    @test parent(sdf[1, 1:2]) === df
-    @test parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
-
-    # iteration and collect
-    ref = ["a", "b", "c"]
-    df = DataFrame(permutedims(ref))
-    dfr = df[1, :]
-    @test Base.IteratorEltype(dfr) == Base.EltypeUnknown()
-    @test collect(dfr) == ref
-    @test eltype(collect(dfr)) === String
-    for (v1, v2) in zip(ref, dfr)
-        @test v1 == v2
-    end
-    for (i, v) in enumerate(dfr)
-        @test v == ref[i]
-    end
-    dfr = DataFrame(a=1, b=true, c=1.0)[1,:]
-    @test eltype(collect(dfr)) === Real
-
-    @testset "duplicate column" begin
-        df = DataFrame([11:16 21:26 31:36 41:46])
-        sdf = view(df, [3,1,4], [3,1,4])
-        dfr1 = df[2, [2,2,2]]
-        dfr2 = sdf[2, [2,2,2]]
-        @test names(dfr1) == fill(:x2, 3)
-        @test names(dfr2) == fill(:x1, 3)
-        @test values(dfr1) == (22, 22, 22)
-        @test values(dfr2) == (11, 11, 11)
-        @test dfr1.x2 == 22
-        dfr1.x2 = 100
-        @test values(dfr1) == (100, 100, 100)
-        @test df[2, 2] == 100
-        @test_throws KeyError dfr1.x1
-        @test dfr2.x1 == 11
-        dfr2.x1 = 200
-        @test values(dfr2) == (200, 200, 200)
-        @test df[1, 1] == 200
-        @test_throws KeyError dfr2.x2
-    end
-
-    @testset "conversion and push!" begin
-            df = DataFrame(x=1, y=2)
-
-            @test df == DataFrame(df[1, :])
-            @test df[1:1, [2,1]] == DataFrame(df[1, [2,1]])
-            @test df[1:1, 1:1] == DataFrame(df[1, 1:1])
-            @test_throws ArgumentError DataFrame(df[1, [1,1]])
-
-            @test_throws ArgumentError push!(df, df[1, 1:1])
-            @test df == DataFrame(x=1, y=2)
-
-            @test_throws ArgumentError push!(df, df[1, [2,2]])
-            @test df == DataFrame(x=1, y=2)
-
-            @test_throws ArgumentError push!(df, df[1, [2,1,2]])
-            @test df == DataFrame(x=1, y=2)
-
-            @test push!(df, df[1, :]) == DataFrame(x=[1, 1], y=[2, 2])
-            @test push!(df, df[1, [2,1]]) == DataFrame(x=[1, 1, 1], y=[2, 2, 2])
-    end
-
-    @testset "show" begin
-        df = DataFrame(a=nothing, b=1)
-
-        @test sprint(show, DataFrameRow(df, 1, :)) == """
-            DataFrameRow
-            │ Row │ a       │ b     │
-            │     │ Nothing │ $(Int) │
-            ├─────┼─────────┼───────┤
-            │ 1   │         │ 1     │"""
-
-
-        df = DataFrame(a=1:3, b=["a", "b", "c"], c=Int64[1,0,1])
-        dfr = df[2, 2:3]
-
-        @test sprint(show, dfr) == """
-            DataFrameRow
-            │ Row │ b      │ c     │
-            │     │ String │ Int64 │
-            ├─────┼────────┼───────┤
-            │ 2   │ b      │ 0     │"""
-
-        @test sprint(show, "text/html", dfr) == "<p>DataFrameRow</p><table class=\"data-frame\">" *
-                                   "<thead><tr><th></th><th>b</th><th>c</th></tr>" *
-                                   "<tr><th></th><th>String</th><th>Int64</th></tr></thead>" *
-                                   "<tbody><p>1 rows × 2 columns</p><tr><th>2</th>" *
-                                   "<td>b</td><td>0</td></tr></tbody></table>"
-
-        @test sprint(show, "text/latex", dfr) == """
-            \\begin{tabular}{r|cc}
-            \t& b & c\\\\
-            \t\\hline
-            \t& String & Int64\\\\
-            \t\\hline
-            \t2 & b & 0 \\\\
-            \\end{tabular}
-            """
-
-        @test sprint(show, "text/csv", dfr) == """
-            \"b\",\"c\"
-            \"b\",0
-            """
-
-        @test sprint(show, "text/tab-separated-values", dfr) == """
-            \"b\"\t\"c\"
-            \"b\"\t0
-            """
-    end
+@test names(DataFrameRow(df, 1, :)) == [:a, :b, :c, :d]
+@test names(DataFrameRow(df, 3, [3, 2])) == [:c, :b]
+@test copy(DataFrameRow(df, 3, [3, 2])) == (c = "C", b = 1.2)
+@test copy(DataFrameRow(sdf, 2, [3, 2])) == (b = 1.2, a = 3)
+@test copy(DataFrameRow(sdf, 2, :)) == (c = "C", a = 3, b = 1.2)
+@test DataFrameRow(df, 3, [3, 2]) == df[3, [3, 2]] == view(df, 3, [3, 2])
+@test DataFrameRow(sdf, 2, [3, 2]) == sdf[2, [3, 2]] == view(sdf, 2, [3, 2])
+@test DataFrameRow(sdf, 2, :) == sdf[2, :] == view(sdf, 2, :)
+@test DataFrameRow(df, 3, 2:3) === df[3, 2:3]
+@test view(df, 3, 2:3) === df[3, 2:3]
+@test_throws ArgumentError DataFrameRow(df, 1, :a)
+@test_throws ArgumentError DataFrameRow(df, 1, 1)
+@test_throws BoundsError DataFrameRow(df, 1, 1:10)
+@test_throws BoundsError DataFrameRow(df, 1, [1:10;])
+@test_throws BoundsError DataFrameRow(df, 100, 1:2)
+@test_throws BoundsError DataFrameRow(df, 100, [1:2;])
+@test_throws BoundsError DataFrameRow(df, 100, :)
+@test_throws MethodError DataFrameRow(df, true, 1:2)
+if VERSION ≥ v"1.0.0"
+    # this test throws a warning on Julia 0.7
+    @test_throws ArgumentError DataFrameRow(sdf, true, 1:2)
 end
+
+# getindex
+r = DataFrameRow(df, 2, :)
+@test r[:] === r
+@test view(r, :) === r
+@test r[3] == "B"
+@test_throws BoundsError r[5]
+@test view(r, 3)[] == "B"
+view(r, 3)[] = "BB"
+@test df.c[2] == "BB"
+@test_throws MethodError r[true]
+@test_throws MethodError view(r, true)
+@test copy(r[[:c,:a]]) == (c = "BB", a = 2)
+@test copy(view(r, [:c,:a])) == (c = "BB", a = 2)
+@test copy(r[[true, false, true, false]]) == (a = 2, c = "BB")
+r.c = "B"
+@test df.c[2] == "B"
+@test_throws BoundsError copy(r[[true, false, true]])
+
+r = DataFrameRow(sdf, 2, [3, 1])
+@test r[:] == r
+@test view(r, :) === r
+@test r[2] == "C"
+@test_throws BoundsError r[4]
+@test view(r, 2)[] == "C"
+view(r, 2)[] = "CC"
+@test df.c[3] == "CC"
+@test_throws MethodError r[true]
+@test_throws MethodError view(r, true)
+@test copy(r[[:c,:b]]) == (c = "CC", b = 1.2)
+@test copy(view(r, [:c,:b])) == (c = "CC", b = 1.2)
+@test copy(view(r, [:c,:b])) == (c = "CC", b = 1.2)
+@test copy(r[[false, true]]) == (c = "CC",)
+r.c = "C"
+@test df.c[3] == "C"
+
+#
+# Equality
+#
+@test DataFrameRow(df, 1, :) != DataFrameRow(df2, 1, :)
+@test DataFrameRow(df, 1, [:a]) == DataFrameRow(df2, 1, :)
+@test DataFrameRow(df, 1, [:a]) == DataFrameRow(df2, big(1), :)
+@test DataFrameRow(df, 1, :) != DataFrameRow(df, 2, :)
+@test DataFrameRow(df, 1, :) != DataFrameRow(df, 3, :)
+@test DataFrameRow(df, 1, :) == DataFrameRow(df, 4, :)
+@test ismissing(DataFrameRow(df, 2, :) == DataFrameRow(df, 5, :))
+@test isequal(DataFrameRow(df, 2, :), DataFrameRow(df, 5, :))
+@test ismissing(DataFrameRow(df, 2, :) != DataFrameRow(df, 6, :))
+@test !isequal(DataFrameRow(df, 2, :), DataFrameRow(df, 6, :))
+
+# isless()
+df4 = DataFrame(a=[1, 1, 2, 2, 2, 2, missing, missing],
+                b=Union{Float64, Missing}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
+                c=[:B, missing, :A, :C, :D, :D, :A, :A])
+@test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 2, :))
+@test !isless(DataFrameRow(df4, 2, :), DataFrameRow(df4, 1, :))
+@test !isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 1, :))
+@test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 3, :))
+@test !isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 1, :))
+@test isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 4, :))
+@test !isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 3, :))
+@test isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 5, :))
+@test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 4, :))
+@test !isless(DataFrameRow(df4, 6, :), DataFrameRow(df4, 5, :))
+@test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 6, :))
+@test isless(DataFrameRow(df4, 7, :), DataFrameRow(df4, 8, :))
+@test !isless(DataFrameRow(df4, 8, :), DataFrameRow(df4, 7, :))
+
+# hashing
+@test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 2, :))
+@test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 3, :))
+@test hash(DataFrameRow(df, 1, :)) == hash(DataFrameRow(df, 4, :))
+@test hash(DataFrameRow(df, 2, :)) == hash(DataFrameRow(df, 5, :))
+@test hash(DataFrameRow(df, 2, :)) != hash(DataFrameRow(df, 6, :))
+
+# check that hashrows() function generates the same hashes as DataFrameRow
+df_rowhashes, _ = DataFrames.hashrows(Tuple(columns(df)), false)
+@test df_rowhashes == [hash(dr) for dr in eachrow(df)]
+
+# test incompatible frames
+@test_throws UndefVarError DataFrameRow(df, 1, :) == DataFrameRow(df3, 1, :)
+
+# test RowGroupDict
+N = 20
+d1 = rand(map(Int64, 1:2), N)
+df5 = DataFrame([d1], [:d1])
+df6 = DataFrame(d1 = [2,3])
+
+# test_group("group_rows")
+gd = DataFrames.group_rows(df5)
+@test length(unique(gd.groups)) == 2
+
+# getting groups for the rows of the other frames
+@test length(gd[DataFrameRow(df6, 1, :)]) > 0
+@test_throws KeyError gd[DataFrameRow(df6, 2, :)]
+@test isempty(DataFrames.findrows(gd, df6, (gd.df[1],), (df6[1],), 2))
+
+# grouping empty frame
+gd = DataFrames.group_rows(DataFrame(x=Int[]))
+@test length(unique(gd.groups)) == 0
+
+# grouping single row
+gd = DataFrames.group_rows(df5[1:1,:])
+@test length(unique(gd.groups)) == 1
+
+# getproperty, setproperty! and propertynames
+r = DataFrameRow(df, 1, :)
+@test Base.propertynames(r) == names(df)
+@test r.a === 1
+@test r.b === 2.0
+@test copy(r[[:a,:b]]) === (a=1, b=2.0)
+
+r.a = 2
+@test r.a === 2
+r.b = 1
+@test r.b === 1.0
+
+# keys, values and iteration, size
+@test keys(r) == names(df)
+@test values(r) == (df[1, 1], df[1, 2], df[1, 3], df[1, 4])
+@test collect(pairs(r)) == [:a=>df[1, 1], :b=>df[1, 2], :c=>df[1, 3], :d=>df[1, 4]]
+
+@test haskey(r, :a)
+@test haskey(r, 1)
+@test !haskey(r, :zzz)
+@test !haskey(r, 0)
+@test !haskey(r, 1000)
+@test_throws ArgumentError haskey(r, true)
+
+x = DataFrame(ones(5,4))
+dfr = view(x, 2, 2:3)
+@test names(dfr) == names(x)[2:3]
+dfr = view(x, 2, [4,2])
+@test names(dfr) == names(x)[[4,2]]
+
+x = DataFrame(ones(10,10))
+r = x[3, [8, 5, 1, 3]]
+@test length(r) == 4
+@test lastindex(r) == 4
+@test ndims(r) == 1
+@test ndims(typeof(r)) == 1
+@test size(r) == (4,)
+@test size(r, 1) == 4
+@test_throws BoundsError size(r, 2)
+@test keys(r) == [:x8, :x5, :x1, :x3]
+r[:] = 0.0
+r[1:2] = 2.0
+@test values(r) == (2.0, 2.0, 0.0, 0.0)
+@test collect(pairs(r)) == [:x8 => 2.0, :x5 => 2.0, :x1 => 0.0, :x3 => 0.0]
+
+# convert
+df = DataFrame(a=[1, missing], b=[2.0, 3.0])
+dfr = DataFrameRow(df, 1, :)
+@test convert(Vector, dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
+@test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]
+@test Vector(dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
+@test Vector{Int}(dfr)::Vector{Int} == [1, 2]
+
+# copy
+df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+               b=[2.0, missing, 1.2, 2.0, missing, missing],
+               c=["A", "B", "C", "A", "B", missing])
+@test copy(DataFrameRow(df, 1, :)) == (a = 1, b = 2.0, c = "A")
+@test isequal(copy(DataFrameRow(df, 2, :)), (a = 2, b = missing, c = "B"))
+
+# parent and parentindices
+@test parent(df[2, :]) === df
+@test parentindices(df[2, :]) == (2, Base.OneTo(3))
+@test parent(df[1, 1:3]) === df
+@test parentindices(df[1, [3,2]]) == (1, [3, 2])
+sdf = view(df, [4,3], [:c, :a])
+@test parent(sdf[2, :]) === df
+@test parentindices(sdf[2, :]) == (3, [3, 1])
+@test parent(sdf[1, 1:2]) === df
+@test parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
+
+# iteration and collect
+ref = ["a", "b", "c"]
+df = DataFrame(permutedims(ref))
+dfr = df[1, :]
+@test Base.IteratorEltype(dfr) == Base.EltypeUnknown()
+@test collect(dfr) == ref
+@test eltype(collect(dfr)) === String
+for (v1, v2) in zip(ref, dfr)
+    @test v1 == v2
+end
+for (i, v) in enumerate(dfr)
+    @test v == ref[i]
+end
+dfr = DataFrame(a=1, b=true, c=1.0)[1,:]
+@test eltype(collect(dfr)) === Real
+
+@testset "duplicate column" begin
+    df = DataFrame([11:16 21:26 31:36 41:46])
+    sdf = view(df, [3,1,4], [3,1,4])
+    dfr1 = df[2, [2,2,2]]
+    dfr2 = sdf[2, [2,2,2]]
+    @test names(dfr1) == fill(:x2, 3)
+    @test names(dfr2) == fill(:x1, 3)
+    @test values(dfr1) == (22, 22, 22)
+    @test values(dfr2) == (11, 11, 11)
+    @test dfr1.x2 == 22
+    dfr1.x2 = 100
+    @test values(dfr1) == (100, 100, 100)
+    @test df[2, 2] == 100
+    @test_throws KeyError dfr1.x1
+    @test dfr2.x1 == 11
+    dfr2.x1 = 200
+    @test values(dfr2) == (200, 200, 200)
+    @test df[1, 1] == 200
+    @test_throws KeyError dfr2.x2
+end
+
+@testset "conversion and push!" begin
+        df = DataFrame(x=1, y=2)
+
+        @test df == DataFrame(df[1, :])
+        @test df[1:1, [2,1]] == DataFrame(df[1, [2,1]])
+        @test df[1:1, 1:1] == DataFrame(df[1, 1:1])
+        @test_throws ArgumentError DataFrame(df[1, [1,1]])
+
+        @test_throws ArgumentError push!(df, df[1, 1:1])
+        @test df == DataFrame(x=1, y=2)
+
+        @test_throws ArgumentError push!(df, df[1, [2,2]])
+        @test df == DataFrame(x=1, y=2)
+
+        @test_throws ArgumentError push!(df, df[1, [2,1,2]])
+        @test df == DataFrame(x=1, y=2)
+
+        @test push!(df, df[1, :]) == DataFrame(x=[1, 1], y=[2, 2])
+        @test push!(df, df[1, [2,1]]) == DataFrame(x=[1, 1, 1], y=[2, 2, 2])
+end
+
+@testset "show" begin
+    df = DataFrame(a=nothing, b=1)
+
+    @test sprint(show, DataFrameRow(df, 1, :)) == """
+        DataFrameRow
+        │ Row │ a       │ b     │
+        │     │ Nothing │ $(Int) │
+        ├─────┼─────────┼───────┤
+        │ 1   │         │ 1     │"""
+
+
+    df = DataFrame(a=1:3, b=["a", "b", "c"], c=Int64[1,0,1])
+    dfr = df[2, 2:3]
+
+    @test sprint(show, dfr) == """
+        DataFrameRow
+        │ Row │ b      │ c     │
+        │     │ String │ Int64 │
+        ├─────┼────────┼───────┤
+        │ 2   │ b      │ 0     │"""
+
+    @test sprint(show, "text/html", dfr) == "<p>DataFrameRow</p><table class=\"data-frame\">" *
+                               "<thead><tr><th></th><th>b</th><th>c</th></tr>" *
+                               "<tr><th></th><th>String</th><th>Int64</th></tr></thead>" *
+                               "<tbody><p>1 rows × 2 columns</p><tr><th>2</th>" *
+                               "<td>b</td><td>0</td></tr></tbody></table>"
+
+    @test sprint(show, "text/latex", dfr) == """
+        \\begin{tabular}{r|cc}
+        \t& b & c\\\\
+        \t\\hline
+        \t& String & Int64\\\\
+        \t\\hline
+        \t2 & b & 0 \\\\
+        \\end{tabular}
+        """
+
+    @test sprint(show, "text/csv", dfr) == """
+        \"b\",\"c\"
+        \"b\",0
+        """
+
+    @test sprint(show, "text/tab-separated-values", dfr) == """
+        \"b\"\t\"c\"
+        \"b\"\t0
+        """
+end
+
+end # module

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,49 +1,51 @@
 module TestDeprecated
-    using Test, DataFrames
-    import DataFrames: identifier
 
-    # old sort(df; cols=...) syntax
-    df = DataFrame(a=[1, 3, 2], b=[6, 5, 4])
-    @test sort(df; cols=[:a, :b]) == DataFrame(a=[1, 2, 3], b=[6, 4, 5])
-    sort!(df; cols=[:a, :b])
-    @test df == DataFrame(a=[1, 2, 3], b=[6, 4, 5])
+using Test, DataFrames
+import DataFrames: identifier
 
-    df = DataFrame(a=[1, 3, 2], b=[6, 5, 4])
-    @test sort(df; cols=[:b, :a]) == DataFrame(a=[2, 3, 1], b=[4, 5, 6])
-    sort!(df; cols=[:b, :a])
-    @test df == DataFrame(a=[2, 3, 1], b=[4, 5, 6])
+# old sort(df; cols=...) syntax
+df = DataFrame(a=[1, 3, 2], b=[6, 5, 4])
+@test sort(df; cols=[:a, :b]) == DataFrame(a=[1, 2, 3], b=[6, 4, 5])
+sort!(df; cols=[:a, :b])
+@test df == DataFrame(a=[1, 2, 3], b=[6, 4, 5])
 
-    @test first.(collect(pairs(DataFrameRow(df, 1, :)))) == [:a, :b]
-    @test last.(collect(pairs(DataFrameRow(df, 1, :)))) == [df[1, 1], df[1, 2]]
+df = DataFrame(a=[1, 3, 2], b=[6, 5, 4])
+@test sort(df; cols=[:b, :a]) == DataFrame(a=[2, 3, 1], b=[4, 5, 6])
+sort!(df; cols=[:b, :a])
+@test df == DataFrame(a=[2, 3, 1], b=[4, 5, 6])
 
-    @testset "identifier" begin
-        @test identifier("%_B*_\tC*") == :_B_C_
-        @test identifier("2a") == :x2a
-        @test identifier("!") == :x!
-        @test identifier("\t_*") == :_
-        @test identifier("begin") == :_begin
-        @test identifier("end") == :_end
-    end
+@test first.(collect(pairs(DataFrameRow(df, 1, :)))) == [:a, :b]
+@test last.(collect(pairs(DataFrameRow(df, 1, :)))) == [df[1, 1], df[1, 2]]
 
-    # Check that reserved words are up to date
+@testset "identifier" begin
+    @test identifier("%_B*_\tC*") == :_B_C_
+    @test identifier("2a") == :x2a
+    @test identifier("!") == :x!
+    @test identifier("\t_*") == :_
+    @test identifier("begin") == :_begin
+    @test identifier("end") == :_end
+end
 
-    @testset "reserved words" begin
-        f = "$(Sys.BINDIR)/../../src/julia-parser.scm"
-        if isfile(f)
-            r1 = r"define initial-reserved-words '\(([^)]+)"
-            r2 = r"define \(parse-block s(?: \([^)]+\))?\)\s+\(parse-Nary s (?:parse-eq '\([^(]*|down '\([^)]+\) '[^']+ ')\(([^)]+)"
-            body = read(f, String)
-            m1, m2 = match(r1, body), match(r2, body)
-            if m1 == nothing || m2 == nothing
-                error("Unable to extract keywords from 'julia-parser.scm'.")
-            else
-                s = replace(string(m1.captures[1]," ",m2.captures[1]), r";;.*?\n" => "")
-                rw = Set(split(s, r"\W+"))
-                @test rw == DataFrames.RESERVED_WORDS
-            end
+# Check that reserved words are up to date
+
+@testset "reserved words" begin
+    f = "$(Sys.BINDIR)/../../src/julia-parser.scm"
+    if isfile(f)
+        r1 = r"define initial-reserved-words '\(([^)]+)"
+        r2 = r"define \(parse-block s(?: \([^)]+\))?\)\s+\(parse-Nary s (?:parse-eq '\([^(]*|down '\([^)]+\) '[^']+ ')\(([^)]+)"
+        body = read(f, String)
+        m1, m2 = match(r1, body), match(r2, body)
+        if m1 == nothing || m2 == nothing
+            error("Unable to extract keywords from 'julia-parser.scm'.")
         else
-            @warn("Unable to validate reserved words against parser. ",
-                  "Expected if Julia was not built from source.")
+            s = replace(string(m1.captures[1]," ",m2.captures[1]), r";;.*?\n" => "")
+            rw = Set(split(s, r"\W+"))
+            @test rw == DataFrames.RESERVED_WORDS
         end
+    else
+        @warn("Unable to validate reserved words against parser. ",
+              "Expected if Julia was not built from source.")
     end
 end
+
+end # module

--- a/test/duplicates.jl
+++ b/test/duplicates.jl
@@ -1,23 +1,25 @@
 module TestDuplicates
-    using Test, DataFrames
-    const ≅ = isequal
 
-    @testset "nonunique" begin
-        df = DataFrame(a = [1, 2, 3, 3, 4])
-        udf = DataFrame(a = [1, 2, 3, 4])
-        @test nonunique(df) == [false, false, false, true, false]
-        @test udf == unique(df)
-        unique!(df)
-        @test df == udf
+using Test, DataFrames
+const ≅ = isequal
 
-        pdf = DataFrame(a = CategoricalArray(["a", "a", missing, missing, "b", missing, "a", missing]),
-                        b = CategoricalArray(["a", "b", missing, missing, "b", "a", "a", "a"]))
-        updf = DataFrame(a = CategoricalArray(["a", "a", missing, "b", missing]),
-                        b = CategoricalArray(["a", "b", missing, "b", "a"]))
-        @test nonunique(pdf) == [false, false, false, true, false, false, true, true]
-        @test nonunique(updf) == falses(5)
-        @test updf ≅ unique(pdf)
-        unique!(pdf)
-        @test pdf ≅ updf
-    end
+@testset "nonunique" begin
+    df = DataFrame(a = [1, 2, 3, 3, 4])
+    udf = DataFrame(a = [1, 2, 3, 4])
+    @test nonunique(df) == [false, false, false, true, false]
+    @test udf == unique(df)
+    unique!(df)
+    @test df == udf
+
+    pdf = DataFrame(a = CategoricalArray(["a", "a", missing, missing, "b", missing, "a", missing]),
+                    b = CategoricalArray(["a", "b", missing, missing, "b", "a", "a", "a"]))
+    updf = DataFrame(a = CategoricalArray(["a", "a", missing, "b", missing]),
+                    b = CategoricalArray(["a", "b", missing, "b", "a"]))
+    @test nonunique(pdf) == [false, false, false, true, false, false, true, true]
+    @test nonunique(updf) == falses(5)
+    @test updf ≅ unique(pdf)
+    unique!(pdf)
+    @test pdf ≅ updf
 end
+
+end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1,1031 +1,1033 @@
 module TestGrouping
-    using Test, DataFrames, Random, Statistics
-    const ≅ = isequal
 
-    # Call groupby, checking that groups field is consistent with other fields
-    # (since == and isequal do not use it)
-    function groupby_checked(df::AbstractDataFrame, keys, args...; kwargs...)
-        gd = groupby(df, keys, args...; kwargs...)
+using Test, DataFrames, Random, Statistics
+const ≅ = isequal
+
+# Call groupby, checking that groups field is consistent with other fields
+# (since == and isequal do not use it)
+function groupby_checked(df::AbstractDataFrame, keys, args...; kwargs...)
+    gd = groupby(df, keys, args...; kwargs...)
+    for i in 1:length(gd)
+        @assert findall(==(i), gd.groups) == gd.idx[gd.starts[i]:gd.ends[i]]
+    end
+    gd
+end
+
+@testset "parent" begin
+    df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8])
+    gd = groupby(df, :a)
+    @test parent(gd) === df
+end
+
+@testset "colwise" begin
+    Random.seed!(1)
+    df = DataFrame(a = repeat(Union{Int, Missing}[1, 3, 2, 4], outer=[2]),
+                   b = repeat(Union{Int, Missing}[2, 1], outer=[4]),
+                   c = Vector{Union{Float64, Missing}}(randn(8)))
+
+    missingfree = DataFrame([collect(1:10)], [:x1])
+
+    @testset "::Function, ::AbstractDataFrame" begin
+        cw = colwise(sum, df)
+        answer = [20, 12, -0.4283098098931877]
+        @test isa(cw, Vector{Real})
+        @test size(cw) == (ncol(df),)
+        @test cw == answer
+
+        cw = colwise(sum, missingfree)
+        answer = [55]
+        @test isa(cw, Array{Int, 1})
+        @test size(cw) == (ncol(missingfree),)
+        @test cw == answer
+    end
+
+    @testset "::Function, ::GroupedDataFrame" begin
+        gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+        @test colwise(length, gd) == [[2,2], [2,2]]
+    end
+
+    @testset "::Vector, ::AbstractDataFrame" begin
+        cw = colwise([sum], df)
+        answer = [20 12 -0.4283098098931877]
+        @test isa(cw, Array{Real, 2})
+        @test size(cw) == (length([sum]),ncol(df))
+        @test cw == answer
+
+        cw = colwise([sum, minimum], missingfree)
+        answer = reshape([55, 1], (2,1))
+        @test isa(cw, Array{Int, 2})
+        @test size(cw) == (length([sum, minimum]), ncol(missingfree))
+        @test cw == answer
+
+        cw = colwise([Vector{Union{Int, Missing}}], missingfree)
+        answer = reshape([Vector{Union{Int, Missing}}(1:10)], (1,1))
+        @test isa(cw, Array{Vector{Union{Int, Missing}},2})
+        @test size(cw) == (1, ncol(missingfree))
+        @test cw == answer
+
+        @test_throws MethodError colwise(["Bob", :Susie], DataFrame(A = 1:10, B = 11:20))
+    end
+
+    @testset "::Vector, ::GroupedDataFrame" begin
+        gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+        @test colwise([length], gd) == [[2 2], [2 2]]
+    end
+
+    @testset "::Tuple, ::AbstractDataFrame" begin
+        cw = colwise((sum, length), df)
+        answer = Any[20 12 -0.4283098098931877; 8 8 8]
+        @test isa(cw, Array{Real, 2})
+        @test size(cw) == (length((sum, length)), ncol(df))
+        @test cw == answer
+
+        cw = colwise((sum, length), missingfree)
+        answer = reshape([55, 10], (2,1))
+        @test isa(cw, Array{Int, 2})
+        @test size(cw) == (length((sum, length)), ncol(missingfree))
+        @test cw == answer
+
+        cw = colwise((CategoricalArray, Vector{Union{Int, Missing}}), missingfree)
+        answer = reshape([CategoricalArray(1:10), Vector{Union{Int, Missing}}(1:10)],
+                         (2, ncol(missingfree)))
+        @test typeof(cw) == Array{AbstractVector,2}
+        @test size(cw) == (2, ncol(missingfree))
+        @test cw == answer
+
+        @test_throws MethodError colwise(("Bob", :Susie), DataFrame(A = 1:10, B = 11:20))
+    end
+
+    @testset "::Tuple, ::GroupedDataFrame" begin
+        gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+        @test colwise((length), gd) == [[2,2],[2,2]]
+    end
+end
+
+@testset "by, groupby and map(::Function, ::GroupedDataFrame)" begin
+    Random.seed!(1)
+    df = DataFrame(a = repeat(Union{Int, Missing}[1, 3, 2, 4], outer=[2]),
+                   b = repeat(Union{Int, Missing}[2, 1], outer=[4]),
+                   c = repeat([0, 1], outer=[4]),
+                   x = Vector{Union{Float64, Missing}}(randn(8)))
+
+    f1(df) = DataFrame(xmax = maximum(df.x))
+    f2(df) = (xmax = maximum(df.x),)
+    f3(df) = maximum(df.x)
+    f4(df) = [maximum(df.x), minimum(df.x)]
+    f5(df) = reshape([maximum(df.x), minimum(df.x)], 2, 1)
+    f6(df) = [maximum(df.x) minimum(df.x)]
+    f7(df) = (x2 = df.x.^2,)
+    f8(df) = DataFrame(x2 = df.x.^2)
+
+    for cols in ([:a, :b], [:b, :a], [:a, :c], [:c, :a],
+                 [1, 2], [2, 1], [1, 3], [3, 1],
+                 [true, true, false, false], [true, false, true, false])
+        colssym = names(df[cols])
+        hcatdf = hcat(df[cols], df, makeunique=true)
+        nms = names(hcatdf)
+        res = unique(df[cols])
+        res.xmax = [maximum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x])
+                    for (a, b) in zip(res[colssym[1]], res[colssym[2]])]
+        res2 = unique(df[cols])[repeat(1:4, inner=2), :]
+        res2.x1 = collect(Iterators.flatten(
+            [[maximum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x]),
+              minimum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x])]
+             for (a, b) in zip(res[colssym[1]], res[colssym[2]])]))
+        res3 = unique(df[cols])
+        res3.x1 = [maximum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x])
+                   for (a, b) in zip(res[colssym[1]], res[colssym[2]])]
+        res3.x2 = [minimum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x])
+                   for (a, b) in zip(res[colssym[1]], res[colssym[2]])]
+        res4 = df[cols]
+        res4.x2 = df.x.^2
+        shcatdf = sort(hcatdf, colssym)
+        sres = sort(res, colssym)
+        sres2 = sort(res2, colssym)
+        sres3 = sort(res3, colssym)
+        sres4 = sort(res4, colssym)
+
+        # by() without groups sorting
+        @test sort(by(df, cols, identity), colssym) == shcatdf
+        @test sort(by(df, cols, df -> df[1, :]), colssym) ==
+            shcatdf[.!nonunique(shcatdf, colssym), :]
+        @test by(df, cols, f1) == res
+        @test by(df, cols, f2) == res
+        @test rename(by(df, cols, f3), :x1 => :xmax) == res
+        @test by(df, cols, f4) == res2
+        @test by(df, cols, f5) == res2
+        @test by(df, cols, f6) == res3
+        @test sort(by(df, cols, f7), colssym) == sres4
+        @test sort(by(df, cols, f8), colssym) == sres4
+
+        # by() with groups sorting
+        @test by(df, cols, identity, sort=true) == shcatdf
+        @test by(df, cols, df -> df[1, :], sort=true) ==
+            shcatdf[.!nonunique(shcatdf, colssym), :]
+        @test by(df, cols, f1, sort=true) == sres
+        @test by(df, cols, f2, sort=true) == sres
+        @test rename(by(df, cols, f3, sort=true), :x1 => :xmax) == sres
+        @test by(df, cols, f4, sort=true) == sres2
+        @test by(df, cols, f5, sort=true) == sres2
+        @test by(df, cols, f6, sort=true) == sres3
+        @test by(df, cols, f7, sort=true) == sres4
+        @test by(df, cols, f8, sort=true) == sres4
+
+        @test by(df, [:a], f1) == by(df, :a, f1)
+        @test by(df, [:a], f1, sort=true) == by(df, :a, f1, sort=true)
+
+        # groupby() without groups sorting
+        gd = groupby_checked(df, cols)
+        @test names(parent(gd))[gd.cols] == colssym
+        @test sort(combine(identity, gd), colssym) ==
+            sort(combine(gd), colssym) ==
+            shcatdf
+        @test combine(f1, gd) == res
+        @test combine(f2, gd) == res
+        @test rename(combine(f3, gd), :x1 => :xmax) == res
+        @test combine(f4, gd) == res2
+        @test combine(f5, gd) == res2
+        @test combine(f6, gd) == res3
+        @test sort(combine(f7, gd), colssym) == sort(res4, colssym)
+        @test sort(combine(f8, gd), colssym) == sort(res4, colssym)
+
+        # groupby() with groups sorting
+        gd = groupby_checked(df, cols, sort=true)
+        @test names(parent(gd))[gd.cols] == colssym
         for i in 1:length(gd)
-            @assert findall(==(i), gd.groups) == gd.idx[gd.starts[i]:gd.ends[i]]
+            @test all(gd[i][colssym[1]] .== sres[i, colssym[1]])
+            @test all(gd[i][colssym[2]] .== sres[i, colssym[2]])
         end
-        gd
-    end
+        @test combine(identity, gd) == combine(gd) == shcatdf
+        @test combine(f1, gd) == sres
+        @test combine(f2, gd) == sres
+        @test rename(combine(f3, gd), :x1 => :xmax) == sres
+        @test combine(f4, gd) == sres2
+        @test combine(f5, gd) == sres2
+        @test combine(f6, gd) == sres3
+        @test combine(f7, gd) == sres4
+        @test combine(f8, gd) == sres4
 
-    @testset "parent" begin
-        df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8])
-        gd = groupby(df, :a)
-        @test parent(gd) === df
-    end
-
-    @testset "colwise" begin
-        Random.seed!(1)
-        df = DataFrame(a = repeat(Union{Int, Missing}[1, 3, 2, 4], outer=[2]),
-                       b = repeat(Union{Int, Missing}[2, 1], outer=[4]),
-                       c = Vector{Union{Float64, Missing}}(randn(8)))
-
-        missingfree = DataFrame([collect(1:10)], [:x1])
-
-        @testset "::Function, ::AbstractDataFrame" begin
-            cw = colwise(sum, df)
-            answer = [20, 12, -0.4283098098931877]
-            @test isa(cw, Vector{Real})
-            @test size(cw) == (ncol(df),)
-            @test cw == answer
-
-            cw = colwise(sum, missingfree)
-            answer = [55]
-            @test isa(cw, Array{Int, 1})
-            @test size(cw) == (ncol(missingfree),)
-            @test cw == answer
-        end
-
-        @testset "::Function, ::GroupedDataFrame" begin
-            gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
-            @test colwise(length, gd) == [[2,2], [2,2]]
-        end
-
-        @testset "::Vector, ::AbstractDataFrame" begin
-            cw = colwise([sum], df)
-            answer = [20 12 -0.4283098098931877]
-            @test isa(cw, Array{Real, 2})
-            @test size(cw) == (length([sum]),ncol(df))
-            @test cw == answer
-
-            cw = colwise([sum, minimum], missingfree)
-            answer = reshape([55, 1], (2,1))
-            @test isa(cw, Array{Int, 2})
-            @test size(cw) == (length([sum, minimum]), ncol(missingfree))
-            @test cw == answer
-
-            cw = colwise([Vector{Union{Int, Missing}}], missingfree)
-            answer = reshape([Vector{Union{Int, Missing}}(1:10)], (1,1))
-            @test isa(cw, Array{Vector{Union{Int, Missing}},2})
-            @test size(cw) == (1, ncol(missingfree))
-            @test cw == answer
-
-            @test_throws MethodError colwise(["Bob", :Susie], DataFrame(A = 1:10, B = 11:20))
-        end
-
-        @testset "::Vector, ::GroupedDataFrame" begin
-            gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
-            @test colwise([length], gd) == [[2 2], [2 2]]
-        end
-
-        @testset "::Tuple, ::AbstractDataFrame" begin
-            cw = colwise((sum, length), df)
-            answer = Any[20 12 -0.4283098098931877; 8 8 8]
-            @test isa(cw, Array{Real, 2})
-            @test size(cw) == (length((sum, length)), ncol(df))
-            @test cw == answer
-
-            cw = colwise((sum, length), missingfree)
-            answer = reshape([55, 10], (2,1))
-            @test isa(cw, Array{Int, 2})
-            @test size(cw) == (length((sum, length)), ncol(missingfree))
-            @test cw == answer
-
-            cw = colwise((CategoricalArray, Vector{Union{Int, Missing}}), missingfree)
-            answer = reshape([CategoricalArray(1:10), Vector{Union{Int, Missing}}(1:10)],
-                             (2, ncol(missingfree)))
-            @test typeof(cw) == Array{AbstractVector,2}
-            @test size(cw) == (2, ncol(missingfree))
-            @test cw == answer
-
-            @test_throws MethodError colwise(("Bob", :Susie), DataFrame(A = 1:10, B = 11:20))
-        end
-
-        @testset "::Tuple, ::GroupedDataFrame" begin
-            gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
-            @test colwise((length), gd) == [[2,2],[2,2]]
+        # map() without and with groups sorting
+        for sort in (false, true)
+            gd = groupby_checked(df, cols, sort=sort)
+            v = map(d -> d[[:x]], gd)
+            @test length(gd) == length(v)
+            nms = [colssym; :x]
+            @test v[1] == gd[1][nms]
+            @test v[1] == gd[1][nms] &&
+                v[2] == gd[2][nms] &&
+                v[3] == gd[3][nms] &&
+                v[4] == gd[4][nms]
+            @test names(parent(v))[v.cols] == colssym
+            v = map(f1, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f1, df, cols, sort=sort)
+            v = map(f2, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f2, df, cols, sort=sort)
+            v = map(f3, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f3, df, cols, sort=sort)
+            v = map(f4, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f4, df, cols, sort=sort)
+            v = map(f5, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f5, df, cols, sort=sort)
+            v = map(f5, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f5, df, cols, sort=sort)
+            v = map(f6, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f6, df, cols, sort=sort)
+            v = map(f7, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f7, df, cols, sort=sort)
+            v = map(f8, gd)
+            @test vcat(v[1], v[2], v[3], v[4]) == by(f8, df, cols, sort=sort)
         end
     end
 
-    @testset "by, groupby and map(::Function, ::GroupedDataFrame)" begin
-        Random.seed!(1)
-        df = DataFrame(a = repeat(Union{Int, Missing}[1, 3, 2, 4], outer=[2]),
-                       b = repeat(Union{Int, Missing}[2, 1], outer=[4]),
-                       c = repeat([0, 1], outer=[4]),
-                       x = Vector{Union{Float64, Missing}}(randn(8)))
+    # test number of potential combinations higher than typemax(Int32)
+    N = 2000
+    df2 = DataFrame(v1 = levels!(categorical(rand(1:N, 100)), collect(1:N)),
+                    v2 = levels!(categorical(rand(1:N, 100)), collect(1:N)),
+                    v3 = levels!(categorical(rand(1:N, 100)), collect(1:N)))
+    df2b = mapcols(Vector{Int}, df2)
+    @test groupby_checked(df2, [:v1, :v2, :v3]) ==
+        groupby_checked(df2b, [:v1, :v2, :v3])
 
-        f1(df) = DataFrame(xmax = maximum(df.x))
-        f2(df) = (xmax = maximum(df.x),)
-        f3(df) = maximum(df.x)
-        f4(df) = [maximum(df.x), minimum(df.x)]
-        f5(df) = reshape([maximum(df.x), minimum(df.x)], 2, 1)
-        f6(df) = [maximum(df.x) minimum(df.x)]
-        f7(df) = (x2 = df.x.^2,)
-        f8(df) = DataFrame(x2 = df.x.^2)
+    # grouping empty table
+    @test groupby_checked(DataFrame(A=Int[]), :A).starts == Int[]
+    # grouping single row
+    @test groupby_checked(DataFrame(A=Int[1]), :A).starts == Int[1]
 
-        for cols in ([:a, :b], [:b, :a], [:a, :c], [:c, :a],
-                     [1, 2], [2, 1], [1, 3], [3, 1],
-                     [true, true, false, false], [true, false, true, false])
-            colssym = names(df[cols])
-            hcatdf = hcat(df[cols], df, makeunique=true)
-            nms = names(hcatdf)
-            res = unique(df[cols])
-            res.xmax = [maximum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x])
-                        for (a, b) in zip(res[colssym[1]], res[colssym[2]])]
-            res2 = unique(df[cols])[repeat(1:4, inner=2), :]
-            res2.x1 = collect(Iterators.flatten(
-                [[maximum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x]),
-                  minimum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x])]
-                 for (a, b) in zip(res[colssym[1]], res[colssym[2]])]))
-            res3 = unique(df[cols])
-            res3.x1 = [maximum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x])
-                       for (a, b) in zip(res[colssym[1]], res[colssym[2]])]
-            res3.x2 = [minimum(df[(df[colssym[1]] .== a) .& (df[colssym[2]] .== b), :x])
-                       for (a, b) in zip(res[colssym[1]], res[colssym[2]])]
-            res4 = df[cols]
-            res4.x2 = df.x.^2
-            shcatdf = sort(hcatdf, colssym)
-            sres = sort(res, colssym)
-            sres2 = sort(res2, colssym)
-            sres3 = sort(res3, colssym)
-            sres4 = sort(res4, colssym)
+    # issue #960
+    x = CategoricalArray(collect(1:20))
+    df = DataFrame(v1=x, v2=x)
+    groupby_checked(df, [:v1, :v2])
 
-            # by() without groups sorting
-            @test sort(by(df, cols, identity), colssym) == shcatdf
-            @test sort(by(df, cols, df -> df[1, :]), colssym) ==
-                shcatdf[.!nonunique(shcatdf, colssym), :]
-            @test by(df, cols, f1) == res
-            @test by(df, cols, f2) == res
-            @test rename(by(df, cols, f3), :x1 => :xmax) == res
-            @test by(df, cols, f4) == res2
-            @test by(df, cols, f5) == res2
-            @test by(df, cols, f6) == res3
-            @test sort(by(df, cols, f7), colssym) == sres4
-            @test sort(by(df, cols, f8), colssym) == sres4
+    df2 = by(e->1, DataFrame(x=Int64[]), :x)
+    @test size(df2) == (0, 1)
+    @test sum(df2[:x]) == 0
 
-            # by() with groups sorting
-            @test by(df, cols, identity, sort=true) == shcatdf
-            @test by(df, cols, df -> df[1, :], sort=true) ==
-                shcatdf[.!nonunique(shcatdf, colssym), :]
-            @test by(df, cols, f1, sort=true) == sres
-            @test by(df, cols, f2, sort=true) == sres
-            @test rename(by(df, cols, f3, sort=true), :x1 => :xmax) == sres
-            @test by(df, cols, f4, sort=true) == sres2
-            @test by(df, cols, f5, sort=true) == sres2
-            @test by(df, cols, f6, sort=true) == sres3
-            @test by(df, cols, f7, sort=true) == sres4
-            @test by(df, cols, f8, sort=true) == sres4
+    # Check that reordering levels does not confuse groupby
+    df = DataFrame(Key1 = CategoricalArray(["A", "A", "B", "B", "B", "A"]),
+                   Key2 = CategoricalArray(["A", "B", "A", "B", "B", "A"]),
+                   Value = 1:6)
+    gd = groupby_checked(df, :Key1)
+    @test length(gd) == 2
+    @test gd[1] == DataFrame(Key1="A", Key2=["A", "B", "A"], Value=[1, 2, 6])
+    @test gd[2] == DataFrame(Key1="B", Key2=["A", "B", "B"], Value=[3, 4, 5])
+    gd = groupby_checked(df, [:Key1, :Key2])
+    @test length(gd) == 4
+    @test gd[1] == DataFrame(Key1="A", Key2="A", Value=[1, 6])
+    @test gd[2] == DataFrame(Key1="A", Key2="B", Value=2)
+    @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
+    @test gd[4] == DataFrame(Key1="B", Key2="B", Value=[4, 5])
+    # Reorder levels, add unused level
+    levels!(df[:Key1], ["Z", "B", "A"])
+    levels!(df[:Key2], ["Z", "B", "A"])
+    gd = groupby_checked(df, :Key1)
+    @test gd == groupby_checked(df, :Key1, skipmissing=true)
+    @test length(gd) == 2
+    @test gd[1] == DataFrame(Key1="B", Key2=["A", "B", "B"], Value=[3, 4, 5])
+    @test gd[2] == DataFrame(Key1="A", Key2=["A", "B", "A"], Value=[1, 2, 6])
+    gd = groupby_checked(df, [:Key1, :Key2])
+    @test gd == groupby_checked(df, [:Key1, :Key2], skipmissing=true)
+    @test length(gd) == 4
+    @test gd[1] == DataFrame(Key1="B", Key2="B", Value=[4, 5])
+    @test gd[2] == DataFrame(Key1="B", Key2="A", Value=3)
+    @test gd[3] == DataFrame(Key1="A", Key2="B", Value=2)
+    @test gd[4] == DataFrame(Key1="A", Key2="A", Value=[1, 6])
+    # Make first level unused too
+    replace!(df.Key1, "A"=>"B")
+    gd = groupby_checked(df, :Key1)
+    @test length(gd) == 1
+    @test gd[1] == DataFrame(Key1="B", Key2=["A", "B", "A", "B", "B", "A"], Value=1:6)
+    gd = groupby_checked(df, [:Key1, :Key2])
+    @test gd == groupby_checked(df, [:Key1, :Key2])
+    @test length(gd) == 2
+    @test gd[1] == DataFrame(Key1="B", Key2="B", Value=[2, 4, 5])
+    @test gd[2] == DataFrame(Key1="B", Key2="A", Value=[1, 3, 6])
 
-            @test by(df, [:a], f1) == by(df, :a, f1)
-            @test by(df, [:a], f1, sort=true) == by(df, :a, f1, sort=true)
+    # Check that CategoricalArray column is preserved when returning a value...
+    res = combine(d -> DataFrame(x=d[1, :Key2]), groupby_checked(df, :Key1))
+    @test res.x isa CategoricalVector{String}
+    res = combine(d -> (x=d[1, :Key2],), groupby_checked(df, :Key1))
+    @test res.x isa CategoricalVector{String}
+    # ...and when returning an array
+    res = combine(d -> DataFrame(x=d[:Key1]), groupby_checked(df, :Key1))
+    @test res.x isa CategoricalVector{String}
 
-            # groupby() without groups sorting
-            gd = groupby_checked(df, cols)
-            @test names(parent(gd))[gd.cols] == colssym
-            @test sort(combine(identity, gd), colssym) ==
-                sort(combine(gd), colssym) ==
-                shcatdf
-            @test combine(f1, gd) == res
-            @test combine(f2, gd) == res
-            @test rename(combine(f3, gd), :x1 => :xmax) == res
-            @test combine(f4, gd) == res2
-            @test combine(f5, gd) == res2
-            @test combine(f6, gd) == res3
-            @test sort(combine(f7, gd), colssym) == sort(res4, colssym)
-            @test sort(combine(f8, gd), colssym) == sort(res4, colssym)
+    # Check that CategoricalArray and String give a String...
+    res = combine(d -> d.Key1 == ["A", "A"] ? DataFrame(x=d[1, :Key1]) : DataFrame(x="C"),
+                 groupby_checked(df, :Key1))
+    @test res.x isa Vector{String}
+    res = combine(d -> d.Key1 == ["A", "A"] ? (x=d[1, :Key1],) : (x="C",),
+                  groupby_checked(df, :Key1))
+    @test res.x isa Vector{String}
+    # ...even when CategoricalString comes second
+    res = combine(d -> d.Key1 == ["B", "B"] ? DataFrame(x=d[1, :Key1]) : DataFrame(x="C"),
+                  groupby_checked(df, :Key1))
+    @test res.x isa Vector{String}
+    res = combine(d -> d.Key1 == ["B", "B"] ? (x=d[1, :Key1],) : (x="C",),
+                  groupby_checked(df, :Key1))
+    @test res.x isa Vector{String}
 
-            # groupby() with groups sorting
-            gd = groupby_checked(df, cols, sort=true)
-            @test names(parent(gd))[gd.cols] == colssym
-            for i in 1:length(gd)
-                @test all(gd[i][colssym[1]] .== sres[i, colssym[1]])
-                @test all(gd[i][colssym[2]] .== sres[i, colssym[2]])
-            end
-            @test combine(identity, gd) == combine(gd) == shcatdf
-            @test combine(f1, gd) == sres
-            @test combine(f2, gd) == sres
-            @test rename(combine(f3, gd), :x1 => :xmax) == sres
-            @test combine(f4, gd) == sres2
-            @test combine(f5, gd) == sres2
-            @test combine(f6, gd) == sres3
-            @test combine(f7, gd) == sres4
-            @test combine(f8, gd) == sres4
+    df = DataFrame(x = [1, 2, 3], y = [2, 3, 1])
 
-            # map() without and with groups sorting
-            for sort in (false, true)
-                gd = groupby_checked(df, cols, sort=sort)
-                v = map(d -> d[[:x]], gd)
-                @test length(gd) == length(v)
-                nms = [colssym; :x]
-                @test v[1] == gd[1][nms]
-                @test v[1] == gd[1][nms] &&
-                    v[2] == gd[2][nms] &&
-                    v[3] == gd[3][nms] &&
-                    v[4] == gd[4][nms]
-                @test names(parent(v))[v.cols] == colssym
-                v = map(f1, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f1, df, cols, sort=sort)
-                v = map(f2, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f2, df, cols, sort=sort)
-                v = map(f3, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f3, df, cols, sort=sort)
-                v = map(f4, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f4, df, cols, sort=sort)
-                v = map(f5, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f5, df, cols, sort=sort)
-                v = map(f5, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f5, df, cols, sort=sort)
-                v = map(f6, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f6, df, cols, sort=sort)
-                v = map(f7, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f7, df, cols, sort=sort)
-                v = map(f8, gd)
-                @test vcat(v[1], v[2], v[3], v[4]) == by(f8, df, cols, sort=sort)
-            end
-        end
+    # Test function returning DataFrameRow
+    res = by(d -> DataFrameRow(d, 1, :), df, :x)
+    @test res == DataFrame(x=df.x, x_1=df.x, y=df.y)
 
-        # test number of potential combinations higher than typemax(Int32)
-        N = 2000
-        df2 = DataFrame(v1 = levels!(categorical(rand(1:N, 100)), collect(1:N)),
-                        v2 = levels!(categorical(rand(1:N, 100)), collect(1:N)),
-                        v3 = levels!(categorical(rand(1:N, 100)), collect(1:N)))
-        df2b = mapcols(Vector{Int}, df2)
-        @test groupby_checked(df2, [:v1, :v2, :v3]) ==
-            groupby_checked(df2b, [:v1, :v2, :v3])
+    # Test function returning Tuple
+    res = by(d -> (sum(d.y),), df, :x)
+    @test res == DataFrame(x=df.x, x1=tuple.([2, 3, 1]))
 
-        # grouping empty table
-        @test groupby_checked(DataFrame(A=Int[]), :A).starts == Int[]
-        # grouping single row
-        @test groupby_checked(DataFrame(A=Int[1]), :A).starts == Int[1]
+    # Test with some groups returning empty data frames
+    @test by(d -> d.x == [1] ? DataFrame(z=[]) : DataFrame(z=1), df, :x) ==
+        DataFrame(x=[2, 3], z=[1, 1])
+    v = map(d -> d.x == [1] ? DataFrame(z=[]) : DataFrame(z=1), groupby_checked(df, :x))
+    @test length(v) == 2
+    @test vcat(v[1], v[2]) == DataFrame(x=[2, 3], z=[1, 1])
 
-        # issue #960
-        x = CategoricalArray(collect(1:20))
-        df = DataFrame(v1=x, v2=x)
-        groupby_checked(df, [:v1, :v2])
+    # Test that returning values of different types works with NamedTuple
+    res = by(d -> d.x == [1] ? 1 : 2.0, df, :x)
+    @test res.x1 isa Vector{Float64}
+    @test res.x1 == [1, 2, 2]
+    # Two columns need to be widened at different times
+    res = by(d -> (a=d.x == [1] ? 1 : 2.0, b=d.x == [3] ? missing : "a"), df, :x)
+    @test res.a isa Vector{Float64}
+    @test res.a == [1, 2, 2]
+    @test res.b isa Vector{Union{String,Missing}}
+    @test res.b ≅ ["a", "a", missing]
+    # Corner case: two columns need to be widened at the same time
+    res = by(d -> (a=d.x == [1] ? 1 : 2.0, b=d.x == [1] ? missing : "a"), df, :x)
+    @test res.a isa Vector{Float64}
+    @test res.a == [1, 2, 2]
+    @test res.b isa Vector{Union{String,Missing}}
+    @test res.b ≅ [missing, "a", "a"]
 
-        df2 = by(e->1, DataFrame(x=Int64[]), :x)
-        @test size(df2) == (0, 1)
-        @test sum(df2[:x]) == 0
+    # Test that returning values of different types works with DataFrame
+    res = by(d -> DataFrame(x1 = d.x == [1] ? 1 : 2.0), df, :x)
+    @test res.x1 isa Vector{Float64}
+    @test res.x1 == [1, 2, 2]
+    # Two columns need to be widened at different times
+    res = by(d -> DataFrame(a=d.x == [1] ? 1 : 2.0, b=d.x == [3] ? missing : "a"), df, :x)
+    @test res.a isa Vector{Float64}
+    @test res.a == [1, 2, 2]
+    @test res.b isa Vector{Union{String,Missing}}
+    @test res.b ≅ ["a", "a", missing]
+    # Corner case: two columns need to be widened at the same time
+    res = by(d -> DataFrame(a=d.x == [1] ? 1 : 2.0, b=d.x == [1] ? missing : "a"), df, :x)
+    @test res.a isa Vector{Float64}
+    @test res.a == [1, 2, 2]
+    @test res.b isa Vector{Union{String,Missing}}
+    @test res.b ≅ [missing, "a", "a"]
 
-        # Check that reordering levels does not confuse groupby
-        df = DataFrame(Key1 = CategoricalArray(["A", "A", "B", "B", "B", "A"]),
-                       Key2 = CategoricalArray(["A", "B", "A", "B", "B", "A"]),
-                       Value = 1:6)
+    # Test return values with columns in different orders
+    @test by(d -> d.x == [1] ? (x1=1, x2=3) : (x2=2, x1=4), df, :x) ==
+        DataFrame(x=1:3, x1=[1, 4, 4], x2=[3, 2, 2])
+    @test by(d -> d.x == [1] ? DataFrame(x1=1, x2=3) : DataFrame(x2=2, x1=4), df, :x) ==
+        DataFrame(x=1:3, x1=[1, 4, 4], x2=[3, 2, 2])
+
+    # Test with NamedTuple with columns of incompatible lengths
+    @test_throws DimensionMismatch by(d -> (x1=[1], x2=[3, 4]), df, :x)
+    @test_throws DimensionMismatch by(d -> d.x == [1] ? (x1=[1], x2=[3]) :
+                                                        (x1=[1], x2=[3, 4]), df, :x)
+
+    # Test with incompatible return values
+    @test_throws ArgumentError by(d -> d.x == [1] ? (x1=1,) : DataFrame(x1=1), df, :x)
+    @test_throws ArgumentError by(d -> d.x == [1] ? NamedTuple() : (x1=1), df, :x)
+    @test_throws ArgumentError by(d -> d.x == [1] ? 1 : DataFrame(x1=1), df, :x)
+    @test_throws ArgumentError by(d -> d.x == [1] ? DataFrame() : DataFrame(x1=1), df, :x)
+    # Special case allowed due to how implementation works
+    @test by(d -> d.x == [1] ? 1 : (x1=1), df, :x) == by(d -> 1, df, :x)
+
+    # Test that columns names and types are respected for empty input
+    df = DataFrame(x=Int[], y=String[])
+    res = by(d -> 1, df, :x)
+    @test size(res) == (0, 1)
+    @test res.x isa Vector{Int}
+
+    # Test with empty data frame
+    df = DataFrame(x=[], y=[])
+    gd = groupby_checked(df, :x)
+    @test combine(df -> sum(df.x), gd) == DataFrame(x=[])
+    res = map(df -> sum(df.x), gd)
+    @test length(res) == 0
+    @test res.parent == DataFrame(x=[])
+end
+
+xv = ["A", missing, "B", "B", "A", "B", "A", "A"]
+yv = ["B", "A", "A", missing, "A", missing, "A", "A"]
+@testset "grouping with missings" for x in (xv,
+                                            categorical(xv),
+                                            levels!(categorical(xv), ["A", "B", "X"]),
+                                            levels!(categorical(xv), ["X", "A", "B"])),
+                                      y in (yv,
+                                            categorical(yv),
+                                            levels!(categorical(yv), ["A", "B", "X"]),
+                                            levels!(categorical(yv), ["X", "A", "B"]))
+    df = DataFrame(Key1 = x, Key2 = y, Value = 1:8)
+
+    @testset "sort=false, skipmissing=false" begin
         gd = groupby_checked(df, :Key1)
-        @test length(gd) == 2
-        @test gd[1] == DataFrame(Key1="A", Key2=["A", "B", "A"], Value=[1, 2, 6])
-        @test gd[2] == DataFrame(Key1="B", Key2=["A", "B", "B"], Value=[3, 4, 5])
-        gd = groupby_checked(df, [:Key1, :Key2])
-        @test length(gd) == 4
-        @test gd[1] == DataFrame(Key1="A", Key2="A", Value=[1, 6])
-        @test gd[2] == DataFrame(Key1="A", Key2="B", Value=2)
-        @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
-        @test gd[4] == DataFrame(Key1="B", Key2="B", Value=[4, 5])
-        # Reorder levels, add unused level
-        levels!(df[:Key1], ["Z", "B", "A"])
-        levels!(df[:Key2], ["Z", "B", "A"])
-        gd = groupby_checked(df, :Key1)
-        @test gd == groupby_checked(df, :Key1, skipmissing=true)
-        @test length(gd) == 2
-        @test gd[1] == DataFrame(Key1="B", Key2=["A", "B", "B"], Value=[3, 4, 5])
-        @test gd[2] == DataFrame(Key1="A", Key2=["A", "B", "A"], Value=[1, 2, 6])
-        gd = groupby_checked(df, [:Key1, :Key2])
-        @test gd == groupby_checked(df, [:Key1, :Key2], skipmissing=true)
-        @test length(gd) == 4
-        @test gd[1] == DataFrame(Key1="B", Key2="B", Value=[4, 5])
-        @test gd[2] == DataFrame(Key1="B", Key2="A", Value=3)
-        @test gd[3] == DataFrame(Key1="A", Key2="B", Value=2)
-        @test gd[4] == DataFrame(Key1="A", Key2="A", Value=[1, 6])
-        # Make first level unused too
-        replace!(df.Key1, "A"=>"B")
-        gd = groupby_checked(df, :Key1)
-        @test length(gd) == 1
-        @test gd[1] == DataFrame(Key1="B", Key2=["A", "B", "A", "B", "B", "A"], Value=1:6)
-        gd = groupby_checked(df, [:Key1, :Key2])
-        @test gd == groupby_checked(df, [:Key1, :Key2])
-        @test length(gd) == 2
-        @test gd[1] == DataFrame(Key1="B", Key2="B", Value=[2, 4, 5])
-        @test gd[2] == DataFrame(Key1="B", Key2="A", Value=[1, 3, 6])
-
-        # Check that CategoricalArray column is preserved when returning a value...
-        res = combine(d -> DataFrame(x=d[1, :Key2]), groupby_checked(df, :Key1))
-        @test res.x isa CategoricalVector{String}
-        res = combine(d -> (x=d[1, :Key2],), groupby_checked(df, :Key1))
-        @test res.x isa CategoricalVector{String}
-        # ...and when returning an array
-        res = combine(d -> DataFrame(x=d[:Key1]), groupby_checked(df, :Key1))
-        @test res.x isa CategoricalVector{String}
-
-        # Check that CategoricalArray and String give a String...
-        res = combine(d -> d.Key1 == ["A", "A"] ? DataFrame(x=d[1, :Key1]) : DataFrame(x="C"),
-                     groupby_checked(df, :Key1))
-        @test res.x isa Vector{String}
-        res = combine(d -> d.Key1 == ["A", "A"] ? (x=d[1, :Key1],) : (x="C",),
-                      groupby_checked(df, :Key1))
-        @test res.x isa Vector{String}
-        # ...even when CategoricalString comes second
-        res = combine(d -> d.Key1 == ["B", "B"] ? DataFrame(x=d[1, :Key1]) : DataFrame(x="C"),
-                      groupby_checked(df, :Key1))
-        @test res.x isa Vector{String}
-        res = combine(d -> d.Key1 == ["B", "B"] ? (x=d[1, :Key1],) : (x="C",),
-                      groupby_checked(df, :Key1))
-        @test res.x isa Vector{String}
-
-        df = DataFrame(x = [1, 2, 3], y = [2, 3, 1])
-
-        # Test function returning DataFrameRow
-        res = by(d -> DataFrameRow(d, 1, :), df, :x)
-        @test res == DataFrame(x=df.x, x_1=df.x, y=df.y)
-
-        # Test function returning Tuple
-        res = by(d -> (sum(d.y),), df, :x)
-        @test res == DataFrame(x=df.x, x1=tuple.([2, 3, 1]))
-
-        # Test with some groups returning empty data frames
-        @test by(d -> d.x == [1] ? DataFrame(z=[]) : DataFrame(z=1), df, :x) ==
-            DataFrame(x=[2, 3], z=[1, 1])
-        v = map(d -> d.x == [1] ? DataFrame(z=[]) : DataFrame(z=1), groupby_checked(df, :x))
-        @test length(v) == 2
-        @test vcat(v[1], v[2]) == DataFrame(x=[2, 3], z=[1, 1])
-
-        # Test that returning values of different types works with NamedTuple
-        res = by(d -> d.x == [1] ? 1 : 2.0, df, :x)
-        @test res.x1 isa Vector{Float64}
-        @test res.x1 == [1, 2, 2]
-        # Two columns need to be widened at different times
-        res = by(d -> (a=d.x == [1] ? 1 : 2.0, b=d.x == [3] ? missing : "a"), df, :x)
-        @test res.a isa Vector{Float64}
-        @test res.a == [1, 2, 2]
-        @test res.b isa Vector{Union{String,Missing}}
-        @test res.b ≅ ["a", "a", missing]
-        # Corner case: two columns need to be widened at the same time
-        res = by(d -> (a=d.x == [1] ? 1 : 2.0, b=d.x == [1] ? missing : "a"), df, :x)
-        @test res.a isa Vector{Float64}
-        @test res.a == [1, 2, 2]
-        @test res.b isa Vector{Union{String,Missing}}
-        @test res.b ≅ [missing, "a", "a"]
-
-        # Test that returning values of different types works with DataFrame
-        res = by(d -> DataFrame(x1 = d.x == [1] ? 1 : 2.0), df, :x)
-        @test res.x1 isa Vector{Float64}
-        @test res.x1 == [1, 2, 2]
-        # Two columns need to be widened at different times
-        res = by(d -> DataFrame(a=d.x == [1] ? 1 : 2.0, b=d.x == [3] ? missing : "a"), df, :x)
-        @test res.a isa Vector{Float64}
-        @test res.a == [1, 2, 2]
-        @test res.b isa Vector{Union{String,Missing}}
-        @test res.b ≅ ["a", "a", missing]
-        # Corner case: two columns need to be widened at the same time
-        res = by(d -> DataFrame(a=d.x == [1] ? 1 : 2.0, b=d.x == [1] ? missing : "a"), df, :x)
-        @test res.a isa Vector{Float64}
-        @test res.a == [1, 2, 2]
-        @test res.b isa Vector{Union{String,Missing}}
-        @test res.b ≅ [missing, "a", "a"]
-
-        # Test return values with columns in different orders
-        @test by(d -> d.x == [1] ? (x1=1, x2=3) : (x2=2, x1=4), df, :x) ==
-            DataFrame(x=1:3, x1=[1, 4, 4], x2=[3, 2, 2])
-        @test by(d -> d.x == [1] ? DataFrame(x1=1, x2=3) : DataFrame(x2=2, x1=4), df, :x) ==
-            DataFrame(x=1:3, x1=[1, 4, 4], x2=[3, 2, 2])
-
-        # Test with NamedTuple with columns of incompatible lengths
-        @test_throws DimensionMismatch by(d -> (x1=[1], x2=[3, 4]), df, :x)
-        @test_throws DimensionMismatch by(d -> d.x == [1] ? (x1=[1], x2=[3]) :
-                                                            (x1=[1], x2=[3, 4]), df, :x)
-
-        # Test with incompatible return values
-        @test_throws ArgumentError by(d -> d.x == [1] ? (x1=1,) : DataFrame(x1=1), df, :x)
-        @test_throws ArgumentError by(d -> d.x == [1] ? NamedTuple() : (x1=1), df, :x)
-        @test_throws ArgumentError by(d -> d.x == [1] ? 1 : DataFrame(x1=1), df, :x)
-        @test_throws ArgumentError by(d -> d.x == [1] ? DataFrame() : DataFrame(x1=1), df, :x)
-        # Special case allowed due to how implementation works
-        @test by(d -> d.x == [1] ? 1 : (x1=1), df, :x) == by(d -> 1, df, :x)
-
-        # Test that columns names and types are respected for empty input
-        df = DataFrame(x=Int[], y=String[])
-        res = by(d -> 1, df, :x)
-        @test size(res) == (0, 1)
-        @test res.x isa Vector{Int}
-
-        # Test with empty data frame
-        df = DataFrame(x=[], y=[])
-        gd = groupby_checked(df, :x)
-        @test combine(df -> sum(df.x), gd) == DataFrame(x=[])
-        res = map(df -> sum(df.x), gd)
-        @test length(res) == 0
-        @test res.parent == DataFrame(x=[])
-    end
-
-    xv = ["A", missing, "B", "B", "A", "B", "A", "A"]
-    yv = ["B", "A", "A", missing, "A", missing, "A", "A"]
-    @testset "grouping with missings" for x in (xv,
-                                                categorical(xv),
-                                                levels!(categorical(xv), ["A", "B", "X"]),
-                                                levels!(categorical(xv), ["X", "A", "B"])),
-                                          y in (yv,
-                                                categorical(yv),
-                                                levels!(categorical(yv), ["A", "B", "X"]),
-                                                levels!(categorical(yv), ["X", "A", "B"]))
-        df = DataFrame(Key1 = x, Key2 = y, Value = 1:8)
-
-        @testset "sort=false, skipmissing=false" begin
-            gd = groupby_checked(df, :Key1)
-            @test length(gd) == 3
-            if df.Key1 isa CategoricalVector # Order of missing changes
-                @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
-                @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
-                @test gd[3] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
-            else
-                @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
-                @test gd[2] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
-                @test gd[3] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
-            end
-
-            gd = groupby_checked(df, [:Key1, :Key2])
-            @test length(gd) == 5
-            if df.Key1 isa CategoricalVector && df.Key2 isa CategoricalVector
-                @test gd[1] ≅ DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
-                @test gd[2] == DataFrame(Key1="A", Key2="B", Value=1)
-                @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
-                @test gd[4] ≅ DataFrame(Key1="B", Key2=missing, Value=[4, 6])
-                @test gd[5] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
-            else
-                @test gd[1] == DataFrame(Key1="A", Key2="B", Value=1)
-                @test gd[2] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
-                @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
-                @test gd[4] ≅ DataFrame(Key1="B", Key2=missing, Value=[4, 6])
-                @test gd[5] ≅ DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
-            end
-        end
-
-        @testset "sort=false, skipmissing=true" begin
-            gd = groupby_checked(df, :Key1, skipmissing=true)
-            @test length(gd) == 2
-            @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
-            @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
-
-            gd = groupby_checked(df, [:Key1, :Key2], skipmissing=true)
-            @test length(gd) == 3
-            if df.Key1 isa CategoricalVector && df.Key2 isa CategoricalVector
-                @test gd[1] == DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
-                @test gd[2] == DataFrame(Key1="A", Key2="B", Value=1)
-                @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
-            else
-                @test gd[1] == DataFrame(Key1="A", Key2="B", Value=1)
-                @test gd[2] == DataFrame(Key1="B", Key2="A", Value=3)
-                @test gd[3] == DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
-            end
-        end
-
-        @testset "sort=true, skipmissing=false" begin
-            gd = groupby_checked(df, :Key1, sort=true)
-            @test length(gd) == 3
+        @test length(gd) == 3
+        if df.Key1 isa CategoricalVector # Order of missing changes
             @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
             @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
             @test gd[3] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
+        else
+            @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
+            @test gd[2] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
+            @test gd[3] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
+        end
 
-            gd = groupby_checked(df, [:Key1, :Key2], sort=true)
-            @test length(gd) == 5
+        gd = groupby_checked(df, [:Key1, :Key2])
+        @test length(gd) == 5
+        if df.Key1 isa CategoricalVector && df.Key2 isa CategoricalVector
             @test gd[1] ≅ DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
             @test gd[2] == DataFrame(Key1="A", Key2="B", Value=1)
             @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
             @test gd[4] ≅ DataFrame(Key1="B", Key2=missing, Value=[4, 6])
             @test gd[5] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
+        else
+            @test gd[1] == DataFrame(Key1="A", Key2="B", Value=1)
+            @test gd[2] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
+            @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
+            @test gd[4] ≅ DataFrame(Key1="B", Key2=missing, Value=[4, 6])
+            @test gd[5] ≅ DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
         end
+    end
 
-        @testset "sort=true, skipmissing=true" begin
-            gd = groupby_checked(df, :Key1, sort=true, skipmissing=true)
-            @test length(gd) == 2
-            @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
-            @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
+    @testset "sort=false, skipmissing=true" begin
+        gd = groupby_checked(df, :Key1, skipmissing=true)
+        @test length(gd) == 2
+        @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
+        @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
 
-            gd = groupby_checked(df, [:Key1, :Key2], sort=true, skipmissing=true)
-            @test length(gd) == 3
+        gd = groupby_checked(df, [:Key1, :Key2], skipmissing=true)
+        @test length(gd) == 3
+        if df.Key1 isa CategoricalVector && df.Key2 isa CategoricalVector
             @test gd[1] == DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
             @test gd[2] == DataFrame(Key1="A", Key2="B", Value=1)
             @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
-        end
-    end
-
-    # We need many rows so that optimized CategoricalArray method is used
-    xv = rand(["A", "B", missing], 100)
-    yv = rand(["A", "B", missing], 100)
-    zv = rand(["A", "B", missing], 100)
-    @testset "grouping with three keys" for x in (xv,
-                                                  categorical(xv),
-                                                  levels!(categorical(xv), ["A", "B", "X"]),
-                                                  levels!(categorical(xv), ["X", "A", "B"])),
-                                            y in (yv,
-                                                  categorical(yv),
-                                                  levels!(categorical(yv), ["A", "B", "X"]),
-                                                  levels!(categorical(yv), ["X", "A", "B"])),
-                                            z in (zv,
-                                                  categorical(zv),
-                                                  levels!(categorical(zv), ["A", "B", "X"]),
-                                                  levels!(categorical(zv), ["X", "A", "B"]))
-        df = DataFrame(Key1 = x, Key2 = y, Key3 = z, Value = string.(1:100))
-        dfb = mapcols(Vector{Union{String, Missing}}, df)
-
-        @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true) ≅
-            groupby_checked(dfb, [:Key1, :Key2, :Key3], sort=true)
-        @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true, skipmissing=true) ≅
-              groupby_checked(dfb, [:Key1, :Key2, :Key3], sort=true, skipmissing=true)
-
-        if df.Key1 isa CategoricalVector &&
-           df.Key2 isa CategoricalVector &&
-           df.Key3 isa CategoricalVector
-            @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true) ≅
-                groupby_checked(df, [:Key1, :Key2, :Key3], sort=false)
-            @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true, skipmissing=true) ≅
-                groupby_checked(df, [:Key1, :Key2, :Key3], sort=false, skipmissing=true)
-        end
-    end
-
-    @testset "by, combine and map with pair interface" begin
-        vexp = x -> exp.(x)
-        Random.seed!(1)
-        df = DataFrame(a = repeat([1, 3, 2, 4], outer=[2]),
-                       b = repeat([2, 1], outer=[4]),
-                       c = rand(Int, 8))
-
-        # Only test that different by syntaxes work,
-        # and rely on tests below for deeper checks
-        @test by(:c => sum, df, :a) ==
-            by(df, :a, :c => sum) ==
-            by(df, :a, (:c => sum,)) ==
-            by(df, :a, [:c => sum]) ==
-            by(df, :a, c_sum = :c => sum) ==
-            by(d -> (c_sum=sum(d.c),), df, :a)
-            by(df, :a, d -> (c_sum=sum(d.c),))
-
-        @test by(:c => vexp, df, :a) ==
-            by(df, :a, :c => vexp) ==
-            by(df, :a, (:c => vexp,)) ==
-            by(df, :a, [:c => vexp]) ==
-            by(df, :a, c_function = :c => vexp) ==
-            by(d -> (c_function=vexp(d.c),), df, :a)
-            by(df, :a, d -> (c_function=vexp(d.c),))
-
-        @test by(df, :a, :b => sum, :c => sum) ==
-            by(df, :a, (:b => sum, :c => sum,)) ==
-            by(df, :a, [:b => sum, :c => sum]) ==
-            by(df, :a, b_sum = :b => sum, c_sum = :c => sum) ==
-            by(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), df, :a)
-            by(df, :a, d -> (b_sum=sum(d.b), c_sum=sum(d.c)))
-
-        @test by(df, :a, :b => vexp, :c => identity) ==
-            by(df, :a, (:b => vexp, :c => identity,)) ==
-            by(df, :a, [:b => vexp, :c => identity]) ==
-            by(df, :a, b_function = :b => vexp, c_identity = :c => identity) ==
-            by(d -> (b_function=vexp(d.b), c_identity=identity(d.c)), df, :a)
-            by(df, :a, d -> (b_function=vexp(d.b), c_identity=identity(d.c)))
-
-        gd = groupby(df, :a)
-
-        # Only test that different combine syntaxes work,
-        # and rely on tests below for deeper checks
-        @test combine(:c => sum, gd) ==
-            combine(gd, :c => sum) ==
-            combine(gd, (:c => sum,)) ==
-            combine(gd, [:c => sum]) ==
-            combine(gd, c_sum = :c => sum) ==
-            combine(:c => x -> (c_sum=sum(x),), gd) ==
-            combine(gd, :c => x -> (c_sum=sum(x),)) ==
-            combine(d -> (c_sum=sum(d.c),), gd) ==
-            combine(gd, d -> (c_sum=sum(d.c),))
-
-        @test combine(:c => vexp, gd) ==
-            combine(gd, :c => vexp) ==
-            combine(gd, (:c => vexp,)) ==
-            combine(gd, [:c => vexp]) ==
-            combine(gd, c_function = :c => vexp) ==
-            combine(:c => x -> (c_function=exp.(x),), gd) ==
-            combine(gd, :c => x -> (c_function=exp.(x),)) ==
-            combine(d -> (c_function=exp.(d.c),), gd)
-            combine(gd, d -> (c_function=exp.(d.c),))
-
-        @test combine(gd, :b => sum, :c => sum) ==
-            combine(gd, (:b => sum, :c => sum,)) ==
-            combine(gd, [:b => sum, :c => sum]) ==
-            combine(gd, b_sum = :b => sum, c_sum = :c => sum) ==
-            combine((:b, :c) => x -> (b_sum=sum(x.b), c_sum=sum(x.c)), gd) ==
-            combine(gd, (:b, :c) => x -> (b_sum=sum(x.b), c_sum=sum(x.c))) ==
-            combine(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), gd) ==
-            combine(gd, d -> (b_sum=sum(d.b), c_sum=sum(d.c)))
-
-        @test combine(gd, :b => vexp, :c => identity) ==
-            combine(gd, (:b => vexp, :c => identity,)) ==
-            combine(gd, [:b => vexp, :c => identity]) ==
-            combine(gd, b_function = :b => vexp, c_identity = :c => identity) ==
-            combine((:b, :c) => x -> (b_function=vexp(x.b), c_identity=x.c), gd) ==
-            combine(gd, (:b, :c) => x -> (b_function=vexp(x.b), c_identity=x.c)) ==
-            combine(d -> (b_function=vexp(d.b), c_identity=d.c), gd) ==
-            combine(gd, d -> (b_function=vexp(d.b), c_identity=d.c))
-
-        for f in (map, combine)
-            for col in (:c, 3)
-                @test f(col => sum, gd) == f(d -> (c_sum=sum(d.c),), gd)
-                @test f(col => x -> sum(x), gd) == f(d -> (c_function=sum(d.c),), gd)
-                @test f(col => x -> (z=sum(x),), gd) == f(d -> (z=sum(d.c),), gd)
-                @test f(col => x -> DataFrame(z=sum(x),), gd) == f(d -> (z=sum(d.c),), gd)
-                @test f(col => identity, gd) == f(d -> (c_identity=d.c,), gd)
-                @test f(col => x -> (z=x,), gd) == f(d -> (z=d.c,), gd)
-
-                @test f((xyz = col => sum,), gd) ==
-                    f(d -> (xyz=sum(d.c),), gd)
-                @test f((xyz = col => x -> sum(x),), gd) ==
-                    f(d -> (xyz=sum(d.c),), gd)
-                @test f((xyz = col => x -> (sum(x),),), gd) ==
-                    f(d -> (xyz=(sum(d.c),),), gd)
-                @test_throws ArgumentError f((xyz = col => x -> (z=sum(x),),), gd)
-                @test_throws ArgumentError f((xyz = col => x -> DataFrame(z=sum(x),),), gd)
-                @test_throws ArgumentError f((xyz = col => x -> (z=x,),), gd)
-                @test_throws ArgumentError f(col => x -> (z=1, xzz=[1]), gd)
-
-                for wrap in (vcat, tuple)
-                    @test f(wrap(col => sum), gd) ==
-                        f(d -> (c_sum=sum(d.c),), gd)
-                    @test f(wrap(col => x -> sum(x)), gd) ==
-                        f(d -> (c_function=sum(d.c),), gd)
-                    @test f(wrap(col => x -> (sum(x),)), gd) ==
-                        f(d -> (c_function=(sum(d.c),),), gd)
-                    @test_throws ArgumentError f(wrap(col => x -> (z=sum(x),)), gd)
-                    @test_throws ArgumentError f(wrap(col => x -> DataFrame(z=sum(x),)), gd)
-                    @test_throws ArgumentError f(wrap(col => x -> (z=x,)), gd)
-                    @test_throws ArgumentError f(wrap(col => x -> (z=1, xzz=[1])), gd)
-                end
-            end
-            for cols in ((:b, :c), [:b, :c], (2, 3), 2:3, [2, 3], [false, true, true])
-                @test f(cols => x -> (y=exp.(x.b), z=x.c), gd) ==
-                    f(d -> (y=exp.(d.b), z=d.c), gd)
-                @test f(cols => x -> [exp.(x.b) x.c], gd) ==
-                    f(d -> [exp.(d.b) d.c], gd)
-
-                @test f((xyz = cols => x -> sum(x.b) + sum(x.c),), gd) ==
-                    f(d -> (xyz=sum(d.b) + sum(d.c),), gd)
-                if eltype(cols) === Bool
-                    cols2 = [[false, true, false], [false, false, true]]
-                    @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[2] => sum), gd)
-                    @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[1] => sum), gd)
-                    @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[2] => x -> first(x)), gd)
-                else
-                    cols2 = cols
-                    @test f((xyz = cols2[1] => sum, xzz = cols2[2] => sum), gd) ==
-                        f(d -> (xyz=sum(d.b), xzz=sum(d.c)), gd)
-                    @test f((xyz = cols2[1] => sum, xzz = cols2[1] => sum), gd) ==
-                        f(d -> (xyz=sum(d.b), xzz=sum(d.b)), gd)
-                    @test f((xyz = cols2[1] => sum, xzz = cols2[2] => x -> first(x)), gd) ==
-                        f(d -> (xyz=sum(d.b), xzz=first(d.c)), gd)
-                    @test_throws ArgumentError f((xyz = cols2[1] => vexp, xzz = cols2[2] => sum), gd)
-                end
-
-                @test_throws ArgumentError f(cols => x -> (y=exp.(x.b), z=sum(x.c)), gd)
-                @test_throws ArgumentError f((xyz = cols2 => x -> DataFrame(y=exp.(x.b), z=sum(x.c)),), gd)
-                @test_throws ArgumentError f((xyz = cols2 => x -> [exp.(x.b) x.c],), gd)
-
-                for wrap in (vcat, tuple)
-                    @test f(wrap(cols => x -> sum(x.b) + sum(x.c)), gd) ==
-                        f(d -> sum(d.b) + sum(d.c), gd)
-
-                    if eltype(cols) === Bool
-                        cols2 = [[false, true, false], [false, false, true]]
-                        @test f(wrap(cols2[1] => x -> sum(x.b), cols2[2] => x -> sum(x.c)), gd) ==
-                            f(d -> (x1=sum(d.b), x2=sum(d.c)), gd)
-                        @test f(wrap(cols2[1] => x -> sum(x.b), cols2[2] => x -> first(x.c)), gd) ==
-                            f(d -> (x1=sum(d.b), x2=first(d.c)), gd)
-                    else
-                        cols2 = cols
-                        @test f(wrap(cols[1] => sum, cols[2] => sum), gd) ==
-                            f(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), gd)
-                        @test f(wrap(cols[1] => sum, cols[2] => x -> first(x)), gd) ==
-                            f(d -> (b_sum=sum(d.b), c_function=first(d.c)), gd)
-                        @test_throws ArgumentError f(wrap(cols2[1] => vexp, cols2[2] => sum), gd)
-                    end
-
-                    @test_throws ArgumentError f(wrap(cols => x -> DataFrame(y=exp.(x.b), z=sum(x.c))), gd)
-                    @test_throws ArgumentError f(wrap(cols => x -> [exp.(x.b) x.c]), gd)
-                end
-            end
-        end
-    end
-
-    struct TestType end
-    Base.isless(::TestType, ::Int) = true
-    Base.isless(::Int, ::TestType) = false
-    Base.isless(::TestType, ::TestType) = false
-
-    @testset "combine with aggregation functions" begin
-        Random.seed!(1)
-        df = DataFrame(a = rand(1:5, 20), x1 = rand(Int, 20), x2 = rand(Complex{Int}, 20))
-
-        for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length)
-            gd = groupby_checked(df, :a)
-
-            res = combine(gd, y = :x1 => f)
-            expected = combine(gd, y = :x1 => x -> f(x))
-            @test res ≅ expected
-            @test typeof(res.y) == typeof(expected.y)
-
-            for T in (Union{Missing, Int}, Union{Int, Int8},
-                      Union{Missing, Int, Int8})
-                df.x3 = Vector{T}(df.x1)
-                gd = groupby_checked(df, :a)
-                res = combine(gd, y = :x3 => f)
-                expected = combine(gd, y = :x3 => x -> f(x))
-                @test res ≅ expected
-                @test typeof(res.y) == typeof(expected.y)
-            end
-
-            f === length && continue
-
-            df.x3 = allowmissing(df.x1)
-            df.x3[1] = missing
-            gd = groupby_checked(df, :a)
-            res = combine(gd, y = :x3 => f)
-            expected = combine(gd, y = :x3 => x -> f(x))
-            @test res ≅ expected
-            @test typeof(res.y) == typeof(expected.y)
-            res = combine(gd, y = :x3 => f∘skipmissing)
-            expected = combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
-            @test res ≅ expected
-            @test typeof(res.y) == typeof(expected.y)
-        end
-        # Test complex numbers
-        for f in (sum, prod, mean, var, std, first, last, length)
-            gd = groupby_checked(df, :a)
-
-            res = combine(gd, y = :x2 => f)
-            expected = combine(gd, y = :x2 => x -> f(x))
-            @test res ≅ expected
-            @test typeof(res.y) == typeof(expected.y)
-        end
-        # Test CategoricalArray
-        for f in (maximum, minimum, first, last, length),
-            (T, m) in ((Int, false),
-                       (Union{Missing, Int}, false), (Union{Missing, Int}, true))
-            df.x3 = CategoricalVector{T}(df.x1)
-            m && (df.x3[1] = missing)
-            gd = groupby_checked(df, :a)
-            res = combine(gd, y = :x3 => f)
-            expected = combine(gd, y = :x3 => x -> f(x))
-            @test res ≅ expected
-            @test typeof(res.y) == typeof(expected.y)
-
-            f === length && continue
-
-            res = combine(gd, y = :x3 => f∘skipmissing)
-            expected = combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
-            @test res == expected
-            @test typeof(res.y) == typeof(expected.y)
-            if m
-                gd[1].x3 = missing
-                @test_throws ArgumentError combine(gd, y = :x3 => f∘skipmissing)
-            end
-        end
-        @test combine(gd, y = :x1 => maximum, z = :x2 => sum) ==
-            combine(gd, y = :x1 => x -> maximum(x), z = :x2 => x -> sum(x))
-        # Test floating point corner cases
-        df = DataFrame(a = [1, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6],
-                       x1 = [0.0, 1.0, 2.0, NaN, NaN, NaN, Inf, Inf, Inf, 1.0, NaN, 0.0, -0.0])
-
-        for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length),
-            sort in (false, true),
-            skip in (false, true)
-            gd = groupby_checked(df, :a, sort=sort, skipmissing=skip)
-
-            res = combine(gd, y = :x1 => f)
-            expected = combine(gd, y = :x1 => x -> f(x))
-            @test res ≅ expected
-            @test typeof(res.y) == typeof(expected.y)
-
-            f === length && continue
-
-            df.x3 = allowmissing(df.x1)
-            df.x3[1] = missing
-            gd = groupby_checked(df, :a, sort=sort, skipmissing=skip)
-            res = combine(gd, y = :x3 => f)
-            expected = combine(gd, y = :x3 => x -> f(x))
-            @test res ≅ expected
-            @test typeof(res.y) == typeof(expected.y)
-            res = combine(gd, y = :x3 => f∘skipmissing)
-            expected = combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
-            @test res ≅ expected
-            @test typeof(res.y) == typeof(expected.y)
-        end
-
-        df = DataFrame(x = [1, 1, 2, 2], y = Any[1, 2.0, 3.0, 4.0])
-        res = by(df, :x, z = :y => maximum)
-        @test res.z isa Vector{Float64}
-        @test res.z == by(df, :x, z = :y => x -> maximum(x)).z
-
-        # Test maximum when no promotion rule exists
-        df = DataFrame(x = [1, 1, 2, 2], y = [1, TestType(), TestType(), TestType()])
-        gd = groupby_checked(df, :x)
-        for f in (maximum, minimum)
-            res = combine(gd, z = :y => maximum)
-            @test res.z isa Vector{Any}
-            @test res.z == by(df, :x, z = :y => x -> maximum(x)).z
-        end
-    end
-
-    @testset "iteration protocol" begin
-        gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
-        for v in gd
-            @test size(v) == (2,2)
-        end
-    end
-
-    @testset "getindex" begin
-        df = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
-                       b = 1:8)
-        gd = groupby_checked(df, :a)
-        @test gd[1] isa SubDataFrame
-        @test gd[1] == view(df, [1, 5], :)
-        @test_throws BoundsError gd[5]
-        if VERSION < v"1.0.0-"
-            @test gd[true] == gd[1]
         else
-            @test_throws ArgumentError gd[true]
+            @test gd[1] == DataFrame(Key1="A", Key2="B", Value=1)
+            @test gd[2] == DataFrame(Key1="B", Key2="A", Value=3)
+            @test gd[3] == DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
         end
-        @test_throws MethodError gd["a"]
-        gd2 = gd[[true, false, false, false]]
-        @test length(gd2) == 1
-        @test gd2[1] == gd[1]
-        @test_throws BoundsError gd[[true, false]]
-        gd3 = gd[:]
-        @test gd3 isa GroupedDataFrame
-        @test length(gd3) == 4
-        @test gd3 == gd
-        for i in 1:4
-            @test gd3[i] == gd[i]
-        end
-        gd4 = gd[[1,2]]
-        @test gd4 isa GroupedDataFrame
-        @test length(gd4) == 2
-        for i in 1:2
-            @test gd4[i] == gd[i]
-        end
-        @test_throws BoundsError gd[1:5]
     end
 
-    @testset "== and isequal" begin
-        df1 = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
-                        b = 1:8)
-        df2 = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
-                        b = [1:7;missing])
-        gd1 = groupby_checked(df1, :a)
-        gd2 = groupby_checked(df2, :a)
-        @test gd1 == gd1
-        @test isequal(gd1, gd1)
-        @test ismissing(gd1 == gd2)
-        @test !isequal(gd1, gd2)
-        @test ismissing(gd2 == gd2)
-        @test isequal(gd2, gd2)
-        df1.c = df1.a
-        df2.c = df2.a
-        @test gd1 != groupby_checked(df2, :c)
-        df2[7, :b] = 10
-        @test gd1 != gd2
-        df3 = DataFrame(a = repeat([1, 2, 3, missing], outer=[2]),
-                        b = 1:8)
-        df4 = DataFrame(a = repeat([1, 2, 3, missing], outer=[2]),
-                        b = [1:7;missing])
-        gd3 = groupby_checked(df3, :a)
-        gd4 = groupby_checked(df4, :a)
-        @test ismissing(gd3 == gd4)
-        @test !isequal(gd3, gd4)
-        gd3 = groupby_checked(df3, :a, skipmissing = true)
-        gd4 = groupby_checked(df4, :a, skipmissing = true)
-        @test gd3 == gd4
-        @test isequal(gd3, gd4)
+    @testset "sort=true, skipmissing=false" begin
+        gd = groupby_checked(df, :Key1, sort=true)
+        @test length(gd) == 3
+        @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
+        @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
+        @test gd[3] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
+
+        gd = groupby_checked(df, [:Key1, :Key2], sort=true)
+        @test length(gd) == 5
+        @test gd[1] ≅ DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
+        @test gd[2] == DataFrame(Key1="A", Key2="B", Value=1)
+        @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
+        @test gd[4] ≅ DataFrame(Key1="B", Key2=missing, Value=[4, 6])
+        @test gd[5] ≅ DataFrame(Key1=missing, Key2="A", Value=2)
     end
 
-    @testset "show" begin
-        function capture_stdout(f::Function)
-            oldstdout = stdout
-            rd, wr = redirect_stdout()
-            f()
-            str = String(readavailable(rd))
-            redirect_stdout(oldstdout)
-            size = displaysize(rd)
-            close(rd)
-            close(wr)
-            str, size
-        end
+    @testset "sort=true, skipmissing=true" begin
+        gd = groupby_checked(df, :Key1, sort=true, skipmissing=true)
+        @test length(gd) == 2
+        @test gd[1] == DataFrame(Key1="A", Key2=["B", "A", "A", "A"], Value=[1, 5, 7, 8])
+        @test gd[2] ≅ DataFrame(Key1="B", Key2=["A", missing, missing], Value=[3, 4, 6])
 
-        df = DataFrame(A = Int64[1:4;], B = ["x\"", "∀ε>0: x+ε>x", "z\$", "A\nC"],
-                       C = Float32[1.0, 2.0, 3.0, 4.0])
-        gd = groupby_checked(df, :A)
-        io = IOContext(IOBuffer(), :limit=>true)
-        show(io, gd)
-        str = String(take!(io.io))
-        @test str == """
-        GroupedDataFrame with 4 groups based on key: A
-        First Group (1 row): A = 1
-        │ Row │ A     │ B      │ C       │
-        │     │ Int64 │ String │ Float32 │
-        ├─────┼───────┼────────┼─────────┤
-        │ 1   │ 1     │ x"     │ 1.0     │
-        ⋮
-        Last Group (1 row): A = 4
-        │ Row │ A     │ B      │ C       │
-        │     │ Int64 │ String │ Float32 │
-        ├─────┼───────┼────────┼─────────┤
-        │ 1   │ 4     │ A\\nC   │ 4.0     │"""
-        show(io, gd, allgroups=true)
-        str = String(take!(io.io))
-        @test str == """
-        GroupedDataFrame with 4 groups based on key: A
-        Group 1 (1 row): A = 1
-        │ Row │ A     │ B      │ C       │
-        │     │ Int64 │ String │ Float32 │
-        ├─────┼───────┼────────┼─────────┤
-        │ 1   │ 1     │ x\"     │ 1.0     │
-        Group 2 (1 row): A = 2
-        │ Row │ A     │ B           │ C       │
-        │     │ Int64 │ String      │ Float32 │
-        ├─────┼───────┼─────────────┼─────────┤
-        │ 1   │ 2     │ ∀ε>0: x+ε>x │ 2.0     │
-        Group 3 (1 row): A = 3
-        │ Row │ A     │ B      │ C       │
-        │     │ Int64 │ String │ Float32 │
-        ├─────┼───────┼────────┼─────────┤
-        │ 1   │ 3     │ z\$     │ 3.0     │
-        Group 4 (1 row): A = 4
-        │ Row │ A     │ B      │ C       │
-        │     │ Int64 │ String │ Float32 │
-        ├─────┼───────┼────────┼─────────┤
-        │ 1   │ 4     │ A\\nC   │ 4.0     │"""
-
-        # Test two-argument show
-        str1, dsize = capture_stdout() do
-            show(gd)
-        end
-        io = IOContext(IOBuffer(), :limit=>true, :displaysize=>dsize)
-        show(io, gd)
-        str2 = String(take!(io.io))
-        @test str1 == str2
-
-
-        @test sprint(show, "text/html", gd) ==
-            "<p><b>GroupedDataFrame with 4 groups based on key: A</b></p>" *
-            "<p><i>First Group (1 row): A = 1</i></p><table class=\"data-frame\">" *
-            "<thead><tr><th></th><th>A</th><th>B</th><th>C</th></tr><tr><th></th>" *
-            "<th>Int64</th><th>String</th><th>Float32</th></tr></thead>" *
-            "<tbody><tr><th>1</th><td>1</td><td>x\"</td><td>1.0</td></tr></tbody>" *
-            "</table><p>&vellip;</p><p><i>Last Group (1 row): A = 4</i></p>" *
-            "<table class=\"data-frame\"><thead><tr><th></th><th>A</th><th>B</th><th>C</th></tr>" *
-            "<tr><th></th><th>Int64</th><th>String</th><th>Float32</th></tr></thead>" *
-            "<tbody><tr><th>1</th><td>4</td><td>A\\nC</td><td>4.0</td></tr></tbody></table>"
-
-        @test sprint(show, "text/latex", gd) == """
-            GroupedDataFrame with 4 groups based on key: A
-
-            First Group (1 row): A = 1
-
-            \\begin{tabular}{r|ccc}
-            \t& A & B & C\\\\
-            \t\\hline
-            \t& Int64 & String & Float32\\\\
-            \t\\hline
-            \t1 & 1 & x" & 1.0 \\\\
-            \\end{tabular}
-
-            \$\\dots\$
-
-            Last Group (1 row): A = 4
-
-            \\begin{tabular}{r|ccc}
-            \t& A & B & C\\\\
-            \t\\hline
-            \t& Int64 & String & Float32\\\\
-            \t\\hline
-            \t1 & 4 & A\\textbackslash{}nC & 4.0 \\\\
-            \\end{tabular}
-            """
-
-        gd = groupby(DataFrame(a=[Symbol("&")], b=["&"]), [1,2])
-        @test sprint(show, gd) === """
-            GroupedDataFrame with 1 group based on keys: a, b
-            Group 1 (1 row): a = :&, b = "&"
-            │ Row │ a      │ b      │
-            │     │ Symbol │ String │
-            ├─────┼────────┼────────┤
-            │ 1   │ &      │ &      │"""
-
-        @test sprint(show, "text/html", gd) ==
-            "<p><b>GroupedDataFrame with 1 group based on keys: a, b</b></p><p><i>" *
-            "First Group (1 row): a = :&amp;, b = \"&amp;\"</i></p>" *
-            "<table class=\"data-frame\"><thead><tr><th></th><th>a</th><th>b</th></tr>" *
-            "<tr><th></th><th>Symbol</th><th>String</th></tr></thead><tbody><tr><th>1</th>" *
-            "<td>&amp;</td><td>&amp;</td></tr></tbody></table>"
-
-        @test sprint(show, "text/latex", gd) == """
-            GroupedDataFrame with 1 group based on keys: a, b
-
-            First Group (1 row): a = :\\&, b = "\\&"
-
-            \\begin{tabular}{r|cc}
-            \t& a & b\\\\
-            \t\\hline
-            \t& Symbol & String\\\\
-            \t\\hline
-            \t1 & \\& & \\& \\\\
-            \\end{tabular}
-            """
+        gd = groupby_checked(df, [:Key1, :Key2], sort=true, skipmissing=true)
+        @test length(gd) == 3
+        @test gd[1] == DataFrame(Key1="A", Key2="A", Value=[5, 7, 8])
+        @test gd[2] == DataFrame(Key1="A", Key2="B", Value=1)
+        @test gd[3] == DataFrame(Key1="B", Key2="A", Value=3)
     end
 end
+
+# We need many rows so that optimized CategoricalArray method is used
+xv = rand(["A", "B", missing], 100)
+yv = rand(["A", "B", missing], 100)
+zv = rand(["A", "B", missing], 100)
+@testset "grouping with three keys" for x in (xv,
+                                              categorical(xv),
+                                              levels!(categorical(xv), ["A", "B", "X"]),
+                                              levels!(categorical(xv), ["X", "A", "B"])),
+                                        y in (yv,
+                                              categorical(yv),
+                                              levels!(categorical(yv), ["A", "B", "X"]),
+                                              levels!(categorical(yv), ["X", "A", "B"])),
+                                        z in (zv,
+                                              categorical(zv),
+                                              levels!(categorical(zv), ["A", "B", "X"]),
+                                              levels!(categorical(zv), ["X", "A", "B"]))
+    df = DataFrame(Key1 = x, Key2 = y, Key3 = z, Value = string.(1:100))
+    dfb = mapcols(Vector{Union{String, Missing}}, df)
+
+    @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true) ≅
+        groupby_checked(dfb, [:Key1, :Key2, :Key3], sort=true)
+    @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true, skipmissing=true) ≅
+          groupby_checked(dfb, [:Key1, :Key2, :Key3], sort=true, skipmissing=true)
+
+    if df.Key1 isa CategoricalVector &&
+       df.Key2 isa CategoricalVector &&
+       df.Key3 isa CategoricalVector
+        @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true) ≅
+            groupby_checked(df, [:Key1, :Key2, :Key3], sort=false)
+        @test groupby_checked(df, [:Key1, :Key2, :Key3], sort=true, skipmissing=true) ≅
+            groupby_checked(df, [:Key1, :Key2, :Key3], sort=false, skipmissing=true)
+    end
+end
+
+@testset "by, combine and map with pair interface" begin
+    vexp = x -> exp.(x)
+    Random.seed!(1)
+    df = DataFrame(a = repeat([1, 3, 2, 4], outer=[2]),
+                   b = repeat([2, 1], outer=[4]),
+                   c = rand(Int, 8))
+
+    # Only test that different by syntaxes work,
+    # and rely on tests below for deeper checks
+    @test by(:c => sum, df, :a) ==
+        by(df, :a, :c => sum) ==
+        by(df, :a, (:c => sum,)) ==
+        by(df, :a, [:c => sum]) ==
+        by(df, :a, c_sum = :c => sum) ==
+        by(d -> (c_sum=sum(d.c),), df, :a)
+        by(df, :a, d -> (c_sum=sum(d.c),))
+
+    @test by(:c => vexp, df, :a) ==
+        by(df, :a, :c => vexp) ==
+        by(df, :a, (:c => vexp,)) ==
+        by(df, :a, [:c => vexp]) ==
+        by(df, :a, c_function = :c => vexp) ==
+        by(d -> (c_function=vexp(d.c),), df, :a)
+        by(df, :a, d -> (c_function=vexp(d.c),))
+
+    @test by(df, :a, :b => sum, :c => sum) ==
+        by(df, :a, (:b => sum, :c => sum,)) ==
+        by(df, :a, [:b => sum, :c => sum]) ==
+        by(df, :a, b_sum = :b => sum, c_sum = :c => sum) ==
+        by(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), df, :a)
+        by(df, :a, d -> (b_sum=sum(d.b), c_sum=sum(d.c)))
+
+    @test by(df, :a, :b => vexp, :c => identity) ==
+        by(df, :a, (:b => vexp, :c => identity,)) ==
+        by(df, :a, [:b => vexp, :c => identity]) ==
+        by(df, :a, b_function = :b => vexp, c_identity = :c => identity) ==
+        by(d -> (b_function=vexp(d.b), c_identity=identity(d.c)), df, :a)
+        by(df, :a, d -> (b_function=vexp(d.b), c_identity=identity(d.c)))
+
+    gd = groupby(df, :a)
+
+    # Only test that different combine syntaxes work,
+    # and rely on tests below for deeper checks
+    @test combine(:c => sum, gd) ==
+        combine(gd, :c => sum) ==
+        combine(gd, (:c => sum,)) ==
+        combine(gd, [:c => sum]) ==
+        combine(gd, c_sum = :c => sum) ==
+        combine(:c => x -> (c_sum=sum(x),), gd) ==
+        combine(gd, :c => x -> (c_sum=sum(x),)) ==
+        combine(d -> (c_sum=sum(d.c),), gd) ==
+        combine(gd, d -> (c_sum=sum(d.c),))
+
+    @test combine(:c => vexp, gd) ==
+        combine(gd, :c => vexp) ==
+        combine(gd, (:c => vexp,)) ==
+        combine(gd, [:c => vexp]) ==
+        combine(gd, c_function = :c => vexp) ==
+        combine(:c => x -> (c_function=exp.(x),), gd) ==
+        combine(gd, :c => x -> (c_function=exp.(x),)) ==
+        combine(d -> (c_function=exp.(d.c),), gd)
+        combine(gd, d -> (c_function=exp.(d.c),))
+
+    @test combine(gd, :b => sum, :c => sum) ==
+        combine(gd, (:b => sum, :c => sum,)) ==
+        combine(gd, [:b => sum, :c => sum]) ==
+        combine(gd, b_sum = :b => sum, c_sum = :c => sum) ==
+        combine((:b, :c) => x -> (b_sum=sum(x.b), c_sum=sum(x.c)), gd) ==
+        combine(gd, (:b, :c) => x -> (b_sum=sum(x.b), c_sum=sum(x.c))) ==
+        combine(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), gd) ==
+        combine(gd, d -> (b_sum=sum(d.b), c_sum=sum(d.c)))
+
+    @test combine(gd, :b => vexp, :c => identity) ==
+        combine(gd, (:b => vexp, :c => identity,)) ==
+        combine(gd, [:b => vexp, :c => identity]) ==
+        combine(gd, b_function = :b => vexp, c_identity = :c => identity) ==
+        combine((:b, :c) => x -> (b_function=vexp(x.b), c_identity=x.c), gd) ==
+        combine(gd, (:b, :c) => x -> (b_function=vexp(x.b), c_identity=x.c)) ==
+        combine(d -> (b_function=vexp(d.b), c_identity=d.c), gd) ==
+        combine(gd, d -> (b_function=vexp(d.b), c_identity=d.c))
+
+    for f in (map, combine)
+        for col in (:c, 3)
+            @test f(col => sum, gd) == f(d -> (c_sum=sum(d.c),), gd)
+            @test f(col => x -> sum(x), gd) == f(d -> (c_function=sum(d.c),), gd)
+            @test f(col => x -> (z=sum(x),), gd) == f(d -> (z=sum(d.c),), gd)
+            @test f(col => x -> DataFrame(z=sum(x),), gd) == f(d -> (z=sum(d.c),), gd)
+            @test f(col => identity, gd) == f(d -> (c_identity=d.c,), gd)
+            @test f(col => x -> (z=x,), gd) == f(d -> (z=d.c,), gd)
+
+            @test f((xyz = col => sum,), gd) ==
+                f(d -> (xyz=sum(d.c),), gd)
+            @test f((xyz = col => x -> sum(x),), gd) ==
+                f(d -> (xyz=sum(d.c),), gd)
+            @test f((xyz = col => x -> (sum(x),),), gd) ==
+                f(d -> (xyz=(sum(d.c),),), gd)
+            @test_throws ArgumentError f((xyz = col => x -> (z=sum(x),),), gd)
+            @test_throws ArgumentError f((xyz = col => x -> DataFrame(z=sum(x),),), gd)
+            @test_throws ArgumentError f((xyz = col => x -> (z=x,),), gd)
+            @test_throws ArgumentError f(col => x -> (z=1, xzz=[1]), gd)
+
+            for wrap in (vcat, tuple)
+                @test f(wrap(col => sum), gd) ==
+                    f(d -> (c_sum=sum(d.c),), gd)
+                @test f(wrap(col => x -> sum(x)), gd) ==
+                    f(d -> (c_function=sum(d.c),), gd)
+                @test f(wrap(col => x -> (sum(x),)), gd) ==
+                    f(d -> (c_function=(sum(d.c),),), gd)
+                @test_throws ArgumentError f(wrap(col => x -> (z=sum(x),)), gd)
+                @test_throws ArgumentError f(wrap(col => x -> DataFrame(z=sum(x),)), gd)
+                @test_throws ArgumentError f(wrap(col => x -> (z=x,)), gd)
+                @test_throws ArgumentError f(wrap(col => x -> (z=1, xzz=[1])), gd)
+            end
+        end
+        for cols in ((:b, :c), [:b, :c], (2, 3), 2:3, [2, 3], [false, true, true])
+            @test f(cols => x -> (y=exp.(x.b), z=x.c), gd) ==
+                f(d -> (y=exp.(d.b), z=d.c), gd)
+            @test f(cols => x -> [exp.(x.b) x.c], gd) ==
+                f(d -> [exp.(d.b) d.c], gd)
+
+            @test f((xyz = cols => x -> sum(x.b) + sum(x.c),), gd) ==
+                f(d -> (xyz=sum(d.b) + sum(d.c),), gd)
+            if eltype(cols) === Bool
+                cols2 = [[false, true, false], [false, false, true]]
+                @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[2] => sum), gd)
+                @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[1] => sum), gd)
+                @test_throws MethodError f((xyz = cols[1] => sum, xzz = cols2[2] => x -> first(x)), gd)
+            else
+                cols2 = cols
+                @test f((xyz = cols2[1] => sum, xzz = cols2[2] => sum), gd) ==
+                    f(d -> (xyz=sum(d.b), xzz=sum(d.c)), gd)
+                @test f((xyz = cols2[1] => sum, xzz = cols2[1] => sum), gd) ==
+                    f(d -> (xyz=sum(d.b), xzz=sum(d.b)), gd)
+                @test f((xyz = cols2[1] => sum, xzz = cols2[2] => x -> first(x)), gd) ==
+                    f(d -> (xyz=sum(d.b), xzz=first(d.c)), gd)
+                @test_throws ArgumentError f((xyz = cols2[1] => vexp, xzz = cols2[2] => sum), gd)
+            end
+
+            @test_throws ArgumentError f(cols => x -> (y=exp.(x.b), z=sum(x.c)), gd)
+            @test_throws ArgumentError f((xyz = cols2 => x -> DataFrame(y=exp.(x.b), z=sum(x.c)),), gd)
+            @test_throws ArgumentError f((xyz = cols2 => x -> [exp.(x.b) x.c],), gd)
+
+            for wrap in (vcat, tuple)
+                @test f(wrap(cols => x -> sum(x.b) + sum(x.c)), gd) ==
+                    f(d -> sum(d.b) + sum(d.c), gd)
+
+                if eltype(cols) === Bool
+                    cols2 = [[false, true, false], [false, false, true]]
+                    @test f(wrap(cols2[1] => x -> sum(x.b), cols2[2] => x -> sum(x.c)), gd) ==
+                        f(d -> (x1=sum(d.b), x2=sum(d.c)), gd)
+                    @test f(wrap(cols2[1] => x -> sum(x.b), cols2[2] => x -> first(x.c)), gd) ==
+                        f(d -> (x1=sum(d.b), x2=first(d.c)), gd)
+                else
+                    cols2 = cols
+                    @test f(wrap(cols[1] => sum, cols[2] => sum), gd) ==
+                        f(d -> (b_sum=sum(d.b), c_sum=sum(d.c)), gd)
+                    @test f(wrap(cols[1] => sum, cols[2] => x -> first(x)), gd) ==
+                        f(d -> (b_sum=sum(d.b), c_function=first(d.c)), gd)
+                    @test_throws ArgumentError f(wrap(cols2[1] => vexp, cols2[2] => sum), gd)
+                end
+
+                @test_throws ArgumentError f(wrap(cols => x -> DataFrame(y=exp.(x.b), z=sum(x.c))), gd)
+                @test_throws ArgumentError f(wrap(cols => x -> [exp.(x.b) x.c]), gd)
+            end
+        end
+    end
+end
+
+struct TestType end
+Base.isless(::TestType, ::Int) = true
+Base.isless(::Int, ::TestType) = false
+Base.isless(::TestType, ::TestType) = false
+
+@testset "combine with aggregation functions" begin
+    Random.seed!(1)
+    df = DataFrame(a = rand(1:5, 20), x1 = rand(Int, 20), x2 = rand(Complex{Int}, 20))
+
+    for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length)
+        gd = groupby_checked(df, :a)
+
+        res = combine(gd, y = :x1 => f)
+        expected = combine(gd, y = :x1 => x -> f(x))
+        @test res ≅ expected
+        @test typeof(res.y) == typeof(expected.y)
+
+        for T in (Union{Missing, Int}, Union{Int, Int8},
+                  Union{Missing, Int, Int8})
+            df.x3 = Vector{T}(df.x1)
+            gd = groupby_checked(df, :a)
+            res = combine(gd, y = :x3 => f)
+            expected = combine(gd, y = :x3 => x -> f(x))
+            @test res ≅ expected
+            @test typeof(res.y) == typeof(expected.y)
+        end
+
+        f === length && continue
+
+        df.x3 = allowmissing(df.x1)
+        df.x3[1] = missing
+        gd = groupby_checked(df, :a)
+        res = combine(gd, y = :x3 => f)
+        expected = combine(gd, y = :x3 => x -> f(x))
+        @test res ≅ expected
+        @test typeof(res.y) == typeof(expected.y)
+        res = combine(gd, y = :x3 => f∘skipmissing)
+        expected = combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
+        @test res ≅ expected
+        @test typeof(res.y) == typeof(expected.y)
+    end
+    # Test complex numbers
+    for f in (sum, prod, mean, var, std, first, last, length)
+        gd = groupby_checked(df, :a)
+
+        res = combine(gd, y = :x2 => f)
+        expected = combine(gd, y = :x2 => x -> f(x))
+        @test res ≅ expected
+        @test typeof(res.y) == typeof(expected.y)
+    end
+    # Test CategoricalArray
+    for f in (maximum, minimum, first, last, length),
+        (T, m) in ((Int, false),
+                   (Union{Missing, Int}, false), (Union{Missing, Int}, true))
+        df.x3 = CategoricalVector{T}(df.x1)
+        m && (df.x3[1] = missing)
+        gd = groupby_checked(df, :a)
+        res = combine(gd, y = :x3 => f)
+        expected = combine(gd, y = :x3 => x -> f(x))
+        @test res ≅ expected
+        @test typeof(res.y) == typeof(expected.y)
+
+        f === length && continue
+
+        res = combine(gd, y = :x3 => f∘skipmissing)
+        expected = combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
+        @test res == expected
+        @test typeof(res.y) == typeof(expected.y)
+        if m
+            gd[1].x3 = missing
+            @test_throws ArgumentError combine(gd, y = :x3 => f∘skipmissing)
+        end
+    end
+    @test combine(gd, y = :x1 => maximum, z = :x2 => sum) ==
+        combine(gd, y = :x1 => x -> maximum(x), z = :x2 => x -> sum(x))
+    # Test floating point corner cases
+    df = DataFrame(a = [1, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6],
+                   x1 = [0.0, 1.0, 2.0, NaN, NaN, NaN, Inf, Inf, Inf, 1.0, NaN, 0.0, -0.0])
+
+    for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length),
+        sort in (false, true),
+        skip in (false, true)
+        gd = groupby_checked(df, :a, sort=sort, skipmissing=skip)
+
+        res = combine(gd, y = :x1 => f)
+        expected = combine(gd, y = :x1 => x -> f(x))
+        @test res ≅ expected
+        @test typeof(res.y) == typeof(expected.y)
+
+        f === length && continue
+
+        df.x3 = allowmissing(df.x1)
+        df.x3[1] = missing
+        gd = groupby_checked(df, :a, sort=sort, skipmissing=skip)
+        res = combine(gd, y = :x3 => f)
+        expected = combine(gd, y = :x3 => x -> f(x))
+        @test res ≅ expected
+        @test typeof(res.y) == typeof(expected.y)
+        res = combine(gd, y = :x3 => f∘skipmissing)
+        expected = combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
+        @test res ≅ expected
+        @test typeof(res.y) == typeof(expected.y)
+    end
+
+    df = DataFrame(x = [1, 1, 2, 2], y = Any[1, 2.0, 3.0, 4.0])
+    res = by(df, :x, z = :y => maximum)
+    @test res.z isa Vector{Float64}
+    @test res.z == by(df, :x, z = :y => x -> maximum(x)).z
+
+    # Test maximum when no promotion rule exists
+    df = DataFrame(x = [1, 1, 2, 2], y = [1, TestType(), TestType(), TestType()])
+    gd = groupby_checked(df, :x)
+    for f in (maximum, minimum)
+        res = combine(gd, z = :y => maximum)
+        @test res.z isa Vector{Any}
+        @test res.z == by(df, :x, z = :y => x -> maximum(x)).z
+    end
+end
+
+@testset "iteration protocol" begin
+    gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+    for v in gd
+        @test size(v) == (2,2)
+    end
+end
+
+@testset "getindex" begin
+    df = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
+                   b = 1:8)
+    gd = groupby_checked(df, :a)
+    @test gd[1] isa SubDataFrame
+    @test gd[1] == view(df, [1, 5], :)
+    @test_throws BoundsError gd[5]
+    if VERSION < v"1.0.0-"
+        @test gd[true] == gd[1]
+    else
+        @test_throws ArgumentError gd[true]
+    end
+    @test_throws MethodError gd["a"]
+    gd2 = gd[[true, false, false, false]]
+    @test length(gd2) == 1
+    @test gd2[1] == gd[1]
+    @test_throws BoundsError gd[[true, false]]
+    gd3 = gd[:]
+    @test gd3 isa GroupedDataFrame
+    @test length(gd3) == 4
+    @test gd3 == gd
+    for i in 1:4
+        @test gd3[i] == gd[i]
+    end
+    gd4 = gd[[1,2]]
+    @test gd4 isa GroupedDataFrame
+    @test length(gd4) == 2
+    for i in 1:2
+        @test gd4[i] == gd[i]
+    end
+    @test_throws BoundsError gd[1:5]
+end
+
+@testset "== and isequal" begin
+    df1 = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
+                    b = 1:8)
+    df2 = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
+                    b = [1:7;missing])
+    gd1 = groupby_checked(df1, :a)
+    gd2 = groupby_checked(df2, :a)
+    @test gd1 == gd1
+    @test isequal(gd1, gd1)
+    @test ismissing(gd1 == gd2)
+    @test !isequal(gd1, gd2)
+    @test ismissing(gd2 == gd2)
+    @test isequal(gd2, gd2)
+    df1.c = df1.a
+    df2.c = df2.a
+    @test gd1 != groupby_checked(df2, :c)
+    df2[7, :b] = 10
+    @test gd1 != gd2
+    df3 = DataFrame(a = repeat([1, 2, 3, missing], outer=[2]),
+                    b = 1:8)
+    df4 = DataFrame(a = repeat([1, 2, 3, missing], outer=[2]),
+                    b = [1:7;missing])
+    gd3 = groupby_checked(df3, :a)
+    gd4 = groupby_checked(df4, :a)
+    @test ismissing(gd3 == gd4)
+    @test !isequal(gd3, gd4)
+    gd3 = groupby_checked(df3, :a, skipmissing = true)
+    gd4 = groupby_checked(df4, :a, skipmissing = true)
+    @test gd3 == gd4
+    @test isequal(gd3, gd4)
+end
+
+@testset "show" begin
+    function capture_stdout(f::Function)
+        oldstdout = stdout
+        rd, wr = redirect_stdout()
+        f()
+        str = String(readavailable(rd))
+        redirect_stdout(oldstdout)
+        size = displaysize(rd)
+        close(rd)
+        close(wr)
+        str, size
+    end
+
+    df = DataFrame(A = Int64[1:4;], B = ["x\"", "∀ε>0: x+ε>x", "z\$", "A\nC"],
+                   C = Float32[1.0, 2.0, 3.0, 4.0])
+    gd = groupby_checked(df, :A)
+    io = IOContext(IOBuffer(), :limit=>true)
+    show(io, gd)
+    str = String(take!(io.io))
+    @test str == """
+    GroupedDataFrame with 4 groups based on key: A
+    First Group (1 row): A = 1
+    │ Row │ A     │ B      │ C       │
+    │     │ Int64 │ String │ Float32 │
+    ├─────┼───────┼────────┼─────────┤
+    │ 1   │ 1     │ x"     │ 1.0     │
+    ⋮
+    Last Group (1 row): A = 4
+    │ Row │ A     │ B      │ C       │
+    │     │ Int64 │ String │ Float32 │
+    ├─────┼───────┼────────┼─────────┤
+    │ 1   │ 4     │ A\\nC   │ 4.0     │"""
+    show(io, gd, allgroups=true)
+    str = String(take!(io.io))
+    @test str == """
+    GroupedDataFrame with 4 groups based on key: A
+    Group 1 (1 row): A = 1
+    │ Row │ A     │ B      │ C       │
+    │     │ Int64 │ String │ Float32 │
+    ├─────┼───────┼────────┼─────────┤
+    │ 1   │ 1     │ x\"     │ 1.0     │
+    Group 2 (1 row): A = 2
+    │ Row │ A     │ B           │ C       │
+    │     │ Int64 │ String      │ Float32 │
+    ├─────┼───────┼─────────────┼─────────┤
+    │ 1   │ 2     │ ∀ε>0: x+ε>x │ 2.0     │
+    Group 3 (1 row): A = 3
+    │ Row │ A     │ B      │ C       │
+    │     │ Int64 │ String │ Float32 │
+    ├─────┼───────┼────────┼─────────┤
+    │ 1   │ 3     │ z\$     │ 3.0     │
+    Group 4 (1 row): A = 4
+    │ Row │ A     │ B      │ C       │
+    │     │ Int64 │ String │ Float32 │
+    ├─────┼───────┼────────┼─────────┤
+    │ 1   │ 4     │ A\\nC   │ 4.0     │"""
+
+    # Test two-argument show
+    str1, dsize = capture_stdout() do
+        show(gd)
+    end
+    io = IOContext(IOBuffer(), :limit=>true, :displaysize=>dsize)
+    show(io, gd)
+    str2 = String(take!(io.io))
+    @test str1 == str2
+
+
+    @test sprint(show, "text/html", gd) ==
+        "<p><b>GroupedDataFrame with 4 groups based on key: A</b></p>" *
+        "<p><i>First Group (1 row): A = 1</i></p><table class=\"data-frame\">" *
+        "<thead><tr><th></th><th>A</th><th>B</th><th>C</th></tr><tr><th></th>" *
+        "<th>Int64</th><th>String</th><th>Float32</th></tr></thead>" *
+        "<tbody><tr><th>1</th><td>1</td><td>x\"</td><td>1.0</td></tr></tbody>" *
+        "</table><p>&vellip;</p><p><i>Last Group (1 row): A = 4</i></p>" *
+        "<table class=\"data-frame\"><thead><tr><th></th><th>A</th><th>B</th><th>C</th></tr>" *
+        "<tr><th></th><th>Int64</th><th>String</th><th>Float32</th></tr></thead>" *
+        "<tbody><tr><th>1</th><td>4</td><td>A\\nC</td><td>4.0</td></tr></tbody></table>"
+
+    @test sprint(show, "text/latex", gd) == """
+        GroupedDataFrame with 4 groups based on key: A
+
+        First Group (1 row): A = 1
+
+        \\begin{tabular}{r|ccc}
+        \t& A & B & C\\\\
+        \t\\hline
+        \t& Int64 & String & Float32\\\\
+        \t\\hline
+        \t1 & 1 & x" & 1.0 \\\\
+        \\end{tabular}
+
+        \$\\dots\$
+
+        Last Group (1 row): A = 4
+
+        \\begin{tabular}{r|ccc}
+        \t& A & B & C\\\\
+        \t\\hline
+        \t& Int64 & String & Float32\\\\
+        \t\\hline
+        \t1 & 4 & A\\textbackslash{}nC & 4.0 \\\\
+        \\end{tabular}
+        """
+
+    gd = groupby(DataFrame(a=[Symbol("&")], b=["&"]), [1,2])
+    @test sprint(show, gd) === """
+        GroupedDataFrame with 1 group based on keys: a, b
+        Group 1 (1 row): a = :&, b = "&"
+        │ Row │ a      │ b      │
+        │     │ Symbol │ String │
+        ├─────┼────────┼────────┤
+        │ 1   │ &      │ &      │"""
+
+    @test sprint(show, "text/html", gd) ==
+        "<p><b>GroupedDataFrame with 1 group based on keys: a, b</b></p><p><i>" *
+        "First Group (1 row): a = :&amp;, b = \"&amp;\"</i></p>" *
+        "<table class=\"data-frame\"><thead><tr><th></th><th>a</th><th>b</th></tr>" *
+        "<tr><th></th><th>Symbol</th><th>String</th></tr></thead><tbody><tr><th>1</th>" *
+        "<td>&amp;</td><td>&amp;</td></tr></tbody></table>"
+
+    @test sprint(show, "text/latex", gd) == """
+        GroupedDataFrame with 1 group based on keys: a, b
+
+        First Group (1 row): a = :\\&, b = "\\&"
+
+        \\begin{tabular}{r|cc}
+        \t& a & b\\\\
+        \t\\hline
+        \t& Symbol & String\\\\
+        \t\\hline
+        \t1 & \\& & \\& \\\\
+        \\end{tabular}
+        """
+end
+
+end # module

--- a/test/index.jl
+++ b/test/index.jl
@@ -1,4 +1,5 @@
 module TestIndex
+
 using Test, DataFrames
 using DataFrames: Index, SubIndex
 
@@ -154,4 +155,4 @@ si5 = SubIndex(i, [:C, :D, :E])
     @test names(dfr3) == [:c, :b]
 end
 
-end
+end # module

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,4 +1,5 @@
 module TestIndexing
+
 using Test, DataFrames
 
 @testset "getindex DataFrame" begin
@@ -164,4 +165,4 @@ end
     @test parent(dfr[:]) === df
 end
 
-end
+end # module

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,169 +1,171 @@
 module TestIO
-    using Test, DataFrames, CategoricalArrays, Dates
-    using LaTeXStrings
 
-    # Test LaTeX export
-    @testset "LaTeX export" begin
-        df = DataFrame(A = 1:4,
-                    B = ["\$10.0", "M&F", "A~B", "\\alpha"],
-                    C = [L"\alpha", L"\beta", L"\gamma", L"\sum_{i=1}^n \delta_i"],
-                    D = [1.0, 2.0, missing, 3.0],
-                    E = CategoricalArray(["a", missing, "c", "d"]),
-                    F = Vector{String}(undef, 4)
-                    )
-        str = """
-            \\begin{tabular}{r|cccccc}
-            \t& A & B & C & D & E & F\\\\
-            \t\\hline
-            \t& $(Int) & String & LaTeXStr… & Float64⍰ & Categorical…⍰ & String\\\\
-            \t\\hline
-            \t1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 & a & \\#undef \\\\
-            \t2 & 2 & M\\&F & \$\\beta\$ & 2.0 &  & \\#undef \\\\
-            \t3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  & c & \\#undef \\\\
-            \t4 & 4 & \\textbackslash{}\\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 & d & \\#undef \\\\
-            \\end{tabular}
-            """
-        @test repr(MIME("text/latex"), df) == str
-    end
+using Test, DataFrames, CategoricalArrays, Dates
+using LaTeXStrings
 
-    @testset "Huge LaTeX export" begin
-        df = DataFrame(a=1:1000)
-        ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => false)
-        show(ioc, "text/latex", df)
-        @test length(String(take!(ioc.io))) > 10000
-
-        io = IOBuffer()
-        show(io, "text/latex", df)
-        @test length(String(take!(io))) < 10000
-    end
-
-    #Test HTML output for IJulia and similar
-    @testset "HTML output" begin
-        df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, missing])
-        io = IOBuffer()
-        show(io, "text/html", df)
-        str = String(take!(io))
-        @test str == "<table class=\"data-frame\"><thead><tr><th>" *
-                    "</th><th>Fish</th><th>Mass</th></tr>" *
-                    "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
-                    "<p>2 rows × 2 columns</p>" *
-                    "<tr><th>1</th><td>Suzy</td><td>1.5</td></tr>" *
-                    "<tr><th>2</th><td>Amir</td><td>missing</td></tr></tbody></table>"
-
-        df = DataFrame(Fish = Vector{String}(undef, 2), Mass = [1.5, missing])
-        io = IOBuffer()
-        show(io, "text/html", df)
-        str = String(take!(io))
-        @test str == "<table class=\"data-frame\"><thead><tr><th>" *
-                    "</th><th>Fish</th><th>Mass</th></tr>" *
-                    "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
-                    "<p>2 rows × 2 columns</p>" *
-                    "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
-                    "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
-
-        io = IOBuffer()
-        show(io, MIME"text/html"(), df, summary=false)
-        str = String(take!(io))
-        @test str == "<table class=\"data-frame\"><thead><tr><th>" *
-                    "</th><th>Fish</th><th>Mass</th></tr>" *
-                    "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
-                    "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
-                    "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
-    end
-
-    # test limit attribute of IOContext is used
-    @testset "limit attribute" begin
-        df = DataFrame(a=1:1000)
-        ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => false)
-        show(ioc, "text/html", df)
-        @test length(String(take!(ioc.io))) > 10000
-
-        io = IOBuffer()
-        show(io, "text/html", df)
-        @test length(String(take!(io))) < 10000
-    end
-
-    @testset "printtable" begin
-        df = DataFrame(A = 1:3,
-                    B = 'a':'c',
-                    C = ["A", "B", "C"],
-                    D = CategoricalArray(string.('a':'c')),
-                    E = CategoricalArray(["A", "B", missing]),
-                    F = Vector{Union{Int, Missing}}(1:3),
-                    G = missings(3),
-                    H = fill(missing, 3))
-
-        @test sprint(DataFrames.printtable, df) ==
-            """
-            "A","B","C","D","E","F","G","H"
-            1,"'a'","A","a","A","1",missing,missing
-            2,"'b'","B","b","B","2",missing,missing
-            3,"'c'","C","c",missing,"3",missing,missing
-            """
-    end
-
-    @testset "DataStreams" begin
-        using DataStreams
-        I = DataFrame(id = Int64[1, 2, 3, 4, 5],
-            firstname = Union{String, Missing}["Benjamin", "Wayne", "Sean", "Charles", missing],
-            lastname = String["Chavez", "Burke", "Richards", "Long", "Rose"],
-            salary = Union{Float64, Missing}[missing, 46134.1, 45046.2, 30555.6, 88894.1],
-            rate = Float64[39.44, 33.8, 15.64, 17.67, 34.6],
-            hired = Union{Date, Missing}[Date("2011-07-07"), Date("2016-02-19"), missing,
-                                         Date("2002-01-05"), Date("2008-05-15")],
-            fired = DateTime[DateTime("2016-04-07T14:07:00"), DateTime("2015-03-19T15:01:00"),
-                             DateTime("2006-11-18T05:07:00"), DateTime("2002-07-18T06:24:00"),
-                             DateTime("2007-09-29T12:09:00")],
-            reserved = missings(5)
-        )
-        sink = DataStreams.Data.close!(DataStreams.Data.stream!(I, deepcopy(I)))
-        sch = DataStreams.Data.schema(sink)
-        @test size(sch) == (5, 8)
-        @test DataStreams.Data.header(sch) == ["id", "firstname", "lastname", "salary",
-                                               "rate", "hired", "fired", "reserved"]
-        @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String,
-                                              Union{Float64, Missing}, Float64,
-                                              Union{Date, Missing}, DateTime, Missing)
-        @test sink[:id] == [1:5;]
-
-        transforms = Dict(1=>x->x+1)
-        sink = DataStreams.Data.close!(DataStreams.Data.stream!(I, deepcopy(I);
-                                                                append=true, transforms=transforms))
-        sch = DataStreams.Data.schema(sink)
-        @test size(sch) == (10, 8)
-        @test DataStreams.Data.header(sch) == ["id", "firstname", "lastname", "salary",
-                                               "rate", "hired", "fired", "reserved"]
-        @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String,
-                                              Union{Float64, Missing}, Float64,
-                                              Union{Date, Missing}, DateTime, Missing)
-        @test sink[:id] == [1:5; 2:6]
-
-        sink = DataStreams.Data.close!(Data.stream!(I, DataFrame, deepcopy(I)))
-        sch = DataStreams.Data.schema(sink)
-        @test size(sch) == (5, 8)
-        @test DataStreams.Data.header(sch) == ["id", "firstname", "lastname", "salary",
-                                               "rate", "hired", "fired", "reserved"]
-        @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String,
-                                              Union{Float64, Missing}, Float64,
-                                              Union{Date, Missing}, DateTime, Missing)
-        @test sink[:id] == [1:5;]
-
-        # test DataFrameStream creation
-        dfs = DataFrame(sch)
-        DataStreams.Data.close!(dfs)
-    end
-
-    @testset "csv/tsv output" begin
-        df = DataFrame(a = [1,2], b = [1.0, 2.0])
-        @test sprint(show, "text/csv", df) == """
-        "a","b"
-        1,1.0
-        2,2.0
+# Test LaTeX export
+@testset "LaTeX export" begin
+    df = DataFrame(A = 1:4,
+                B = ["\$10.0", "M&F", "A~B", "\\alpha"],
+                C = [L"\alpha", L"\beta", L"\gamma", L"\sum_{i=1}^n \delta_i"],
+                D = [1.0, 2.0, missing, 3.0],
+                E = CategoricalArray(["a", missing, "c", "d"]),
+                F = Vector{String}(undef, 4)
+                )
+    str = """
+        \\begin{tabular}{r|cccccc}
+        \t& A & B & C & D & E & F\\\\
+        \t\\hline
+        \t& $(Int) & String & LaTeXStr… & Float64⍰ & Categorical…⍰ & String\\\\
+        \t\\hline
+        \t1 & 1 & \\\$10.0 & \$\\alpha\$ & 1.0 & a & \\#undef \\\\
+        \t2 & 2 & M\\&F & \$\\beta\$ & 2.0 &  & \\#undef \\\\
+        \t3 & 3 & A\\textasciitilde{}B & \$\\gamma\$ &  & c & \\#undef \\\\
+        \t4 & 4 & \\textbackslash{}\\textbackslash{}alpha & \$\\sum_{i=1}^n \\delta_i\$ & 3.0 & d & \\#undef \\\\
+        \\end{tabular}
         """
-        @test sprint(show, "text/tab-separated-values", df) == """
-        "a"\t"b"
-        1\t1.0
-        2\t2.0
-        """
-    end
+    @test repr(MIME("text/latex"), df) == str
 end
+
+@testset "Huge LaTeX export" begin
+    df = DataFrame(a=1:1000)
+    ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => false)
+    show(ioc, "text/latex", df)
+    @test length(String(take!(ioc.io))) > 10000
+
+    io = IOBuffer()
+    show(io, "text/latex", df)
+    @test length(String(take!(io))) < 10000
+end
+
+#Test HTML output for IJulia and similar
+@testset "HTML output" begin
+    df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, missing])
+    io = IOBuffer()
+    show(io, "text/html", df)
+    str = String(take!(io))
+    @test str == "<table class=\"data-frame\"><thead><tr><th>" *
+                "</th><th>Fish</th><th>Mass</th></tr>" *
+                "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
+                "<p>2 rows × 2 columns</p>" *
+                "<tr><th>1</th><td>Suzy</td><td>1.5</td></tr>" *
+                "<tr><th>2</th><td>Amir</td><td>missing</td></tr></tbody></table>"
+
+    df = DataFrame(Fish = Vector{String}(undef, 2), Mass = [1.5, missing])
+    io = IOBuffer()
+    show(io, "text/html", df)
+    str = String(take!(io))
+    @test str == "<table class=\"data-frame\"><thead><tr><th>" *
+                "</th><th>Fish</th><th>Mass</th></tr>" *
+                "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
+                "<p>2 rows × 2 columns</p>" *
+                "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
+                "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
+
+    io = IOBuffer()
+    show(io, MIME"text/html"(), df, summary=false)
+    str = String(take!(io))
+    @test str == "<table class=\"data-frame\"><thead><tr><th>" *
+                "</th><th>Fish</th><th>Mass</th></tr>" *
+                "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
+                "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
+                "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
+end
+
+# test limit attribute of IOContext is used
+@testset "limit attribute" begin
+    df = DataFrame(a=1:1000)
+    ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => false)
+    show(ioc, "text/html", df)
+    @test length(String(take!(ioc.io))) > 10000
+
+    io = IOBuffer()
+    show(io, "text/html", df)
+    @test length(String(take!(io))) < 10000
+end
+
+@testset "printtable" begin
+    df = DataFrame(A = 1:3,
+                B = 'a':'c',
+                C = ["A", "B", "C"],
+                D = CategoricalArray(string.('a':'c')),
+                E = CategoricalArray(["A", "B", missing]),
+                F = Vector{Union{Int, Missing}}(1:3),
+                G = missings(3),
+                H = fill(missing, 3))
+
+    @test sprint(DataFrames.printtable, df) ==
+        """
+        "A","B","C","D","E","F","G","H"
+        1,"'a'","A","a","A","1",missing,missing
+        2,"'b'","B","b","B","2",missing,missing
+        3,"'c'","C","c",missing,"3",missing,missing
+        """
+end
+
+@testset "DataStreams" begin
+    using DataStreams
+    I = DataFrame(id = Int64[1, 2, 3, 4, 5],
+        firstname = Union{String, Missing}["Benjamin", "Wayne", "Sean", "Charles", missing],
+        lastname = String["Chavez", "Burke", "Richards", "Long", "Rose"],
+        salary = Union{Float64, Missing}[missing, 46134.1, 45046.2, 30555.6, 88894.1],
+        rate = Float64[39.44, 33.8, 15.64, 17.67, 34.6],
+        hired = Union{Date, Missing}[Date("2011-07-07"), Date("2016-02-19"), missing,
+                                     Date("2002-01-05"), Date("2008-05-15")],
+        fired = DateTime[DateTime("2016-04-07T14:07:00"), DateTime("2015-03-19T15:01:00"),
+                         DateTime("2006-11-18T05:07:00"), DateTime("2002-07-18T06:24:00"),
+                         DateTime("2007-09-29T12:09:00")],
+        reserved = missings(5)
+    )
+    sink = DataStreams.Data.close!(DataStreams.Data.stream!(I, deepcopy(I)))
+    sch = DataStreams.Data.schema(sink)
+    @test size(sch) == (5, 8)
+    @test DataStreams.Data.header(sch) == ["id", "firstname", "lastname", "salary",
+                                           "rate", "hired", "fired", "reserved"]
+    @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String,
+                                          Union{Float64, Missing}, Float64,
+                                          Union{Date, Missing}, DateTime, Missing)
+    @test sink[:id] == [1:5;]
+
+    transforms = Dict(1=>x->x+1)
+    sink = DataStreams.Data.close!(DataStreams.Data.stream!(I, deepcopy(I);
+                                                            append=true, transforms=transforms))
+    sch = DataStreams.Data.schema(sink)
+    @test size(sch) == (10, 8)
+    @test DataStreams.Data.header(sch) == ["id", "firstname", "lastname", "salary",
+                                           "rate", "hired", "fired", "reserved"]
+    @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String,
+                                          Union{Float64, Missing}, Float64,
+                                          Union{Date, Missing}, DateTime, Missing)
+    @test sink[:id] == [1:5; 2:6]
+
+    sink = DataStreams.Data.close!(Data.stream!(I, DataFrame, deepcopy(I)))
+    sch = DataStreams.Data.schema(sink)
+    @test size(sch) == (5, 8)
+    @test DataStreams.Data.header(sch) == ["id", "firstname", "lastname", "salary",
+                                           "rate", "hired", "fired", "reserved"]
+    @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String,
+                                          Union{Float64, Missing}, Float64,
+                                          Union{Date, Missing}, DateTime, Missing)
+    @test sink[:id] == [1:5;]
+
+    # test DataFrameStream creation
+    dfs = DataFrame(sch)
+    DataStreams.Data.close!(dfs)
+end
+
+@testset "csv/tsv output" begin
+    df = DataFrame(a = [1,2], b = [1.0, 2.0])
+    @test sprint(show, "text/csv", df) == """
+    "a","b"
+    1,1.0
+    2,2.0
+    """
+    @test sprint(show, "text/tab-separated-values", df) == """
+    "a"\t"b"
+    1\t1.0
+    2\t2.0
+    """
+end
+
+end # module

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -1,127 +1,129 @@
 module TestIteration
-    using Test, DataFrames
-    using DataFrames: columns
 
-    df = DataFrame(A = Vector{Union{Int, Missing}}(1:2), B = Vector{Union{Int, Missing}}(2:3))
+using Test, DataFrames
+using DataFrames: columns
 
-    @test size(eachrow(df)) == (size(df, 1),)
-    @test eachrow(df)[1] == DataFrameRow(df, 1, :)
-    @test collect(eachrow(df)) isa Vector{<:DataFrameRow}
-    @test eltype(eachrow(df)) <: DataFrameRow
-    for row in eachrow(df)
-        @test isa(row, DataFrameRow)
-        @test (row[:B] - row[:A]) == 1
-        # issue #683 (https://github.com/JuliaData/DataFrames.jl/pull/683)
-        @test collect(pairs(row)) isa Vector{Pair{Symbol, Int}}
-    end
+df = DataFrame(A = Vector{Union{Int, Missing}}(1:2), B = Vector{Union{Int, Missing}}(2:3))
 
-    # TODO - clean up redundant tests after eachcol deprecation
-    @test size(eachcol(df)) == (size(df, 2),)
-    @test size(eachcol(df, true)) == (size(df, 2),)
-    @test size(columns(df)) == (size(df, 2),)
-    @test size(eachcol(df, false)) == (size(df, 2),)
-    @test length(eachcol(df)) == size(df, 2)
-    @test length(eachcol(df, true)) == size(df, 2)
-    @test length(columns(df)) == size(df, 2)
-    @test length(eachcol(df, false)) == size(df, 2)
-    @test eachcol(df)[1] == (:A => df[1]) # this will be df[1] after eachcol deprecation
-    @test eachcol(df, true)[1] == (:A => df[1])
-    @test columns(df)[1] == df[1]
-    @test eachcol(df, false)[1] == df[1]
-    @test collect(eachcol(df)) isa Vector{Pair{Symbol, AbstractVector}}
-    @test collect(eachcol(df, true)) isa Vector{Pair{Symbol, AbstractVector}}
-    @test collect(eachcol(df)) == [:A => [1, 2], :B => [2, 3]]
-    @test collect(eachcol(df, true)) == [:A => [1, 2], :B => [2, 3]]
-    @test collect(columns(df)) isa Vector{AbstractVector}
-    @test collect(eachcol(df, false)) isa Vector{AbstractVector}
-    @test collect(columns(df)) == [[1, 2], [2, 3]]
-    @test collect(eachcol(df, false)) == [[1, 2], [2, 3]]
-    @test eltype(eachcol(df)) == Pair{Symbol, AbstractVector}
-    @test eltype(eachcol(df, true)) == Pair{Symbol, AbstractVector}
-    @test eltype(columns(df)) == AbstractVector
-    @test eltype(eachcol(df, false)) == AbstractVector
-    for col in eachcol(df)
-        @test typeof(col) <: Pair{Symbol, <:AbstractVector}
-    end
-    for col in eachcol(df, true)
-        @test typeof(col) <: Pair{Symbol, <:AbstractVector}
-    end
-    for col in columns(df)
-        @test isa(col, AbstractVector)
-    end
-    for col in eachcol(df, false)
-        @test isa(col, AbstractVector)
-    end
-
-    @test map(x -> minimum(convert(Array, x)), eachrow(df)) == [1,2]
-    @test map(Vector, eachrow(df)) == [[1, 2], [2, 3]]
-    @test mapcols(minimum, df) == DataFrame(A = [1], B = [2])
-    @test map(minimum, eachcol(df)) == DataFrame(A = [1], B = [2]) # this is deprecated
-    @test map(minimum, eachcol(df, true)) == DataFrame(A = [1], B = [2]) # this is deprecated
-    @test map(minimum, columns(df)) == [1, 2]
-    @test map(minimum, eachcol(df, false)) == [1, 2]
-    @test eltypes(mapcols(Vector{Float64}, df)) == [Float64, Float64]
-    @test eltypes(map(Vector{Float64}, eachcol(df))) == [Float64, Float64] # this is deprecated
-    @test eltypes(map(Vector{Float64}, eachcol(df, true))) == [Float64, Float64] # this is deprecated
-    @test eltype(map(Vector{Float64}, columns(df))) == Vector{Float64}
-    @test eltype(map(Vector{Float64}, eachcol(df, false))) == Vector{Float64}
-
-    # test mapcols corner cases
-    # this behavior might change when we rework setindex! to follow standard broadcasting rules
-    # notice that now mixing vectors and scalars is allowed in some cases but not in others
-    # this is likely to change
-    df_mapcols = DataFrame(a=1:10, b=11:20)
-    @test mapcols(sum, df_mapcols) == DataFrame(a=55, b=155)
-    @test mapcols(x -> x[1] == 1 ? 0 : [0], df_mapcols) == DataFrame(a=0, b=0)
-    @test mapcols(x -> x[1] == 1 ? x : 0, df_mapcols) == DataFrame(a=1:10, b=0)
-    @test_throws ArgumentError mapcols(x -> x[1] != 1 ? x : 0, df_mapcols)
-
-    row = DataFrameRow(df, 1, :)
-
-    row[:A] = 100
-    @test df[1, :A] == 100
-
-    row[1] = 101
-    @test df[1, :A] == 101
-
-    df = DataFrame(A = Vector{Union{Int, Missing}}(1:4), B = Union{String, Missing}["M", "F", "F", "M"])
-
-    s1 = view(df, 1:3, :)
-    s1[2,:A] = 4
-    @test df[2, :A] == 4
-    @test view(s1, 1:2, :) == view(df, 1:2, :)
-
-    s2 = view(df, 1:2:3, :)
-    s2[2, :B] = "M"
-    @test df[3, :B] == "M"
-    @test view(s2, 1:1:2, :) == view(df, [1,3], :)
-
-    @test_throws MethodError for x in df; end
-
-    @testset "SubDataFrame" begin
-        df = DataFrame([11:16 21:26 31:36 41:46])
-        sdf = view(df, [3,1,4], [3,1,4])
-        @test sdf == df[[3,1,4], [3,1,4]]
-        @test eachrow(sdf) == eachrow(df[[3,1,4], [3,1,4]])
-        @test eachcol(sdf, true) == eachcol(df[[3,1,4], [3,1,4]], true)
-        @test eachcol(sdf, false) == eachcol(df[[3,1,4], [3,1,4]], false)
-        @test size(eachrow(sdf)) == (3,)
-        @test size(eachcol(sdf, true)) == (3,)
-        @test size(eachcol(sdf, false)) == (3,)
-    end
-
-    @testset "parent mutation" begin
-        df = DataFrame([11:16 21:26 31:36 41:46])
-        sdf = view(df, [3,1,4], [3,1,4])
-        erd = eachrow(df)
-        erv = eachrow(sdf)
-        names!(df, Symbol.(string.("y", 1:4)))
-        df[1] = 51:56
-        @test df[1, :] == erd[1]
-        @test copy(erv[1]) == (y3=33, y1=53, y4=43)
-        df.z = 1
-        @test length(erd[1]) == 5 # the added column is reflected
-        deletecols!(df, [4,5])
-        @test copy(erd[1]) == (y1 = 51, y2 = 21, y3 = 31) # the removed columns are reflected
-    end
+@test size(eachrow(df)) == (size(df, 1),)
+@test eachrow(df)[1] == DataFrameRow(df, 1, :)
+@test collect(eachrow(df)) isa Vector{<:DataFrameRow}
+@test eltype(eachrow(df)) <: DataFrameRow
+for row in eachrow(df)
+    @test isa(row, DataFrameRow)
+    @test (row[:B] - row[:A]) == 1
+    # issue #683 (https://github.com/JuliaData/DataFrames.jl/pull/683)
+    @test collect(pairs(row)) isa Vector{Pair{Symbol, Int}}
 end
+
+# TODO - clean up redundant tests after eachcol deprecation
+@test size(eachcol(df)) == (size(df, 2),)
+@test size(eachcol(df, true)) == (size(df, 2),)
+@test size(columns(df)) == (size(df, 2),)
+@test size(eachcol(df, false)) == (size(df, 2),)
+@test length(eachcol(df)) == size(df, 2)
+@test length(eachcol(df, true)) == size(df, 2)
+@test length(columns(df)) == size(df, 2)
+@test length(eachcol(df, false)) == size(df, 2)
+@test eachcol(df)[1] == (:A => df[1]) # this will be df[1] after eachcol deprecation
+@test eachcol(df, true)[1] == (:A => df[1])
+@test columns(df)[1] == df[1]
+@test eachcol(df, false)[1] == df[1]
+@test collect(eachcol(df)) isa Vector{Pair{Symbol, AbstractVector}}
+@test collect(eachcol(df, true)) isa Vector{Pair{Symbol, AbstractVector}}
+@test collect(eachcol(df)) == [:A => [1, 2], :B => [2, 3]]
+@test collect(eachcol(df, true)) == [:A => [1, 2], :B => [2, 3]]
+@test collect(columns(df)) isa Vector{AbstractVector}
+@test collect(eachcol(df, false)) isa Vector{AbstractVector}
+@test collect(columns(df)) == [[1, 2], [2, 3]]
+@test collect(eachcol(df, false)) == [[1, 2], [2, 3]]
+@test eltype(eachcol(df)) == Pair{Symbol, AbstractVector}
+@test eltype(eachcol(df, true)) == Pair{Symbol, AbstractVector}
+@test eltype(columns(df)) == AbstractVector
+@test eltype(eachcol(df, false)) == AbstractVector
+for col in eachcol(df)
+    @test typeof(col) <: Pair{Symbol, <:AbstractVector}
+end
+for col in eachcol(df, true)
+    @test typeof(col) <: Pair{Symbol, <:AbstractVector}
+end
+for col in columns(df)
+    @test isa(col, AbstractVector)
+end
+for col in eachcol(df, false)
+    @test isa(col, AbstractVector)
+end
+
+@test map(x -> minimum(convert(Array, x)), eachrow(df)) == [1,2]
+@test map(Vector, eachrow(df)) == [[1, 2], [2, 3]]
+@test mapcols(minimum, df) == DataFrame(A = [1], B = [2])
+@test map(minimum, eachcol(df)) == DataFrame(A = [1], B = [2]) # this is deprecated
+@test map(minimum, eachcol(df, true)) == DataFrame(A = [1], B = [2]) # this is deprecated
+@test map(minimum, columns(df)) == [1, 2]
+@test map(minimum, eachcol(df, false)) == [1, 2]
+@test eltypes(mapcols(Vector{Float64}, df)) == [Float64, Float64]
+@test eltypes(map(Vector{Float64}, eachcol(df))) == [Float64, Float64] # this is deprecated
+@test eltypes(map(Vector{Float64}, eachcol(df, true))) == [Float64, Float64] # this is deprecated
+@test eltype(map(Vector{Float64}, columns(df))) == Vector{Float64}
+@test eltype(map(Vector{Float64}, eachcol(df, false))) == Vector{Float64}
+
+# test mapcols corner cases
+# this behavior might change when we rework setindex! to follow standard broadcasting rules
+# notice that now mixing vectors and scalars is allowed in some cases but not in others
+# this is likely to change
+df_mapcols = DataFrame(a=1:10, b=11:20)
+@test mapcols(sum, df_mapcols) == DataFrame(a=55, b=155)
+@test mapcols(x -> x[1] == 1 ? 0 : [0], df_mapcols) == DataFrame(a=0, b=0)
+@test mapcols(x -> x[1] == 1 ? x : 0, df_mapcols) == DataFrame(a=1:10, b=0)
+@test_throws ArgumentError mapcols(x -> x[1] != 1 ? x : 0, df_mapcols)
+
+row = DataFrameRow(df, 1, :)
+
+row[:A] = 100
+@test df[1, :A] == 100
+
+row[1] = 101
+@test df[1, :A] == 101
+
+df = DataFrame(A = Vector{Union{Int, Missing}}(1:4), B = Union{String, Missing}["M", "F", "F", "M"])
+
+s1 = view(df, 1:3, :)
+s1[2,:A] = 4
+@test df[2, :A] == 4
+@test view(s1, 1:2, :) == view(df, 1:2, :)
+
+s2 = view(df, 1:2:3, :)
+s2[2, :B] = "M"
+@test df[3, :B] == "M"
+@test view(s2, 1:1:2, :) == view(df, [1,3], :)
+
+@test_throws MethodError for x in df; end
+
+@testset "SubDataFrame" begin
+    df = DataFrame([11:16 21:26 31:36 41:46])
+    sdf = view(df, [3,1,4], [3,1,4])
+    @test sdf == df[[3,1,4], [3,1,4]]
+    @test eachrow(sdf) == eachrow(df[[3,1,4], [3,1,4]])
+    @test eachcol(sdf, true) == eachcol(df[[3,1,4], [3,1,4]], true)
+    @test eachcol(sdf, false) == eachcol(df[[3,1,4], [3,1,4]], false)
+    @test size(eachrow(sdf)) == (3,)
+    @test size(eachcol(sdf, true)) == (3,)
+    @test size(eachcol(sdf, false)) == (3,)
+end
+
+@testset "parent mutation" begin
+    df = DataFrame([11:16 21:26 31:36 41:46])
+    sdf = view(df, [3,1,4], [3,1,4])
+    erd = eachrow(df)
+    erv = eachrow(sdf)
+    names!(df, Symbol.(string.("y", 1:4)))
+    df[1] = 51:56
+    @test df[1, :] == erd[1]
+    @test copy(erv[1]) == (y3=33, y1=53, y4=43)
+    df.z = 1
+    @test length(erd[1]) == 5 # the added column is reflected
+    deletecols!(df, [4,5])
+    @test copy(erd[1]) == (y1 = 51, y2 = 21, y3 = 31) # the removed columns are reflected
+end
+
+end # module

--- a/test/join.jl
+++ b/test/join.jl
@@ -1,675 +1,677 @@
 module TestJoin
-    using Test, DataFrames
-    using DataFrames: similar_missing
-    using DataFrames: columns
-    const ≅ = isequal
 
-    name = DataFrame(ID = Union{Int, Missing}[1, 2, 3],
-                    Name = Union{String, Missing}["John Doe", "Jane Doe", "Joe Blogs"])
-    job = DataFrame(ID = Union{Int, Missing}[1, 2, 2, 4],
-                    Job = Union{String, Missing}["Lawyer", "Doctor", "Florist", "Farmer"])
-    # Test output of various join types
-    outer = DataFrame(ID = [1, 2, 2, 3, 4],
-                      Name = ["John Doe", "Jane Doe", "Jane Doe", "Joe Blogs", missing],
-                      Job = ["Lawyer", "Doctor", "Florist", missing, "Farmer"])
-
-    # (Tests use current column ordering but don't promote it)
-    right = outer[Bool[!ismissing(x) for x in outer[:Job]], [:ID, :Name, :Job]]
-    left = outer[Bool[!ismissing(x) for x in outer[:Name]], :]
-    inner = left[Bool[!ismissing(x) for x in left[:Job]], :]
-    semi = unique(inner[[:ID, :Name]])
-    anti = left[Bool[ismissing(x) for x in left[:Job]], [:ID, :Name]]
-    
-    @testset "join types" begin
-        # Join on symbols or vectors of symbols
-        join(name, job, on = :ID)
-        join(name, job, on = [:ID])
-    
-        # Soon we won't allow natural joins
-        @test_throws ArgumentError join(name, job)
-    
-
-        @test join(name, job, on = :ID) == inner
-        @test join(name, job, on = :ID, kind = :inner) == inner
-        @test join(name, job, on = :ID, kind = :outer) ≅ outer
-        @test join(name, job, on = :ID, kind = :left) ≅ left
-        @test join(name, job, on = :ID, kind = :right) ≅ right
-        @test join(name, job, on = :ID, kind = :semi) == semi
-        @test join(name, job, on = :ID, kind = :anti) == anti
-        @test_throws ArgumentError join(name, job)
-        @test_throws ArgumentError join(name, job, on=:ID, kind=:other)
-
-        # Join with no non-key columns
-        on = [:ID]
-        nameid = name[on]
-        jobid = job[on]
-
-        @test join(nameid, jobid, on = :ID) == inner[on]
-        @test join(nameid, jobid, on = :ID, kind = :inner) == inner[on]
-        @test join(nameid, jobid, on = :ID, kind = :outer) == outer[on]
-        @test join(nameid, jobid, on = :ID, kind = :left) == left[on]
-        @test join(nameid, jobid, on = :ID, kind = :right) == right[on]
-        @test join(nameid, jobid, on = :ID, kind = :semi) == semi[on]
-        @test join(nameid, jobid, on = :ID, kind = :anti) == anti[on]
-
-        # Join on multiple keys
-        df1 = DataFrame(A = 1, B = 2, C = 3)
-        df2 = DataFrame(A = 1, B = 2, D = 4)
-
-        join(df1, df2, on = [:A, :B])
-
-        # Test output of cross joins
-        df1 = DataFrame(A = 1:2, B = 'a':'b')
-        df2 = DataFrame(A = 1:3, C = 3:5)
-
-        cross = DataFrame(A = [1, 1, 1, 2, 2, 2],
-                        B = ['a', 'a', 'a', 'b', 'b', 'b'],
-                        C = [3, 4, 5, 3, 4, 5])
-
-        @test join(df1, df2[[:C]], kind = :cross) == cross
-
-        # Cross joins handle naming collisions
-        @test size(join(df1, df1, kind = :cross, makeunique=true)) == (4, 4)
-
-        # Cross joins don't take keys
-        @test_throws ArgumentError join(df1, df2, on = :A, kind = :cross)
-    end
-
-    @testset "Test empty inputs 1" begin
-        simple_df(len::Int, col=:A) = (df = DataFrame();
-                                       df[col]=Vector{Union{Int, Missing}}(1:len);
-                                       df)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :left) == simple_df(0)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :left) == simple_df(2)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :left) == simple_df(0)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :right) == simple_df(0)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :right) == simple_df(2)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :right) == simple_df(0)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :inner) == simple_df(0)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :inner) == simple_df(0)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :inner) == simple_df(0)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :outer) == simple_df(0)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :outer) == simple_df(2)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :outer) == simple_df(2)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :semi) == simple_df(0)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :semi) == simple_df(0)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :semi) == simple_df(0)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :anti) == simple_df(0)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :anti) == simple_df(2)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :anti) == simple_df(0)
-        @test join(simple_df(0), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
-                                                                               B=Int[])
-        @test join(simple_df(0), simple_df(2, :B), kind = :cross) == DataFrame(A=Int[],
-                                                                               B=Int[])
-        @test join(simple_df(2), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
-                                                                               B=Int[])
-    end
-
-    @testset "Test empty inputs 2" begin
-        simple_df(len::Int, col=:A) = (df = DataFrame(); df[col]=collect(1:len); df)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :left) ==  simple_df(0)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :left) ==  simple_df(2)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :left) ==  simple_df(0)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :right) == simple_df(0)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :right) == simple_df(2)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :right) == simple_df(0)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :inner) == simple_df(0)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :inner) == simple_df(0)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :inner) == simple_df(0)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :outer) == simple_df(0)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :outer) == simple_df(2)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :outer) == simple_df(2)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :semi) ==  simple_df(0)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :semi) ==  simple_df(0)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :semi) ==  simple_df(0)
-        @test join(simple_df(0), simple_df(0), on = :A, kind = :anti) ==  simple_df(0)
-        @test join(simple_df(2), simple_df(0), on = :A, kind = :anti) ==  simple_df(2)
-        @test join(simple_df(0), simple_df(2), on = :A, kind = :anti) ==  simple_df(0)
-        @test join(simple_df(0), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
-                                                                               B=Int[])
-        @test join(simple_df(0), simple_df(2, :B), kind = :cross) == DataFrame(A=Int[],
-                                                                               B=Int[])
-        @test join(simple_df(2), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
-                                                                               B=Int[])
-    end
-
-    @testset "issue #960" begin
-        df1 = DataFrame(A = 1:50,
-                        B = 1:50,
-                        C = 1)
-        categorical!(df1, :A)
-        categorical!(df1, :B)
-        join(df1, df1, on = [:A, :B], kind = :inner, makeunique=true)
-        # Test that join works when mixing Array{Union{T, Missing}} with Array{T} (issue #1088)
-        df = DataFrame(Name = Union{String, Missing}["A", "B", "C"],
-                    Mass = [1.5, 2.2, 1.1])
-        df2 = DataFrame(Name = ["A", "B", "C", "A"],
-                        Quantity = [3, 3, 2, 4])
-        @test join(df2, df, on=:Name, kind=:left) == DataFrame(Name = ["A", "B", "C", "A"],
-                                                            Quantity = [3, 3, 2, 4],
-                                                            Mass = [1.5, 2.2, 1.1, 1.5])
-
-        # Test that join works when mixing Array{Union{T, Missing}} with Array{T} (issue #1151)
-        df = DataFrame([collect(1:10), collect(2:11)], [:x, :y])
-        dfmissing = DataFrame(x = Vector{Union{Int, Missing}}(1:10),
-                            z = Vector{Union{Int, Missing}}(3:12))
-        @test join(df, dfmissing, on = :x) ==
-            DataFrame([collect(1:10), collect(2:11), collect(3:12)], [:x, :y, :z])
-        @test join(dfmissing, df, on = :x) ==
-            DataFrame([Vector{Union{Int, Missing}}(1:10), Vector{Union{Int, Missing}}(3:12),
-                    collect(2:11)], [:x, :z, :y])
-    end
-
-    @testset "all joins" begin
-        df1 = DataFrame(Any[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
-        df2 = DataFrame(Any[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
-
-        @test join(df1, df2, kind=:cross, makeunique=true) ==
-            DataFrame(Any[repeat([1, 3, 5], inner = 5),
-                          repeat([1, 3, 5], inner = 5),
-                          repeat([0, 1, 2, 3, 4], outer = 3),
-                          repeat([0, 1, 2, 3, 4], outer = 3)],
-                      [:id, :fid, :id_1, :fid_1])
-        @test typeof.(columns(join(df1, df2, kind=:cross, makeunique=true))) ==
-            [Vector{Int}, Vector{Float64}, Vector{Int}, Vector{Float64}]
-
-        i(on) = join(df1, df2, on = on, kind = :inner, makeunique=true)
-        l(on) = join(df1, df2, on = on, kind = :left, makeunique=true)
-        r(on) = join(df1, df2, on = on, kind = :right, makeunique=true)
-        o(on) = join(df1, df2, on = on, kind = :outer, makeunique=true)
-        s(on) = join(df1, df2, on = on, kind = :semi, makeunique=true)
-        a(on) = join(df1, df2, on = on, kind = :anti, makeunique=true)
-
-        @test s(:id) ==
-              s(:fid) ==
-              s([:id, :fid]) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
-        @test typeof.(columns(s(:id))) ==
-              typeof.(columns(s(:fid))) ==
-              typeof.(columns(s([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
-        @test a(:id) ==
-              a(:fid) ==
-              a([:id, :fid]) == DataFrame([[5], [5]], [:id, :fid])
-        @test typeof.(columns(a(:id))) ==
-              typeof.(columns(a(:fid))) ==
-              typeof.(columns(a([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
-
-        on = :id
-        @test i(on) == DataFrame([[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
-        @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Float64}]
-        @test l(on) ≅ DataFrame(id = [1, 3, 5],
-                                fid = [1, 3, 5],
-                                fid_1 = [1, 3, missing])
-        @test typeof.(columns(l(on))) ==
-            [Vector{Int}, Vector{Float64}, Vector{Union{Float64, Missing}}]
-        @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
-                                fid = [1, 3, missing, missing, missing],
-                                fid_1 = [1, 3, 0, 2, 4])
-        @test typeof.(columns(r(on))) ==
-            [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Float64}]
-        @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
-                                fid = [1, 3, 5, missing, missing, missing],
-                                fid_1 = [1, 3, missing, 0, 2, 4])
-        @test typeof.(columns(o(on))) ==
-            [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Union{Float64, Missing}}]
-
-        on = :fid
-        @test i(on) == DataFrame([[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
-        @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Int}]
-        @test l(on) ≅ DataFrame(id = [1, 3, 5],
-                                fid = [1, 3, 5],
-                                id_1 = [1, 3, missing])
-        @test typeof.(columns(l(on))) == [Vector{Int}, Vector{Float64},
-                                         Vector{Union{Int, Missing}}]
-        @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
-                                fid = [1, 3, 0, 2, 4],
-                                id_1 = [1, 3, 0, 2, 4])
-        @test typeof.(columns(r(on))) == [Vector{Union{Int, Missing}}, Vector{Float64},
-                                         Vector{Int}]
-        @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
-                                fid = [1, 3, 5, 0, 2, 4],
-                                id_1 = [1, 3, missing, 0, 2, 4])
-        @test typeof.(columns(o(on))) == [Vector{Union{Int, Missing}}, Vector{Float64},
-                                         Vector{Union{Int, Missing}}]
-
-        on = [:id, :fid]
-        @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
-        @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}]
-        @test l(on) == DataFrame(id = [1, 3, 5], fid = [1, 3, 5])
-        @test typeof.(columns(l(on))) == [Vector{Int}, Vector{Float64}]
-        @test r(on) == DataFrame(id = [1, 3, 0, 2, 4], fid = [1, 3, 0, 2, 4])
-        @test typeof.(columns(r(on))) == [Vector{Int}, Vector{Float64}]
-        @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4], fid = [1, 3, 5, 0, 2, 4])
-        @test typeof.(columns(o(on))) == [Vector{Int}, Vector{Float64}]
-    end
-
-    @testset "all joins with CategoricalArrays" begin
-        df1 = DataFrame(Any[CategoricalArray([1, 3, 5]),
-                            CategoricalArray([1.0, 3.0, 5.0])], [:id, :fid])
-        df2 = DataFrame(Any[CategoricalArray([0, 1, 2, 3, 4]),
-                            CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
-
-        @test join(df1, df2, kind=:cross, makeunique=true) ==
-            DataFrame([repeat([1, 3, 5], inner = 5),
-                       repeat([1, 3, 5], inner = 5),
-                       repeat([0, 1, 2, 3, 4], outer = 3),
-                       repeat([0, 1, 2, 3, 4], outer = 3)],
-                      [:id, :fid, :id_1, :fid_1])
-        @test all(isa.(columns(join(df1, df2, kind=:cross, makeunique=true)),
-                       [CategoricalVector{T} for T in (Int, Float64, Int, Float64)]))
-
-        i(on) = join(df1, df2, on = on, kind = :inner, makeunique=true)
-        l(on) = join(df1, df2, on = on, kind = :left, makeunique=true)
-        r(on) = join(df1, df2, on = on, kind = :right, makeunique=true)
-        o(on) = join(df1, df2, on = on, kind = :outer, makeunique=true)
-        s(on) = join(df1, df2, on = on, kind = :semi, makeunique=true)
-        a(on) = join(df1, df2, on = on, kind = :anti, makeunique=true)
-
-        @test s(:id) ==
-              s(:fid) ==
-              s([:id, :fid]) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
-        @test typeof.(columns(s(:id))) ==
-              typeof.(columns(s(:fid))) ==
-              typeof.(columns(s([:id, :fid])))
-        @test all(isa.(columns(s(:id)),
-                       [CategoricalVector{T} for T in (Int, Float64)]))
-
-        @test a(:id) ==
-              a(:fid) ==
-              a([:id, :fid]) == DataFrame([[5], [5]], [:id, :fid])
-        @test typeof.(columns(a(:id))) ==
-              typeof.(columns(a(:fid))) ==
-              typeof.(columns(a([:id, :fid])))
-        @test all(isa.(columns(a(:id)),
-                       [CategoricalVector{T} for T in (Int, Float64)]))
-
-        on = :id
-        @test i(on) == DataFrame([[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
-        @test all(isa.(columns(i(on)),
-                       [CategoricalVector{T} for T in (Int, Float64, Float64)]))
-        @test l(on) ≅ DataFrame(id = [1, 3, 5],
-                                fid = [1, 3, 5],
-                                fid_1 = [1, 3, missing])
-        @test all(isa.(columns(l(on)),
-                       [CategoricalVector{T} for T in (Int,Float64,Union{Float64, Missing})]))
-        @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
-                                fid = [1, 3, missing, missing, missing],
-                                fid_1 = [1, 3, 0, 2, 4])
-        @test all(isa.(columns(r(on)),
-                       [CategoricalVector{T} for T in (Int,Union{Float64, Missing},Float64)]))
-        @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
-                                fid = [1, 3, 5, missing, missing, missing],
-                                fid_1 = [1, 3, missing, 0, 2, 4])
-        @test all(isa.(columns(o(on)),
-                       [CategoricalVector{T} for T in (Int,Union{Float64,Missing},Union{Float64, Missing})]))
-
-        on = :fid
-        @test i(on) == DataFrame([[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
-        @test all(isa.(columns(i(on)),
-                       [CategoricalVector{T} for T in (Int, Float64, Int)]))
-        @test l(on) ≅ DataFrame(id = [1, 3, 5],
-                                fid = [1, 3, 5],
-                                id_1 = [1, 3, missing])
-        @test all(isa.(columns(l(on)),
-                       [CategoricalVector{T} for T in (Int, Float64, Union{Int, Missing})]))
-        @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
-                                fid = [1, 3, 0, 2, 4],
-                                id_1 = [1, 3, 0, 2, 4])
-        @test all(isa.(columns(r(on)),
-                       [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Int)]))
-        @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
-                                fid = [1, 3, 5, 0, 2, 4],
-                                id_1 = [1, 3, missing, 0, 2, 4])
-        @test all(isa.(columns(o(on)),
-                       [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Union{Int, Missing})]))
-
-        on = [:id, :fid]
-        @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
-        @test all(isa.(columns(i(on)),
-                       [CategoricalVector{T} for T in (Int, Float64)]))
-        @test l(on) == DataFrame(id = [1, 3, 5],
-                                 fid = [1, 3, 5])
-        @test all(isa.(columns(l(on)),
-                       [CategoricalVector{T} for T in (Int, Float64)]))
-        @test r(on) == DataFrame(id = [1, 3, 0, 2, 4],
-                                 fid = [1, 3, 0, 2, 4])
-        @test all(isa.(columns(r(on)),
-                       [CategoricalVector{T} for T in (Int, Float64)]))
-        @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4],
-                                 fid = [1, 3, 5, 0, 2, 4])
-        @test all(isa.(columns(o(on)),
-                       [CategoricalVector{T} for T in (Int, Float64)]))
-    end
-
-    @testset "maintain CategoricalArray levels ordering on join - non-`on` cols" begin
-        A = DataFrame(a = [1, 2, 3], b = ["a", "b", "c"])
-        B = DataFrame(b = ["a", "b", "c"], c = CategoricalVector(["a", "b", "b"]))
-        levels!(B[:c], ["b", "a"])
-        @test levels(join(A, B, on=:b, kind=:inner)[:c]) == ["b", "a"]
-        @test levels(join(B, A, on=:b, kind=:inner)[:c]) == ["b", "a"]
-        @test levels(join(A, B, on=:b, kind =:left)[:c]) == ["b", "a"]
-        @test levels(join(A, B, on=:b, kind=:right)[:c]) == ["b", "a"]
-        @test levels(join(A, B, on=:b, kind=:outer)[:c]) == ["b", "a"]
-        @test levels(join(B, A, on=:b, kind =:semi)[:c]) == ["b", "a"]
-    end
-
-    @testset "maintain CategoricalArray levels ordering on join - ordering conflicts" begin
-        A = DataFrame(a = [1, 2, 3, 4], b = CategoricalVector(["a", "b", "c", "d"]))
-        levels!(A[:b], ["d", "c", "b", "a"])
-        B = DataFrame(b = CategoricalVector(["a", "b", "c"]), c = [5, 6, 7])
-        @test levels(join(A, B, on=:b, kind=:inner)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind=:inner)[:b]) == ["a", "b", "c"]
-        @test levels(join(A, B, on=:b, kind=:left)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind=:left)[:b]) == ["a", "b", "c"]
-        @test levels(join(A, B, on=:b, kind=:right)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind=:right)[:b]) == ["a", "b", "d", "c"]
-        @test levels(join(B, A, on=:b, kind=:outer)[:b]) == ["a", "b", "d", "c"]
-        @test levels(join(A, B, on=:b, kind=:outer)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(A, B, on=:b, kind = :semi)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind = :semi)[:b]) == ["a", "b", "c"]
-    end
-
-    @testset "maintain CategoricalArray levels ordering on join - left is categorical" begin
-        A = DataFrame(a = [1, 2, 3, 4], b = CategoricalVector(["a", "b", "c", "d"]))
-        levels!(A[:b], ["d", "c", "b", "a"])
-        B = DataFrame(b = ["a", "b", "c"], c = [5, 6, 7])
-        @test levels(join(A, B, on=:b)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b)[:b]) == ["a", "b", "c"]
-        @test levels(join(A, B, on=:b, kind=:inner)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind=:inner)[:b]) == ["a", "b", "c"]
-        @test levels(join(A, B, on=:b, kind=:left)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind=:left)[:b]) == ["a", "b", "c"]
-        @test levels(join(A, B, on=:b, kind=:right)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind=:right)[:b]) == ["a", "b", "c", "d"]
-        @test levels(join(A, B, on=:b, kind=:outer)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind=:outer)[:b]) == ["a", "b", "c", "d"]
-        @test levels(join(A, B, on=:b, kind = :semi)[:b]) == ["d", "c", "b", "a"]
-        @test levels(join(B, A, on=:b, kind = :semi)[:b]) == ["a", "b", "c"]
-    end
-
-    @testset "join on columns with different left/right names" begin
-        global left = DataFrame(id = 1:7, sid = string.(1:7))
-        global right = DataFrame(ID = 3:10, SID = string.(3:10))
-        @test join(left, right, on = (:id, :ID), kind=:inner) ==
-            DataFrame(id = 3:7, sid = string.(3:7), SID = string.(3:7))
-        @test join(left, right, on = :id => :ID, kind=:inner) ==
-            DataFrame(id = 3:7, sid = string.(3:7), SID = string.(3:7))
-        @test join(left, right, on = [(:id, :ID)], kind=:inner) ==
-            DataFrame(id = 3:7, sid = string.(3:7), SID = string.(3:7))
-        @test join(left, right, on = [:id => :ID], kind=:inner) ==
-            DataFrame(id = 3:7, sid = string.(3:7), SID = string.(3:7))
-        @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:inner) ==
-            DataFrame(id = 3:7, sid = string.(3:7))
-        @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:inner) ==
-            DataFrame(id = 3:7, sid = string.(3:7))
-
-        @test join(left, right, on = (:id, :ID), kind=:left) ≅
-            DataFrame(id = 1:7, sid = string.(1:7),
-                      SID = [missing, missing, string.(3:7)...])
-        @test join(left, right, on = :id => :ID, kind=:left) ≅
-            DataFrame(id = 1:7, sid = string.(1:7),
-                      SID = [missing, missing, string.(3:7)...])
-        @test join(left, right, on = [(:id, :ID)], kind=:left) ≅
-            DataFrame(id = 1:7, sid = string.(1:7),
-                      SID = [missing, missing, string.(3:7)...])
-        @test join(left, right, on = [:id => :ID], kind=:left) ≅
-            DataFrame(id = 1:7, sid = string.(1:7),
-                      SID = [missing, missing, string.(3:7)...])
-        @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:left) ==
-            DataFrame(id = 1:7, sid = string.(1:7))
-        @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:left) ==
-            DataFrame(id = 1:7, sid = string.(1:7))
-
-        @test join(left, right, on = (:id, :ID), kind=:right) ≅
-            DataFrame(id = 3:10, sid = [string.(3:7)..., missing, missing, missing],
-                     SID = string.(3:10))
-        @test join(left, right, on = :id => :ID, kind=:right) ≅
-            DataFrame(id = 3:10, sid = [string.(3:7)..., missing, missing, missing],
-                     SID = string.(3:10))
-        @test join(left, right, on = [(:id, :ID)], kind=:right) ≅
-            DataFrame(id = 3:10, sid = [string.(3:7)..., missing, missing, missing],
-                     SID = string.(3:10))
-        @test join(left, right, on = [:id => :ID], kind=:right) ≅
-            DataFrame(id = 3:10, sid = [string.(3:7)..., missing, missing, missing],
-                     SID = string.(3:10))
-        @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:right) ≅
-            DataFrame(id = 3:10, sid = string.(3:10))
-        @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:right) ≅
-            DataFrame(id = 3:10, sid = string.(3:10))
-
-        @test join(left, right, on = (:id, :ID), kind=:outer) ≅
-            DataFrame(id = 1:10, sid = [string.(1:7)..., missing, missing, missing],
-                      SID = [missing, missing, string.(3:10)...])
-        @test join(left, right, on = :id => :ID, kind=:outer) ≅
-            DataFrame(id = 1:10, sid = [string.(1:7)..., missing, missing, missing],
-                      SID = [missing, missing, string.(3:10)...])
-        @test join(left, right, on = [(:id, :ID)], kind=:outer) ≅
-            DataFrame(id = 1:10, sid = [string.(1:7)..., missing, missing, missing],
-                      SID = [missing, missing, string.(3:10)...])
-        @test join(left, right, on = [:id => :ID], kind=:outer) ≅
-            DataFrame(id = 1:10, sid = [string.(1:7)..., missing, missing, missing],
-                      SID = [missing, missing, string.(3:10)...])
-        @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:outer) ≅
-            DataFrame(id = 1:10, sid = string.(1:10))
-        @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:outer) ≅
-            DataFrame(id = 1:10, sid = string.(1:10))
-
-        @test join(left, right, on = (:id, :ID), kind=:semi) ==
-            DataFrame(id = 3:7, sid = string.(3:7))
-        @test join(left, right, on = :id => :ID, kind=:semi) ==
-            DataFrame(id = 3:7, sid = string.(3:7))
-        @test join(left, right, on = [(:id, :ID)], kind=:semi) ==
-            DataFrame(id = 3:7, sid = string.(3:7))
-        @test join(left, right, on = [:id => :ID], kind=:semi) ==
-            DataFrame(id = 3:7, sid = string.(3:7))
-        @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:semi) ==
-            DataFrame(id = 3:7, sid = string.(3:7))
-        @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:semi) ==
-            DataFrame(id = 3:7, sid = string.(3:7))
-
-        @test join(left, right, on = (:id, :ID), kind=:anti) ==
-            DataFrame(id = 1:2, sid = string.(1:2))
-        @test join(left, right, on = :id => :ID, kind=:anti) ==
-            DataFrame(id = 1:2, sid = string.(1:2))
-        @test join(left, right, on = [(:id, :ID)], kind=:anti) ==
-            DataFrame(id = 1:2, sid = string.(1:2))
-        @test join(left, right, on = [:id => :ID], kind=:anti) ==
-            DataFrame(id = 1:2, sid = string.(1:2))
-        @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:anti) ==
-            DataFrame(id = 1:2, sid = string.(1:2))
-        @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:anti) ==
-            DataFrame(id = 1:2, sid = string.(1:2))
-    end
-
-    @testset "join with a column of type Any" begin
-        l = DataFrame(a=Any[1:7;], b=[1:7;])
-        r = DataFrame(a=Any[3:10;], b=[3:10;])
-
-        # join by :a and :b (Any is the on-column)
-        @test join(l, r, on=[:a, :b], kind=:inner) ≅ DataFrame(a=Any[3:7;], b=3:7)
-        @test eltypes(join(l, r, on=[:a, :b], kind=:inner)) == [Any, Int]
-
-        @test join(l, r, on=[:a, :b], kind=:left) ≅ DataFrame(a=Any[1:7;], b=1:7)
-        @test eltypes(join(l, r, on=[:a, :b], kind=:left)) == [Any, Int]
-
-        @test join(l, r, on=[:a, :b], kind=:right) ≅ DataFrame(a=Any[3:10;], b=3:10)
-        @test eltypes(join(l, r, on=[:a, :b], kind=:right)) == [Any, Int]
-
-        @test join(l, r, on=[:a, :b], kind=:outer) ≅ DataFrame(a=Any[1:10;], b=1:10)
-        @test eltypes(join(l, r, on=[:a, :b], kind=:outer)) == [Any, Int]
-
-        # join by :b (Any is not on-column)
-        @test join(l, r, on=:b, kind=:inner, makeunique=true) ≅
-            DataFrame(a=Any[3:7;], b=3:7, a_1=Any[3:7;])
-        @test eltypes(join(l, r, on=:b, kind=:inner, makeunique=true)) == [Any, Int, Any]
-
-        @test join(l, r, on=:b, kind=:left, makeunique=true) ≅
-            DataFrame(a=Any[1:7;], b=1:7, a_1=[fill(missing, 2); 3:7;])
-        @test eltypes(join(l, r, on=:b, kind=:left, makeunique=true)) == [Any, Int, Any]
-
-        @test join(l, r, on=:b, kind=:right, makeunique=true) ≅
-            DataFrame(a=[3:7; fill(missing, 3)], b=3:10, a_1=Any[3:10;])
-        @test eltypes(join(l, r, on=:b, kind=:right, makeunique=true)) == [Any, Int, Any]
-
-        @test join(l, r, on=:b, kind=:outer, makeunique=true) ≅
-            DataFrame(a=[1:7; fill(missing, 3)], b=1:10, a_1=[fill(missing, 2); 3:10;])
-        @test eltypes(join(l, r, on=:b, kind=:outer, makeunique=true)) == [Any, Int, Any]
-    end
-
-    @testset "joins with categorical columns and no matching rows" begin
-        l = DataFrame(a=1:3, b=categorical(["a", "b", "c"]))
-        r = DataFrame(a=4:5, b=categorical(["d", "e"]))
-        nl = size(l, 1)
-        nr = size(r, 1)
-
-        CS = eltype(l[:b])
-
-        # joins by a and b
-        @test join(l, r, on=[:a, :b], kind=:inner) ≅ DataFrame(a=Int[], b=similar(l[:a], 0))
-        @test eltypes(join(l, r, on=[:a, :b], kind=:inner)) == [Int, CS]
-
-        @test join(l, r, on=[:a, :b], kind=:left) ≅ DataFrame(a=l[:a], b=l[:b])
-        @test eltypes(join(l, r, on=[:a, :b], kind=:left)) == [Int, CS]
-
-        @test join(l, r, on=[:a, :b], kind=:right) ≅ DataFrame(a=r[:a], b=r[:b])
-        @test eltypes(join(l, r, on=[:a, :b], kind=:right)) == [Int, CS]
-
-        @test join(l, r, on=[:a, :b], kind=:outer) ≅
-            DataFrame(a=vcat(l[:a], r[:a]), b=vcat(l[:b], r[:b]))
-        @test eltypes(join(l, r, on=[:a, :b], kind=:outer)) == [Int, CS]
-
-        # joins by a
-        @test join(l, r, on=:a, kind=:inner, makeunique=true) ≅
-            DataFrame(a=Int[], b=similar(l[:b], 0), b_1=similar(r[:b], 0))
-        @test eltypes(join(l, r, on=:a, kind=:inner, makeunique=true)) == [Int, CS, CS]
-
-        @test join(l, r, on=:a, kind=:left, makeunique=true) ≅
-            DataFrame(a=l[:a], b=l[:b], b_1=similar_missing(r[:b], nl))
-        @test eltypes(join(l, r, on=:a, kind=:left, makeunique=true)) ==
-            [Int, CS, Union{CS, Missing}]
-
-        @test join(l, r, on=:a, kind=:right, makeunique=true) ≅
-            DataFrame(a=r[:a], b=similar_missing(l[:b], nr), b_1=r[:b])
-        @test eltypes(join(l, r, on=:a, kind=:right, makeunique=true)) ==
-            [Int, Union{CS, Missing}, CS]
-
-        @test join(l, r, on=:a, kind=:outer, makeunique=true) ≅
-            DataFrame(a=vcat(l[:a], r[:a]),
-                      b=vcat(l[:b], fill(missing, nr)),
-                      b_1=vcat(fill(missing, nl), r[:b]))
-        @test eltypes(join(l, r, on=:a, kind=:outer, makeunique=true)) ==
-            [Int, Union{CS, Missing}, Union{CS, Missing}]
-
-        # joins by b
-        @test join(l, r, on=:b, kind=:inner, makeunique=true) ≅
-            DataFrame(a=Int[], b=similar(l[:b], 0), a_1=similar(r[:b], 0))
-        @test eltypes(join(l, r, on=:b, kind=:inner, makeunique=true)) == [Int, CS, Int]
-
-        @test join(l, r, on=:b, kind=:left, makeunique=true) ≅
-            DataFrame(a=l[:a], b=l[:b], a_1=fill(missing, nl))
-        @test eltypes(join(l, r, on=:b, kind=:left, makeunique=true)) ==
-            [Int, CS, Union{Int, Missing}]
-
-        @test join(l, r, on=:b, kind=:right, makeunique=true) ≅
-            DataFrame(a=fill(missing, nr), b=r[:b], a_1=r[:a])
-        @test eltypes(join(l, r, on=:b, kind=:right, makeunique=true)) ==
-            [Union{Int, Missing}, CS, Int]
-
-        @test join(l, r, on=:b, kind=:outer, makeunique=true) ≅
-            DataFrame(a=vcat(l[:a], fill(missing, nr)),
-                      b=vcat(l[:b], r[:b]),
-                      a_1=vcat(fill(missing, nl), r[:a]))
-        @test eltypes(join(l, r, on=:b, kind=:outer, makeunique=true)) ==
-            [Union{Int, Missing}, CS, Union{Int, Missing}]
-    end
-
-    @testset "indicator columns" begin
-        outer_indicator = DataFrame(ID = [1, 2, 2, 3, 4],
-                                    Name = ["John Doe", "Jane Doe", "Jane Doe", "Joe Blogs", missing],
-                                    Job = ["Lawyer", "Doctor", "Florist", missing, "Farmer"],
-                                    _merge = ["both", "both", "both", "left_only", "right_only"])
-
-        # Check that input data frame isn't modified (#1434)
-        pre_join_name = copy(name)
-        pre_join_job = copy(job)
-        @test join(name, job, on = :ID, kind = :outer, indicator=:_merge,
-                   makeunique=true) ≅ outer_indicator
-        @test name ≅ pre_join_name
-        @test job ≅ pre_join_job
-
-        # Works with conflicting names
-        name2 = DataFrame(ID = [1, 2, 3], Name = ["John Doe", "Jane Doe", "Joe Blogs"],
-                         _left = [1, 1, 1])
-        job2 = DataFrame(ID = [1, 2, 2, 4], Job = ["Lawyer", "Doctor", "Florist", "Farmer"],
-                        _left = [1, 1, 1, 1])
-
-        outer_indicator = DataFrame(ID = [1, 2, 2, 3, 4],
-                                    Name = ["John Doe", "Jane Doe", "Jane Doe", "Joe Blogs", missing],
-                                    _left = [1, 1, 1, 1, missing],
-                                    Job = ["Lawyer", "Doctor", "Florist", missing, "Farmer"],
-                                    _left_1 = [1, 1, 1, missing, 1],
-                                    _left_2 = ["both", "both", "both", "left_only", "right_only"])
-
-        @test join(name2, job2, on = :ID, kind = :outer, indicator=:_left,
-                   makeunique=true) ≅ outer_indicator
-    end
-
-    @testset "test checks of merge key uniqueness" begin
-        @test_throws ArgumentError join(name, job, on=:ID, validate=(false, true))
-        @test_throws ArgumentError join(name, job, on=:ID, validate=(true, true))
-        @test_throws ArgumentError join(job, name, on=:ID, validate=(true, false))
-        @test_throws ArgumentError join(job, name, on=:ID, validate=(true, true))
-        @test_throws ArgumentError join(job, job, on=:ID, validate=(true, true))
-
-        @test join(name, job, on=:ID, validate=(true, false)) ==  inner
-        @test join(name, job, on=:ID, kind=:inner, validate=(false, false)) == inner
-
-        # Make sure ok with various special values
-        for special in [missing, NaN, 0.0, -0.0]
-            name_w_special = DataFrame(ID = [1, 2, 3, special],
-                                       Name = ["John Doe", "Jane Doe", "Joe Blogs", "Maria Tester"])
-            @test join(name_w_special, job, on=:ID, validate=(true, false)) ==  inner
-
-            # Make sure duplicated special values still an exception
-            name_w_special_dups = DataFrame(ID = [1, 2, 3, special, special],
-                                            Name = ["John Doe", "Jane Doe", "Joe Blogs",
-                                                    "Maria Tester", "Jill Jillerson"])
-            @test_throws ArgumentError join(name_w_special_dups, name, on=:ID,
-                                            validate=(true, false))
-        end
-
-        # Check 0.0 and -0.0 seen as different
-        name_w_zeros = DataFrame(ID = [1, 2, 3, 0.0, -0.0],
-                                 Name = ["John Doe", "Jane Doe",
-                                         "Joe Blogs", "Maria Tester",
-                                         "Jill Jillerson"])
-        name_w_zeros2 = DataFrame(ID = [1, 2, 3, 0.0, -0.0],
-                                  Name = ["John Doe", "Jane Doe",
-                                          "Joe Blogs", "Maria Tester",
-                                          "Jill Jillerson"],
-                                  Name_1 = ["John Doe", "Jane Doe",
-                                            "Joe Blogs", "Maria Tester",
-                                            "Jill Jillerson"])
-
-        @test join(name_w_zeros, name_w_zeros, on=:ID, validate=(true, true),
-                   makeunique=true) ≅ name_w_zeros2
-
-        # Check for multiple-column merge keys
-        name_multi = DataFrame(ID1 = [1, 1, 2],
-                               ID2 = ["a", "b", "a"],
-                               Name = ["John Doe", "Jane Doe", "Joe Blogs"])
-        job_multi = DataFrame(ID1 = [1, 2, 2, 4],
-                              ID2 = ["a", "b", "b", "c"],
-                              Job = ["Lawyer", "Doctor", "Florist", "Farmer"])
-        outer_multi = DataFrame(ID1 = [1, 1, 2, 2, 2, 4],
-                                ID2 = ["a", "b", "a", "b", "b", "c"],
-                                Name = ["John Doe", "Jane Doe", "Joe Blogs",
-                                        missing, missing, missing],
-                                Job = ["Lawyer", missing, missing,
-                                       "Doctor", "Florist",  "Farmer"])
-
-         @test join(name_multi, job_multi, on=[:ID1, :ID2], kind=:outer,
-                    validate=(true, false)) ≅ outer_multi
-         @test_throws ArgumentError join(name_multi, job_multi, on=[:ID1, :ID2], kind=:outer,
-                                         validate=(false, true))
-    end
+using Test, DataFrames
+using DataFrames: similar_missing
+using DataFrames: columns
+const ≅ = isequal
+
+name = DataFrame(ID = Union{Int, Missing}[1, 2, 3],
+                Name = Union{String, Missing}["John Doe", "Jane Doe", "Joe Blogs"])
+job = DataFrame(ID = Union{Int, Missing}[1, 2, 2, 4],
+                Job = Union{String, Missing}["Lawyer", "Doctor", "Florist", "Farmer"])
+# Test output of various join types
+outer = DataFrame(ID = [1, 2, 2, 3, 4],
+                  Name = ["John Doe", "Jane Doe", "Jane Doe", "Joe Blogs", missing],
+                  Job = ["Lawyer", "Doctor", "Florist", missing, "Farmer"])
+
+# (Tests use current column ordering but don't promote it)
+right = outer[Bool[!ismissing(x) for x in outer[:Job]], [:ID, :Name, :Job]]
+left = outer[Bool[!ismissing(x) for x in outer[:Name]], :]
+inner = left[Bool[!ismissing(x) for x in left[:Job]], :]
+semi = unique(inner[[:ID, :Name]])
+anti = left[Bool[ismissing(x) for x in left[:Job]], [:ID, :Name]]
+
+@testset "join types" begin
+    # Join on symbols or vectors of symbols
+    join(name, job, on = :ID)
+    join(name, job, on = [:ID])
+
+    # Soon we won't allow natural joins
+    @test_throws ArgumentError join(name, job)
+
+
+    @test join(name, job, on = :ID) == inner
+    @test join(name, job, on = :ID, kind = :inner) == inner
+    @test join(name, job, on = :ID, kind = :outer) ≅ outer
+    @test join(name, job, on = :ID, kind = :left) ≅ left
+    @test join(name, job, on = :ID, kind = :right) ≅ right
+    @test join(name, job, on = :ID, kind = :semi) == semi
+    @test join(name, job, on = :ID, kind = :anti) == anti
+    @test_throws ArgumentError join(name, job)
+    @test_throws ArgumentError join(name, job, on=:ID, kind=:other)
+
+    # Join with no non-key columns
+    on = [:ID]
+    nameid = name[on]
+    jobid = job[on]
+
+    @test join(nameid, jobid, on = :ID) == inner[on]
+    @test join(nameid, jobid, on = :ID, kind = :inner) == inner[on]
+    @test join(nameid, jobid, on = :ID, kind = :outer) == outer[on]
+    @test join(nameid, jobid, on = :ID, kind = :left) == left[on]
+    @test join(nameid, jobid, on = :ID, kind = :right) == right[on]
+    @test join(nameid, jobid, on = :ID, kind = :semi) == semi[on]
+    @test join(nameid, jobid, on = :ID, kind = :anti) == anti[on]
+
+    # Join on multiple keys
+    df1 = DataFrame(A = 1, B = 2, C = 3)
+    df2 = DataFrame(A = 1, B = 2, D = 4)
+
+    join(df1, df2, on = [:A, :B])
+
+    # Test output of cross joins
+    df1 = DataFrame(A = 1:2, B = 'a':'b')
+    df2 = DataFrame(A = 1:3, C = 3:5)
+
+    cross = DataFrame(A = [1, 1, 1, 2, 2, 2],
+                    B = ['a', 'a', 'a', 'b', 'b', 'b'],
+                    C = [3, 4, 5, 3, 4, 5])
+
+    @test join(df1, df2[[:C]], kind = :cross) == cross
+
+    # Cross joins handle naming collisions
+    @test size(join(df1, df1, kind = :cross, makeunique=true)) == (4, 4)
+
+    # Cross joins don't take keys
+    @test_throws ArgumentError join(df1, df2, on = :A, kind = :cross)
 end
+
+@testset "Test empty inputs 1" begin
+    simple_df(len::Int, col=:A) = (df = DataFrame();
+                                   df[col]=Vector{Union{Int, Missing}}(1:len);
+                                   df)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :left) == simple_df(0)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :left) == simple_df(2)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :left) == simple_df(0)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :right) == simple_df(0)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :right) == simple_df(2)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :right) == simple_df(0)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :inner) == simple_df(0)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :inner) == simple_df(0)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :inner) == simple_df(0)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :outer) == simple_df(0)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :outer) == simple_df(2)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :outer) == simple_df(2)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :semi) == simple_df(0)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :semi) == simple_df(0)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :semi) == simple_df(0)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :anti) == simple_df(0)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :anti) == simple_df(2)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :anti) == simple_df(0)
+    @test join(simple_df(0), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                           B=Int[])
+    @test join(simple_df(0), simple_df(2, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                           B=Int[])
+    @test join(simple_df(2), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                           B=Int[])
+end
+
+@testset "Test empty inputs 2" begin
+    simple_df(len::Int, col=:A) = (df = DataFrame(); df[col]=collect(1:len); df)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :left) ==  simple_df(0)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :left) ==  simple_df(2)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :left) ==  simple_df(0)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :right) == simple_df(0)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :right) == simple_df(2)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :right) == simple_df(0)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :inner) == simple_df(0)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :inner) == simple_df(0)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :inner) == simple_df(0)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :outer) == simple_df(0)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :outer) == simple_df(2)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :outer) == simple_df(2)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :semi) ==  simple_df(0)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :semi) ==  simple_df(0)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :semi) ==  simple_df(0)
+    @test join(simple_df(0), simple_df(0), on = :A, kind = :anti) ==  simple_df(0)
+    @test join(simple_df(2), simple_df(0), on = :A, kind = :anti) ==  simple_df(2)
+    @test join(simple_df(0), simple_df(2), on = :A, kind = :anti) ==  simple_df(0)
+    @test join(simple_df(0), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                           B=Int[])
+    @test join(simple_df(0), simple_df(2, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                           B=Int[])
+    @test join(simple_df(2), simple_df(0, :B), kind = :cross) == DataFrame(A=Int[],
+                                                                           B=Int[])
+end
+
+@testset "issue #960" begin
+    df1 = DataFrame(A = 1:50,
+                    B = 1:50,
+                    C = 1)
+    categorical!(df1, :A)
+    categorical!(df1, :B)
+    join(df1, df1, on = [:A, :B], kind = :inner, makeunique=true)
+    # Test that join works when mixing Array{Union{T, Missing}} with Array{T} (issue #1088)
+    df = DataFrame(Name = Union{String, Missing}["A", "B", "C"],
+                Mass = [1.5, 2.2, 1.1])
+    df2 = DataFrame(Name = ["A", "B", "C", "A"],
+                    Quantity = [3, 3, 2, 4])
+    @test join(df2, df, on=:Name, kind=:left) == DataFrame(Name = ["A", "B", "C", "A"],
+                                                        Quantity = [3, 3, 2, 4],
+                                                        Mass = [1.5, 2.2, 1.1, 1.5])
+
+    # Test that join works when mixing Array{Union{T, Missing}} with Array{T} (issue #1151)
+    df = DataFrame([collect(1:10), collect(2:11)], [:x, :y])
+    dfmissing = DataFrame(x = Vector{Union{Int, Missing}}(1:10),
+                        z = Vector{Union{Int, Missing}}(3:12))
+    @test join(df, dfmissing, on = :x) ==
+        DataFrame([collect(1:10), collect(2:11), collect(3:12)], [:x, :y, :z])
+    @test join(dfmissing, df, on = :x) ==
+        DataFrame([Vector{Union{Int, Missing}}(1:10), Vector{Union{Int, Missing}}(3:12),
+                collect(2:11)], [:x, :z, :y])
+end
+
+@testset "all joins" begin
+    df1 = DataFrame(Any[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
+    df2 = DataFrame(Any[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
+
+    @test join(df1, df2, kind=:cross, makeunique=true) ==
+        DataFrame(Any[repeat([1, 3, 5], inner = 5),
+                      repeat([1, 3, 5], inner = 5),
+                      repeat([0, 1, 2, 3, 4], outer = 3),
+                      repeat([0, 1, 2, 3, 4], outer = 3)],
+                  [:id, :fid, :id_1, :fid_1])
+    @test typeof.(columns(join(df1, df2, kind=:cross, makeunique=true))) ==
+        [Vector{Int}, Vector{Float64}, Vector{Int}, Vector{Float64}]
+
+    i(on) = join(df1, df2, on = on, kind = :inner, makeunique=true)
+    l(on) = join(df1, df2, on = on, kind = :left, makeunique=true)
+    r(on) = join(df1, df2, on = on, kind = :right, makeunique=true)
+    o(on) = join(df1, df2, on = on, kind = :outer, makeunique=true)
+    s(on) = join(df1, df2, on = on, kind = :semi, makeunique=true)
+    a(on) = join(df1, df2, on = on, kind = :anti, makeunique=true)
+
+    @test s(:id) ==
+          s(:fid) ==
+          s([:id, :fid]) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
+    @test typeof.(columns(s(:id))) ==
+          typeof.(columns(s(:fid))) ==
+          typeof.(columns(s([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
+    @test a(:id) ==
+          a(:fid) ==
+          a([:id, :fid]) == DataFrame([[5], [5]], [:id, :fid])
+    @test typeof.(columns(a(:id))) ==
+          typeof.(columns(a(:fid))) ==
+          typeof.(columns(a([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
+
+    on = :id
+    @test i(on) == DataFrame([[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
+    @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Float64}]
+    @test l(on) ≅ DataFrame(id = [1, 3, 5],
+                            fid = [1, 3, 5],
+                            fid_1 = [1, 3, missing])
+    @test typeof.(columns(l(on))) ==
+        [Vector{Int}, Vector{Float64}, Vector{Union{Float64, Missing}}]
+    @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
+                            fid = [1, 3, missing, missing, missing],
+                            fid_1 = [1, 3, 0, 2, 4])
+    @test typeof.(columns(r(on))) ==
+        [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Float64}]
+    @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
+                            fid = [1, 3, 5, missing, missing, missing],
+                            fid_1 = [1, 3, missing, 0, 2, 4])
+    @test typeof.(columns(o(on))) ==
+        [Vector{Int}, Vector{Union{Float64, Missing}}, Vector{Union{Float64, Missing}}]
+
+    on = :fid
+    @test i(on) == DataFrame([[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
+    @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}, Vector{Int}]
+    @test l(on) ≅ DataFrame(id = [1, 3, 5],
+                            fid = [1, 3, 5],
+                            id_1 = [1, 3, missing])
+    @test typeof.(columns(l(on))) == [Vector{Int}, Vector{Float64},
+                                     Vector{Union{Int, Missing}}]
+    @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
+                            fid = [1, 3, 0, 2, 4],
+                            id_1 = [1, 3, 0, 2, 4])
+    @test typeof.(columns(r(on))) == [Vector{Union{Int, Missing}}, Vector{Float64},
+                                     Vector{Int}]
+    @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
+                            fid = [1, 3, 5, 0, 2, 4],
+                            id_1 = [1, 3, missing, 0, 2, 4])
+    @test typeof.(columns(o(on))) == [Vector{Union{Int, Missing}}, Vector{Float64},
+                                     Vector{Union{Int, Missing}}]
+
+    on = [:id, :fid]
+    @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
+    @test typeof.(columns(i(on))) == [Vector{Int}, Vector{Float64}]
+    @test l(on) == DataFrame(id = [1, 3, 5], fid = [1, 3, 5])
+    @test typeof.(columns(l(on))) == [Vector{Int}, Vector{Float64}]
+    @test r(on) == DataFrame(id = [1, 3, 0, 2, 4], fid = [1, 3, 0, 2, 4])
+    @test typeof.(columns(r(on))) == [Vector{Int}, Vector{Float64}]
+    @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4], fid = [1, 3, 5, 0, 2, 4])
+    @test typeof.(columns(o(on))) == [Vector{Int}, Vector{Float64}]
+end
+
+@testset "all joins with CategoricalArrays" begin
+    df1 = DataFrame(Any[CategoricalArray([1, 3, 5]),
+                        CategoricalArray([1.0, 3.0, 5.0])], [:id, :fid])
+    df2 = DataFrame(Any[CategoricalArray([0, 1, 2, 3, 4]),
+                        CategoricalArray([0.0, 1.0, 2.0, 3.0, 4.0])], [:id, :fid])
+
+    @test join(df1, df2, kind=:cross, makeunique=true) ==
+        DataFrame([repeat([1, 3, 5], inner = 5),
+                   repeat([1, 3, 5], inner = 5),
+                   repeat([0, 1, 2, 3, 4], outer = 3),
+                   repeat([0, 1, 2, 3, 4], outer = 3)],
+                  [:id, :fid, :id_1, :fid_1])
+    @test all(isa.(columns(join(df1, df2, kind=:cross, makeunique=true)),
+                   [CategoricalVector{T} for T in (Int, Float64, Int, Float64)]))
+
+    i(on) = join(df1, df2, on = on, kind = :inner, makeunique=true)
+    l(on) = join(df1, df2, on = on, kind = :left, makeunique=true)
+    r(on) = join(df1, df2, on = on, kind = :right, makeunique=true)
+    o(on) = join(df1, df2, on = on, kind = :outer, makeunique=true)
+    s(on) = join(df1, df2, on = on, kind = :semi, makeunique=true)
+    a(on) = join(df1, df2, on = on, kind = :anti, makeunique=true)
+
+    @test s(:id) ==
+          s(:fid) ==
+          s([:id, :fid]) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
+    @test typeof.(columns(s(:id))) ==
+          typeof.(columns(s(:fid))) ==
+          typeof.(columns(s([:id, :fid])))
+    @test all(isa.(columns(s(:id)),
+                   [CategoricalVector{T} for T in (Int, Float64)]))
+
+    @test a(:id) ==
+          a(:fid) ==
+          a([:id, :fid]) == DataFrame([[5], [5]], [:id, :fid])
+    @test typeof.(columns(a(:id))) ==
+          typeof.(columns(a(:fid))) ==
+          typeof.(columns(a([:id, :fid])))
+    @test all(isa.(columns(a(:id)),
+                   [CategoricalVector{T} for T in (Int, Float64)]))
+
+    on = :id
+    @test i(on) == DataFrame([[1, 3], [1, 3], [1, 3]], [:id, :fid, :fid_1])
+    @test all(isa.(columns(i(on)),
+                   [CategoricalVector{T} for T in (Int, Float64, Float64)]))
+    @test l(on) ≅ DataFrame(id = [1, 3, 5],
+                            fid = [1, 3, 5],
+                            fid_1 = [1, 3, missing])
+    @test all(isa.(columns(l(on)),
+                   [CategoricalVector{T} for T in (Int,Float64,Union{Float64, Missing})]))
+    @test r(on) ≅ DataFrame(id = [1, 3, 0, 2, 4],
+                            fid = [1, 3, missing, missing, missing],
+                            fid_1 = [1, 3, 0, 2, 4])
+    @test all(isa.(columns(r(on)),
+                   [CategoricalVector{T} for T in (Int,Union{Float64, Missing},Float64)]))
+    @test o(on) ≅ DataFrame(id = [1, 3, 5, 0, 2, 4],
+                            fid = [1, 3, 5, missing, missing, missing],
+                            fid_1 = [1, 3, missing, 0, 2, 4])
+    @test all(isa.(columns(o(on)),
+                   [CategoricalVector{T} for T in (Int,Union{Float64,Missing},Union{Float64, Missing})]))
+
+    on = :fid
+    @test i(on) == DataFrame([[1, 3], [1.0, 3.0], [1, 3]], [:id, :fid, :id_1])
+    @test all(isa.(columns(i(on)),
+                   [CategoricalVector{T} for T in (Int, Float64, Int)]))
+    @test l(on) ≅ DataFrame(id = [1, 3, 5],
+                            fid = [1, 3, 5],
+                            id_1 = [1, 3, missing])
+    @test all(isa.(columns(l(on)),
+                   [CategoricalVector{T} for T in (Int, Float64, Union{Int, Missing})]))
+    @test r(on) ≅ DataFrame(id = [1, 3, missing, missing, missing],
+                            fid = [1, 3, 0, 2, 4],
+                            id_1 = [1, 3, 0, 2, 4])
+    @test all(isa.(columns(r(on)),
+                   [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Int)]))
+    @test o(on) ≅ DataFrame(id = [1, 3, 5, missing, missing, missing],
+                            fid = [1, 3, 5, 0, 2, 4],
+                            id_1 = [1, 3, missing, 0, 2, 4])
+    @test all(isa.(columns(o(on)),
+                   [CategoricalVector{T} for T in (Union{Int, Missing}, Float64, Union{Int, Missing})]))
+
+    on = [:id, :fid]
+    @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
+    @test all(isa.(columns(i(on)),
+                   [CategoricalVector{T} for T in (Int, Float64)]))
+    @test l(on) == DataFrame(id = [1, 3, 5],
+                             fid = [1, 3, 5])
+    @test all(isa.(columns(l(on)),
+                   [CategoricalVector{T} for T in (Int, Float64)]))
+    @test r(on) == DataFrame(id = [1, 3, 0, 2, 4],
+                             fid = [1, 3, 0, 2, 4])
+    @test all(isa.(columns(r(on)),
+                   [CategoricalVector{T} for T in (Int, Float64)]))
+    @test o(on) == DataFrame(id = [1, 3, 5, 0, 2, 4],
+                             fid = [1, 3, 5, 0, 2, 4])
+    @test all(isa.(columns(o(on)),
+                   [CategoricalVector{T} for T in (Int, Float64)]))
+end
+
+@testset "maintain CategoricalArray levels ordering on join - non-`on` cols" begin
+    A = DataFrame(a = [1, 2, 3], b = ["a", "b", "c"])
+    B = DataFrame(b = ["a", "b", "c"], c = CategoricalVector(["a", "b", "b"]))
+    levels!(B[:c], ["b", "a"])
+    @test levels(join(A, B, on=:b, kind=:inner)[:c]) == ["b", "a"]
+    @test levels(join(B, A, on=:b, kind=:inner)[:c]) == ["b", "a"]
+    @test levels(join(A, B, on=:b, kind =:left)[:c]) == ["b", "a"]
+    @test levels(join(A, B, on=:b, kind=:right)[:c]) == ["b", "a"]
+    @test levels(join(A, B, on=:b, kind=:outer)[:c]) == ["b", "a"]
+    @test levels(join(B, A, on=:b, kind =:semi)[:c]) == ["b", "a"]
+end
+
+@testset "maintain CategoricalArray levels ordering on join - ordering conflicts" begin
+    A = DataFrame(a = [1, 2, 3, 4], b = CategoricalVector(["a", "b", "c", "d"]))
+    levels!(A[:b], ["d", "c", "b", "a"])
+    B = DataFrame(b = CategoricalVector(["a", "b", "c"]), c = [5, 6, 7])
+    @test levels(join(A, B, on=:b, kind=:inner)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind=:inner)[:b]) == ["a", "b", "c"]
+    @test levels(join(A, B, on=:b, kind=:left)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind=:left)[:b]) == ["a", "b", "c"]
+    @test levels(join(A, B, on=:b, kind=:right)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind=:right)[:b]) == ["a", "b", "d", "c"]
+    @test levels(join(B, A, on=:b, kind=:outer)[:b]) == ["a", "b", "d", "c"]
+    @test levels(join(A, B, on=:b, kind=:outer)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(A, B, on=:b, kind = :semi)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind = :semi)[:b]) == ["a", "b", "c"]
+end
+
+@testset "maintain CategoricalArray levels ordering on join - left is categorical" begin
+    A = DataFrame(a = [1, 2, 3, 4], b = CategoricalVector(["a", "b", "c", "d"]))
+    levels!(A[:b], ["d", "c", "b", "a"])
+    B = DataFrame(b = ["a", "b", "c"], c = [5, 6, 7])
+    @test levels(join(A, B, on=:b)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b)[:b]) == ["a", "b", "c"]
+    @test levels(join(A, B, on=:b, kind=:inner)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind=:inner)[:b]) == ["a", "b", "c"]
+    @test levels(join(A, B, on=:b, kind=:left)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind=:left)[:b]) == ["a", "b", "c"]
+    @test levels(join(A, B, on=:b, kind=:right)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind=:right)[:b]) == ["a", "b", "c", "d"]
+    @test levels(join(A, B, on=:b, kind=:outer)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind=:outer)[:b]) == ["a", "b", "c", "d"]
+    @test levels(join(A, B, on=:b, kind = :semi)[:b]) == ["d", "c", "b", "a"]
+    @test levels(join(B, A, on=:b, kind = :semi)[:b]) == ["a", "b", "c"]
+end
+
+@testset "join on columns with different left/right names" begin
+    global left = DataFrame(id = 1:7, sid = string.(1:7))
+    global right = DataFrame(ID = 3:10, SID = string.(3:10))
+    @test join(left, right, on = (:id, :ID), kind=:inner) ==
+        DataFrame(id = 3:7, sid = string.(3:7), SID = string.(3:7))
+    @test join(left, right, on = :id => :ID, kind=:inner) ==
+        DataFrame(id = 3:7, sid = string.(3:7), SID = string.(3:7))
+    @test join(left, right, on = [(:id, :ID)], kind=:inner) ==
+        DataFrame(id = 3:7, sid = string.(3:7), SID = string.(3:7))
+    @test join(left, right, on = [:id => :ID], kind=:inner) ==
+        DataFrame(id = 3:7, sid = string.(3:7), SID = string.(3:7))
+    @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:inner) ==
+        DataFrame(id = 3:7, sid = string.(3:7))
+    @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:inner) ==
+        DataFrame(id = 3:7, sid = string.(3:7))
+
+    @test join(left, right, on = (:id, :ID), kind=:left) ≅
+        DataFrame(id = 1:7, sid = string.(1:7),
+                  SID = [missing, missing, string.(3:7)...])
+    @test join(left, right, on = :id => :ID, kind=:left) ≅
+        DataFrame(id = 1:7, sid = string.(1:7),
+                  SID = [missing, missing, string.(3:7)...])
+    @test join(left, right, on = [(:id, :ID)], kind=:left) ≅
+        DataFrame(id = 1:7, sid = string.(1:7),
+                  SID = [missing, missing, string.(3:7)...])
+    @test join(left, right, on = [:id => :ID], kind=:left) ≅
+        DataFrame(id = 1:7, sid = string.(1:7),
+                  SID = [missing, missing, string.(3:7)...])
+    @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:left) ==
+        DataFrame(id = 1:7, sid = string.(1:7))
+    @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:left) ==
+        DataFrame(id = 1:7, sid = string.(1:7))
+
+    @test join(left, right, on = (:id, :ID), kind=:right) ≅
+        DataFrame(id = 3:10, sid = [string.(3:7)..., missing, missing, missing],
+                 SID = string.(3:10))
+    @test join(left, right, on = :id => :ID, kind=:right) ≅
+        DataFrame(id = 3:10, sid = [string.(3:7)..., missing, missing, missing],
+                 SID = string.(3:10))
+    @test join(left, right, on = [(:id, :ID)], kind=:right) ≅
+        DataFrame(id = 3:10, sid = [string.(3:7)..., missing, missing, missing],
+                 SID = string.(3:10))
+    @test join(left, right, on = [:id => :ID], kind=:right) ≅
+        DataFrame(id = 3:10, sid = [string.(3:7)..., missing, missing, missing],
+                 SID = string.(3:10))
+    @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:right) ≅
+        DataFrame(id = 3:10, sid = string.(3:10))
+    @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:right) ≅
+        DataFrame(id = 3:10, sid = string.(3:10))
+
+    @test join(left, right, on = (:id, :ID), kind=:outer) ≅
+        DataFrame(id = 1:10, sid = [string.(1:7)..., missing, missing, missing],
+                  SID = [missing, missing, string.(3:10)...])
+    @test join(left, right, on = :id => :ID, kind=:outer) ≅
+        DataFrame(id = 1:10, sid = [string.(1:7)..., missing, missing, missing],
+                  SID = [missing, missing, string.(3:10)...])
+    @test join(left, right, on = [(:id, :ID)], kind=:outer) ≅
+        DataFrame(id = 1:10, sid = [string.(1:7)..., missing, missing, missing],
+                  SID = [missing, missing, string.(3:10)...])
+    @test join(left, right, on = [:id => :ID], kind=:outer) ≅
+        DataFrame(id = 1:10, sid = [string.(1:7)..., missing, missing, missing],
+                  SID = [missing, missing, string.(3:10)...])
+    @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:outer) ≅
+        DataFrame(id = 1:10, sid = string.(1:10))
+    @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:outer) ≅
+        DataFrame(id = 1:10, sid = string.(1:10))
+
+    @test join(left, right, on = (:id, :ID), kind=:semi) ==
+        DataFrame(id = 3:7, sid = string.(3:7))
+    @test join(left, right, on = :id => :ID, kind=:semi) ==
+        DataFrame(id = 3:7, sid = string.(3:7))
+    @test join(left, right, on = [(:id, :ID)], kind=:semi) ==
+        DataFrame(id = 3:7, sid = string.(3:7))
+    @test join(left, right, on = [:id => :ID], kind=:semi) ==
+        DataFrame(id = 3:7, sid = string.(3:7))
+    @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:semi) ==
+        DataFrame(id = 3:7, sid = string.(3:7))
+    @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:semi) ==
+        DataFrame(id = 3:7, sid = string.(3:7))
+
+    @test join(left, right, on = (:id, :ID), kind=:anti) ==
+        DataFrame(id = 1:2, sid = string.(1:2))
+    @test join(left, right, on = :id => :ID, kind=:anti) ==
+        DataFrame(id = 1:2, sid = string.(1:2))
+    @test join(left, right, on = [(:id, :ID)], kind=:anti) ==
+        DataFrame(id = 1:2, sid = string.(1:2))
+    @test join(left, right, on = [:id => :ID], kind=:anti) ==
+        DataFrame(id = 1:2, sid = string.(1:2))
+    @test join(left, right, on = [(:id, :ID), (:sid, :SID)], kind=:anti) ==
+        DataFrame(id = 1:2, sid = string.(1:2))
+    @test join(left, right, on = [:id => :ID, :sid => :SID], kind=:anti) ==
+        DataFrame(id = 1:2, sid = string.(1:2))
+end
+
+@testset "join with a column of type Any" begin
+    l = DataFrame(a=Any[1:7;], b=[1:7;])
+    r = DataFrame(a=Any[3:10;], b=[3:10;])
+
+    # join by :a and :b (Any is the on-column)
+    @test join(l, r, on=[:a, :b], kind=:inner) ≅ DataFrame(a=Any[3:7;], b=3:7)
+    @test eltypes(join(l, r, on=[:a, :b], kind=:inner)) == [Any, Int]
+
+    @test join(l, r, on=[:a, :b], kind=:left) ≅ DataFrame(a=Any[1:7;], b=1:7)
+    @test eltypes(join(l, r, on=[:a, :b], kind=:left)) == [Any, Int]
+
+    @test join(l, r, on=[:a, :b], kind=:right) ≅ DataFrame(a=Any[3:10;], b=3:10)
+    @test eltypes(join(l, r, on=[:a, :b], kind=:right)) == [Any, Int]
+
+    @test join(l, r, on=[:a, :b], kind=:outer) ≅ DataFrame(a=Any[1:10;], b=1:10)
+    @test eltypes(join(l, r, on=[:a, :b], kind=:outer)) == [Any, Int]
+
+    # join by :b (Any is not on-column)
+    @test join(l, r, on=:b, kind=:inner, makeunique=true) ≅
+        DataFrame(a=Any[3:7;], b=3:7, a_1=Any[3:7;])
+    @test eltypes(join(l, r, on=:b, kind=:inner, makeunique=true)) == [Any, Int, Any]
+
+    @test join(l, r, on=:b, kind=:left, makeunique=true) ≅
+        DataFrame(a=Any[1:7;], b=1:7, a_1=[fill(missing, 2); 3:7;])
+    @test eltypes(join(l, r, on=:b, kind=:left, makeunique=true)) == [Any, Int, Any]
+
+    @test join(l, r, on=:b, kind=:right, makeunique=true) ≅
+        DataFrame(a=[3:7; fill(missing, 3)], b=3:10, a_1=Any[3:10;])
+    @test eltypes(join(l, r, on=:b, kind=:right, makeunique=true)) == [Any, Int, Any]
+
+    @test join(l, r, on=:b, kind=:outer, makeunique=true) ≅
+        DataFrame(a=[1:7; fill(missing, 3)], b=1:10, a_1=[fill(missing, 2); 3:10;])
+    @test eltypes(join(l, r, on=:b, kind=:outer, makeunique=true)) == [Any, Int, Any]
+end
+
+@testset "joins with categorical columns and no matching rows" begin
+    l = DataFrame(a=1:3, b=categorical(["a", "b", "c"]))
+    r = DataFrame(a=4:5, b=categorical(["d", "e"]))
+    nl = size(l, 1)
+    nr = size(r, 1)
+
+    CS = eltype(l[:b])
+
+    # joins by a and b
+    @test join(l, r, on=[:a, :b], kind=:inner) ≅ DataFrame(a=Int[], b=similar(l[:a], 0))
+    @test eltypes(join(l, r, on=[:a, :b], kind=:inner)) == [Int, CS]
+
+    @test join(l, r, on=[:a, :b], kind=:left) ≅ DataFrame(a=l[:a], b=l[:b])
+    @test eltypes(join(l, r, on=[:a, :b], kind=:left)) == [Int, CS]
+
+    @test join(l, r, on=[:a, :b], kind=:right) ≅ DataFrame(a=r[:a], b=r[:b])
+    @test eltypes(join(l, r, on=[:a, :b], kind=:right)) == [Int, CS]
+
+    @test join(l, r, on=[:a, :b], kind=:outer) ≅
+        DataFrame(a=vcat(l[:a], r[:a]), b=vcat(l[:b], r[:b]))
+    @test eltypes(join(l, r, on=[:a, :b], kind=:outer)) == [Int, CS]
+
+    # joins by a
+    @test join(l, r, on=:a, kind=:inner, makeunique=true) ≅
+        DataFrame(a=Int[], b=similar(l[:b], 0), b_1=similar(r[:b], 0))
+    @test eltypes(join(l, r, on=:a, kind=:inner, makeunique=true)) == [Int, CS, CS]
+
+    @test join(l, r, on=:a, kind=:left, makeunique=true) ≅
+        DataFrame(a=l[:a], b=l[:b], b_1=similar_missing(r[:b], nl))
+    @test eltypes(join(l, r, on=:a, kind=:left, makeunique=true)) ==
+        [Int, CS, Union{CS, Missing}]
+
+    @test join(l, r, on=:a, kind=:right, makeunique=true) ≅
+        DataFrame(a=r[:a], b=similar_missing(l[:b], nr), b_1=r[:b])
+    @test eltypes(join(l, r, on=:a, kind=:right, makeunique=true)) ==
+        [Int, Union{CS, Missing}, CS]
+
+    @test join(l, r, on=:a, kind=:outer, makeunique=true) ≅
+        DataFrame(a=vcat(l[:a], r[:a]),
+                  b=vcat(l[:b], fill(missing, nr)),
+                  b_1=vcat(fill(missing, nl), r[:b]))
+    @test eltypes(join(l, r, on=:a, kind=:outer, makeunique=true)) ==
+        [Int, Union{CS, Missing}, Union{CS, Missing}]
+
+    # joins by b
+    @test join(l, r, on=:b, kind=:inner, makeunique=true) ≅
+        DataFrame(a=Int[], b=similar(l[:b], 0), a_1=similar(r[:b], 0))
+    @test eltypes(join(l, r, on=:b, kind=:inner, makeunique=true)) == [Int, CS, Int]
+
+    @test join(l, r, on=:b, kind=:left, makeunique=true) ≅
+        DataFrame(a=l[:a], b=l[:b], a_1=fill(missing, nl))
+    @test eltypes(join(l, r, on=:b, kind=:left, makeunique=true)) ==
+        [Int, CS, Union{Int, Missing}]
+
+    @test join(l, r, on=:b, kind=:right, makeunique=true) ≅
+        DataFrame(a=fill(missing, nr), b=r[:b], a_1=r[:a])
+    @test eltypes(join(l, r, on=:b, kind=:right, makeunique=true)) ==
+        [Union{Int, Missing}, CS, Int]
+
+    @test join(l, r, on=:b, kind=:outer, makeunique=true) ≅
+        DataFrame(a=vcat(l[:a], fill(missing, nr)),
+                  b=vcat(l[:b], r[:b]),
+                  a_1=vcat(fill(missing, nl), r[:a]))
+    @test eltypes(join(l, r, on=:b, kind=:outer, makeunique=true)) ==
+        [Union{Int, Missing}, CS, Union{Int, Missing}]
+end
+
+@testset "indicator columns" begin
+    outer_indicator = DataFrame(ID = [1, 2, 2, 3, 4],
+                                Name = ["John Doe", "Jane Doe", "Jane Doe", "Joe Blogs", missing],
+                                Job = ["Lawyer", "Doctor", "Florist", missing, "Farmer"],
+                                _merge = ["both", "both", "both", "left_only", "right_only"])
+
+    # Check that input data frame isn't modified (#1434)
+    pre_join_name = copy(name)
+    pre_join_job = copy(job)
+    @test join(name, job, on = :ID, kind = :outer, indicator=:_merge,
+               makeunique=true) ≅ outer_indicator
+    @test name ≅ pre_join_name
+    @test job ≅ pre_join_job
+
+    # Works with conflicting names
+    name2 = DataFrame(ID = [1, 2, 3], Name = ["John Doe", "Jane Doe", "Joe Blogs"],
+                     _left = [1, 1, 1])
+    job2 = DataFrame(ID = [1, 2, 2, 4], Job = ["Lawyer", "Doctor", "Florist", "Farmer"],
+                    _left = [1, 1, 1, 1])
+
+    outer_indicator = DataFrame(ID = [1, 2, 2, 3, 4],
+                                Name = ["John Doe", "Jane Doe", "Jane Doe", "Joe Blogs", missing],
+                                _left = [1, 1, 1, 1, missing],
+                                Job = ["Lawyer", "Doctor", "Florist", missing, "Farmer"],
+                                _left_1 = [1, 1, 1, missing, 1],
+                                _left_2 = ["both", "both", "both", "left_only", "right_only"])
+
+    @test join(name2, job2, on = :ID, kind = :outer, indicator=:_left,
+               makeunique=true) ≅ outer_indicator
+end
+
+@testset "test checks of merge key uniqueness" begin
+    @test_throws ArgumentError join(name, job, on=:ID, validate=(false, true))
+    @test_throws ArgumentError join(name, job, on=:ID, validate=(true, true))
+    @test_throws ArgumentError join(job, name, on=:ID, validate=(true, false))
+    @test_throws ArgumentError join(job, name, on=:ID, validate=(true, true))
+    @test_throws ArgumentError join(job, job, on=:ID, validate=(true, true))
+
+    @test join(name, job, on=:ID, validate=(true, false)) ==  inner
+    @test join(name, job, on=:ID, kind=:inner, validate=(false, false)) == inner
+
+    # Make sure ok with various special values
+    for special in [missing, NaN, 0.0, -0.0]
+        name_w_special = DataFrame(ID = [1, 2, 3, special],
+                                   Name = ["John Doe", "Jane Doe", "Joe Blogs", "Maria Tester"])
+        @test join(name_w_special, job, on=:ID, validate=(true, false)) ==  inner
+
+        # Make sure duplicated special values still an exception
+        name_w_special_dups = DataFrame(ID = [1, 2, 3, special, special],
+                                        Name = ["John Doe", "Jane Doe", "Joe Blogs",
+                                                "Maria Tester", "Jill Jillerson"])
+        @test_throws ArgumentError join(name_w_special_dups, name, on=:ID,
+                                        validate=(true, false))
+    end
+
+    # Check 0.0 and -0.0 seen as different
+    name_w_zeros = DataFrame(ID = [1, 2, 3, 0.0, -0.0],
+                             Name = ["John Doe", "Jane Doe",
+                                     "Joe Blogs", "Maria Tester",
+                                     "Jill Jillerson"])
+    name_w_zeros2 = DataFrame(ID = [1, 2, 3, 0.0, -0.0],
+                              Name = ["John Doe", "Jane Doe",
+                                      "Joe Blogs", "Maria Tester",
+                                      "Jill Jillerson"],
+                              Name_1 = ["John Doe", "Jane Doe",
+                                        "Joe Blogs", "Maria Tester",
+                                        "Jill Jillerson"])
+
+    @test join(name_w_zeros, name_w_zeros, on=:ID, validate=(true, true),
+               makeunique=true) ≅ name_w_zeros2
+
+    # Check for multiple-column merge keys
+    name_multi = DataFrame(ID1 = [1, 1, 2],
+                           ID2 = ["a", "b", "a"],
+                           Name = ["John Doe", "Jane Doe", "Joe Blogs"])
+    job_multi = DataFrame(ID1 = [1, 2, 2, 4],
+                          ID2 = ["a", "b", "b", "c"],
+                          Job = ["Lawyer", "Doctor", "Florist", "Farmer"])
+    outer_multi = DataFrame(ID1 = [1, 1, 2, 2, 2, 4],
+                            ID2 = ["a", "b", "a", "b", "b", "c"],
+                            Name = ["John Doe", "Jane Doe", "Joe Blogs",
+                                    missing, missing, missing],
+                            Job = ["Lawyer", missing, missing,
+                                   "Doctor", "Florist",  "Farmer"])
+
+     @test join(name_multi, job_multi, on=[:ID1, :ID2], kind=:outer,
+                validate=(true, false)) ≅ outer_multi
+     @test_throws ArgumentError join(name_multi, job_multi, on=[:ID1, :ID2], kind=:outer,
+                                     validate=(false, true))
+end
+
+end # module

--- a/test/show.jl
+++ b/test/show.jl
@@ -1,334 +1,335 @@
 module TestShow
-    using DataFrames, Random, Test
 
-    function capture_stdout(f::Function)
-        oldstdout = stdout
-        rd, wr = redirect_stdout()
-        f()
-        str = String(readavailable(rd))
-        redirect_stdout(oldstdout)
-        size = displaysize(rd)
-        close(rd)
-        close(wr)
-        str, size
-    end
+using DataFrames, Random, Test
 
-    # In the future newline character \n should be added to this test case
-    df = DataFrame(A = Int64[1:4;], B = ["x\"", "∀ε>0: x+ε>x", "z\$", "A\nC"],
-                   C = Float32[1.0, 2.0, 3.0, 4.0])
-
-    refstr = """
-    4×3 DataFrame
-    │ Row │ A     │ B           │ C       │
-    │     │ Int64 │ String      │ Float32 │
-    ├─────┼───────┼─────────────┼─────────┤
-    │ 1   │ 1     │ x"          │ 1.0     │
-    │ 2   │ 2     │ ∀ε>0: x+ε>x │ 2.0     │
-    │ 3   │ 3     │ z\$          │ 3.0     │
-    │ 4   │ 4     │ A\\nC        │ 4.0     │"""
-
-    for allrows in [true, false], allcols in [true, false]
-        io = IOBuffer()
-        show(io, df, allcols=allcols)
-        str = String(take!(io))
-        @test str == refstr
-    end
-
-    Random.seed!(1)
-    df_big = DataFrame(rand(25,5))
-
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
-    show(io, df_big)
-    str = String(take!(io.io))
-    @test str == """
-    25×5 DataFrame. Omitted printing of 2 columns
-    │ Row │ x1       │ x2       │ x3       │
-    │     │ Float64  │ Float64  │ Float64  │
-    ├─────┼──────────┼──────────┼──────────┤
-    │ 1   │ 0.236033 │ 0.644883 │ 0.440897 │
-    ⋮
-    │ 24  │ 0.278582 │ 0.241591 │ 0.990741 │
-    │ 25  │ 0.751313 │ 0.884837 │ 0.550334 │"""
-
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
-    show(io, df_big, allcols=true)
-    str = String(take!(io.io))
-    @test str == """
-    25×5 DataFrame
-    │ Row │ x1       │ x2       │ x3       │
-    │     │ Float64  │ Float64  │ Float64  │
-    ├─────┼──────────┼──────────┼──────────┤
-    │ 1   │ 0.236033 │ 0.644883 │ 0.440897 │
-    ⋮
-    │ 24  │ 0.278582 │ 0.241591 │ 0.990741 │
-    │ 25  │ 0.751313 │ 0.884837 │ 0.550334 │
-
-    │ Row │ x4       │ x5       │
-    │     │ Float64  │ Float64  │
-    ├─────┼──────────┼──────────┤
-    │ 1   │ 0.580782 │ 0.138763 │
-    ⋮
-    │ 24  │ 0.762276 │ 0.755415 │
-    │ 25  │ 0.339081 │ 0.649056 │"""
-
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
-    show(io, df_big, allrows=true, allcols=true)
-    str = String(take!(io.io))
-    @test str == """
-    25×5 DataFrame
-    │ Row │ x1         │ x2        │
-    │     │ Float64    │ Float64   │
-    ├─────┼────────────┼───────────┤
-    │ 1   │ 0.236033   │ 0.644883  │
-    │ 2   │ 0.346517   │ 0.0778264 │
-    │ 3   │ 0.312707   │ 0.848185  │
-    │ 4   │ 0.00790928 │ 0.0856352 │
-    │ 5   │ 0.488613   │ 0.553206  │
-    │ 6   │ 0.210968   │ 0.46335   │
-    │ 7   │ 0.951916   │ 0.185821  │
-    │ 8   │ 0.999905   │ 0.111981  │
-    │ 9   │ 0.251662   │ 0.976312  │
-    │ 10  │ 0.986666   │ 0.0516146 │
-    │ 11  │ 0.555751   │ 0.53803   │
-    │ 12  │ 0.437108   │ 0.455692  │
-    │ 13  │ 0.424718   │ 0.279395  │
-    │ 14  │ 0.773223   │ 0.178246  │
-    │ 15  │ 0.28119    │ 0.548983  │
-    │ 16  │ 0.209472   │ 0.370971  │
-    │ 17  │ 0.251379   │ 0.894166  │
-    │ 18  │ 0.0203749  │ 0.648054  │
-    │ 19  │ 0.287702   │ 0.417039  │
-    │ 20  │ 0.859512   │ 0.144566  │
-    │ 21  │ 0.0769509  │ 0.622403  │
-    │ 22  │ 0.640396   │ 0.872334  │
-    │ 23  │ 0.873544   │ 0.524975  │
-    │ 24  │ 0.278582   │ 0.241591  │
-    │ 25  │ 0.751313   │ 0.884837  │
-
-    │ Row │ x3        │ x4        │
-    │     │ Float64   │ Float64   │
-    ├─────┼───────────┼───────────┤
-    │ 1   │ 0.440897  │ 0.580782  │
-    │ 2   │ 0.404673  │ 0.768359  │
-    │ 3   │ 0.736787  │ 0.519525  │
-    │ 4   │ 0.953803  │ 0.514863  │
-    │ 5   │ 0.0951856 │ 0.998136  │
-    │ 6   │ 0.519675  │ 0.603682  │
-    │ 7   │ 0.0135403 │ 0.758775  │
-    │ 8   │ 0.303399  │ 0.590953  │
-    │ 9   │ 0.702557  │ 0.722086  │
-    │ 10  │ 0.596537  │ 0.953207  │
-    │ 11  │ 0.638935  │ 0.384411  │
-    │ 12  │ 0.872347  │ 0.320011  │
-    │ 13  │ 0.548635  │ 0.865625  │
-    │ 14  │ 0.262992  │ 0.45457   │
-    │ 15  │ 0.526443  │ 0.420287  │
-    │ 16  │ 0.465019  │ 0.225151  │
-    │ 17  │ 0.275519  │ 0.286169  │
-    │ 18  │ 0.461823  │ 0.309144  │
-    │ 19  │ 0.951861  │ 0.170391  │
-    │ 20  │ 0.288737  │ 0.147162  │
-    │ 21  │ 0.661232  │ 0.230063  │
-    │ 22  │ 0.194568  │ 0.0929292 │
-    │ 23  │ 0.393193  │ 0.681415  │
-    │ 24  │ 0.990741  │ 0.762276  │
-    │ 25  │ 0.550334  │ 0.339081  │
-
-    │ Row │ x5        │
-    │     │ Float64   │
-    ├─────┼───────────┤
-    │ 1   │ 0.138763  │
-    │ 2   │ 0.456446  │
-    │ 3   │ 0.739918  │
-    │ 4   │ 0.816004  │
-    │ 5   │ 0.114529  │
-    │ 6   │ 0.748928  │
-    │ 7   │ 0.878108  │
-    │ 8   │ 0.930481  │
-    │ 9   │ 0.896291  │
-    │ 10  │ 0.663145  │
-    │ 11  │ 0.472799  │
-    │ 12  │ 0.880525  │
-    │ 13  │ 0.0141033 │
-    │ 14  │ 0.502774  │
-    │ 15  │ 0.224851  │
-    │ 16  │ 0.287858  │
-    │ 17  │ 0.104033  │
-    │ 18  │ 0.475749  │
-    │ 19  │ 0.416681  │
-    │ 20  │ 0.521387  │
-    │ 21  │ 0.908499  │
-    │ 22  │ 0.102832  │
-    │ 23  │ 0.670421  │
-    │ 24  │ 0.755415  │
-    │ 25  │ 0.649056  │"""
-
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
-    show(io, df_big, allrows=true, allcols=false)
-    str = String(take!(io.io))
-    @test str == """
-    25×5 DataFrame. Omitted printing of 3 columns
-    │ Row │ x1         │ x2        │
-    │     │ Float64    │ Float64   │
-    ├─────┼────────────┼───────────┤
-    │ 1   │ 0.236033   │ 0.644883  │
-    │ 2   │ 0.346517   │ 0.0778264 │
-    │ 3   │ 0.312707   │ 0.848185  │
-    │ 4   │ 0.00790928 │ 0.0856352 │
-    │ 5   │ 0.488613   │ 0.553206  │
-    │ 6   │ 0.210968   │ 0.46335   │
-    │ 7   │ 0.951916   │ 0.185821  │
-    │ 8   │ 0.999905   │ 0.111981  │
-    │ 9   │ 0.251662   │ 0.976312  │
-    │ 10  │ 0.986666   │ 0.0516146 │
-    │ 11  │ 0.555751   │ 0.53803   │
-    │ 12  │ 0.437108   │ 0.455692  │
-    │ 13  │ 0.424718   │ 0.279395  │
-    │ 14  │ 0.773223   │ 0.178246  │
-    │ 15  │ 0.28119    │ 0.548983  │
-    │ 16  │ 0.209472   │ 0.370971  │
-    │ 17  │ 0.251379   │ 0.894166  │
-    │ 18  │ 0.0203749  │ 0.648054  │
-    │ 19  │ 0.287702   │ 0.417039  │
-    │ 20  │ 0.859512   │ 0.144566  │
-    │ 21  │ 0.0769509  │ 0.622403  │
-    │ 22  │ 0.640396   │ 0.872334  │
-    │ 23  │ 0.873544   │ 0.524975  │
-    │ 24  │ 0.278582   │ 0.241591  │
-    │ 25  │ 0.751313   │ 0.884837  │"""
-
-    # Test two-argument show
-    str1, size = capture_stdout() do
-        show(df)
-    end
-    io = IOContext(IOBuffer(), :limit=>true, :displaysize=>size)
-    show(io, df)
-    str2 = String(take!(io.io))
-    @test str1 == str2
-
-    str1, size = capture_stdout() do
-        show(df_big)
-    end
-    io = IOContext(IOBuffer(), :limit=>true, :displaysize=>size)
-    show(io, df_big)
-    str2 = String(take!(io.io))
-    @test str1 == str2
-
-    subdf = view(df, [2, 3], :)
-    io = IOBuffer()
-    show(io, subdf, allrows=true, allcols=false)
-    str = String(take!(io))
-    @test str == """
-    2×3 SubDataFrame
-    │ Row │ A     │ B           │ C       │
-    │     │ Int64 │ String      │ Float32 │
-    ├─────┼───────┼─────────────┼─────────┤
-    │ 1   │ 2     │ ∀ε>0: x+ε>x │ 2.0     │
-    │ 2   │ 3     │ z\$          │ 3.0     │"""
-    show(io, subdf, allrows=true)
-    show(io, subdf, allcols=true)
-    show(io, subdf, allcols=true, allrows=true)
-
-    df = DataFrame(A = Vector{String}(undef, 3))
-
-    A = DataFrames.StackedVector(Any[[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-    show(io, A)
-    A = DataFrames.RepeatedVector([1, 2, 3], 5, 1)
-    show(io, A)
-    A = DataFrames.RepeatedVector([1, 2, 3], 1, 5)
-    show(io, A)
-
-    #Test colored show output (for REPL and similar)
-    df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, missing])
-    @test sprint(show, df, context=:color=>true) == """
-        2×2 DataFrame
-        │ Row │ Fish   │ Mass     │
-        │     │ \e[90mString\e[39m │ \e[90mFloat64⍰\e[39m │
-        ├─────┼────────┼──────────┤
-        │ 1   │ Suzy   │ 1.5      │
-        │ 2   │ Amir   │ \e[90mmissing\e[39m  │"""
-
-    # Test showing missing
-    df = DataFrame(A = [:Symbol, missing, :missing],
-                   B = [missing, "String", "missing"],
-                   C = [:missing, "missing", missing])
-    @test sprint(show, df, context=:color=>true) == """
-        3×3 DataFrame
-        │ Row │ A       │ B       │ C       │
-        │     │ \e[90mSymbol⍰\e[39m │ \e[90mString⍰\e[39m │ \e[90mAny\e[39m     │
-        ├─────┼─────────┼─────────┼─────────┤
-        │ 1   │ Symbol  │ \e[90mmissing\e[39m │ missing │
-        │ 2   │ \e[90mmissing\e[39m │ String  │ missing │
-        │ 3   │ missing │ missing │ \e[90mmissing\e[39m │"""
-
-    # Test showing nothing
-    df_nothing = DataFrame(A = [1.0, 2.0, 3.0], B = ["g", "g", nothing])
-    io = IOBuffer()
-    show(io, df_nothing)
-    str = String(take!(io))
-    @test str == """
-    3×2 DataFrame
-    │ Row │ A       │ B      │
-    │     │ Float64 │ Union… │
-    ├─────┼─────────┼────────┤
-    │ 1   │ 1.0     │ g      │
-    │ 2   │ 2.0     │ g      │
-    │ 3   │ 3.0     │        │"""
-
-    # Test computing width for Array{String} columns
-    df = DataFrame([["a"]], [:x])
-    io = IOBuffer()
-    show(io, df)
-    str = String(take!(io))
-    @test str == """
-    1×1 DataFrame
-    │ Row │ x      │
-    │     │ String │
-    ├─────┼────────┤
-    │ 1   │ a      │"""
-
-    # Test escape characters
-    df = DataFrame(a = ["1\n1", "2\t2", "3\r3", "4\$4", "5\"5", "6\\6"])
-    io = IOBuffer()
-    show(io, df)
-    str = String(take!(io))
-    @test str == """
-    6×1 DataFrame
-    │ Row │ a      │
-    │     │ String │
-    ├─────┼────────┤
-    │ 1   │ 1\\n1   │
-    │ 2   │ 2\\t2   │
-    │ 3   │ 3\\r3   │
-    │ 4   │ 4\$4    │
-    │ 5   │ 5"5    │
-    │ 6   │ 6\\\\6   │"""
-
-    # Test categorical values
-    df = DataFrame(a = categorical([1,2,3]), b = categorical(["a", "b", missing]))
-    io = IOBuffer()
-    show(io, df)
-    str = String(take!(io))
-    @test str == """
-    3×2 DataFrame
-    │ Row │ a            │ b             │
-    │     │ Categorical… │ Categorical…⍰ │
-    ├─────┼──────────────┼───────────────┤
-    │ 1   │ 1            │ a             │
-    │ 2   │ 2            │ b             │
-    │ 3   │ 3            │ missing       │"""
-
-    # Test BigFloat
-    df = DataFrame(a = [big(1.0), missing])
-    io = IOBuffer()
-    show(io, df)
-    str = String(take!(io))
-    @test str == """
-    2×1 DataFrame
-    │ Row │ a         │
-    │     │ BigFloat⍰ │
-    ├─────┼───────────┤
-    │ 1   │ 1.0       │
-    │ 2   │ missing   │"""
-
+function capture_stdout(f::Function)
+    oldstdout = stdout
+    rd, wr = redirect_stdout()
+    f()
+    str = String(readavailable(rd))
+    redirect_stdout(oldstdout)
+    size = displaysize(rd)
+    close(rd)
+    close(wr)
+    str, size
 end
+
+# In the future newline character \n should be added to this test case
+df = DataFrame(A = Int64[1:4;], B = ["x\"", "∀ε>0: x+ε>x", "z\$", "A\nC"],
+               C = Float32[1.0, 2.0, 3.0, 4.0])
+
+refstr = """
+4×3 DataFrame
+│ Row │ A     │ B           │ C       │
+│     │ Int64 │ String      │ Float32 │
+├─────┼───────┼─────────────┼─────────┤
+│ 1   │ 1     │ x"          │ 1.0     │
+│ 2   │ 2     │ ∀ε>0: x+ε>x │ 2.0     │
+│ 3   │ 3     │ z\$          │ 3.0     │
+│ 4   │ 4     │ A\\nC        │ 4.0     │"""
+
+for allrows in [true, false], allcols in [true, false]
+    io = IOBuffer()
+    show(io, df, allcols=allcols)
+    str = String(take!(io))
+    @test str == refstr
+end
+
+Random.seed!(1)
+df_big = DataFrame(rand(25,5))
+
+io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+show(io, df_big)
+str = String(take!(io.io))
+@test str == """
+25×5 DataFrame. Omitted printing of 2 columns
+│ Row │ x1       │ x2       │ x3       │
+│     │ Float64  │ Float64  │ Float64  │
+├─────┼──────────┼──────────┼──────────┤
+│ 1   │ 0.236033 │ 0.644883 │ 0.440897 │
+⋮
+│ 24  │ 0.278582 │ 0.241591 │ 0.990741 │
+│ 25  │ 0.751313 │ 0.884837 │ 0.550334 │"""
+
+io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+show(io, df_big, allcols=true)
+str = String(take!(io.io))
+@test str == """
+25×5 DataFrame
+│ Row │ x1       │ x2       │ x3       │
+│     │ Float64  │ Float64  │ Float64  │
+├─────┼──────────┼──────────┼──────────┤
+│ 1   │ 0.236033 │ 0.644883 │ 0.440897 │
+⋮
+│ 24  │ 0.278582 │ 0.241591 │ 0.990741 │
+│ 25  │ 0.751313 │ 0.884837 │ 0.550334 │
+
+│ Row │ x4       │ x5       │
+│     │ Float64  │ Float64  │
+├─────┼──────────┼──────────┤
+│ 1   │ 0.580782 │ 0.138763 │
+⋮
+│ 24  │ 0.762276 │ 0.755415 │
+│ 25  │ 0.339081 │ 0.649056 │"""
+
+io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+show(io, df_big, allrows=true, allcols=true)
+str = String(take!(io.io))
+@test str == """
+25×5 DataFrame
+│ Row │ x1         │ x2        │
+│     │ Float64    │ Float64   │
+├─────┼────────────┼───────────┤
+│ 1   │ 0.236033   │ 0.644883  │
+│ 2   │ 0.346517   │ 0.0778264 │
+│ 3   │ 0.312707   │ 0.848185  │
+│ 4   │ 0.00790928 │ 0.0856352 │
+│ 5   │ 0.488613   │ 0.553206  │
+│ 6   │ 0.210968   │ 0.46335   │
+│ 7   │ 0.951916   │ 0.185821  │
+│ 8   │ 0.999905   │ 0.111981  │
+│ 9   │ 0.251662   │ 0.976312  │
+│ 10  │ 0.986666   │ 0.0516146 │
+│ 11  │ 0.555751   │ 0.53803   │
+│ 12  │ 0.437108   │ 0.455692  │
+│ 13  │ 0.424718   │ 0.279395  │
+│ 14  │ 0.773223   │ 0.178246  │
+│ 15  │ 0.28119    │ 0.548983  │
+│ 16  │ 0.209472   │ 0.370971  │
+│ 17  │ 0.251379   │ 0.894166  │
+│ 18  │ 0.0203749  │ 0.648054  │
+│ 19  │ 0.287702   │ 0.417039  │
+│ 20  │ 0.859512   │ 0.144566  │
+│ 21  │ 0.0769509  │ 0.622403  │
+│ 22  │ 0.640396   │ 0.872334  │
+│ 23  │ 0.873544   │ 0.524975  │
+│ 24  │ 0.278582   │ 0.241591  │
+│ 25  │ 0.751313   │ 0.884837  │
+
+│ Row │ x3        │ x4        │
+│     │ Float64   │ Float64   │
+├─────┼───────────┼───────────┤
+│ 1   │ 0.440897  │ 0.580782  │
+│ 2   │ 0.404673  │ 0.768359  │
+│ 3   │ 0.736787  │ 0.519525  │
+│ 4   │ 0.953803  │ 0.514863  │
+│ 5   │ 0.0951856 │ 0.998136  │
+│ 6   │ 0.519675  │ 0.603682  │
+│ 7   │ 0.0135403 │ 0.758775  │
+│ 8   │ 0.303399  │ 0.590953  │
+│ 9   │ 0.702557  │ 0.722086  │
+│ 10  │ 0.596537  │ 0.953207  │
+│ 11  │ 0.638935  │ 0.384411  │
+│ 12  │ 0.872347  │ 0.320011  │
+│ 13  │ 0.548635  │ 0.865625  │
+│ 14  │ 0.262992  │ 0.45457   │
+│ 15  │ 0.526443  │ 0.420287  │
+│ 16  │ 0.465019  │ 0.225151  │
+│ 17  │ 0.275519  │ 0.286169  │
+│ 18  │ 0.461823  │ 0.309144  │
+│ 19  │ 0.951861  │ 0.170391  │
+│ 20  │ 0.288737  │ 0.147162  │
+│ 21  │ 0.661232  │ 0.230063  │
+│ 22  │ 0.194568  │ 0.0929292 │
+│ 23  │ 0.393193  │ 0.681415  │
+│ 24  │ 0.990741  │ 0.762276  │
+│ 25  │ 0.550334  │ 0.339081  │
+
+│ Row │ x5        │
+│     │ Float64   │
+├─────┼───────────┤
+│ 1   │ 0.138763  │
+│ 2   │ 0.456446  │
+│ 3   │ 0.739918  │
+│ 4   │ 0.816004  │
+│ 5   │ 0.114529  │
+│ 6   │ 0.748928  │
+│ 7   │ 0.878108  │
+│ 8   │ 0.930481  │
+│ 9   │ 0.896291  │
+│ 10  │ 0.663145  │
+│ 11  │ 0.472799  │
+│ 12  │ 0.880525  │
+│ 13  │ 0.0141033 │
+│ 14  │ 0.502774  │
+│ 15  │ 0.224851  │
+│ 16  │ 0.287858  │
+│ 17  │ 0.104033  │
+│ 18  │ 0.475749  │
+│ 19  │ 0.416681  │
+│ 20  │ 0.521387  │
+│ 21  │ 0.908499  │
+│ 22  │ 0.102832  │
+│ 23  │ 0.670421  │
+│ 24  │ 0.755415  │
+│ 25  │ 0.649056  │"""
+
+io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+show(io, df_big, allrows=true, allcols=false)
+str = String(take!(io.io))
+@test str == """
+25×5 DataFrame. Omitted printing of 3 columns
+│ Row │ x1         │ x2        │
+│     │ Float64    │ Float64   │
+├─────┼────────────┼───────────┤
+│ 1   │ 0.236033   │ 0.644883  │
+│ 2   │ 0.346517   │ 0.0778264 │
+│ 3   │ 0.312707   │ 0.848185  │
+│ 4   │ 0.00790928 │ 0.0856352 │
+│ 5   │ 0.488613   │ 0.553206  │
+│ 6   │ 0.210968   │ 0.46335   │
+│ 7   │ 0.951916   │ 0.185821  │
+│ 8   │ 0.999905   │ 0.111981  │
+│ 9   │ 0.251662   │ 0.976312  │
+│ 10  │ 0.986666   │ 0.0516146 │
+│ 11  │ 0.555751   │ 0.53803   │
+│ 12  │ 0.437108   │ 0.455692  │
+│ 13  │ 0.424718   │ 0.279395  │
+│ 14  │ 0.773223   │ 0.178246  │
+│ 15  │ 0.28119    │ 0.548983  │
+│ 16  │ 0.209472   │ 0.370971  │
+│ 17  │ 0.251379   │ 0.894166  │
+│ 18  │ 0.0203749  │ 0.648054  │
+│ 19  │ 0.287702   │ 0.417039  │
+│ 20  │ 0.859512   │ 0.144566  │
+│ 21  │ 0.0769509  │ 0.622403  │
+│ 22  │ 0.640396   │ 0.872334  │
+│ 23  │ 0.873544   │ 0.524975  │
+│ 24  │ 0.278582   │ 0.241591  │
+│ 25  │ 0.751313   │ 0.884837  │"""
+
+# Test two-argument show
+str1, size = capture_stdout() do
+    show(df)
+end
+io = IOContext(IOBuffer(), :limit=>true, :displaysize=>size)
+show(io, df)
+str2 = String(take!(io.io))
+@test str1 == str2
+
+str1, size = capture_stdout() do
+    show(df_big)
+end
+io = IOContext(IOBuffer(), :limit=>true, :displaysize=>size)
+show(io, df_big)
+str2 = String(take!(io.io))
+@test str1 == str2
+
+subdf = view(df, [2, 3], :)
+io = IOBuffer()
+show(io, subdf, allrows=true, allcols=false)
+str = String(take!(io))
+@test str == """
+2×3 SubDataFrame
+│ Row │ A     │ B           │ C       │
+│     │ Int64 │ String      │ Float32 │
+├─────┼───────┼─────────────┼─────────┤
+│ 1   │ 2     │ ∀ε>0: x+ε>x │ 2.0     │
+│ 2   │ 3     │ z\$          │ 3.0     │"""
+show(io, subdf, allrows=true)
+show(io, subdf, allcols=true)
+show(io, subdf, allcols=true, allrows=true)
+
+df = DataFrame(A = Vector{String}(undef, 3))
+
+A = DataFrames.StackedVector(Any[[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+show(io, A)
+A = DataFrames.RepeatedVector([1, 2, 3], 5, 1)
+show(io, A)
+A = DataFrames.RepeatedVector([1, 2, 3], 1, 5)
+show(io, A)
+
+#Test colored show output (for REPL and similar)
+df = DataFrame(Fish = ["Suzy", "Amir"], Mass = [1.5, missing])
+@test sprint(show, df, context=:color=>true) == """
+    2×2 DataFrame
+    │ Row │ Fish   │ Mass     │
+    │     │ \e[90mString\e[39m │ \e[90mFloat64⍰\e[39m │
+    ├─────┼────────┼──────────┤
+    │ 1   │ Suzy   │ 1.5      │
+    │ 2   │ Amir   │ \e[90mmissing\e[39m  │"""
+
+# Test showing missing
+df = DataFrame(A = [:Symbol, missing, :missing],
+               B = [missing, "String", "missing"],
+               C = [:missing, "missing", missing])
+@test sprint(show, df, context=:color=>true) == """
+    3×3 DataFrame
+    │ Row │ A       │ B       │ C       │
+    │     │ \e[90mSymbol⍰\e[39m │ \e[90mString⍰\e[39m │ \e[90mAny\e[39m     │
+    ├─────┼─────────┼─────────┼─────────┤
+    │ 1   │ Symbol  │ \e[90mmissing\e[39m │ missing │
+    │ 2   │ \e[90mmissing\e[39m │ String  │ missing │
+    │ 3   │ missing │ missing │ \e[90mmissing\e[39m │"""
+
+# Test showing nothing
+df_nothing = DataFrame(A = [1.0, 2.0, 3.0], B = ["g", "g", nothing])
+io = IOBuffer()
+show(io, df_nothing)
+str = String(take!(io))
+@test str == """
+3×2 DataFrame
+│ Row │ A       │ B      │
+│     │ Float64 │ Union… │
+├─────┼─────────┼────────┤
+│ 1   │ 1.0     │ g      │
+│ 2   │ 2.0     │ g      │
+│ 3   │ 3.0     │        │"""
+
+# Test computing width for Array{String} columns
+df = DataFrame([["a"]], [:x])
+io = IOBuffer()
+show(io, df)
+str = String(take!(io))
+@test str == """
+1×1 DataFrame
+│ Row │ x      │
+│     │ String │
+├─────┼────────┤
+│ 1   │ a      │"""
+
+# Test escape characters
+df = DataFrame(a = ["1\n1", "2\t2", "3\r3", "4\$4", "5\"5", "6\\6"])
+io = IOBuffer()
+show(io, df)
+str = String(take!(io))
+@test str == """
+6×1 DataFrame
+│ Row │ a      │
+│     │ String │
+├─────┼────────┤
+│ 1   │ 1\\n1   │
+│ 2   │ 2\\t2   │
+│ 3   │ 3\\r3   │
+│ 4   │ 4\$4    │
+│ 5   │ 5"5    │
+│ 6   │ 6\\\\6   │"""
+
+# Test categorical values
+df = DataFrame(a = categorical([1,2,3]), b = categorical(["a", "b", missing]))
+io = IOBuffer()
+show(io, df)
+str = String(take!(io))
+@test str == """
+3×2 DataFrame
+│ Row │ a            │ b             │
+│     │ Categorical… │ Categorical…⍰ │
+├─────┼──────────────┼───────────────┤
+│ 1   │ 1            │ a             │
+│ 2   │ 2            │ b             │
+│ 3   │ 3            │ missing       │"""
+
+# Test BigFloat
+df = DataFrame(a = [big(1.0), missing])
+io = IOBuffer()
+show(io, df)
+str = String(take!(io))
+@test str == """
+2×1 DataFrame
+│ Row │ a         │
+│     │ BigFloat⍰ │
+├─────┼───────────┤
+│ 1   │ 1.0       │
+│ 2   │ missing   │"""
+
+end # module

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -1,105 +1,107 @@
 module TestSort
-    using DataFrames, Random, Test
 
-    dv1 = [9, 1, 8, missing, 3, 3, 7, missing]
-    dv2 = [9, 1, 8, missing, 3, 3, 7, missing]
-    dv3 = Vector{Union{Int, Missing}}(1:8)
-    cv1 = CategoricalArray(dv1, ordered=true)
+using DataFrames, Random, Test
 
-    d = DataFrame(dv1 = dv1, dv2 = dv2, dv3 = dv3, cv1 = cv1)
+dv1 = [9, 1, 8, missing, 3, 3, 7, missing]
+dv2 = [9, 1, 8, missing, 3, 3, 7, missing]
+dv3 = Vector{Union{Int, Missing}}(1:8)
+cv1 = CategoricalArray(dv1, ordered=true)
 
-    @test sortperm(d) == sortperm(dv1)
-    @test sortperm(d[[:dv3, :dv1]]) == sortperm(dv3)
-    @test sort(d, :dv1)[:dv3] == sortperm(dv1)
-    @test sort(d, :dv2)[:dv3] == sortperm(dv1)
-    @test sort(d, :cv1)[:dv3] == sortperm(dv1)
-    @test sort(d, [:dv1, :cv1])[:dv3] == sortperm(dv1)
-    @test sort(d, [:dv1, :dv3])[:dv3] == sortperm(dv1)
-    @test sort(d, (:dv1, :cv1))[:dv3] == sortperm(dv1)
-    @test sort(d, (:dv1, :dv3))[:dv3] == sortperm(dv1)
+d = DataFrame(dv1 = dv1, dv2 = dv2, dv3 = dv3, cv1 = cv1)
 
-    df = DataFrame(rank=rand(1:12, 1000),
-                   chrom=rand(1:24, 1000),
-                   pos=rand(1:100000, 1000))
+@test sortperm(d) == sortperm(dv1)
+@test sortperm(d[[:dv3, :dv1]]) == sortperm(dv3)
+@test sort(d, :dv1)[:dv3] == sortperm(dv1)
+@test sort(d, :dv2)[:dv3] == sortperm(dv1)
+@test sort(d, :cv1)[:dv3] == sortperm(dv1)
+@test sort(d, [:dv1, :cv1])[:dv3] == sortperm(dv1)
+@test sort(d, [:dv1, :dv3])[:dv3] == sortperm(dv1)
+@test sort(d, (:dv1, :cv1))[:dv3] == sortperm(dv1)
+@test sort(d, (:dv1, :dv3))[:dv3] == sortperm(dv1)
 
-    @test issorted(sort(df))
-    @test issorted(sort(df, rev=true), rev=true)
-    @test issorted(sort(df, [:chrom,:pos])[[:chrom,:pos]])
+df = DataFrame(rank=rand(1:12, 1000),
+               chrom=rand(1:24, 1000),
+               pos=rand(1:100000, 1000))
 
-    ds = sort(df, (order(:rank, rev=true),:chrom,:pos))
-    @test issorted(ds, (order(:rank, rev=true),:chrom,:pos))
-    @test issorted(ds, rev=(true, false, false))
+@test issorted(sort(df))
+@test issorted(sort(df, rev=true), rev=true)
+@test issorted(sort(df, [:chrom,:pos])[[:chrom,:pos]])
 
-    ds2 = sort(df, (:rank, :chrom, :pos), rev=(true, false, false))
-    @test issorted(ds2, (order(:rank, rev=true), :chrom, :pos))
-    @test issorted(ds2, rev=(true, false, false))
+ds = sort(df, (order(:rank, rev=true),:chrom,:pos))
+@test issorted(ds, (order(:rank, rev=true),:chrom,:pos))
+@test issorted(ds, rev=(true, false, false))
 
-    @test ds2 == ds
+ds2 = sort(df, (:rank, :chrom, :pos), rev=(true, false, false))
+@test issorted(ds2, (order(:rank, rev=true), :chrom, :pos))
+@test issorted(ds2, rev=(true, false, false))
 
-    sort!(df, (:rank, :chrom, :pos), rev=(true, false, false))
-    @test issorted(df, (order(:rank, rev=true), :chrom, :pos))
-    @test issorted(df, rev=(true, false, false))
+@test ds2 == ds
 
-    @test df == ds
+sort!(df, (:rank, :chrom, :pos), rev=(true, false, false))
+@test issorted(df, (order(:rank, rev=true), :chrom, :pos))
+@test issorted(df, rev=(true, false, false))
 
-    df = DataFrame(x = [3, 1, 2, 1], y = ["b", "c", "a", "b"])
-    @test !issorted(df, :x)
-    @test issorted(sort(df, :x), :x)
+@test df == ds
 
-    x = DataFrame(a=1:3,b=3:-1:1,c=3:-1:1)
-    @test issorted(x)
-    @test !issorted(x, [:b,:c])
-    @test !issorted(x[2:3], [:b,:c])
-    @test issorted(sort(x,[2,3]), [:b,:c])
-    @test issorted(sort(x[2:3]), [:b,:c])
+df = DataFrame(x = [3, 1, 2, 1], y = ["b", "c", "a", "b"])
+@test !issorted(df, :x)
+@test issorted(sort(df, :x), :x)
 
-    # Check that columns that shares the same underlying array are only permuted once PR#1072
-    df = DataFrame(a=[2,1])
-    df[:b] = df[:a]
-    sort!(df, :a)
-    @test df == DataFrame(a=[1,2],b=[1,2])
+x = DataFrame(a=1:3,b=3:-1:1,c=3:-1:1)
+@test issorted(x)
+@test !issorted(x, [:b,:c])
+@test !issorted(x[2:3], [:b,:c])
+@test issorted(sort(x,[2,3]), [:b,:c])
+@test issorted(sort(x[2:3]), [:b,:c])
 
-    x = DataFrame(x=[1,2,3,4], y=[1,3,2,4])
-    sort!(x, :y)
-    @test x[:y] == [1,2,3,4]
-    @test x[:x] == [1,3,2,4]
+# Check that columns that shares the same underlying array are only permuted once PR#1072
+df = DataFrame(a=[2,1])
+df[:b] = df[:a]
+sort!(df, :a)
+@test df == DataFrame(a=[1,2],b=[1,2])
 
-    @test_throws ArgumentError sort(x, by=:x)
+x = DataFrame(x=[1,2,3,4], y=[1,3,2,4])
+sort!(x, :y)
+@test x[:y] == [1,2,3,4]
+@test x[:x] == [1,3,2,4]
 
-    Random.seed!(1)
-    # here there will be probably no ties
-    df_rand1 = DataFrame(rand(100, 4))
-    # but here we know we will have ties
-    df_rand2 = df_rand1[:]
-    df_rand2[:x1] = shuffle([fill(1, 50); fill(2, 50)])
-    df_rand2[:x4] = shuffle([fill(1, 50); fill(2, 50)])
+@test_throws ArgumentError sort(x, by=:x)
 
-    # test sorting by 1 column
-    for df_rand in [df_rand1, df_rand2]
-        # testing sort
-        for n1 in names(df_rand)
-            # passing column name
-            @test sort(df_rand, n1) == df_rand[sortperm(df_rand[n1]),:]
-            # passing vector with one column name
-            @test sort(df_rand, [n1]) == df_rand[sortperm(df_rand[n1]),:]
-            # passing vector with two column names
-            for n2 in setdiff(names(df_rand), [n1])
-                @test sort(df_rand, [n1,n2]) == df_rand[sortperm(collect(zip(df_rand[n1],
-                                                                             df_rand[n2]))),:]
-            end
+Random.seed!(1)
+# here there will be probably no ties
+df_rand1 = DataFrame(rand(100, 4))
+# but here we know we will have ties
+df_rand2 = df_rand1[:]
+df_rand2[:x1] = shuffle([fill(1, 50); fill(2, 50)])
+df_rand2[:x4] = shuffle([fill(1, 50); fill(2, 50)])
+
+# test sorting by 1 column
+for df_rand in [df_rand1, df_rand2]
+    # testing sort
+    for n1 in names(df_rand)
+        # passing column name
+        @test sort(df_rand, n1) == df_rand[sortperm(df_rand[n1]),:]
+        # passing vector with one column name
+        @test sort(df_rand, [n1]) == df_rand[sortperm(df_rand[n1]),:]
+        # passing vector with two column names
+        for n2 in setdiff(names(df_rand), [n1])
+            @test sort(df_rand, [n1,n2]) == df_rand[sortperm(collect(zip(df_rand[n1],
+                                                                         df_rand[n2]))),:]
         end
-        # testing if sort! is consistent with issorted and sort
-        ref_df = df_rand[:]
-        for n1 in names(df_rand)
-            @test sort!(df_rand, n1) == sort(ref_df, n1)
+    end
+    # testing if sort! is consistent with issorted and sort
+    ref_df = df_rand[:]
+    for n1 in names(df_rand)
+        @test sort!(df_rand, n1) == sort(ref_df, n1)
+        @test issorted(df_rand, n1)
+        @test sort!(df_rand, [n1]) == sort(ref_df, [n1])
+        @test issorted(df_rand, [n1])
+        for n2 in setdiff(names(df_rand), [n1])
+            @test sort!(df_rand, [n1, n2]) == sort(ref_df, [n1, n2])
             @test issorted(df_rand, n1)
-            @test sort!(df_rand, [n1]) == sort(ref_df, [n1])
-            @test issorted(df_rand, [n1])
-            for n2 in setdiff(names(df_rand), [n1])
-                @test sort!(df_rand, [n1, n2]) == sort(ref_df, [n1, n2])
-                @test issorted(df_rand, n1)
-                @test issorted(df_rand, [n1, n2])
-            end
+            @test issorted(df_rand, [n1, n2])
         end
     end
 end
+
+end # module

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -1,212 +1,214 @@
 module TestSubDataFrame
-    using Test, DataFrames
 
-    @testset "copy - SubDataFrame" begin
-        df = DataFrame(x = 1:10, y = 1.0:10.0)
-        sdf = view(df, 1:2, 1:1)
-        @test sdf isa SubDataFrame
-        @test copy(sdf) isa DataFrame
-        @test sdf == copy(sdf)
-        @test view(sdf, :, :) === sdf
-    end
+using Test, DataFrames
 
-    @testset "view -- DataFrame" begin
-        df = DataFrame(x = 1:10, y = 1.0:10.0)
-        @test view(df, 1, :) == DataFrameRow(df, 1, :)
-        @test view(df, UInt(1), :) == DataFrameRow(df, 1, :)
-        @test view(df, BigInt(1), :) == DataFrameRow(df, 1, :)
-        @test view(df, UInt(1):UInt(1), :) == SubDataFrame(df, 1:1, :)
-        @test view(df, BigInt(1):BigInt(1), :) == SubDataFrame(df, 1:1, :)
-        @test view(df, 1:2, :) == first(df, 2)
-        @test view(df, vcat(trues(2), falses(8)), :) == first(df, 2)
-        @test view(df, [1, 2], :) == first(df, 2)
-        @test view(df, 1, :x) == view(df[:x], 1)
-        @test view(df, 1, :x) isa SubArray
-        @test size(view(df, 1, :x)) == ()
-        @test view(df, 1:2, :x) == df[:x][1:2]
-        @test view(df, 1:2, :x) isa SubArray
-        @test view(df, vcat(trues(2), falses(8)), :x) == view(df[:x], vcat(trues(2), falses(8)))
-        @test view(df, [1, 2], :x) == view(df[:x], [1, 2])
-        @test view(df, 1, 1) == view(df[1], 1)
-        @test view(df, 1, 1) isa SubArray
-        @test size(view(df, 1, 1)) == ()
-        @test view(df, 1:2, 1) == df[1][1:2]
-        @test view(df, 1:2, 1) isa SubArray
-        @test view(df, vcat(trues(2), falses(8)), 1) == view(df[1], vcat(trues(2), falses(8)))
-        @test view(df, [1, 2], 1) == view(df[1], [1,2])
-        @test view(df, 1:2, 1) == df[1][1:2]
-        @test view(df, 1:2, 1) isa SubArray
-        @test view(df, 1, [:x, :y]) == DataFrameRow(df[[:x, :y]], 1, :)
-        @test view(df, 1, [:x, :y]) == DataFrameRow(df, 1, [:x, :y])
-        @test view(df, 1:2, [:x, :y]) == first(df, 2)
-        @test view(df, vcat(trues(2), falses(8)), [:x, :y]) == first(df, 2)
-        @test view(df, [1, 2], [:x, :y]) == first(df, 2)
-        @test view(df, 1, [1, 2]) == DataFrameRow(df[1:2], 1, :)
-        @test view(df, 1, [1, 2]) == DataFrameRow(df, 1, 1:2)
-        @test view(df, 1:2, [1, 2]) == first(df, 2)
-        @test view(df, vcat(trues(2), falses(8)), [1, 2]) == first(df, 2)
-        @test view(df, [1, 2], [1, 2]) == first(df, 2)
-        @test view(df, 1, trues(2)) == DataFrameRow(df[trues(2)], 1, :)
-        @test view(df, 1, trues(2)) == DataFrameRow(df, 1, trues(2))
-        @test view(df, 1:2, trues(2)) == first(df, 2)
-        @test view(df, vcat(trues(2), falses(8)), trues(2)) == first(df, 2)
-        @test view(df, [1, 2], trues(2)) == first(df, 2)
-        @test view(df, Integer[1, 2], :) == first(df, 2)
-        @test view(df, UInt[1, 2], :) == first(df, 2)
-        @test view(df, BigInt[1, 2], :) == first(df, 2)
-        @test view(df, Union{Int, Missing}[1, 2], :) == first(df, 2)
-        @test view(df, Union{Integer, Missing}[1, 2], :) == first(df, 2)
-        @test view(df, Union{UInt, Missing}[1, 2], :) == first(df, 2)
-        @test view(df, Union{BigInt, Missing}[1, 2], :) == first(df, 2)
-        @test view(df, :) == df
-        @test view(df, :, :) == df
-        @test view(df, 1, :) == DataFrameRow(df, 1, :)
-        @test view(df, :, 1) == df[:, 1]
-        @test view(df, :, 1) isa SubArray
-        @test_throws ArgumentError view(df, [missing, 1])
-        @test_throws ArgumentError view(df, [missing, 1], :)
-    end
-
-    @testset "view -- SubDataFrame" begin
-        df = view(DataFrame(x = 1:10, y = 1.0:10.0), 1:10, :)
-        @test view(df, 1, :) == DataFrameRow(df, 1, :)
-        @test view(df, UInt(1), :) == DataFrameRow(df, 1, :)
-        @test view(df, BigInt(1), :) == DataFrameRow(df, 1, :)
-        @test view(df, 1:2, :) == first(df, 2)
-        @test view(df, vcat(trues(2), falses(8)), :) == first(df, 2)
-        @test view(df, [1, 2], :) == first(df, 2)
-        @test view(df, 1, :x) == view(df[:x], 1)
-        @test view(df, 1, 1) isa SubArray
-        @test size(view(df, 1, 1)) == ()
-        @test view(df, 1:2, :x) == view(df[:x], 1:2)
-        @test view(df, vcat(trues(2), falses(8)), :x) == view(df[:x], vcat(trues(2), falses(8)))
-        @test view(df, [1, 2], :x) == view(df[:x], [1, 2])
-        @test view(df, 1, 1) == view(df[1], 1)
-        @test view(df, 1, 1) isa SubArray
-        @test size(view(df, 1, 1)) == ()
-        @test view(df, 1:2, 1) == view(df[:x], 1:2)
-        @test view(df, vcat(trues(2), falses(8)), 1) == view(df[:x], vcat(trues(2), falses(8)))
-        @test view(df, [1, 2], 1) == view(df[:x], [1, 2])
-        @test view(df, 1, [:x, :y]) == DataFrameRow(df[[:x,:y]], 1, :)
-        @test view(df, 1, [:x, :y]) == DataFrameRow(df, 1, [:x,:y])
-        @test view(df, 1:2, [:x, :y]) == first(df, 2)
-        @test view(df, vcat(trues(2), falses(8)), [:x, :y]) == first(df, 2)
-        @test view(df, [1, 2], [:x, :y]) == first(df, 2)
-        @test view(df, 1, [1, 2]) == DataFrameRow(df[1:2], 1, :)
-        @test view(df, 1, [1, 2]) == DataFrameRow(df, 1, 1:2)
-        @test view(df, 1:2, [1, 2]) == first(df, 2)
-        @test view(df, vcat(trues(2), falses(8)), [1, 2]) == first(df, 2)
-        @test view(df, [1, 2], [1, 2]) == first(df, 2)
-        @test view(df, 1, trues(2)) == DataFrameRow(df[trues(2)], 1, :)
-        @test view(df, 1, trues(2)) == DataFrameRow(df, 1, trues(2))
-        @test view(df, 1:2, trues(2)) == first(df, 2)
-        @test view(df, vcat(trues(2), falses(8)), trues(2)) == first(df, 2)
-        @test view(df, [1, 2], trues(2)) == first(df, 2)
-        @test view(df, Integer[1, 2], :) == first(df, 2)
-        @test view(df, UInt[1, 2], :) == first(df, 2)
-        @test view(df, BigInt[1, 2], :) == first(df, 2)
-        @test view(df, Union{Int, Missing}[1, 2], :) == first(df, 2)
-        @test view(df, Union{Integer, Missing}[1, 2], :) == first(df, 2)
-        @test view(df, Union{UInt, Missing}[1, 2], :) == first(df, 2)
-        @test view(df, Union{BigInt, Missing}[1, 2], :) == first(df, 2)
-        @test view(df, :) == df
-        @test view(df, :, :) == df
-        @test view(df, 1, :) == DataFrameRow(df, 1, :)
-        @test view(df, :, 1) == df[:, 1]
-        @test view(df, :, 1) isa SubArray
-        @test_throws ArgumentError view(df, [missing, 1])
-        @test_throws ArgumentError view(df, [missing, 1], :)
-        @test_throws ArgumentError view(df, :, true)
-    end
-
-    @testset "getproperty, setproperty! and propertynames" begin
-        x = collect(1:10)
-        y = collect(1.0:10.0)
-        df = view(DataFrame(x = x, y = y), 2:6, :)
-
-        @test Base.propertynames(df) == names(df)
-
-        @test df.x == 2:6
-        @test df.y == 2:6
-        @test_throws KeyError df.z
-
-        df.x = 1:5
-        @test df.x == 1:5
-        @test x == [1; 1:5; 7:10]
-        df.y = 1
-        @test df.y == [1, 1, 1, 1, 1]
-        @test y == [1; 1; 1; 1; 1; 1; 7:10]
-        @test_throws ArgumentError df.z = 1:5
-        @test_throws ArgumentError df.z = 1
-    end
-
-    @testset "index" begin
-        y = 1.0:10.0
-        df = view(DataFrame(y=y), 2:6, :)
-        df2 = view(DataFrame(x=y, y=y), 2:6, 2:2)
-        @test DataFrames.index(df) == DataFrames.index(df2)
-        @test haskey(DataFrames.index(df2), :y)
-        @test !haskey(DataFrames.index(df2), :x)
-        @test haskey(DataFrames.index(df2), 1)
-        @test !haskey(DataFrames.index(df2), 2)
-        @test !haskey(DataFrames.index(df2), 0)
-        @test_throws ArgumentError haskey(DataFrames.index(df2), true)
-        @test keys(DataFrames.index(df2)) == [:y]
-
-        x = DataFrame(ones(5,4))
-        df = view(x, 2:3, 2:3)
-        @test names(df) == names(x)[2:3]
-        df = view(x, 2:3, [4,2])
-        @test names(df) == names(x)[[4,2]]
-    end
-
-    @testset "dump" begin
-        y = 1.0:10.0
-        df = view(DataFrame(y=y), 2:6, :)
-        refstr = string("SubDataFrame{DataFrame,DataFrames.Index,",
-                        "UnitRange{$Int}}  5 observations of 1 variables\n",
-                        "  y: [2.0, 3.0, 4.0, 5.0, 6.0]\n\n")
-        @test sprint(dump, df) == refstr
-    end
-
-    @testset "deleterows!" begin
-        y = 1.0:10.0
-        df = view(DataFrame(y=y), 2:6, :)
-        @test_throws ArgumentError deleterows!(df, 1)
-    end
-
-    @testset "parent" begin
-        df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                       b=[2.0, missing, 1.2, 2.0, missing, missing],
-                       c=["A", "B", "C", "A", "B", missing])
-        @test parent(view(df, [4, 2], :)) === df
-        @test parentindices(view(df, [4, 2], :)) == ([4,2], Base.OneTo(3))
-        @test parent(view(df, [4, 2], 1:3)) === df
-        @test parentindices(view(df, [4, 2], 1:3)) == ([4, 2], Base.OneTo(3))
-    end
-
-    @testset "duplicate column" begin
-        df = DataFrame([11:16 21:26 31:36 41:46])
-        sdf = view(df, [3,1,4], [3,3,3])
-        @test names(sdf) == fill(:x3, 3)
-        @test sdf[1] == [33, 31, 34]
-        @test sdf[1] === sdf[2] === sdf[3]
-        @test sdf.x3[1] == 33
-        sdf.x3[1] = 333
-        @test df.x3[3] == 333
-        @test_throws KeyError sdf.x1
-    end
-
-    @testset "conversion to DataFrame" begin
-        df = DataFrame([11:16 21:26 31:36 41:46])
-        sdf = view(df, [3,1,4], [3,2,1])
-        df2 = DataFrame(sdf)
-        @test df2 isa DataFrame
-        @test df2 == df[[3,1,4], [3,2,1]]
-        @test all(x -> x isa Vector{Int}, eachcol(df2, false))
-        df2 = convert(DataFrame, sdf)
-        @test df2 isa DataFrame
-        @test df2 == df[[3,1,4], [3,2,1]]
-        @test all(x -> x isa Vector{Int}, eachcol(df2, false))
-    end
+@testset "copy - SubDataFrame" begin
+    df = DataFrame(x = 1:10, y = 1.0:10.0)
+    sdf = view(df, 1:2, 1:1)
+    @test sdf isa SubDataFrame
+    @test copy(sdf) isa DataFrame
+    @test sdf == copy(sdf)
+    @test view(sdf, :, :) === sdf
 end
+
+@testset "view -- DataFrame" begin
+    df = DataFrame(x = 1:10, y = 1.0:10.0)
+    @test view(df, 1, :) == DataFrameRow(df, 1, :)
+    @test view(df, UInt(1), :) == DataFrameRow(df, 1, :)
+    @test view(df, BigInt(1), :) == DataFrameRow(df, 1, :)
+    @test view(df, UInt(1):UInt(1), :) == SubDataFrame(df, 1:1, :)
+    @test view(df, BigInt(1):BigInt(1), :) == SubDataFrame(df, 1:1, :)
+    @test view(df, 1:2, :) == first(df, 2)
+    @test view(df, vcat(trues(2), falses(8)), :) == first(df, 2)
+    @test view(df, [1, 2], :) == first(df, 2)
+    @test view(df, 1, :x) == view(df[:x], 1)
+    @test view(df, 1, :x) isa SubArray
+    @test size(view(df, 1, :x)) == ()
+    @test view(df, 1:2, :x) == df[:x][1:2]
+    @test view(df, 1:2, :x) isa SubArray
+    @test view(df, vcat(trues(2), falses(8)), :x) == view(df[:x], vcat(trues(2), falses(8)))
+    @test view(df, [1, 2], :x) == view(df[:x], [1, 2])
+    @test view(df, 1, 1) == view(df[1], 1)
+    @test view(df, 1, 1) isa SubArray
+    @test size(view(df, 1, 1)) == ()
+    @test view(df, 1:2, 1) == df[1][1:2]
+    @test view(df, 1:2, 1) isa SubArray
+    @test view(df, vcat(trues(2), falses(8)), 1) == view(df[1], vcat(trues(2), falses(8)))
+    @test view(df, [1, 2], 1) == view(df[1], [1,2])
+    @test view(df, 1:2, 1) == df[1][1:2]
+    @test view(df, 1:2, 1) isa SubArray
+    @test view(df, 1, [:x, :y]) == DataFrameRow(df[[:x, :y]], 1, :)
+    @test view(df, 1, [:x, :y]) == DataFrameRow(df, 1, [:x, :y])
+    @test view(df, 1:2, [:x, :y]) == first(df, 2)
+    @test view(df, vcat(trues(2), falses(8)), [:x, :y]) == first(df, 2)
+    @test view(df, [1, 2], [:x, :y]) == first(df, 2)
+    @test view(df, 1, [1, 2]) == DataFrameRow(df[1:2], 1, :)
+    @test view(df, 1, [1, 2]) == DataFrameRow(df, 1, 1:2)
+    @test view(df, 1:2, [1, 2]) == first(df, 2)
+    @test view(df, vcat(trues(2), falses(8)), [1, 2]) == first(df, 2)
+    @test view(df, [1, 2], [1, 2]) == first(df, 2)
+    @test view(df, 1, trues(2)) == DataFrameRow(df[trues(2)], 1, :)
+    @test view(df, 1, trues(2)) == DataFrameRow(df, 1, trues(2))
+    @test view(df, 1:2, trues(2)) == first(df, 2)
+    @test view(df, vcat(trues(2), falses(8)), trues(2)) == first(df, 2)
+    @test view(df, [1, 2], trues(2)) == first(df, 2)
+    @test view(df, Integer[1, 2], :) == first(df, 2)
+    @test view(df, UInt[1, 2], :) == first(df, 2)
+    @test view(df, BigInt[1, 2], :) == first(df, 2)
+    @test view(df, Union{Int, Missing}[1, 2], :) == first(df, 2)
+    @test view(df, Union{Integer, Missing}[1, 2], :) == first(df, 2)
+    @test view(df, Union{UInt, Missing}[1, 2], :) == first(df, 2)
+    @test view(df, Union{BigInt, Missing}[1, 2], :) == first(df, 2)
+    @test view(df, :) == df
+    @test view(df, :, :) == df
+    @test view(df, 1, :) == DataFrameRow(df, 1, :)
+    @test view(df, :, 1) == df[:, 1]
+    @test view(df, :, 1) isa SubArray
+    @test_throws ArgumentError view(df, [missing, 1])
+    @test_throws ArgumentError view(df, [missing, 1], :)
+end
+
+@testset "view -- SubDataFrame" begin
+    df = view(DataFrame(x = 1:10, y = 1.0:10.0), 1:10, :)
+    @test view(df, 1, :) == DataFrameRow(df, 1, :)
+    @test view(df, UInt(1), :) == DataFrameRow(df, 1, :)
+    @test view(df, BigInt(1), :) == DataFrameRow(df, 1, :)
+    @test view(df, 1:2, :) == first(df, 2)
+    @test view(df, vcat(trues(2), falses(8)), :) == first(df, 2)
+    @test view(df, [1, 2], :) == first(df, 2)
+    @test view(df, 1, :x) == view(df[:x], 1)
+    @test view(df, 1, 1) isa SubArray
+    @test size(view(df, 1, 1)) == ()
+    @test view(df, 1:2, :x) == view(df[:x], 1:2)
+    @test view(df, vcat(trues(2), falses(8)), :x) == view(df[:x], vcat(trues(2), falses(8)))
+    @test view(df, [1, 2], :x) == view(df[:x], [1, 2])
+    @test view(df, 1, 1) == view(df[1], 1)
+    @test view(df, 1, 1) isa SubArray
+    @test size(view(df, 1, 1)) == ()
+    @test view(df, 1:2, 1) == view(df[:x], 1:2)
+    @test view(df, vcat(trues(2), falses(8)), 1) == view(df[:x], vcat(trues(2), falses(8)))
+    @test view(df, [1, 2], 1) == view(df[:x], [1, 2])
+    @test view(df, 1, [:x, :y]) == DataFrameRow(df[[:x,:y]], 1, :)
+    @test view(df, 1, [:x, :y]) == DataFrameRow(df, 1, [:x,:y])
+    @test view(df, 1:2, [:x, :y]) == first(df, 2)
+    @test view(df, vcat(trues(2), falses(8)), [:x, :y]) == first(df, 2)
+    @test view(df, [1, 2], [:x, :y]) == first(df, 2)
+    @test view(df, 1, [1, 2]) == DataFrameRow(df[1:2], 1, :)
+    @test view(df, 1, [1, 2]) == DataFrameRow(df, 1, 1:2)
+    @test view(df, 1:2, [1, 2]) == first(df, 2)
+    @test view(df, vcat(trues(2), falses(8)), [1, 2]) == first(df, 2)
+    @test view(df, [1, 2], [1, 2]) == first(df, 2)
+    @test view(df, 1, trues(2)) == DataFrameRow(df[trues(2)], 1, :)
+    @test view(df, 1, trues(2)) == DataFrameRow(df, 1, trues(2))
+    @test view(df, 1:2, trues(2)) == first(df, 2)
+    @test view(df, vcat(trues(2), falses(8)), trues(2)) == first(df, 2)
+    @test view(df, [1, 2], trues(2)) == first(df, 2)
+    @test view(df, Integer[1, 2], :) == first(df, 2)
+    @test view(df, UInt[1, 2], :) == first(df, 2)
+    @test view(df, BigInt[1, 2], :) == first(df, 2)
+    @test view(df, Union{Int, Missing}[1, 2], :) == first(df, 2)
+    @test view(df, Union{Integer, Missing}[1, 2], :) == first(df, 2)
+    @test view(df, Union{UInt, Missing}[1, 2], :) == first(df, 2)
+    @test view(df, Union{BigInt, Missing}[1, 2], :) == first(df, 2)
+    @test view(df, :) == df
+    @test view(df, :, :) == df
+    @test view(df, 1, :) == DataFrameRow(df, 1, :)
+    @test view(df, :, 1) == df[:, 1]
+    @test view(df, :, 1) isa SubArray
+    @test_throws ArgumentError view(df, [missing, 1])
+    @test_throws ArgumentError view(df, [missing, 1], :)
+    @test_throws ArgumentError view(df, :, true)
+end
+
+@testset "getproperty, setproperty! and propertynames" begin
+    x = collect(1:10)
+    y = collect(1.0:10.0)
+    df = view(DataFrame(x = x, y = y), 2:6, :)
+
+    @test Base.propertynames(df) == names(df)
+
+    @test df.x == 2:6
+    @test df.y == 2:6
+    @test_throws KeyError df.z
+
+    df.x = 1:5
+    @test df.x == 1:5
+    @test x == [1; 1:5; 7:10]
+    df.y = 1
+    @test df.y == [1, 1, 1, 1, 1]
+    @test y == [1; 1; 1; 1; 1; 1; 7:10]
+    @test_throws ArgumentError df.z = 1:5
+    @test_throws ArgumentError df.z = 1
+end
+
+@testset "index" begin
+    y = 1.0:10.0
+    df = view(DataFrame(y=y), 2:6, :)
+    df2 = view(DataFrame(x=y, y=y), 2:6, 2:2)
+    @test DataFrames.index(df) == DataFrames.index(df2)
+    @test haskey(DataFrames.index(df2), :y)
+    @test !haskey(DataFrames.index(df2), :x)
+    @test haskey(DataFrames.index(df2), 1)
+    @test !haskey(DataFrames.index(df2), 2)
+    @test !haskey(DataFrames.index(df2), 0)
+    @test_throws ArgumentError haskey(DataFrames.index(df2), true)
+    @test keys(DataFrames.index(df2)) == [:y]
+
+    x = DataFrame(ones(5,4))
+    df = view(x, 2:3, 2:3)
+    @test names(df) == names(x)[2:3]
+    df = view(x, 2:3, [4,2])
+    @test names(df) == names(x)[[4,2]]
+end
+
+@testset "dump" begin
+    y = 1.0:10.0
+    df = view(DataFrame(y=y), 2:6, :)
+    refstr = string("SubDataFrame{DataFrame,DataFrames.Index,",
+                    "UnitRange{$Int}}  5 observations of 1 variables\n",
+                    "  y: [2.0, 3.0, 4.0, 5.0, 6.0]\n\n")
+    @test sprint(dump, df) == refstr
+end
+
+@testset "deleterows!" begin
+    y = 1.0:10.0
+    df = view(DataFrame(y=y), 2:6, :)
+    @test_throws ArgumentError deleterows!(df, 1)
+end
+
+@testset "parent" begin
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing])
+    @test parent(view(df, [4, 2], :)) === df
+    @test parentindices(view(df, [4, 2], :)) == ([4,2], Base.OneTo(3))
+    @test parent(view(df, [4, 2], 1:3)) === df
+    @test parentindices(view(df, [4, 2], 1:3)) == ([4, 2], Base.OneTo(3))
+end
+
+@testset "duplicate column" begin
+    df = DataFrame([11:16 21:26 31:36 41:46])
+    sdf = view(df, [3,1,4], [3,3,3])
+    @test names(sdf) == fill(:x3, 3)
+    @test sdf[1] == [33, 31, 34]
+    @test sdf[1] === sdf[2] === sdf[3]
+    @test sdf.x3[1] == 33
+    sdf.x3[1] = 333
+    @test df.x3[3] == 333
+    @test_throws KeyError sdf.x1
+end
+
+@testset "conversion to DataFrame" begin
+    df = DataFrame([11:16 21:26 31:36 41:46])
+    sdf = view(df, [3,1,4], [3,2,1])
+    df2 = DataFrame(sdf)
+    @test df2 isa DataFrame
+    @test df2 == df[[3,1,4], [3,2,1]]
+    @test all(x -> x isa Vector{Int}, eachcol(df2, false))
+    df2 = convert(DataFrame, sdf)
+    @test df2 isa DataFrame
+    @test df2 == df[[3,1,4], [3,2,1]]
+    @test all(x -> x isa Vector{Int}, eachcol(df2, false))
+end
+
+end # module

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -1,4 +1,5 @@
 module TestTables
+
 using Test, Tables, DataFrames, CategoricalArrays
 
 struct NamedTupleIterator{T <: NamedTuple}
@@ -142,4 +143,5 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test ct.b == cat == cat2
     end
 end
-end
+
+end # module

--- a/test/tabletraits.jl
+++ b/test/tabletraits.jl
@@ -1,4 +1,5 @@
 module TestTableTraits
+
 using Test, DataFrames, IteratorInterfaceExtensions, TableTraits, DataValues
 
 struct ColumnSource
@@ -32,4 +33,4 @@ end
 
 end
 
-end
+end # module

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,31 +1,33 @@
 module TestUtils
-    using Test, DataFrames, Statistics, StatsBase, Random
-    #
-    # make_unique(df::AbstractDataFrame, makeunique::Bool)
-    #
-    @testset "make_unique" begin
-        @test DataFrames.make_unique([:x, :x, :x_1, :x2], makeunique=true) == [:x, :x_2, :x_1, :x2]
-        @test_throws ArgumentError DataFrames.make_unique([:x, :x, :x_1, :x2], makeunique=false)
-        @test DataFrames.make_unique([:x, :x_1, :x2], makeunique=false) == [:x, :x_1, :x2]
-    end
-    #
-    # repeat(df::AbstractDataFrame, count::Integer)
-    #
-    @testset "count" begin
-        df = DataFrame(a = 1:2, b = 3:4)
-        ref = DataFrame(a = repeat(1:2, 2),
-                        b = repeat(3:4, 2))
-        @test repeat(df, 2) == ref
-        @test repeat(view(df, 1:2, :), 2) == ref
-    end
-    #
-    # repeat(df::AbstractDataFrame; inner::Integer = 1, outer::Integer = 1)
-    #
-    @testset "inner_outer" begin
-        df = DataFrame(a = 1:2, b = 3:4)
-        ref = DataFrame(a = repeat(1:2, inner = 2, outer = 3),
-                        b = repeat(3:4, inner = 2, outer = 3))
-        @test repeat(df, inner = 2, outer = 3) == ref
-        @test repeat(view(df, 1:2, :), inner = 2, outer = 3) == ref
-    end
+
+using Test, DataFrames, Statistics, StatsBase, Random
+#
+# make_unique(df::AbstractDataFrame, makeunique::Bool)
+#
+@testset "make_unique" begin
+    @test DataFrames.make_unique([:x, :x, :x_1, :x2], makeunique=true) == [:x, :x_2, :x_1, :x2]
+    @test_throws ArgumentError DataFrames.make_unique([:x, :x, :x_1, :x2], makeunique=false)
+    @test DataFrames.make_unique([:x, :x_1, :x2], makeunique=false) == [:x, :x_1, :x2]
 end
+#
+# repeat(df::AbstractDataFrame, count::Integer)
+#
+@testset "count" begin
+    df = DataFrame(a = 1:2, b = 3:4)
+    ref = DataFrame(a = repeat(1:2, 2),
+                    b = repeat(3:4, 2))
+    @test repeat(df, 2) == ref
+    @test repeat(view(df, 1:2, :), 2) == ref
+end
+#
+# repeat(df::AbstractDataFrame; inner::Integer = 1, outer::Integer = 1)
+#
+@testset "inner_outer" begin
+    df = DataFrame(a = 1:2, b = 3:4)
+    ref = DataFrame(a = repeat(1:2, inner = 2, outer = 3),
+                    b = repeat(3:4, inner = 2, outer = 3))
+    @test repeat(df, inner = 2, outer = 3) == ref
+    @test repeat(view(df, 1:2, :), inner = 2, outer = 3) == ref
+end
+
+end # module


### PR DESCRIPTION
In this PR I fix the indentation in test files to follow standard Julia recommendations.
That is: I removed indentation of code inside `module` clause.
The reason is that:
1. sometimes we did it and sometimes we did not do it
2. these 4 spaces sometimes matter for longer expressions when I want to avoid wrapping

@nalimilan I would also remove files `test/stdin.sh` and `test/data/iris.csv` as I think they are not used anywhere (but I might have missed something).