### PR TITLE
Call Pkg.develop before Pkg.instantiate when building docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       julia: 1.0
       os: linux
       script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate();
-                                    Pkg.develop(PackageSpec(path=pwd()))'
+        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                    Pkg.instantiate()'
         - julia --project=docs/ docs/make.jl
       after_success: skip


### PR DESCRIPTION
This is the recommended code. See https://github.com/JuliaStats/StatsBase.jl/pull/480#discussion_r270540283.