### PR TITLE
Undeprecate DataFrameRow constructor, fix line length, reorganize tests

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -69,7 +69,6 @@ end
 Base.@propagate_inbounds DataFrameRow(df::AbstractDataFrame, row::Integer) =
     DataFrameRow(df, row, :)
 
-
 row(r::DataFrameRow) = getfield(r, :row)
 Base.parent(r::DataFrameRow) = getfield(r, :df)
 Base.parentindices(r::DataFrameRow) = (row(r), parentcols(index(r)))

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -3,7 +3,7 @@
 
 A view of one row of an `AbstractDataFrame`.
 
-A `DataFrameRow` is constructed with `view` or `getindex` when one row and a
+A `DataFrameRow` is returned by `getindex` or `view` functions when one row and a
 selection of columns are requested, or when iterating the result
 of the call to the [`eachrow`](@ref) function.
 

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -7,6 +7,12 @@ A `DataFrameRow` is constructed with `view` or `getindex` when one row and a
 selection of columns are requested, or when iterating the result
 of the call to the [`eachrow`](@ref) function.
 
+You can also call a `DataFrameRow` constructor directly using the following syntax:
+
+```
+DataFrameRow(parent::AbstractDataFrame, row::Integer, cols=:)
+```
+
 A `DataFrameRow` supports the iteration interface and can therefore be passed to
 functions that expect a collection as an argument.
 
@@ -30,6 +36,8 @@ df = DataFrame(a = repeat([1, 2, 3, 4], outer=[2]),
 sdf1 = view(df, 2, :)
 sdf2 = @view df[end, [:a]]
 sdf3 = eachrow(df)[1]
+sdf4 = DataFrameRow(df, 2, 1:2)
+sdf5 = DataFrameRow(df, 1)
 ```
 """
 struct DataFrameRow{D<:AbstractDataFrame,S<:AbstractIndex}
@@ -37,8 +45,8 @@ struct DataFrameRow{D<:AbstractDataFrame,S<:AbstractIndex}
     colindex::S
     row::Int
 
-    @inline DataFrameRow(df::D, colindex::S, row::Union{Signed, Unsigned}) where {D<:AbstractDataFrame,S<:AbstractIndex} =
-        new{D,S}(df, colindex, row)
+    @inline DataFrameRow(df::D, colindex::S, row::Union{Signed, Unsigned}) where
+        {D<:AbstractDataFrame,S<:AbstractIndex} = new{D,S}(df, colindex, row)
 end
 
 Base.@propagate_inbounds function DataFrameRow(df::DataFrame, row::Integer, cols)
@@ -58,16 +66,22 @@ Base.@propagate_inbounds function DataFrameRow(sdf::SubDataFrame, row::Integer, 
     @inbounds DataFrameRow(parent(sdf), colindex, rows(sdf)[row])
 end
 
+Base.@propagate_inbounds DataFrameRow(df::AbstractDataFrame, row::Integer) =
+    DataFrameRow(df, row, :)
+
+
 row(r::DataFrameRow) = getfield(r, :row)
 Base.parent(r::DataFrameRow) = getfield(r, :df)
 Base.parentindices(r::DataFrameRow) = (row(r), parentcols(index(r)))
 
 Base.@propagate_inbounds Base.view(adf::AbstractDataFrame, rowind::Integer, ::Colon) =
     DataFrameRow(adf, rowind, :)
-Base.@propagate_inbounds Base.view(adf::AbstractDataFrame, rowind::Integer, colinds::AbstractVector) =
+Base.@propagate_inbounds Base.view(adf::AbstractDataFrame, rowind::Integer,
+                                   colinds::AbstractVector) =
     DataFrameRow(adf, rowind, colinds)
 
-Base.@propagate_inbounds Base.getindex(df::AbstractDataFrame, rowind::Integer, colinds::AbstractVector) =
+Base.@propagate_inbounds Base.getindex(df::AbstractDataFrame, rowind::Integer,
+                                       colinds::AbstractVector) =
     DataFrameRow(df, rowind, colinds)
 Base.@propagate_inbounds Base.getindex(df::AbstractDataFrame, rowind::Integer, ::Colon) =
     DataFrameRow(df, rowind, :)
@@ -140,7 +154,8 @@ Base.Vector(dfr::DataFrameRow) = convert(Vector, dfr)
 Base.Vector{T}(dfr::DataFrameRow) where T = convert(Vector{T}, dfr)
 
 Base.keys(r::DataFrameRow) = names(r)
-Base.values(r::DataFrameRow) = ntuple(col -> parent(r)[row(r), parentcols(index(r), col)], length(r))
+Base.values(r::DataFrameRow) =
+    ntuple(col -> parent(r)[row(r), parentcols(index(r), col)], length(r))
 
 """
     copy(dfr::DataFrameRow)
@@ -150,8 +165,10 @@ Convert a `DataFrameRow` to a `NamedTuple`.
 Base.copy(r::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
 
 # hash column element
-Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) = hash(v[i], h)
-Base.@propagate_inbounds function hash_colel(v::AbstractCategoricalArray, i, h::UInt = zero(UInt))
+Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) =
+    hash(v[i], h)
+Base.@propagate_inbounds function hash_colel(v::AbstractCategoricalArray, i,
+                                             h::UInt = zero(UInt))
     ref = v.refs[i]
     if eltype(v) >: Missing && ref == 0
         hash(missing, h)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -7,7 +7,7 @@ A `DataFrameRow` is constructed with `view` or `getindex` when one row and a
 selection of columns are requested, or when iterating the result
 of the call to the [`eachrow`](@ref) function.
 
-You can also call a `DataFrameRow` constructor directly using the following syntax:
+The `DataFrameRow` constructor can also be called directly:
 
 ```
 DataFrameRow(parent::AbstractDataFrame, row::Integer, cols=:)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1374,6 +1374,5 @@ import Base: convert
 @deprecate convert(::Type{Array{T}}, df::AbstractDataFrame) where {T} convert(Matrix{T}, df)
 @deprecate convert(::Type{Array}, dfr::DataFrameRow) permutedims(Vector(dfr))
 
-@deprecate DataFrameRow(df::AbstractDataFrame, row::Integer) DataFrameRow(df, row, :)
 @deprecate SubDataFrame(df::AbstractDataFrame, rows::AbstractVector{<:Integer}) SubDataFrame(df, rows, :)
 @deprecate SubDataFrame(df::AbstractDataFrame, ::Colon) SubDataFrame(df, :, :)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -1,13 +1,15 @@
 module TestDataFrameRow
 
-using Test, DataFrames
+using Test, DataFrames, Random
 using DataFrames: columns
 
-@testset "constructors" begin
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+ref_df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
                    b=[2.0, missing, 1.2, 2.0, missing, missing],
                    c=["A", "B", "C", "A", "B", missing],
                    d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+
+@testset "constructors" begin
+    df = deepcopy(ref_df)
     sdf = view(df, [5, 3], [3, 1, 2])
 
     @test names(DataFrameRow(df, 1, :)) == [:a, :b, :c, :d]
@@ -39,10 +41,7 @@ using DataFrames: columns
 end
 
 @testset "getindex and setindex!" begin
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing],
-                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    df = deepcopy(ref_df)
     sdf = view(df, [5, 3], [3, 1, 2])
 
     r = DataFrameRow(df, 2, :)
@@ -81,10 +80,7 @@ end
 end
 
 @testset "equality" begin
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing],
-                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    df = deepcopy(ref_df)
     df2 = DataFrame(a = [1, 2, 3])
 
     @test DataFrameRow(df, 1, :) != DataFrameRow(df2, 1, :)
@@ -111,30 +107,27 @@ end
 end
 
 @testset "isless" begin
-    df4 = DataFrame(a=[1, 1, 2, 2, 2, 2, missing, missing],
-                    b=Union{Float64, Missing}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
-                    c=[:B, missing, :A, :C, :D, :D, :A, :A])
+    df = DataFrame(a=[1, 1, 2, 2, 2, 2, missing, missing],
+                   b=Union{Float64, Missing}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
+                   c=[:B, missing, :A, :C, :D, :D, :A, :A])
 
-    @test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 2, :))
-    @test !isless(DataFrameRow(df4, 2, :), DataFrameRow(df4, 1, :))
-    @test !isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 1, :))
-    @test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 3, :))
-    @test !isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 1, :))
-    @test isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 4, :))
-    @test !isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 3, :))
-    @test isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 5, :))
-    @test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 4, :))
-    @test !isless(DataFrameRow(df4, 6, :), DataFrameRow(df4, 5, :))
-    @test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 6, :))
-    @test isless(DataFrameRow(df4, 7, :), DataFrameRow(df4, 8, :))
-    @test !isless(DataFrameRow(df4, 8, :), DataFrameRow(df4, 7, :))
+    @test isless(DataFrameRow(df, 1, :), DataFrameRow(df, 2, :))
+    @test !isless(DataFrameRow(df, 2, :), DataFrameRow(df, 1, :))
+    @test !isless(DataFrameRow(df, 1, :), DataFrameRow(df, 1, :))
+    @test isless(DataFrameRow(df, 1, :), DataFrameRow(df, 3, :))
+    @test !isless(DataFrameRow(df, 3, :), DataFrameRow(df, 1, :))
+    @test isless(DataFrameRow(df, 3, :), DataFrameRow(df, 4, :))
+    @test !isless(DataFrameRow(df, 4, :), DataFrameRow(df, 3, :))
+    @test isless(DataFrameRow(df, 4, :), DataFrameRow(df, 5, :))
+    @test !isless(DataFrameRow(df, 5, :), DataFrameRow(df, 4, :))
+    @test !isless(DataFrameRow(df, 6, :), DataFrameRow(df, 5, :))
+    @test !isless(DataFrameRow(df, 5, :), DataFrameRow(df, 6, :))
+    @test isless(DataFrameRow(df, 7, :), DataFrameRow(df, 8, :))
+    @test !isless(DataFrameRow(df, 8, :), DataFrameRow(df, 7, :))
 end
 
 @testset "hashing" begin
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing],
-                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    df = deepcopy(ref_df)
 
     @test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 2, :))
     @test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 3, :))
@@ -149,34 +142,30 @@ end
 
 @testset "grouping" begin
     # test RowGroupDict
-    N = 20
-    d1 = rand(map(Int64, 1:2), N)
-    df5 = DataFrame([d1], [:d1])
-    df6 = DataFrame(d1 = [2,3])
+    Random.seed!(1234)
+    df1 = DataFrame(d1=rand(1:2, 1000))
+    df2 = DataFrame(d1=[2,3])
 
     # test_group("group_rows")
-    gd = DataFrames.group_rows(df5)
+    gd = DataFrames.group_rows(df1)
     @test length(unique(gd.groups)) == 2
 
     # getting groups for the rows of the other frames
-    @test length(gd[DataFrameRow(df6, 1, :)]) > 0
-    @test_throws KeyError gd[DataFrameRow(df6, 2, :)]
-    @test isempty(DataFrames.findrows(gd, df6, (gd.df[1],), (df6[1],), 2))
+    @test length(gd[DataFrameRow(df2, 1, :)]) > 0
+    @test_throws KeyError gd[DataFrameRow(df2, 2, :)]
+    @test isempty(DataFrames.findrows(gd, df2, (gd.df[1],), (df2[1],), 2))
 
     # grouping empty frame
     gd = DataFrames.group_rows(DataFrame(x=Int[]))
     @test length(unique(gd.groups)) == 0
 
     # grouping single row
-    gd = DataFrames.group_rows(df5[1:1,:])
+    gd = DataFrames.group_rows(df1[1:1,:])
     @test length(unique(gd.groups)) == 1
 end
 
 @testset "getproperty, setproperty! and propertynames" begin
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing],
-                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    df = deepcopy(ref_df)
 
     r = DataFrameRow(df, 1, :)
     @test Base.propertynames(r) == names(df)
@@ -191,10 +180,7 @@ end
 end
 
 @testset "keys, values and iteration, size" begin
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing],
-                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    df = deepcopy(ref_df)
     r = DataFrameRow(df, 1, :)
 
     @test keys(r) == names(df)
@@ -239,17 +225,13 @@ end
     @test Vector(dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
     @test Vector{Int}(dfr)::Vector{Int} == [1, 2]
 
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing])
+    df = df[1:3]
     @test copy(DataFrameRow(df, 1, :)) == (a = 1, b = 2.0, c = "A")
     @test isequal(copy(DataFrameRow(df, 2, :)), (a = 2, b = missing, c = "B"))
 end
 
 @testset "parent and parentindices" begin
-    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-                   b=[2.0, missing, 1.2, 2.0, missing, missing],
-                   c=["A", "B", "C", "A", "B", missing])
+    df = deepcopy(ref_df)[1:3]
 
     @test parent(df[2, :]) === df
     @test parentindices(df[2, :]) == (2, Base.OneTo(3))

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -3,226 +3,281 @@ module TestDataFrameRow
 using Test, DataFrames
 using DataFrames: columns
 
-df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-               b=[2.0, missing, 1.2, 2.0, missing, missing],
-               c=["A", "B", "C", "A", "B", missing],
-               d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
-df2 = DataFrame(a = [1, 2, 3])
-sdf = view(df, [5, 3], [3, 1, 2])
+@testset "constructors" begin
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing],
+                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    sdf = view(df, [5, 3], [3, 1, 2])
 
-@test names(DataFrameRow(df, 1, :)) == [:a, :b, :c, :d]
-@test names(DataFrameRow(df, 3, [3, 2])) == [:c, :b]
-@test copy(DataFrameRow(df, 3, [3, 2])) == (c = "C", b = 1.2)
-@test copy(DataFrameRow(sdf, 2, [3, 2])) == (b = 1.2, a = 3)
-@test copy(DataFrameRow(sdf, 2, :)) == (c = "C", a = 3, b = 1.2)
-@test DataFrameRow(df, 3, [3, 2]) == df[3, [3, 2]] == view(df, 3, [3, 2])
-@test DataFrameRow(sdf, 2, [3, 2]) == sdf[2, [3, 2]] == view(sdf, 2, [3, 2])
-@test DataFrameRow(sdf, 2, :) == sdf[2, :] == view(sdf, 2, :)
-@test DataFrameRow(df, 3, 2:3) === df[3, 2:3]
-@test view(df, 3, 2:3) === df[3, 2:3]
-@test_throws ArgumentError DataFrameRow(df, 1, :a)
-@test_throws ArgumentError DataFrameRow(df, 1, 1)
-@test_throws BoundsError DataFrameRow(df, 1, 1:10)
-@test_throws BoundsError DataFrameRow(df, 1, [1:10;])
-@test_throws BoundsError DataFrameRow(df, 100, 1:2)
-@test_throws BoundsError DataFrameRow(df, 100, [1:2;])
-@test_throws BoundsError DataFrameRow(df, 100, :)
-@test_throws MethodError DataFrameRow(df, true, 1:2)
-if VERSION ≥ v"1.0.0"
-    # this test throws a warning on Julia 0.7
-    @test_throws ArgumentError DataFrameRow(sdf, true, 1:2)
+    @test names(DataFrameRow(df, 1, :)) == [:a, :b, :c, :d]
+    @test DataFrameRow(df, 1) == DataFrameRow(df, 1, :)
+    @test names(DataFrameRow(df, 3, [3, 2])) == [:c, :b]
+    @test copy(DataFrameRow(df, 3, [3, 2])) == (c = "C", b = 1.2)
+    @test copy(DataFrameRow(sdf, 2, [3, 2])) == (b = 1.2, a = 3)
+    @test copy(DataFrameRow(sdf, 2, :)) == (c = "C", a = 3, b = 1.2)
+    @test DataFrameRow(sdf, 2) == DataFrameRow(sdf, 2, :)
+    @test DataFrameRow(df, 3, [3, 2]) == df[3, [3, 2]] == view(df, 3, [3, 2])
+    @test DataFrameRow(sdf, 2, [3, 2]) == sdf[2, [3, 2]] == view(sdf, 2, [3, 2])
+    @test DataFrameRow(sdf, 2, :) == sdf[2, :] == view(sdf, 2, :)
+    @test DataFrameRow(df, 3, 2:3) === df[3, 2:3]
+    @test view(df, 3, 2:3) === df[3, 2:3]
+    @test_throws ArgumentError DataFrameRow(df, 1, :a)
+    @test_throws ArgumentError DataFrameRow(df, 1, 1)
+    @test_throws BoundsError DataFrameRow(df, 1, 1:10)
+    @test_throws BoundsError DataFrameRow(df, 1, [1:10;])
+    @test_throws BoundsError DataFrameRow(df, 100, 1:2)
+    @test_throws BoundsError DataFrameRow(df, 100, [1:2;])
+    @test_throws BoundsError DataFrameRow(df, 100, :)
+    @test_throws BoundsError DataFrameRow(df, 100)
+    @test_throws MethodError DataFrameRow(df, true, 1:2)
+    @test_throws MethodError DataFrameRow(df, true)
+    if VERSION ≥ v"1.0.0"
+        # this test throws a warning on Julia 0.7
+        @test_throws ArgumentError DataFrameRow(sdf, true, 1:2)
+    end
 end
 
-# getindex
-r = DataFrameRow(df, 2, :)
-@test r[:] === r
-@test view(r, :) === r
-@test r[3] == "B"
-@test_throws BoundsError r[5]
-@test view(r, 3)[] == "B"
-view(r, 3)[] = "BB"
-@test df.c[2] == "BB"
-@test_throws MethodError r[true]
-@test_throws MethodError view(r, true)
-@test copy(r[[:c,:a]]) == (c = "BB", a = 2)
-@test copy(view(r, [:c,:a])) == (c = "BB", a = 2)
-@test copy(r[[true, false, true, false]]) == (a = 2, c = "BB")
-r.c = "B"
-@test df.c[2] == "B"
-@test_throws BoundsError copy(r[[true, false, true]])
+@testset "getindex and setindex!" begin
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing],
+                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    sdf = view(df, [5, 3], [3, 1, 2])
 
-r = DataFrameRow(sdf, 2, [3, 1])
-@test r[:] == r
-@test view(r, :) === r
-@test r[2] == "C"
-@test_throws BoundsError r[4]
-@test view(r, 2)[] == "C"
-view(r, 2)[] = "CC"
-@test df.c[3] == "CC"
-@test_throws MethodError r[true]
-@test_throws MethodError view(r, true)
-@test copy(r[[:c,:b]]) == (c = "CC", b = 1.2)
-@test copy(view(r, [:c,:b])) == (c = "CC", b = 1.2)
-@test copy(view(r, [:c,:b])) == (c = "CC", b = 1.2)
-@test copy(r[[false, true]]) == (c = "CC",)
-r.c = "C"
-@test df.c[3] == "C"
+    r = DataFrameRow(df, 2, :)
+    @test r[:] === r
+    @test view(r, :) === r
+    @test r[3] == "B"
+    @test_throws BoundsError r[5]
+    @test view(r, 3)[] == "B"
+    view(r, 3)[] = "BB"
+    @test df.c[2] == "BB"
+    @test_throws MethodError r[true]
+    @test_throws MethodError view(r, true)
+    @test copy(r[[:c,:a]]) == (c = "BB", a = 2)
+    @test copy(view(r, [:c,:a])) == (c = "BB", a = 2)
+    @test copy(r[[true, false, true, false]]) == (a = 2, c = "BB")
+    r.c = "B"
+    @test df.c[2] == "B"
+    @test_throws BoundsError copy(r[[true, false, true]])
 
-#
-# Equality
-#
-@test DataFrameRow(df, 1, :) != DataFrameRow(df2, 1, :)
-@test DataFrameRow(df, 1, [:a]) == DataFrameRow(df2, 1, :)
-@test DataFrameRow(df, 1, [:a]) == DataFrameRow(df2, big(1), :)
-@test DataFrameRow(df, 1, :) != DataFrameRow(df, 2, :)
-@test DataFrameRow(df, 1, :) != DataFrameRow(df, 3, :)
-@test DataFrameRow(df, 1, :) == DataFrameRow(df, 4, :)
-@test ismissing(DataFrameRow(df, 2, :) == DataFrameRow(df, 5, :))
-@test isequal(DataFrameRow(df, 2, :), DataFrameRow(df, 5, :))
-@test ismissing(DataFrameRow(df, 2, :) != DataFrameRow(df, 6, :))
-@test !isequal(DataFrameRow(df, 2, :), DataFrameRow(df, 6, :))
-
-# isless()
-df4 = DataFrame(a=[1, 1, 2, 2, 2, 2, missing, missing],
-                b=Union{Float64, Missing}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
-                c=[:B, missing, :A, :C, :D, :D, :A, :A])
-@test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 2, :))
-@test !isless(DataFrameRow(df4, 2, :), DataFrameRow(df4, 1, :))
-@test !isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 1, :))
-@test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 3, :))
-@test !isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 1, :))
-@test isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 4, :))
-@test !isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 3, :))
-@test isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 5, :))
-@test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 4, :))
-@test !isless(DataFrameRow(df4, 6, :), DataFrameRow(df4, 5, :))
-@test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 6, :))
-@test isless(DataFrameRow(df4, 7, :), DataFrameRow(df4, 8, :))
-@test !isless(DataFrameRow(df4, 8, :), DataFrameRow(df4, 7, :))
-
-# hashing
-@test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 2, :))
-@test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 3, :))
-@test hash(DataFrameRow(df, 1, :)) == hash(DataFrameRow(df, 4, :))
-@test hash(DataFrameRow(df, 2, :)) == hash(DataFrameRow(df, 5, :))
-@test hash(DataFrameRow(df, 2, :)) != hash(DataFrameRow(df, 6, :))
-
-# check that hashrows() function generates the same hashes as DataFrameRow
-df_rowhashes, _ = DataFrames.hashrows(Tuple(columns(df)), false)
-@test df_rowhashes == [hash(dr) for dr in eachrow(df)]
-
-# test incompatible frames
-@test_throws UndefVarError DataFrameRow(df, 1, :) == DataFrameRow(df3, 1, :)
-
-# test RowGroupDict
-N = 20
-d1 = rand(map(Int64, 1:2), N)
-df5 = DataFrame([d1], [:d1])
-df6 = DataFrame(d1 = [2,3])
-
-# test_group("group_rows")
-gd = DataFrames.group_rows(df5)
-@test length(unique(gd.groups)) == 2
-
-# getting groups for the rows of the other frames
-@test length(gd[DataFrameRow(df6, 1, :)]) > 0
-@test_throws KeyError gd[DataFrameRow(df6, 2, :)]
-@test isempty(DataFrames.findrows(gd, df6, (gd.df[1],), (df6[1],), 2))
-
-# grouping empty frame
-gd = DataFrames.group_rows(DataFrame(x=Int[]))
-@test length(unique(gd.groups)) == 0
-
-# grouping single row
-gd = DataFrames.group_rows(df5[1:1,:])
-@test length(unique(gd.groups)) == 1
-
-# getproperty, setproperty! and propertynames
-r = DataFrameRow(df, 1, :)
-@test Base.propertynames(r) == names(df)
-@test r.a === 1
-@test r.b === 2.0
-@test copy(r[[:a,:b]]) === (a=1, b=2.0)
-
-r.a = 2
-@test r.a === 2
-r.b = 1
-@test r.b === 1.0
-
-# keys, values and iteration, size
-@test keys(r) == names(df)
-@test values(r) == (df[1, 1], df[1, 2], df[1, 3], df[1, 4])
-@test collect(pairs(r)) == [:a=>df[1, 1], :b=>df[1, 2], :c=>df[1, 3], :d=>df[1, 4]]
-
-@test haskey(r, :a)
-@test haskey(r, 1)
-@test !haskey(r, :zzz)
-@test !haskey(r, 0)
-@test !haskey(r, 1000)
-@test_throws ArgumentError haskey(r, true)
-
-x = DataFrame(ones(5,4))
-dfr = view(x, 2, 2:3)
-@test names(dfr) == names(x)[2:3]
-dfr = view(x, 2, [4,2])
-@test names(dfr) == names(x)[[4,2]]
-
-x = DataFrame(ones(10,10))
-r = x[3, [8, 5, 1, 3]]
-@test length(r) == 4
-@test lastindex(r) == 4
-@test ndims(r) == 1
-@test ndims(typeof(r)) == 1
-@test size(r) == (4,)
-@test size(r, 1) == 4
-@test_throws BoundsError size(r, 2)
-@test keys(r) == [:x8, :x5, :x1, :x3]
-r[:] = 0.0
-r[1:2] = 2.0
-@test values(r) == (2.0, 2.0, 0.0, 0.0)
-@test collect(pairs(r)) == [:x8 => 2.0, :x5 => 2.0, :x1 => 0.0, :x3 => 0.0]
-
-# convert
-df = DataFrame(a=[1, missing], b=[2.0, 3.0])
-dfr = DataFrameRow(df, 1, :)
-@test convert(Vector, dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
-@test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]
-@test Vector(dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
-@test Vector{Int}(dfr)::Vector{Int} == [1, 2]
-
-# copy
-df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
-               b=[2.0, missing, 1.2, 2.0, missing, missing],
-               c=["A", "B", "C", "A", "B", missing])
-@test copy(DataFrameRow(df, 1, :)) == (a = 1, b = 2.0, c = "A")
-@test isequal(copy(DataFrameRow(df, 2, :)), (a = 2, b = missing, c = "B"))
-
-# parent and parentindices
-@test parent(df[2, :]) === df
-@test parentindices(df[2, :]) == (2, Base.OneTo(3))
-@test parent(df[1, 1:3]) === df
-@test parentindices(df[1, [3,2]]) == (1, [3, 2])
-sdf = view(df, [4,3], [:c, :a])
-@test parent(sdf[2, :]) === df
-@test parentindices(sdf[2, :]) == (3, [3, 1])
-@test parent(sdf[1, 1:2]) === df
-@test parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
-
-# iteration and collect
-ref = ["a", "b", "c"]
-df = DataFrame(permutedims(ref))
-dfr = df[1, :]
-@test Base.IteratorEltype(dfr) == Base.EltypeUnknown()
-@test collect(dfr) == ref
-@test eltype(collect(dfr)) === String
-for (v1, v2) in zip(ref, dfr)
-    @test v1 == v2
+    r = DataFrameRow(sdf, 2, [3, 1])
+    @test r[:] == r
+    @test view(r, :) === r
+    @test r[2] == "C"
+    @test_throws BoundsError r[4]
+    @test view(r, 2)[] == "C"
+    view(r, 2)[] = "CC"
+    @test df.c[3] == "CC"
+    @test_throws MethodError r[true]
+    @test_throws MethodError view(r, true)
+    @test copy(r[[:c,:b]]) == (c = "CC", b = 1.2)
+    @test copy(view(r, [:c,:b])) == (c = "CC", b = 1.2)
+    @test copy(view(r, [:c,:b])) == (c = "CC", b = 1.2)
+    @test copy(r[[false, true]]) == (c = "CC",)
+    r.c = "C"
+    @test df.c[3] == "C"
 end
-for (i, v) in enumerate(dfr)
-    @test v == ref[i]
+
+@testset "equality" begin
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing],
+                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    df2 = DataFrame(a = [1, 2, 3])
+
+    @test DataFrameRow(df, 1, :) != DataFrameRow(df2, 1, :)
+    @test DataFrameRow(df, 1, [:a]) == DataFrameRow(df2, 1, :)
+    @test DataFrameRow(df, 1, [:a]) == DataFrameRow(df2, big(1), :)
+    @test DataFrameRow(df, 1, :) != DataFrameRow(df, 2, :)
+    @test DataFrameRow(df, 1, :) != DataFrameRow(df, 3, :)
+    @test DataFrameRow(df, 1, :) == DataFrameRow(df, 4, :)
+    @test ismissing(DataFrameRow(df, 2, :) == DataFrameRow(df, 5, :))
+    @test isequal(DataFrameRow(df, 2, :), DataFrameRow(df, 5, :))
+    @test ismissing(DataFrameRow(df, 2, :) != DataFrameRow(df, 6, :))
+    @test !isequal(DataFrameRow(df, 2, :), DataFrameRow(df, 6, :))
+
+    dc_df = deepcopy(df)
+    @test DataFrameRow(df, 1, :) == DataFrameRow(dc_df, 1, :)
+    @test DataFrameRow(df, 1, 1:2) == DataFrameRow(dc_df, 1, 1:2)
+    @test DataFrameRow(df, 1, [1,2]) != DataFrameRow(dc_df, 1, [2,1])
+    dc_df[1,1] = 2
+    @test DataFrameRow(df, 1, :) != DataFrameRow(dc_df, 1, :)
+    @test DataFrameRow(df, 1, 1:2) != DataFrameRow(dc_df, 1, 1:2)
+    @test DataFrameRow(df, 1, [2]) == DataFrameRow(dc_df, 1, [2])
+    rename!(df, :b=>:z)
+    @test DataFrameRow(df, 1, [2]) != DataFrameRow(dc_df, 1, [2])
 end
-dfr = DataFrame(a=1, b=true, c=1.0)[1,:]
-@test eltype(collect(dfr)) === Real
+
+@testset "isless" begin
+    df4 = DataFrame(a=[1, 1, 2, 2, 2, 2, missing, missing],
+                    b=Union{Float64, Missing}[2.0, 3.0, 1.0, 2.0, 2.0, 2.0, 2.0, 3.0],
+                    c=[:B, missing, :A, :C, :D, :D, :A, :A])
+
+    @test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 2, :))
+    @test !isless(DataFrameRow(df4, 2, :), DataFrameRow(df4, 1, :))
+    @test !isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 1, :))
+    @test isless(DataFrameRow(df4, 1, :), DataFrameRow(df4, 3, :))
+    @test !isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 1, :))
+    @test isless(DataFrameRow(df4, 3, :), DataFrameRow(df4, 4, :))
+    @test !isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 3, :))
+    @test isless(DataFrameRow(df4, 4, :), DataFrameRow(df4, 5, :))
+    @test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 4, :))
+    @test !isless(DataFrameRow(df4, 6, :), DataFrameRow(df4, 5, :))
+    @test !isless(DataFrameRow(df4, 5, :), DataFrameRow(df4, 6, :))
+    @test isless(DataFrameRow(df4, 7, :), DataFrameRow(df4, 8, :))
+    @test !isless(DataFrameRow(df4, 8, :), DataFrameRow(df4, 7, :))
+end
+
+@testset "hashing" begin
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing],
+                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+
+    @test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 2, :))
+    @test hash(DataFrameRow(df, 1, :)) != hash(DataFrameRow(df, 3, :))
+    @test hash(DataFrameRow(df, 1, :)) == hash(DataFrameRow(df, 4, :))
+    @test hash(DataFrameRow(df, 2, :)) == hash(DataFrameRow(df, 5, :))
+    @test hash(DataFrameRow(df, 2, :)) != hash(DataFrameRow(df, 6, :))
+
+    # check that hashrows() function generates the same hashes as DataFrameRow
+    df_rowhashes, _ = DataFrames.hashrows(Tuple(columns(df)), false)
+    @test df_rowhashes == [hash(dr) for dr in eachrow(df)]
+end
+
+@testset "grouping" begin
+    # test RowGroupDict
+    N = 20
+    d1 = rand(map(Int64, 1:2), N)
+    df5 = DataFrame([d1], [:d1])
+    df6 = DataFrame(d1 = [2,3])
+
+    # test_group("group_rows")
+    gd = DataFrames.group_rows(df5)
+    @test length(unique(gd.groups)) == 2
+
+    # getting groups for the rows of the other frames
+    @test length(gd[DataFrameRow(df6, 1, :)]) > 0
+    @test_throws KeyError gd[DataFrameRow(df6, 2, :)]
+    @test isempty(DataFrames.findrows(gd, df6, (gd.df[1],), (df6[1],), 2))
+
+    # grouping empty frame
+    gd = DataFrames.group_rows(DataFrame(x=Int[]))
+    @test length(unique(gd.groups)) == 0
+
+    # grouping single row
+    gd = DataFrames.group_rows(df5[1:1,:])
+    @test length(unique(gd.groups)) == 1
+end
+
+@testset "getproperty, setproperty! and propertynames" begin
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing],
+                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+
+    r = DataFrameRow(df, 1, :)
+    @test Base.propertynames(r) == names(df)
+    @test r.a === 1
+    @test r.b === 2.0
+    @test copy(r[[:a,:b]]) === (a=1, b=2.0)
+
+    r.a = 2
+    @test r.a === 2
+    r.b = 1
+    @test r.b === 1.0
+end
+
+@testset "keys, values and iteration, size" begin
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing],
+                   d=CategoricalArray([:A, missing, :C, :A, missing, :C]))
+    r = DataFrameRow(df, 1, :)
+
+    @test keys(r) == names(df)
+    @test values(r) == (df[1, 1], df[1, 2], df[1, 3], df[1, 4])
+    @test collect(pairs(r)) == [:a=>df[1, 1], :b=>df[1, 2], :c=>df[1, 3], :d=>df[1, 4]]
+
+    @test haskey(r, :a)
+    @test haskey(r, 1)
+    @test !haskey(r, :zzz)
+    @test !haskey(r, 0)
+    @test !haskey(r, 1000)
+    @test_throws ArgumentError haskey(r, true)
+
+    x = DataFrame(ones(5,4))
+    dfr = view(x, 2, 2:3)
+    @test names(dfr) == names(x)[2:3]
+    dfr = view(x, 2, [4,2])
+    @test names(dfr) == names(x)[[4,2]]
+
+    x = DataFrame(ones(10,10))
+    r = x[3, [8, 5, 1, 3]]
+    @test length(r) == 4
+    @test lastindex(r) == 4
+    @test ndims(r) == 1
+    @test ndims(typeof(r)) == 1
+    @test size(r) == (4,)
+    @test size(r, 1) == 4
+    @test_throws BoundsError size(r, 2)
+    @test keys(r) == [:x8, :x5, :x1, :x3]
+    r[:] = 0.0
+    r[1:2] = 2.0
+    @test values(r) == (2.0, 2.0, 0.0, 0.0)
+    @test collect(pairs(r)) == [:x8 => 2.0, :x5 => 2.0, :x1 => 0.0, :x3 => 0.0]
+end
+
+@testset "convert and copy" begin
+    df = DataFrame(a=[1, missing], b=[2.0, 3.0])
+    dfr = DataFrameRow(df, 1, :)
+
+    @test convert(Vector, dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
+    @test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]
+    @test Vector(dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
+    @test Vector{Int}(dfr)::Vector{Int} == [1, 2]
+
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing])
+    @test copy(DataFrameRow(df, 1, :)) == (a = 1, b = 2.0, c = "A")
+    @test isequal(copy(DataFrameRow(df, 2, :)), (a = 2, b = missing, c = "B"))
+end
+
+@testset "parent and parentindices" begin
+    df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
+                   b=[2.0, missing, 1.2, 2.0, missing, missing],
+                   c=["A", "B", "C", "A", "B", missing])
+
+    @test parent(df[2, :]) === df
+    @test parentindices(df[2, :]) == (2, Base.OneTo(3))
+    @test parent(df[1, 1:3]) === df
+    @test parentindices(df[1, [3,2]]) == (1, [3, 2])
+    sdf = view(df, [4,3], [:c, :a])
+    @test parent(sdf[2, :]) === df
+    @test parentindices(sdf[2, :]) == (3, [3, 1])
+    @test parent(sdf[1, 1:2]) === df
+    @test parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
+end
+
+@testset "iteration and collect" begin
+    ref = ["a", "b", "c"]
+    df = DataFrame(permutedims(ref))
+    dfr = df[1, :]
+    @test Base.IteratorEltype(dfr) == Base.EltypeUnknown()
+    @test collect(dfr) == ref
+    @test eltype(collect(dfr)) === String
+    for (v1, v2) in zip(ref, dfr)
+        @test v1 == v2
+    end
+    for (i, v) in enumerate(dfr)
+        @test v == ref[i]
+    end
+    dfr = DataFrame(a=1, b=true, c=1.0)[1,:]
+    @test eltype(collect(dfr)) === Real
+end
 
 @testset "duplicate column" begin
     df = DataFrame([11:16 21:26 31:36 41:46])

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -225,7 +225,7 @@ end
     @test Vector(dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
     @test Vector{Int}(dfr)::Vector{Int} == [1, 2]
 
-    df = df[1:3]
+    df = deepcopy(ref_df)[1:3]
     @test copy(DataFrameRow(df, 1, :)) == (a = 1, b = 2.0, c = "A")
     @test isequal(copy(DataFrameRow(df, 2, :)), (a = 2, b = missing, c = "B"))
 end


### PR DESCRIPTION
This fixes https://github.com/JuliaData/DataFrames.jl/issues/1696.
Additionally I have cleaned up some related line length issues in the code
and reorganized test code, because it was hard to reason about.