### PR TITLE
Fix two-argument show for DataFrameRow

### DIFF
--- a/src/dataframerow/show.jl
+++ b/src/dataframerow/show.jl
@@ -9,7 +9,7 @@ function Base.show(io::IO, dfr::DataFrameRow;
 end
 
 Base.show(dfr::DataFrameRow;
-          allcols::Bool = !get(io, :limit, true),
-          splitcols = get(io, :limit, true),
+          allcols::Bool = !get(stdout, :limit, true),
+          splitcols = get(stdout, :limit, true),
           rowlabel::Symbol = :Row) =
     show(stdout, dfr, allcols=allcols, splitcols=splitcols, rowlabel=rowlabel)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -308,11 +308,11 @@ end
         oldstdout = stdout
         rd, wr = redirect_stdout()
         f()
-        str = String(readavailable(rd))
         redirect_stdout(oldstdout)
         size = displaysize(rd)
-        close(rd)
         close(wr)
+        str = read(rd, String)
+        close(rd)
         str, size
     end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -6,11 +6,11 @@ function capture_stdout(f::Function)
     oldstdout = stdout
     rd, wr = redirect_stdout()
     f()
-    str = String(readavailable(rd))
     redirect_stdout(oldstdout)
     size = displaysize(rd)
-    close(rd)
     close(wr)
+    str = read(rd, String)
+    close(rd)
     str, size
 end
 


### PR DESCRIPTION
Spotted at https://discourse.julialang.org/t/how-to-show-all-columns-with-dataframerow/20883.