### PR TITLE
Use optimized grouping method for PooledArrays

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -12,4 +12,4 @@ Compat 0.59.0
 Tables 0.1.14
 IteratorInterfaceExtensions 0.1.1
 TableTraits 0.4.0
-PooledArrays
+PooledArrays 0.5.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -12,3 +12,4 @@ Compat 0.59.0
 Tables 0.1.14
 IteratorInterfaceExtensions 0.1.1
 TableTraits 0.4.0
+PooledArrays

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -6,7 +6,7 @@ module DataFrames
 ##
 ##############################################################################
 
-using Reexport, StatsBase, SortingAlgorithms, Compat, Statistics, Unicode, Printf
+using Reexport, StatsBase, SortingAlgorithms, Compat, Statistics, Unicode, Printf, PooledArrays
 @reexport using CategoricalArrays, Missings
 using Base.Sort, Base.Order, Base.Iterators
 

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -149,7 +149,7 @@ end
 nlevels(x::PooledArray) = length(x.pool)
 nlevels(x) = length(levels(x))
 
-function row_group_slots(cols::NTuple{N,<:Union{CategoricalArray,PooledArray}},
+function row_group_slots(cols::NTuple{N,<:Union{CategoricalVector,PooledVector}},
                          hash::Val{false},
                          groups::Union{Vector{Int}, Nothing} = nothing,
                          skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool} where N
@@ -191,11 +191,11 @@ function row_group_slots(cols::NTuple{N,<:Union{CategoricalArray,PooledArray}},
             refmap = Vector{Int}(undef, nlevs + 1)
             refmap[1] = skipmissing ? -1 : nlevs
             refmap[2:end] .= CategoricalArrays.order(col.pool) .- 1
-        else
+        else # PooledVector
             # First value in refmap is never used
             refmap = collect(-1:nlevs-1)
             if eltype(col) >: Missing
-                missingind = get(col.pool, missing, 0)
+                missingind = get(col.invpool, missing, 0)
                 if skipmissing && missingind > 0
                     refmap[missingind+1] = -1
                     refmap[missingind+2:end] .-= 1

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -146,7 +146,10 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     return ngroups, rhashes, gslots, false
 end
 
-function row_group_slots(cols::NTuple{N,<:CategoricalVector},
+nlevels(x::PooledArray) = length(x.pool)
+nlevels(x) = length(levels(x))
+
+function row_group_slots(cols::NTuple{N,<:Union{CategoricalArray,PooledArray}},
                          hash::Val{false},
                          groups::Union{Vector{Int}, Nothing} = nothing,
                          skipmissing::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool} where N
@@ -157,7 +160,7 @@ function row_group_slots(cols::NTuple{N,<:CategoricalVector},
     # If missings are to be skipped, they will all go to group 1,
     # which will be removed by group_rows
     ngroupstup = map(cols) do c
-        length(levels(c)) + (!skipmissing && eltype(c) >: Missing)
+        nlevels(c) + (!skipmissing && eltype(c) >: Missing)
     end
     ngroups = prod(ngroupstup) + skipmissing
 
@@ -180,13 +183,25 @@ function row_group_slots(cols::NTuple{N,<:CategoricalVector},
     # which will be removed by group_rows
     seen[1] = skipmissing
     refmaps = map(cols) do col
-        # When levels are in the same order as the index and there are no missing values,
-        # we could simply use refs, but the performance gain is negligible,
-        # so always sort groups in the order of levels
-        nlevels = length(levels(col))
-        refmap = Vector{Int}(undef, nlevels + 1)
-        refmap[1] = nlevels
-        refmap[2:end] .= CategoricalArrays.order(col.pool) .- 1
+        nlevs = nlevels(col)
+        if col isa CategoricalVector
+            # When levels are in the same order as the index and there are no missing values,
+            # we could simply use refs, but the performance gain is negligible,
+            # so always sort groups in the order of levels
+            refmap = Vector{Int}(undef, nlevs + 1)
+            refmap[1] = skipmissing ? -1 : nlevs
+            refmap[2:end] .= CategoricalArrays.order(col.pool) .- 1
+        else
+            # First value in refmap is never used
+            refmap = collect(-1:nlevs-1)
+            if eltype(col) >: Missing
+                missingind = get(col.pool, missing, 0)
+                if skipmissing && missingind > 0
+                    refmap[missingind+1] = -1
+                    refmap[missingind+2:end] .-= 1
+                end
+            end
+        end
         refmap
     end
     strides = (cumprod(collect(reverse(ngroupstup)))[end-1:-1:1]..., 1)::NTuple{N,Int}
@@ -195,9 +210,10 @@ function row_group_slots(cols::NTuple{N,<:CategoricalVector},
         let i=i # Workaround for julia#15276
             refs = map(c -> c.refs[i], cols)
         end
-        j = sum(map((m, r, s) -> m[r+1] * s, refmaps, refs, strides)) + 1
+        vals = map((m, r, s) -> m[r+1] * s, refmaps, refs, strides)
+        j = sum(vals) + 1
         if skipmissing
-            j = any(iszero, refs) ? 1 : j + 1
+            j = any(x -> x < 0, vals) ? 1 : j + 1
         end
         groups[i] = j
         seen[j] = true
@@ -216,7 +232,8 @@ function row_group_slots(cols::NTuple{N,<:CategoricalVector},
         # To catch potential bugs inducing unnecessary computations
         @assert oldngroups != ngroups
     end
-    return ngroups, UInt[], Int[], true
+    sorted = all(col -> col isa CategoricalVector, cols)
+    return ngroups, UInt[], Int[], sorted
 end
 
 # Builds RowGroupDict for a given DataFrame.


### PR DESCRIPTION
The PR currently adds a dependency on PooledArrays. I'm not sure what's the best approach. We could define a custom method behind `@require PooledArrays` to avoid the dependency (calling a separate function to avoid duplicating the code). But I figured we may want to add a `pool!` function to parallel `categorical!`, in which case we would have to take the dependency anyway. Though we can defer this issue for later, and use `@require` until then.

Most of the work was to adapt tests to make them more generic. I've added a helper for that. Note that it is better to ignore whitespace to see what actually changed.

Obligatory benchmark:
```julia
using DataFrames, BenchmarkTools, PooledArrays

df1 = DataFrame(key1=categorical(string.(rand(1:10, 500_000))),
                key2=categorical(string.(rand(1:10, 500_000))));
df1p = DataFrame(key1=PooledArray(string.(rand(1:10, 500_000))),
                 key2=PooledArray(string.(rand(1:10, 500_000))));

df2 = DataFrame(key1=categorical(string.(rand(1:1000, 500_000))),
                key2=categorical(string.(rand(1:1000, 500_000))));
df2p = DataFrame(key1=PooledArray(string.(rand(1:1000, 500_000))),
                 key2=PooledArray(string.(rand(1:1000, 500_000))));

# master
julia> @btime groupby(df1, :key1);

  2.304 ms (51 allocations: 7.63 MiB)

julia> @btime groupby(df2, :key1);
  4.240 ms (51 allocations: 7.66 MiB)

julia> @btime groupby(df1, [:key1, :key2]);
  3.364 ms (53 allocations: 7.63 MiB)

julia> @btime groupby(df2, [:key1, :key2]);
  37.651 ms (59 allocations: 22.23 MiB)

julia> @btime groupby(df1p, :key1);
  28.769 ms (48 allocations: 15.45 MiB)

julia> @btime groupby(df2p, :key1);
  34.061 ms (48 allocations: 15.46 MiB)

julia> @btime groupby(df1p, [:key1, :key2]);
  58.622 ms (499949 allocations: 23.08 MiB)

julia> @btime groupby(df2p, [:key1, :key2]);
  82.056 ms (106523 allocations: 23.08 MiB)


# This PR
julia> @btime groupby(df1, :key1);
  2.357 ms (51 allocations: 7.63 MiB)

julia> @btime groupby(df2, :key1);
  4.197 ms (51 allocations: 7.66 MiB)

julia> @btime groupby(df1, [:key1, :key2]);
  3.337 ms (53 allocations: 7.63 MiB)

julia> @btime groupby(df2, [:key1, :key2]);
  41.909 ms (59 allocations: 22.23 MiB)


julia> @btime groupby(df1p, :key1);
  2.308 ms (51 allocations: 7.63 MiB)

julia> @btime groupby(df2p, :key1);
  4.163 ms (51 allocations: 7.66 MiB)

julia> @btime groupby(df1p, [:key1, :key2]);
  3.249 ms (53 allocations: 7.63 MiB)

julia> @btime groupby(df2p, [:key1, :key2]);
  37.511 ms (59 allocations: 22.24 MiB)
```