### PR TITLE
document nrow and ncol

### DIFF
--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -48,6 +48,8 @@ insertcols!
 mapcols
 names!
 nonunique
+nrow
+ncol
 rename!
 rename
 repeat

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1125,34 +1125,32 @@ Base.parentindices(adf::AbstractDataFrame) = axes(adf)
 
 ## Documentation for methods defined elsewhere
 
-# nrow, ncol
+function nrow end
+function ncol end
+
 """
-Number of rows or columns in an AbstractDataFrame
+    nrow(df::AbstractDataFrame)
+    ncol(df::AbstractDataFrame)
 
-```julia
-nrow(df::AbstractDataFrame)
-ncol(df::AbstractDataFrame)
-```
 
-**Arguments**
-
-* `df` : the AbstractDataFrame
-
-**Result**
-
-* `::AbstractDataFrame` : the updated version
+Return the number of rows or columns in an `AbstractDataFrame` `df`.
 
 See also [`size`](@ref).
 
-NOTE: these functions may be depreciated for `size`.
-
 **Examples**
 
-```julia
-df = DataFrame(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10))
-size(df)
-nrow(df)
-ncol(df)
+```jldoctest
+julia> df = DataFrame(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10));
+
+julia> size(df)
+(10, 3)
+
+julia> nrow(df)
+10
+
+julia> ncol(df)
+3
 ```
 
 """
+(nrow, ncol)

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -95,7 +95,6 @@ Base.@propagate_inbounds Base.view(adf::AbstractDataFrame, rowinds, colinds) =
 
 index(sdf::SubDataFrame) = getfield(sdf, :colindex)
 
-# TODO: Remove these
 nrow(sdf::SubDataFrame) = ncol(sdf) > 0 ? length(rows(sdf))::Int : 0
 ncol(sdf::SubDataFrame) = length(index(sdf))
 


### PR DESCRIPTION
Clean up and enable `nrow` and `ncol` documentation.
My current understanding is that in the end we tend to want to keep them in 1.0.