### PR TITLE
Make names return internal names

### DIFF
--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -10,23 +10,6 @@ Pages = ["functions.md"]
 
 ## Grouping, Joining, and Split-Apply-Combine
 
-```@docs
-aggregate
-by
-colwise
-combine
-groupby
-groupindices
-groupvars
-join
-map
-melt
-stack
-unstack
-stackdf
-meltdf
-```
-
 ## Basics
 
 ```@docs
@@ -45,6 +28,7 @@ filter
 filter!
 insertcols!
 mapcols
+names
 names!
 nonunique
 rename!
@@ -57,4 +41,21 @@ unique!
 permutecols!
 vcat
 append!
+```
+
+```@docs
+aggregate
+by
+colwise
+combine
+groupby
+groupindices
+groupvars
+join
+map
+melt
+stack
+unstack
+stackdf
+meltdf
 ```

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -83,8 +83,13 @@ abstract type AbstractDataFrame end
 ##
 ##############################################################################
 
+"""
+    names(df::AbstractDataFrame)
+
+Return a vector of column names in the `df` data frame. The returned vector
+should not be modified. If you need to modify it use `copy(names(df))`.
+"""
 Base.names(df::AbstractDataFrame) = names(index(df))
-_names(df::AbstractDataFrame) = _names(index(df))
 
 """
 Set column names
@@ -402,7 +407,7 @@ function StatsBase.describe(df::AbstractDataFrame; stats::Union{Symbol,AbstractV
 
     # Put the summary stats into the return data frame
     data = DataFrame()
-    data[:variable] = names(df)
+    data[:variable] = copy(names(df))
 
     # An array of Dicts for summary statistics
     column_stats_dicts = map(columns(df)) do col

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -30,7 +30,7 @@ function printtable(io::IO,
     n, p = size(df)
     etypes = eltypes(df)
     if header
-        cnames = _names(df)
+        cnames = names(df)
         for j in 1:p
             print(io, quotemark)
             print(io, cnames[j])
@@ -101,7 +101,7 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
     if rowid !== nothing && n != 1
         throw(ArgumentError("rowid may be passed only with a single row data frame"))
     end
-    cnames = _names(df)
+    cnames = names(df)
     write(io, "<table class=\"data-frame\">")
     write(io, "<thead>")
     write(io, "<tr>")
@@ -238,7 +238,7 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
         mxrow = nrows
     end
 
-    cnames = _names(df)
+    cnames = names(df)
     alignment = repeat("c", ncols)
     write(io, "\\begin{tabular}{r|")
     write(io, alignment)

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -168,7 +168,7 @@ Base.IndexStyle(::Type{<:DataFrameColumns}) = Base.IndexLinear()
 @inline function Base.getindex(itr::DataFrameColumns{<:AbstractDataFrame,
                                                      Pair{Symbol, AbstractVector}}, j::Int)
     @boundscheck checkbounds(itr, j)
-    @inbounds _names(itr.df)[j] => itr.df[j]
+    @inbounds names(itr.df)[j] => itr.df[j]
 end
 
 @inline function Base.getindex(itr::DataFrameColumns{<:AbstractDataFrame, AbstractVector}, j::Int)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -81,7 +81,7 @@ function stack(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
     cnames = names(df)[id_vars]
     insert!(cnames, 1, value_name)
     insert!(cnames, 1, variable_name)
-    DataFrame(AbstractVector[repeat(_names(df)[measure_vars], inner=nrow(df)),   # variable
+    DataFrame(AbstractVector[repeat(names(df)[measure_vars], inner=nrow(df)),   # variable
                   vcat([df[c] for c in measure_vars]...),             # value
                   [repeat(df[c], outer=N) for c in id_vars]...],      # id_var columns
               cnames)
@@ -221,7 +221,7 @@ function _unstack(df::AbstractDataFrame, rowkey::Int,
         kref = keycol.refs[k]
         if kref <= 0 # we have found missing in colkey
             if !warned_missing
-                @warn("Missing value in variable $(_names(df)[colkey]) at row $k. Skipping.")
+                @warn("Missing value in variable $(names(df)[colkey]) at row $k. Skipping.")
                 warned_missing = true
             end
             continue # skip processing it
@@ -254,7 +254,7 @@ function _unstack(df::AbstractDataFrame, rowkey::Int,
     copyto!(col, levs)
     hadmissing && (col[end] = missing)
     df2 = DataFrame(unstacked_val, map(Symbol, levels(keycol)))
-    insertcols!(df2, 1, _names(df)[rowkey] => col)
+    insertcols!(df2, 1, names(df)[rowkey] => col)
 end
 
 unstack(df::AbstractDataFrame, rowkey::ColumnIndex,
@@ -267,7 +267,7 @@ unstack(df::AbstractDataFrame, colkey::ColumnIndex, value::ColumnIndex) =
 
 # group on anything not a key or value
 unstack(df::AbstractDataFrame, colkey::Int, value::Int) =
-    unstack(df, setdiff(_names(df), _names(df)[[colkey, value]]), colkey, value)
+    unstack(df, setdiff(names(df), names(df)[[colkey, value]]), colkey, value)
 
 unstack(df::AbstractDataFrame, rowkeys, colkey::ColumnIndex, value::ColumnIndex) =
     unstack(df, rowkeys, index(df)[colkey], index(df)[value])
@@ -304,7 +304,7 @@ function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Symbol},
         kref = keycol.refs[k]
         if kref <= 0
             if !warned_missing
-                @warn("Missing value in variable $(_names(df)[colkey]) at row $k. Skipping.")
+                @warn("Missing value in variable $(names(df)[colkey]) at row $k. Skipping.")
                 warned_missing = true
             end
             continue
@@ -512,7 +512,7 @@ function stackdf(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
     cnames = names(df)[id_vars]
     insert!(cnames, 1, value_name)
     insert!(cnames, 1, variable_name)
-    DataFrame(AbstractVector[RepeatedVector(_names(df)[measure_vars], nrow(df), 1), # variable
+    DataFrame(AbstractVector[RepeatedVector(names(df)[measure_vars], nrow(df), 1), # variable
                              StackedVector(Any[df[c] for c in measure_vars]),       # value
                              [RepeatedVector(df[c], 1, N) for c in id_vars]...],    # id_var columns
               cnames)

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -422,7 +422,7 @@ function showrows(io::IO,
         end
         print(io, " │ ")
         for j in leftcol:rightcol
-            s = _names(df)[j]
+            s = names(df)[j]
             ourshowcompact(io, s)
             padding = maxwidths[j] - ourstrwidth(s)
             for itr in 1:padding

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -257,7 +257,7 @@ end
 function Base.getindex(df::DataFrame, col_inds::AbstractVector)
     selected_columns = index(df)[col_inds]
     new_columns = _columns(df)[selected_columns]
-    return DataFrame(new_columns, Index(_names(df)[selected_columns]))
+    return DataFrame(new_columns, Index(names(df)[selected_columns]))
 end
 
 # df[:] => DataFrame
@@ -308,7 +308,7 @@ end
     end
     selected_columns = index(df)[col_inds]
     new_columns = AbstractVector[dv[row_inds] for dv in _columns(df)[selected_columns]]
-    return DataFrame(new_columns, Index(_names(df)[selected_columns]))
+    return DataFrame(new_columns, Index(names(df)[selected_columns]))
 end
 
 # df[:, SingleColumnIndex] => AbstractVector
@@ -321,7 +321,7 @@ end
 function Base.getindex(df::DataFrame, row_ind::Colon, col_inds::AbstractVector)
     selected_columns = index(df)[col_inds]
     new_columns = AbstractVector[copy(dv) for dv in _columns(df)[selected_columns]]
-    return DataFrame(new_columns, Index(_names(df)[selected_columns]))
+    return DataFrame(new_columns, Index(names(df)[selected_columns]))
 end
 
 # df[MultiRowIndex, :] => DataFrame
@@ -337,7 +337,7 @@ end
 # df[:, :] => DataFrame
 function Base.getindex(df::DataFrame, ::Colon, ::Colon)
     new_columns = AbstractVector[copy(dv) for dv in _columns(df)]
-    return DataFrame(new_columns, Index(_names(df)))
+    return DataFrame(new_columns, Index(names(df)))
 end
 
 ##############################################################################
@@ -1060,7 +1060,7 @@ julia> df1
 ```
 """
 function Base.append!(df1::DataFrame, df2::AbstractDataFrame)
-    _names(df1) == _names(df2) || error("Column names do not match")
+    names(df1) == names(df2) || error("Column names do not match")
     nrows, ncols = size(df1)
     try
         for j in 1:ncols
@@ -1089,7 +1089,7 @@ Base.convert(::Type{DataFrame}, d::AbstractDict) = DataFrame(d)
 
 function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple})
     i = 1
-    for nm in _names(df)
+    for nm in names(df)
         try
             push!(df[i], row[nm])
         catch
@@ -1120,7 +1120,7 @@ function Base.push!(df::DataFrame, iterable::Any)
             for j in 1:(i - 1)
                 pop!(_columns(df)[j])
             end
-            msg = "Error adding $t to column :$(_names(df)[i]). Possible type mis-match."
+            msg = "Error adding $t to column :$(names(df)[i]). Possible type mis-match."
             throw(ArgumentError(msg))
         end
         i += 1

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -96,8 +96,7 @@ Base.@propagate_inbounds Base.setindex!(r::DataFrameRow, value::Any, idx) =
 
 index(r::DataFrameRow) = getfield(r, :colindex)
 
-Base.names(r::DataFrameRow) = _names(parent(r))[parentcols(index(r), :)]
-_names(r::DataFrameRow) = view(_names(parent(r)), parentcols(index(r), :))
+Base.names(r::DataFrameRow) = view(names(parent(r)), parentcols(index(r), :))
 
 Base.haskey(r::DataFrameRow, key::Bool) =
     throw(ArgumentError("invalid key: $key of type Bool"))
@@ -194,7 +193,7 @@ function Base.:(==)(r1::DataFrameRow, r2::DataFrameRow)
         parentcols(index(r1)) == parentcols(index(r2)) || return false
         row(r1) == row(r2) && return true
     else
-        _names(r1) == _names(r2) || return false
+        names(r1) == names(r2) || return false
     end
     all(((a, b),) -> a == b, zip(r1, r2))
 end
@@ -204,7 +203,7 @@ function Base.isequal(r1::DataFrameRow, r2::DataFrameRow)
         parentcols(index(r1)) == parentcols(index(r2)) || return false
         row(r1) == row(r2) && return true
     else
-        _names(r1) == _names(r2) || return false
+        names(r1) == names(r2) || return false
     end
     all(((a, b),) -> isequal(a, b), zip(r1, r2))
 end
@@ -240,7 +239,7 @@ function Base.push!(df::DataFrame, dfr::DataFrameRow)
         # corner case when push!-ing
         size(df, 2) == length(dfr) || throw(ArgumentError("Inconsistent number of columns"))
         i = 1
-        for nm in _names(df)
+        for nm in names(df)
             try
                 push!(df[i], dfr[nm])
             catch

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -136,7 +136,6 @@ function Base.isequal(gd1::GroupedDataFrame, gd2::GroupedDataFrame)
 end
 
 Base.names(gd::GroupedDataFrame) = names(gd.parent)
-_names(gd::GroupedDataFrame) = _names(gd.parent)
 
 """
     map(cols => f, gd::GroupedDataFrame)
@@ -1091,14 +1090,14 @@ aggregate(groupby(df, :a), [sum, x->mean(skipmissing(x))])
 aggregate(d::AbstractDataFrame, fs::Any; sort::Bool=false) =
     aggregate(d, [fs], sort=sort)
 function aggregate(d::AbstractDataFrame, fs::AbstractVector; sort::Bool=false)
-    headers = _makeheaders(fs, _names(d))
+    headers = _makeheaders(fs, names(d))
     _aggregate(d, fs, headers, sort)
 end
 
 # Applies aggregate to non-key cols of each SubDataFrame of a GroupedDataFrame
 aggregate(gd::GroupedDataFrame, f::Any; sort::Bool=false) = aggregate(gd, [f], sort=sort)
 function aggregate(gd::GroupedDataFrame, fs::AbstractVector; sort::Bool=false)
-    headers = _makeheaders(fs, setdiff(_names(gd), _names(gd.parent[gd.cols])))
+    headers = _makeheaders(fs, setdiff(names(gd), names(gd.parent[gd.cols])))
     res = combine(x -> _aggregate(without(x, gd.cols), fs, headers), gd)
     sort && sort!(res, headers)
     res
@@ -1156,4 +1155,4 @@ groupindices(gd::GroupedDataFrame) = replace(gd.groups, 0=>missing)
 
 Return a vector of column names in `parent(gd)` used for grouping.
 """
-groupvars(gd::GroupedDataFrame) = _names(gd)[gd.cols]
+groupvars(gd::GroupedDataFrame) = names(gd)[gd.cols]

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -203,7 +203,7 @@ end
 # Helpers
 
 function add_names(ind::Index, add_ind::AbstractIndex; makeunique::Bool=false)
-    u = names(add_ind)
+    u = copy(names(add_ind))
 
     seen = Set(names(ind))
     dups = Int[]

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -31,6 +31,13 @@ end
     @test names(dfc) == [:a, :b]
     @test names(dfdc) == [:a, :b]
 
+    @test names(df) === index(df).names
+    @test names(dfc) === index(dfc).names
+    @test names(dfdc) === index(dfdc).names
+    @test names(dfc) !== names(df)
+    @test names(dfdc) !== names(df)
+    @test names(dfc) !== names(dfdc)
+
     @test dfc[1, :a] === 4
     @test dfdc[1, :a] === 2
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -3,6 +3,7 @@ module TestDataFrame
 using Dates, DataFrames, LinearAlgebra, Statistics, Random, Test
 using DataFrames: _columns
 using DataFrames: columns
+using DataFrames: index
 const ≅ = isequal
 const ≇ = !isequal
 

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -13,8 +13,11 @@ ref_df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
     sdf = view(df, [5, 3], [3, 1, 2])
 
     @test names(DataFrameRow(df, 1, :)) == [:a, :b, :c, :d]
+    @test names(DataFrameRow(df, 1, :)) === view(index(df).names, :)
     @test DataFrameRow(df, 1) == DataFrameRow(df, 1, :)
     @test names(DataFrameRow(df, 3, [3, 2])) == [:c, :b]
+    rng = [3, 2]
+    @test names(DataFrameRow(df, 3, rng)) == view(index(df).names, rng)
     @test copy(DataFrameRow(df, 3, [3, 2])) == (c = "C", b = 1.2)
     @test copy(DataFrameRow(sdf, 2, [3, 2])) == (b = 1.2, a = 3)
     @test copy(DataFrameRow(sdf, 2, :)) == (c = "C", a = 3, b = 1.2)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -1,7 +1,7 @@
 module TestDataFrameRow
 
 using Test, DataFrames, Random
-using DataFrames: columns
+using DataFrames: columns, index
 
 ref_df = DataFrame(a=Union{Int, Missing}[1, 2, 3, 1, 2, 2],
                    b=[2.0, missing, 1.2, 2.0, missing, missing],

--- a/test/index.jl
+++ b/test/index.jl
@@ -57,6 +57,7 @@ end
 @test i[Symbol[]] == Int[]
 
 @test names(i) == [:A,:B]
+@test names(i) === i.names
 @test names!(i, [:a,:a], makeunique=true) == Index([:a,:a_1])
 @test_throws ArgumentError names!(i, [:a,:a])
 @test names!(i, [:a,:b]) == Index([:a,:b])

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -1,6 +1,7 @@
 module TestSubDataFrame
 
 using Test, DataFrames
+using DataFrames: index
 
 @testset "copy - SubDataFrame" begin
     df = DataFrame(x = 1:10, y = 1.0:10.0)
@@ -145,14 +146,14 @@ end
     y = 1.0:10.0
     df = view(DataFrame(y=y), 2:6, :)
     df2 = view(DataFrame(x=y, y=y), 2:6, 2:2)
-    @test DataFrames.index(df) == DataFrames.index(df2)
-    @test haskey(DataFrames.index(df2), :y)
-    @test !haskey(DataFrames.index(df2), :x)
-    @test haskey(DataFrames.index(df2), 1)
-    @test !haskey(DataFrames.index(df2), 2)
-    @test !haskey(DataFrames.index(df2), 0)
-    @test_throws ArgumentError haskey(DataFrames.index(df2), true)
-    @test keys(DataFrames.index(df2)) == [:y]
+    @test index(df) == index(df2)
+    @test haskey(index(df2), :y)
+    @test !haskey(index(df2), :x)
+    @test haskey(index(df2), 1)
+    @test !haskey(index(df2), 2)
+    @test !haskey(index(df2), 0)
+    @test_throws ArgumentError haskey(index(df2), true)
+    @test keys(index(df2)) == [:y]
 
     x = DataFrame(ones(5,4))
     df = view(x, 2:3, 2:3)

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -125,7 +125,7 @@ end
     y = collect(1.0:10.0)
     df = view(DataFrame(x = x, y = y), 2:6, :)
 
-    @test Base.propertynames(df) == names(df)
+    @test Base.propertynames(df) === names(df)
 
     @test df.x == 2:6
     @test df.y == 2:6
@@ -157,6 +157,7 @@ end
     x = DataFrame(ones(5,4))
     df = view(x, 2:3, 2:3)
     @test names(df) == names(x)[2:3]
+    @test names(df) === view(names(x), 2:3)
     df = view(x, 2:3, [4,2])
     @test names(df) == names(x)[[4,2]]
 end


### PR DESCRIPTION
This PR follows #1655. It should not be treated lightly I think as it can lead to tricky bugs (so let us wait to see the feedback).

I have checked that we did not mutate `names(df)` anywhere in the package.