### PR TITLE
Remove deepcopy

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -778,12 +778,6 @@ end
 #   gets its own Index.
 Base.copy(df::DataFrame) = DataFrame(copy(_columns(df)), copy(index(df)))
 
-# Deepcopy is recursive -- if a column is a vector of DataFrames, each of
-#   those DataFrames is deepcopied.
-function Base.deepcopy(df::DataFrame)
-    DataFrame(deepcopy(_columns(df)), deepcopy(index(df)))
-end
-
 ##############################################################################
 ##
 ## Deletion / Subsetting

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -20,7 +20,6 @@ Base.length(x::Index) = length(x.names)
 Base.names(x::Index) = copy(x.names)
 _names(x::Index) = x.names
 Base.copy(x::Index) = Index(copy(x.lookup), copy(x.names))
-Base.deepcopy(x::Index) = copy(x) # all eltypes immutable
 Base.isequal(x::AbstractIndex, y::AbstractIndex) = _names(x) == _names(y) # it is enough to check names
 Base.:(==)(x::AbstractIndex, y::AbstractIndex) = isequal(x, y)
 


### PR DESCRIPTION
It does not appear to be needed and other packages generally don't define it.