### PR TITLE
Add compress argument to categorical!()

### DIFF
--- a/docs/src/man/categorical.md
+++ b/docs/src/man/categorical.md
@@ -135,7 +135,7 @@ julia> eltypes(df)
  CategoricalString{UInt32}
  String
 
-julia> categorical!(df, compress=true) # change all columns to be categorical with compression
+julia> categorical!(df, compress=true) # change all columns with eltype <: AbstractString to be categorical with compression
 6×2 DataFrame
 │ Row │ A            │ B            │
 │     │ Categorical… │ Categorical… │

--- a/docs/src/man/categorical.md
+++ b/docs/src/man/categorical.md
@@ -77,7 +77,8 @@ julia> sort(cv)
 
 ```
 
-By default, a `CategoricalArray` is able to represent 2<sup>32</sup> different levels. You can use less memory by calling the `compress` function, or by calling the `categorical` function with the `compress` argument set to `true`:
+By default, a `CategoricalArray` is able to represent 2<sup>32</sup> different levels. You
+can use less memory by calling the `compress` function:
 
 ```jldoctest categorical
 julia> cv = compress(cv)
@@ -89,21 +90,12 @@ julia> cv = compress(cv)
  "Group B"
  missing
 
-julia> cv = categorical(["Group A", missing, "Group A",
-                    "Group B", "Group B", missing], true)
-6-element CategoricalArray{Union{Missing, String},1,UInt8}:
- "Group A"
- missing  
- "Group A"
- "Group B"
- "Group B"
- missing
-
 ```
 
 Often, you will have factors encoded inside a DataFrame with `Array` columns instead of
 `CategoricalArray` columns. You can convert one or more columns of the DataFrame using the
-`categorical!` function, which modifies the input DataFrame in-place. Compression is used by default.
+`categorical!` function, which modifies the input DataFrame in-place. Compression can be
+applied by setting the `compress` keyword argument to `true`.
 
 ```jldoctest categorical
 julia> using DataFrames
@@ -126,7 +118,7 @@ julia> eltypes(df)
  String
  String
 
-julia> categorical!(df, :A, false) # change the column `:A` to be categorical without compression
+julia> categorical!(df, :A) # change the column `:A` to be categorical
 6×2 DataFrame
 │ Row │ A            │ B      │
 │     │ Categorical… │ String │
@@ -143,7 +135,7 @@ julia> eltypes(df)
  CategoricalString{UInt32}
  String
 
-julia> categorical!(df) # change all columns to be categorical with compression
+julia> categorical!(df, compress=true) # change all columns to be categorical with compression
 6×2 DataFrame
 │ Row │ A            │ B            │
 │     │ Categorical… │ Categorical… │

--- a/docs/src/man/categorical.md
+++ b/docs/src/man/categorical.md
@@ -20,7 +20,7 @@ The naive encoding used in an `Array` represents every entry of this vector as a
 julia> using CategoricalArrays
 
 julia> cv = CategoricalArray(v)
-6-element CategoricalArrays.CategoricalArray{String,1,UInt32}:
+6-element CategoricalArray{String,1,UInt32}:
  "Group A"
  "Group A"
  "Group A"
@@ -37,7 +37,7 @@ julia> using Missings
 
 julia> cv = CategoricalArray(["Group A", missing, "Group A",
                               "Group B", "Group B", missing])
-6-element CategoricalArrays.CategoricalArray{Union{Missing, String},1,UInt32}:
+6-element CategoricalArray{Union{Missing, String},1,UInt32}:
  "Group A"
  missing
  "Group A"
@@ -67,7 +67,7 @@ julia> levels(cv)
  "Group A"
 
 julia> sort(cv)
-6-element CategoricalArrays.CategoricalArray{Union{Missing, String},1,UInt32}:
+6-element CategoricalArray{Union{Missing, String},1,UInt32}:
  "Group B"
  "Group B"
  "Group A"
@@ -77,13 +77,23 @@ julia> sort(cv)
 
 ```
 
-By default, a `CategoricalArray` is able to represent 2<sup>32</sup>differents levels. You can use less memory by calling the `compress` function:
+By default, a `CategoricalArray` is able to represent 2<sup>32</sup> different levels. You can use less memory by calling the `compress` function, or by calling the `categorical` function with the `compress` argument set to `true`:
 
 ```jldoctest categorical
 julia> cv = compress(cv)
-6-element CategoricalArrays.CategoricalArray{Union{Missing, String},1,UInt8}:
+6-element CategoricalArray{Union{Missing, String},1,UInt8}:
  "Group A"
  missing
+ "Group A"
+ "Group B"
+ "Group B"
+ missing
+
+julia> cv = categorical(["Group A", missing, "Group A",
+                    "Group B", "Group B", missing], true)
+6-element CategoricalArray{Union{Missing, String},1,UInt8}:
+ "Group A"
+ missing  
  "Group A"
  "Group B"
  "Group B"
@@ -93,7 +103,7 @@ julia> cv = compress(cv)
 
 Often, you will have factors encoded inside a DataFrame with `Array` columns instead of
 `CategoricalArray` columns. You can convert one or more columns of the DataFrame using the
-`categorical!` function, which modifies the input DataFrame in-place.
+`categorical!` function, which modifies the input DataFrame in-place. Compression is used by default.
 
 ```jldoctest categorical
 julia> using DataFrames
@@ -112,11 +122,11 @@ julia> df = DataFrame(A = ["A", "B", "C", "D", "D", "A"],
 │ 6   │ A      │ Y      │
 
 julia> eltypes(df)
-2-element Array{Type,1}:
+2-element Array{DataType,1}:
  String
  String
 
-julia> categorical!(df, :A) # change the column `:A` to be categorical
+julia> categorical!(df, :A, false) # change the column `:A` to be categorical without compression
 6×2 DataFrame
 │ Row │ A            │ B      │
 │     │ Categorical… │ String │
@@ -129,11 +139,11 @@ julia> categorical!(df, :A) # change the column `:A` to be categorical
 │ 6   │ A            │ Y      │
 
 julia> eltypes(df)
-2-element Array{Type,1}:
- CategoricalArrays.CategoricalString{UInt32}
+2-element Array{DataType,1}:
+ CategoricalString{UInt32}
  String
 
-julia> categorical!(df) # change all columns to be categorical
+julia> categorical!(df) # change all columns to be categorical with compression
 6×2 DataFrame
 │ Row │ A            │ B            │
 │     │ Categorical… │ Categorical… │
@@ -146,9 +156,9 @@ julia> categorical!(df) # change all columns to be categorical
 │ 6   │ A            │ Y            │
 
 julia> eltypes(df)
-2-element Array{Type,1}:
- CategoricalArrays.CategoricalString{UInt32}
- CategoricalArrays.CategoricalString{UInt32}
+2-element Array{DataType,1}:
+ CategoricalString{UInt8}
+ CategoricalString{UInt8}
 
 ```
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1007,22 +1007,24 @@ end
 ##
 ##############################################################################
 
-function categorical!(df::DataFrame, cname::Union{Integer, Symbol})
-    df[cname] = CategoricalVector(df[cname])
+function categorical!(df::DataFrame, cname::Union{Integer, Symbol},
+                      compress::Bool=true)
+    df[cname] = categorical(df[cname], compress)
     df
 end
 
-function categorical!(df::DataFrame, cnames::Vector{<:Union{Integer, Symbol}})
+function categorical!(df::DataFrame, cnames::Vector{<:Union{Integer, Symbol}},
+                      compress::Bool=true)
     for cname in cnames
-        df[cname] = CategoricalVector(df[cname])
+        df[cname] = categorical(df[cname], compress)
     end
     df
 end
 
-function categorical!(df::DataFrame)
+function categorical!(df::DataFrame, compress::Bool=true)
     for i in 1:size(df, 2)
         if eltype(df[i]) <: AbstractString
-            df[i] = CategoricalVector(df[i])
+            df[i] = categorical(df[i], compress)
         end
     end
     df

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1007,21 +1007,21 @@ end
 ##
 ##############################################################################
 
-function categorical!(df::DataFrame, cname::Union{Integer, Symbol},
-                      compress::Bool=true)
+function categorical!(df::DataFrame, cname::Union{Integer, Symbol};
+                      compress::Bool=false)
     df[cname] = categorical(df[cname], compress)
     df
 end
 
-function categorical!(df::DataFrame, cnames::Vector{<:Union{Integer, Symbol}},
-                      compress::Bool=true)
+function categorical!(df::DataFrame, cnames::Vector{<:Union{Integer, Symbol}};
+                      compress::Bool=false)
     for cname in cnames
         df[cname] = categorical(df[cname], compress)
     end
     df
 end
 
-function categorical!(df::DataFrame, compress::Bool=true)
+function categorical!(df::DataFrame; compress::Bool=false)
     for i in 1:size(df, 2)
         if eltype(df[i]) <: AbstractString
             df[i] = categorical(df[i], compress)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -572,16 +572,26 @@ DRT = CategoricalArrays.DefaultRefType
 
 @testset "categorical!" begin
     df = DataFrame([["a", "b"], ['a', 'b'], [true, false], 1:2, ["x", "y"]])
-    @test all(map(<:, eltypes(categorical!(df)),
-                  [CategoricalArrays.CategoricalString,
+    @test all(map(<:, eltypes(categorical!(deepcopy(df), false)), # no compression
+                  [CategoricalArrays.CategoricalString{UInt32},
                    Char, Bool, Int,
-                   CategoricalArrays.CategoricalString]))
-    @test all(map(<:, eltypes(categorical!(df, names(df))),
-                  [CategoricalArrays.CategoricalString,
-                   CategoricalArrays.CategoricalValue{Char},
-                   CategoricalArrays.CategoricalValue{Bool},
-                   CategoricalArrays.CategoricalValue{Int},
-                   CategoricalArrays.CategoricalString]))
+                   CategoricalArrays.CategoricalString{UInt32}]))
+    @test all(map(<:, eltypes(categorical!(deepcopy(df))), # compression
+                  [CategoricalArrays.CategoricalString{UInt8},
+                   Char, Bool, Int,
+                   CategoricalArrays.CategoricalString{UInt8}]))
+    @test all(map(<:, eltypes(categorical!(df, names(df), false)), # no compression
+                  [CategoricalArrays.CategoricalString{UInt32},
+                   CategoricalArrays.CategoricalValue{Char,UInt32},
+                   CategoricalArrays.CategoricalValue{Bool,UInt32},
+                   CategoricalArrays.CategoricalValue{Int,UInt32},
+                   CategoricalArrays.CategoricalString{UInt32}]))
+    @test all(map(<:, eltypes(categorical!(df, names(df))), # compression
+                  [CategoricalArrays.CategoricalString{UInt8},
+                   CategoricalArrays.CategoricalValue{Char,UInt8},
+                   CategoricalArrays.CategoricalValue{Bool,UInt8},
+                   CategoricalArrays.CategoricalValue{Int,UInt8},
+                   CategoricalArrays.CategoricalString{UInt8}]))
 end
 
 @testset "unstack promotion to support missing values" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -572,21 +572,21 @@ DRT = CategoricalArrays.DefaultRefType
 
 @testset "categorical!" begin
     df = DataFrame([["a", "b"], ['a', 'b'], [true, false], 1:2, ["x", "y"]])
-    @test all(map(<:, eltypes(categorical!(deepcopy(df), false)), # no compression
+    @test all(map(<:, eltypes(categorical!(deepcopy(df))),
                   [CategoricalArrays.CategoricalString{UInt32},
                    Char, Bool, Int,
                    CategoricalArrays.CategoricalString{UInt32}]))
-    @test all(map(<:, eltypes(categorical!(deepcopy(df))), # compression
+    @test all(map(<:, eltypes(categorical!(deepcopy(df), compress=true)),
                   [CategoricalArrays.CategoricalString{UInt8},
                    Char, Bool, Int,
                    CategoricalArrays.CategoricalString{UInt8}]))
-    @test all(map(<:, eltypes(categorical!(df, names(df), false)), # no compression
+    @test all(map(<:, eltypes(categorical!(df, names(df))),
                   [CategoricalArrays.CategoricalString{UInt32},
                    CategoricalArrays.CategoricalValue{Char,UInt32},
                    CategoricalArrays.CategoricalValue{Bool,UInt32},
                    CategoricalArrays.CategoricalValue{Int,UInt32},
                    CategoricalArrays.CategoricalString{UInt32}]))
-    @test all(map(<:, eltypes(categorical!(df, names(df))), # compression
+    @test all(map(<:, eltypes(categorical!(df, names(df), compress=true)),
                   [CategoricalArrays.CategoricalString{UInt8},
                    CategoricalArrays.CategoricalValue{Char,UInt8},
                    CategoricalArrays.CategoricalValue{Bool,UInt8},


### PR DESCRIPTION
I have made `categorical!` add compression by default. Under the hood `categorical!` calls `CategoricalArrays.categorical`, which selects the smallest `Unsigned` type to represent the pool of categorical elements.

```julia
julia> using DataFrames

julia> df = DataFrame(a = 1:typemax(UInt8));

julia> categorical!(df, :a);

julia> eltypes(df)
1-element Array{DataType,1}:
 CategoricalValue{Int64,UInt8}

julia> df = DataFrame(a = 1:typemax(UInt8)+1);

julia> categorical!(df, :a);

julia> eltypes(df)
1-element Array{DataType,1}:
 CategoricalValue{Int64,UInt16}

julia> df = DataFrame(a = 1:typemax(UInt16)+1);

julia> categorical!(df, :a);

julia> eltypes(df)
1-element Array{DataType,1}:
 CategoricalValue{Int64,UInt32}
```

I also updated the categorical docs and tests.

Closes #1733 