### PR TITLE
Additional fixes of DataFrame constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.18.0"
+version = "0.18.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -15,8 +15,6 @@ DataFrame(columns::NTuple{N,AbstractVector}, names::NTuple{N,Symbol};
           makeunique::Bool=false, copycols::Bool=true)
 DataFrame(columns::Matrix, names::Vector{Symbol}; makeunique::Bool=false)
 DataFrame(kwargs...)
-DataFrame(pairs::Pair{Symbol}...; makeunique::Bool=false, copycols::Bool=true)
-DataFrame(pairs::AbstractVector{Pair{Symbol, <:AbstractVector}}; copycols::Bool=true)
 DataFrame(pairs::NTuple{N, Pair{Symbol, AbstractVector}}; copycols::Bool=true)
 DataFrame() # an empty DataFrame
 DataFrame(column_eltypes::Vector, names::AbstractVector{Symbol}, nrows::Integer=0;
@@ -44,7 +42,9 @@ DataFrame(::Union{DataFrame, SubDataFrame}; copycols::Bool=true)
                   `CategoricalVector`
 * `ds` : `AbstractDict` of columns
 * `table` : any type that implements the
-  [Tables.jl](https://github.com/JuliaData/Tables.jl) interface
+  [Tables.jl](https://github.com/JuliaData/Tables.jl) interface; in particular
+  a value of type `NTuple{N, Pair{Symbol, AbstractVector}}` or an `AbstractVector`
+  whose each element has `Pair{Symbol, <:AbstractVector}` type is a table.
 * `copycols` : whether vectors passed as columns should be copied; note that
   `DataFrame(kwargs...)` does not support this keyword argument and always copies columns.
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -22,6 +22,7 @@ DataFrame(column_eltypes::Vector, names::AbstractVector{Symbol}, nrows::Integer=
 DataFrame(ds::AbstractDict; copycols::Bool=true)
 DataFrame(table; makeunique::Bool=false, copycols::Bool=true)
 DataFrame(::Union{DataFrame, SubDataFrame}; copycols::Bool=true)
+DataFrame(::GroupedDataFrame)
 ```
 
 **Arguments**

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1172,7 +1172,12 @@ function _aggregate(d::AbstractDataFrame, fs::AbstractVector,
     res
 end
 
-function DataFrame(gd::GroupedDataFrame)
+function DataFrame(gd::GroupedDataFrame; copycols::Bool=true)
+    if copycols
+        throw(ArgumentError("It is not possible to construct a `DataFrame`" *
+                            "from GroupedDataFrame with `copycols=false`"))
+
+    end
     length(gd) == 0 && return similar(parent(gd), 0)
     idx = similar(gd.idx)
     doff = 1

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1173,7 +1173,7 @@ function _aggregate(d::AbstractDataFrame, fs::AbstractVector,
 end
 
 function DataFrame(gd::GroupedDataFrame; copycols::Bool=true)
-    if copycols
+    if !copycols
         throw(ArgumentError("It is not possible to construct a `DataFrame`" *
                             "from GroupedDataFrame with `copycols=false`"))
 

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1176,7 +1176,6 @@ function DataFrame(gd::GroupedDataFrame; copycols::Bool=true)
     if !copycols
         throw(ArgumentError("It is not possible to construct a `DataFrame`" *
                             "from GroupedDataFrame with `copycols=false`"))
-
     end
     length(gd) == 0 && return similar(parent(gd), 0)
     idx = similar(gd.idx)

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -38,7 +38,7 @@ end
 Base.append!(df::DataFrame, x) = append!(df, DataFrame(x, copycols=false))
 
 # This supports the Tables.RowTable type; needed to avoid ambiguities w/ another constructor
-function DataFrame(x::Vector{<:NamedTuple}, copycols::Bool=true)
+function DataFrame(x::Vector{<:NamedTuple}; copycols::Bool=true)
     if !copycols
         throw(ArgumentError("It is not possible to construct a `DataFrame`" *
                             "from a `Vector{<:NamedTuple}` with `copycols=false`"))

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -38,8 +38,13 @@ end
 Base.append!(df::DataFrame, x) = append!(df, DataFrame(x, copycols=false))
 
 # This supports the Tables.RowTable type; needed to avoid ambiguities w/ another constructor
-DataFrame(x::Vector{<:NamedTuple}) =
+function DataFrame(x::Vector{<:NamedTuple}, copycols::Bool=true)
+    if !copycols
+        throw(ArgumentError("It is not possible to construct a `DataFrame`" *
+                            "from a `Vector{<:NamedTuple}` with `copycols=false`"))
+    end
     fromcolumns(Tables.columns(Tables.IteratorWrapper(x)), copycols=false)
+end
 DataFrame!(x::Vector{<:NamedTuple}) =
     throw(ArgumentError("It is not possible to construct a `DataFrame` from " *
                         "`$(typeof(x))` without allocating new columns: use " *

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1104,6 +1104,9 @@ end
 
         gd2 = gd[[2,1]]
         @test DataFrame(gd2) == df[[3,5,2,4], :]
+
+        @test_throws ArgumentError DataFrame!(gd)
+        @test_throws ArgumentError DataFrame(gd, copycols=false)
     end
 
     df = DataFrame(a=Int[], b=[], c=Union{Missing, String}[])

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -162,7 +162,7 @@ end
     @test df.a == [1, 3]
     @test df.b == [2, 4]
     @test_throws ArgumentError DataFrame!(v)
-    @test_throws DataFrame(v, copycols=false)
+    @test_throws ArgumentError DataFrame(v, copycols=false)
 end
 
 end # module

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -162,6 +162,7 @@ end
     @test df.a == [1, 3]
     @test df.b == [2, 4]
     @test_throws ArgumentError DataFrame!(v)
+    @test_throws DataFrame(v, copycols=false)
 end
 
 end # module


### PR DESCRIPTION
This PR fixes the following problem:
```
julia> gd = groupby(DataFrame(rand(3,4)), :x1)
GroupedDataFrame with 3 groups based on key: x1
First Group (1 row): x1 = 0.6359046443565228
│ Row │ x1       │ x2       │ x3       │ x4       │
│     │ Float64  │ Float64  │ Float64  │ Float64  │
├─────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ 0.635905 │ 0.310854 │ 0.695098 │ 0.579583 │
⋮
Last Group (1 row): x1 = 0.0519420235728989
│ Row │ x1       │ x2       │ x3       │ x4       │
│     │ Float64  │ Float64  │ Float64  │ Float64  │
├─────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ 0.051942 │ 0.666328 │ 0.896186 │ 0.775949 │

julia> DataFrame!(gd)
3×4 DataFrame
│ Row │ x1         │ x2         │ x3          │ x4          │
│     │ SubArray…  │ SubArray…  │ SubArray…   │ SubArray…   │
├─────┼────────────┼────────────┼─────────────┼─────────────┤
│ 1   │ [0.635905] │ [0.310854] │ [0.695098]  │ [0.579583]  │
│ 2   │ [0.116937] │ [0.6347]   │ [0.0623185] │ [0.0985515] │
│ 3   │ [0.051942] │ [0.666328] │ [0.896186]  │ [0.775949]  │
```

Now calling `DataFrame!` on `GroupedDataFrame` will error.

We should merge this before we release a patch for 0.18.0.

@quinnj - actually the reason of this problem is that Tables.jl is very aggressive in trying to convert to a `DataFrame` anything that is "iterable" even if the schema is `nothing` (maybe this is what we want, but I wanted to make sure that this is intended there).