### PR TITLE
Ensure GroupedDataFrame starts at index 1

### DIFF
--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -258,6 +258,14 @@ function group_rows(df::AbstractDataFrame, hash::Bool = true, sort::Bool = false
 
     # drop group 1 which contains rows with missings in grouping columns
     if skipmissing
+        s = starts[2]
+        if s > 1
+            N = length(rperm) - s + 1
+            copyto!(rperm, 1, rperm, s, N)
+            resize!(rperm, N)
+            starts .-= s .- 1
+            stops .-= s .- 1
+        end
         popfirst!(starts)
         popfirst!(stops)
         groups .-= 1

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -6,6 +6,11 @@ module TestGrouping
     # (since == and isequal do not use it)
     function groupby_checked(df::AbstractDataFrame, keys, args...; kwargs...)
         gd = groupby(df, keys, args...; kwargs...)
+        @assert sortperm(gd.starts) == sortperm(gd.ends)
+        @assert isempty(gd.starts) || minimum(gd.starts) == 1
+        @assert isempty(gd.ends) || maximum(gd.ends) == length(gd.idx)
+        @assert length(gd.starts) == length(gd.ends)
+        @assert length(gd.idx) == count(!iszero, gd.groups)
         for i in 1:length(gd)
             @assert findall(==(i), gd.groups) == gd.idx[gd.starts[i]:gd.ends[i]]
         end


### PR DESCRIPTION
Storing indices of a ghost group could be confusing and makes the code more complex later.