### PR TITLE
Use Missings.T instead of Base.nonmissingtype

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -36,7 +36,7 @@ function compacttype(T::Type, maxwidth::Int=8)
     sT = string(T)
     length(sT) ≤ maxwidth && return sT
     if T >: Missing
-        T = Base.nonmissingtype(T)
+        T = Missings.T(T)
         sT = string(T)
         suffix = "⍰"
         # handle the case when after removing Missing union type name is short


### PR DESCRIPTION
`Base.nonmissingtype` has bugs in some corner cases. `Missings.T` uses `typesubtract` instead. See also https://github.com/JuliaLang/julia/pull/31016.

Fixes https://github.com/JuliaData/DataFrames.jl/issues/1728. I don't think it's worth adding a test as `Missings.T` is covered elsewhere, and there's no end in testing printing on corner cases like this.