### PR TITLE
Add an example to skip :variable and :value variable.

### DIFF
--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -244,7 +244,7 @@ julia> first(widedf, 6)
 │ 6   │ setosa        │ 6     │ 1.7         │ 0.4        │ 5.4         │ 3.9        │
 ```
 
-You can even skip the `:variable` and `:value` variables and use:
+You can even skip passing the `:variable` and `:value` values as positional arguments, as they will be used by default, and write:
 ```jldoctest reshape
 julia> widedf = unstack(longdf);
 


### PR DESCRIPTION
Add one more example to skip :variable and :value variables when using unstack().