### PR TITLE
use _columns in similar

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -244,7 +244,7 @@ that is different than the number of rows present in `df`.
 """
 function Base.similar(df::AbstractDataFrame, rows::Integer = size(df, 1))
     rows < 0 && throw(ArgumentError("the number of rows must be non-negative"))
-    DataFrame(AbstractVector[similar(x, rows) for x in columns(df)], copy(index(df)))
+    DataFrame(AbstractVector[similar(x, rows) for x in _columns(df)], copy(index(df)))
 end
 
 ##############################################################################


### PR DESCRIPTION
Using `_columns` gets ride of 1 level of indirection.
My bencmarks show 10% speedup,
and 1 less allocation from doing this.

using `_columns` is safe, as they are them selves passed to `similar` so the originals will not be in danger od mutation