### PR TITLE
Remove some old deprecated methods

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -29,26 +29,8 @@ function DataFrame(column_eltypes::AbstractVector{T}, cnames::AbstractVector{Sym
     return DataFrame(updated_types, cnames, nrows, makeunique=makeunique)
 end
 
-@deprecate by(d::AbstractDataFrame, cols, s::Vector{Symbol}) aggregate(d, cols, map(eval, s))
-@deprecate by(d::AbstractDataFrame, cols, s::Symbol) aggregate(d, cols, eval(s))
-
-@deprecate nullable!(df::AbstractDataFrame, col::ColumnIndex) allowmissing!(df, col)
-@deprecate nullable!(df::AbstractDataFrame, cols::Vector{<:ColumnIndex}) allowmissing!(df, cols)
-@deprecate nullable!(colnames::Array{Symbol,1}, df::AbstractDataFrame) allowmissing!(df, colnames)
-@deprecate nullable!(colnums::Array{Int,1}, df::AbstractDataFrame) allowmissing!(df, colnums)
-
-import Base: keys, values, insert!
-@deprecate keys(df::AbstractDataFrame) names(df)
-@deprecate values(df::AbstractDataFrame) eachcol(df)
+import Base: insert!
 @deprecate insert!(df::DataFrame, df2::AbstractDataFrame) (foreach(col -> df[col] = df2[col], names(df2)); df)
-
-@deprecate pool categorical
-@deprecate pool! categorical!
-
-@deprecate complete_cases! dropmissing!
-@deprecate complete_cases completecases
-
-@deprecate sub(df::AbstractDataFrame, rows) view(df, rows, :)
 
 ## write.table
 export writetable
@@ -1340,16 +1322,6 @@ macro tsv_str(s, flags...)
                  :tsv_str)
     inlinetable(s, flags...; separator='\t')
 end
-
-@deprecate rename!(x::AbstractDataFrame, from::AbstractArray, to::AbstractArray) rename!(x, [f=>t for (f, t) in zip(from, to)])
-@deprecate rename!(x::AbstractDataFrame, from::Symbol, to::Symbol) rename!(x, from => to)
-@deprecate rename!(x::Index, f::Function) rename!(f, x)
-@deprecate rename(x::AbstractDataFrame, from::AbstractArray, to::AbstractArray) rename(x, [f=>t for (f, t) in zip(from, to)])
-@deprecate rename(x::AbstractDataFrame, from::Symbol, to::Symbol) rename(x, from => to)
-@deprecate rename(x::Index, f::Function) rename(f, x)
-
-import Base: vcat
-@deprecate vcat(x::Vector{<:AbstractDataFrame}) vcat(x...)
 
 @deprecate showcols(df::AbstractDataFrame, all::Bool=false, values::Bool=true) describe(df, :eltype, :nmissing, :first, :last)
 @deprecate showcols(io::IO, df::AbstractDataFrame, all::Bool=false, values::Bool=true) show(io, describe(df, :eltype, :nmissing, :first, :last), all)


### PR DESCRIPTION
Moving towards cleaning up src/deprecated.jl I propose to remove deprecations for methods that have been deprecated for a long time already. With others we probably can wait as they have been changed more recently (and a major thing related to file reading/writing is waiting for CSV.jl rewrite that is going on currently).