### PR TITLE
Remove dependency on CodecZlib and TranscodingStreams

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,8 +6,6 @@ SortingAlgorithms
 Reexport
 WeakRefStrings 0.4.0
 DataStreams 0.3.0
-CodecZlib 0.4
-TranscodingStreams
 Compat 0.59.0
 Tables 0.1.15
 IteratorInterfaceExtensions 0.1.1

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -70,6 +70,8 @@ function writetable(filename::AbstractString,
 
     if endswith(filename, ".bz") || endswith(filename, ".bz2")
         throw(ArgumentError("BZip2 compression not yet implemented"))
+    elseif endswith(filename, ".gz")
+        throw(ArgumentError("GZip compression no longer implemented"))
     end
 
     if append && isfile(filename) && filesize(filename) > 0
@@ -91,9 +93,7 @@ function writetable(filename::AbstractString,
         end
     end
 
-    encoder = endswith(filename, ".gz") ? GzipCompressorStream : NoopStream
-
-    open(encoder, filename, append ? "a" : "w") do io
+    open(filename, append ? "a" : "w") do io
         printtable(io,
                    df,
                    header = header,
@@ -1118,8 +1118,7 @@ function readtable(pathname::AbstractString;
         error("URL retrieval not yet implemented")
     # (2) Path is GZip file
     elseif endswith(pathname, ".gz")
-        nbytes = 2 * filesize(pathname)
-        io = open(_r, GzipDecompressorStream, pathname, "r")
+        error("GZip decompression no longer implemented")
     # (3) Path is BZip2 file
     elseif endswith(pathname, ".bz") || endswith(pathname, ".bz2")
         error("BZip2 decompression not yet implemented")

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -22,8 +22,6 @@ import Base: keys, values, insert!
 @deprecate sub(df::AbstractDataFrame, rows) view(df, rows, :)
 
 ## write.table
-using CodecZlib, TranscodingStreams
-
 export writetable
 """
 Write data to a tabular-file format (CSV, TSV, ...)


### PR DESCRIPTION
This avoids requiring admin privileges on Windows. Without these, `readtable` no longer supports .csv.gz files, but it's deprecated.

Fixes https://github.com/JuliaData/DataFrames.jl/issues/1754.