### PR TITLE
Improve append!

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1076,7 +1076,7 @@ julia> df1
 function Base.append!(df1::DataFrame, df2::AbstractDataFrame)
     if ncol(df1) == 0
         for (n, v) in eachcol(df2, true)
-            df1[n] = collect(v) # make sure df1 contains Vector-s
+            df1[n] = copy(v) # make sure df1 does not reuse df2
         end
         return df1
     end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1034,7 +1034,7 @@ end
 Add the rows of `df2` to the end of `df1`.
 
 Column names must be equal (including order), with the following exceptions:
-* If `df1` has no columns then newly allocated `Vector`s representing data in all
+* If `df1` has no columns then copies of
   columns from `df2` are added to it.
 * If `df2` has no columns then calling `append!` leaves `df1` unchanged.
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -549,7 +549,7 @@ df = DataFrame(A = 1:10, B = 'A':'J')
 
 @testset "append!" begin
     df = DataFrame(A = 1:2, B = 1:2)
-    df2 = DataFrame(A=1:4, B = 1:4)
+    df2 = DataFrame(A = 1:4, B = 1:4)
     @test append!(df, DataFrame(A = 3:4, B = [3.0, 4.0])) == df2
     @test_throws InexactError append!(df, DataFrame(A = 3:4, B = [3.5, 4.5]))
     @test df == df2

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -546,13 +546,24 @@ df = DataFrame(A = 1:10, B = 'A':'J')
 @test !(df[:] === df)
 @test !(df[:,:] === df)
 
-df = DataFrame(A = 1:2, B = 1:2)
-df2 = DataFrame(A=1:4, B = 1:4)
-@test append!(df, DataFrame(A = 3:4, B = [3.0, 4.0])) == df2
-@test_throws InexactError append!(df, DataFrame(A = 3:4, B = [3.5, 4.5]))
-@test df == df2
-@test_throws MethodError append!(df, DataFrame(A = 3:4, B = ["a", "b"]))
-@test df == df2
+
+@testset "append!" begin
+    df = DataFrame(A = 1:2, B = 1:2)
+    df2 = DataFrame(A=1:4, B = 1:4)
+    @test append!(df, DataFrame(A = 3:4, B = [3.0, 4.0])) == df2
+    @test_throws InexactError append!(df, DataFrame(A = 3:4, B = [3.5, 4.5]))
+    @test df == df2
+    @test_throws MethodError append!(df, DataFrame(A = 3:4, B = ["a", "b"]))
+    @test df == df2
+
+    df3 = append!(DataFrame(), df)
+    @test df3 == df
+    @test df3[1] !== df[1]
+    @test df3[2] !== df[2]
+
+    df4 = append!(df3, DataFrame())
+    @test (df4 === df3) == df
+end
 
 df = DataFrame(A = Vector{Union{Int, Missing}}(1:3), B = Vector{Union{Int, Missing}}(4:6))
 DRT = CategoricalArrays.DefaultRefType

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -556,13 +556,16 @@ df = DataFrame(A = 1:10, B = 'A':'J')
     @test_throws MethodError append!(df, DataFrame(A = 3:4, B = ["a", "b"]))
     @test df == df2
 
-    df3 = append!(DataFrame(), df)
+    dfx = DataFrame()
+    df3 = append!(dfx, df)
+    @test dfx === df3
     @test df3 == df
     @test df3[1] !== df[1]
     @test df3[2] !== df[2]
 
     df4 = append!(df3, DataFrame())
-    @test (df4 === df3) == df
+    @test df4 === df3
+    @test df4 == df
 end
 
 df = DataFrame(A = Vector{Union{Int, Missing}}(1:3), B = Vector{Union{Int, Missing}}(4:6))


### PR DESCRIPTION
This follows the comment from @nalimilan here https://discourse.julialang.org/t/best-way-to-iteratively-add-to-a-dataframe/21084/8.

Changes:
* allow to `append!` a data frame with 0 columns to an existing data frame (and this is a no-op)
* allow to `append!` to a `DataFrame` with 0 columns; in this case new columns are added (this is an exception) with freshly allocated column data; in this case it is problematic what should be the exact type of `AbstractVector` to create (this is why this change is slightly problematic); I have decided to recommend creating a `Vector` in this case