### PR TITLE
Improve groupby

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -79,7 +79,7 @@ end
 """
 function groupby(df::AbstractDataFrame, cols::AbstractVector;
                  sort::Bool = false, skipmissing::Bool = false)
-    intcols = index(df)[cols]
+    intcols = convert(Vector{Int}, index(df)[cols])
     sdf = df[intcols]
     df_groups = group_rows(sdf, false, sort, skipmissing)
     GroupedDataFrame(df, intcols, df_groups.groups, df_groups.rperm,

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -44,6 +44,13 @@ end
     @test parent(gd) === df
 end
 
+@testset "accepted columns" begin
+    df = DataFrame(A=[1,1,1,2,2,2], B=[1,2,1,2,1,2], C=1:6)
+    @test groupby(df, [1,2]) == groupby(df, 1:2) == groupby(df, [:A, :B])
+    @test groupby(df, [2,1]) == groupby(df, 2:-1:1) == groupby(df, [:B, :A])
+end
+
+
 @testset "colwise" begin
     Random.seed!(1)
     df = DataFrame(a = repeat(Union{Int, Missing}[1, 3, 2, 4], outer=[2]),


### PR DESCRIPTION
A small fix as now `groupby` fails when you pass range as columns specification (e.g. `groupby(df, 1:2)` throws an error).