### PR TITLE
Add optimized reduce(vcat, dataframes)

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1024,6 +1024,10 @@ function _vcat(dfs::AbstractVector{<:AbstractDataFrame})
     return DataFrame(cols, header)
 end
 
+function Base.reduce(::typeof(vcat), dfs::AbstractVector{<:AbstractDataFrame})
+    return _vcat(dfs)
+end
+
 ##############################################################################
 ##
 ## repeat

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -156,9 +156,12 @@ end
 end
 
 @testset "vcat >2 args" begin
-    @test vcat(DataFrame(), DataFrame(), DataFrame()) == DataFrame()
+    empty_dfs = [DataFrame(), DataFrame(), DataFrame()]
+    @test vcat(empty_dfs...) == reduce(vcat, empty_dfs) == DataFrame()
+    
     df = DataFrame(x = trues(1), y = falses(1))
-    @test vcat(df, df, df) == DataFrame(x = trues(3), y = falses(3))
+    dfs = [df, df, df]
+    @test vcat(dfs...) ==reduce(vcat, dfs) == DataFrame(x = trues(3), y = falses(3))
 end
 
 @testset "vcat mixed coltypes" begin
@@ -210,9 +213,12 @@ end
     @test vcat(df2, df1, df2) == DataFrame([[2, 4, 6, 7, 8, 9, 2, 4, 6],
                                             [8, 10, 12, 4, 5, 6, 8, 10, 12],
                                             [14, 16, 18, 1, 2, 3, 14, 16, 18]] ,[:C, :B, :A])
+    
     @test size(vcat(df1, df1, df1, df2, df2, df2)) == (18, 3)
     df3 = df1[[1, 3, 2]]
     res = vcat(df1, df1, df1, df2, df2, df2, df3, df3, df3, df3)
+    @test res == reduce(vcat, [df1, df1, df1, df2, df2, df2, df3, df3, df3, df3])
+
     @test size(res) == (30, 3)
     @test res[1:3,:] == df1
     @test res[4:6,:] == df1
@@ -226,7 +232,7 @@ end
     df1 = DataFrame(A = 1, B = 2)
     df2 = DataFrame(B = 12, A = 11)
     df3 = DataFrame(A = [1, 11], B = [2, 12])
-    @test [df1; df2] == df3
+    @test [df1; df2] == df3 == reduce(vcat, [df1, df2])
 end
 
 @testset "vcat errors" begin
@@ -244,6 +250,8 @@ end
     @test err.value.msg == "column(s) B are missing from argument(s) 1"
     # multiple missing 1 column
     err = @test_throws ArgumentError vcat(df1, df2, df2, df2, df2, df2)
+    err2 = @test_throws ArgumentError reduce(vcat, [df1, df2, df2, df2, df2, df2])
+    @test err == err2
     @test err.value.msg == "column(s) B are missing from argument(s) 2, 3, 4, 5 and 6"
     # argument missing >1 columns
     df1 = DataFrame(A = 1:3, B = 1:3, C = 1:3, D = 1:3, E = 1:3)
@@ -285,6 +293,6 @@ end
 end
 x = view(DataFrame(A = Vector{Union{Missing, Int}}(1:3)), 2:2, :)
 y = DataFrame(A = 4:5)
-@test vcat(x, y) == DataFrame(A = [2, 4, 5])
+@test vcat(x, y) == DataFrame(A = [2, 4, 5]) == reduce(vcat, [x,y])
 
 end # module

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -293,6 +293,6 @@ end
 end
 x = view(DataFrame(A = Vector{Union{Missing, Int}}(1:3)), 2:2, :)
 y = DataFrame(A = 4:5)
-@test vcat(x, y) == DataFrame(A = [2, 4, 5]) == reduce(vcat, [x,y])
+@test vcat(x, y) == DataFrame(A = [2, 4, 5]) == reduce(vcat, [x, y])
 
 end # module


### PR DESCRIPTION
https://github.com/JuliaLang/julia/issues/21672
makes this the preferred phrasing for `vcat`ing collections of matrixes.
it is nice for it to be the same for dataframes.

this very thinly wraps the existing `_vcat`, see the timing.

```
julia> using BenchmarkTools

julia> dataframes = [DataFrame(;A=1:100, B=rand(100), C=fill(i,100)) for i in 1:50];

julia> @btime vcat($(dataframes)...);
  37.223 μs (422 allocations: 138.52 KiB)

julia> @btime reduce(vcat, $(dataframes));
  595.878 μs (4904 allocations: 3.21 MiB)

julia> @btime DataFrames._vcat($(dataframes));
  36.184 μs (420 allocations: 137.59 KiB)

julia> dataframes = [DataFrame(;A=1:100, B=rand(100), C=fill(i,100)) for i in 1:500];

julia> @btime vcat($(dataframes)...);
  306.130 μs (3572 allocations: 1.31 MiB)

julia> @btime DataFrames._vcat($(dataframes));
  298.962 μs (3570 allocations: 1.30 MiB)

julia> dataframes = [DataFrame(;A=1:100, B=rand(100), C=fill(i,100)) for i in 1:5000];

julia> @btime vcat($(dataframes)...);
  6.841 ms (62016 allocations: 13.50 MiB)

julia> @btime DataFrames._vcat($(dataframes));
  6.411 ms (62011 allocations: 13.35 MiB)

julia> dataframes = [DataFrame(;A=1:100, B=rand(100), C=fill(i,100)) for i in 1:500_000];

julia> @btime vcat($(dataframes)...);
  3.216 s (6497016 allocations: 1.32 GiB)

julia> @btime DataFrames._vcat($(dataframes));
  3.528 s (6497011 allocations: 1.31 GiB)
```

Only a little faster than splatting.
The splatting penalty is pretty low for this vs that actual time involved.