### PR TITLE
add instructions for setting up Jupyter Notebook with DataFrames.jl

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -11,6 +11,12 @@ Pkg.add("DataFrames")
 
 Throughout the rest of this tutorial, we will assume that you have installed the DataFrames package and have already typed `using DataFrames` to bring all of the relevant variables into your current namespace.
 
+### Setting up Jupyter Notebook for work with DataFrames.jl
+
+By default Jupyter Notebook will limit the number of rows and columns when displaying a data frame to roughly fit the screen size (like in the REPL).
+
+You can override this behavior by setting `ENV["COLUMNS"]` or `ENV["LINES"]` variables to hold the maximum width and height of output in characters respectively before using the `notebook` function. Alternatively you can add the following entry `"COLUMNS": "1000", "LINES": "100"` to `"env"` variable in your Jupyter kernel file. See [here](https://jupyter-client.readthedocs.io/en/stable/kernels.html) for information about location and specification of Jupyter kernels.
+
 ## The `DataFrame` Type
 
 Objects of the `DataFrame` type represent a data table as a series of vectors, each corresponding to a column or variable. The simplest way of constructing a `DataFrame` is to pass column vectors using keyword arguments or pairs:

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -11,14 +11,20 @@ Pkg.add("DataFrames")
 
 Throughout the rest of this tutorial, we will assume that you have installed the DataFrames package and have already typed `using DataFrames` to bring all of the relevant variables into your current namespace.
 
-### Setting up Jupyter Notebook for work with DataFrames.jl
+!!! note
 
-By default Jupyter Notebook will limit the number of rows and columns when displaying a data frame to roughly fit the screen size (like in the REPL).
+    By default Jupyter Notebook will limit the number of rows and columns when displaying a data frame to roughly
+    fit the screen size (like in the REPL).
 
-You can override this behavior by setting the `ENV["COLUMNS"]` or `ENV["LINES"]` variables to hold the maximum width and height of output in characters respectively before using the `notebook` function.
+    You can override this behavior by setting the `ENV["COLUMNS"]` or `ENV["LINES"]` variables to hold the maximum
+    width and height of output in characters respectively before using the `notebook` function.
 
-Alternatively, you may want to set the maximum number of data frame rows to print to `100` and the maximum output width in characters to `1000` for every Julia session using some Jupyter kernel file (numbers `100` and `1000` are only examples and can be adjusted). In such case add `"COLUMNS": "1000", "LINES": "100"` entry to the `"env"` variable in this Jupyter kernel file.
-See [here](https://jupyter-client.readthedocs.io/en/stable/kernels.html) for information about location and specification of Jupyter kernels.
+    Alternatively, you may want to set the maximum number of data frame rows to print to `100` and the maximum
+    output width in characters to `1000` for every Julia session using some Jupyter kernel file (numbers `100`
+    and `1000` are only examples and can be adjusted). In such case add a `"COLUMNS": "1000", "LINES": "100"`
+    entry to the `"env"` variable in this Jupyter kernel file.
+    See [here](https://jupyter-client.readthedocs.io/en/stable/kernels.html) for information about location
+    and specification of Jupyter kernels.
 
 ## The `DataFrame` Type
 

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -15,7 +15,10 @@ Throughout the rest of this tutorial, we will assume that you have installed the
 
 By default Jupyter Notebook will limit the number of rows and columns when displaying a data frame to roughly fit the screen size (like in the REPL).
 
-You can override this behavior by setting `ENV["COLUMNS"]` or `ENV["LINES"]` variables to hold the maximum width and height of output in characters respectively before using the `notebook` function. Alternatively you can add the following entry `"COLUMNS": "1000", "LINES": "100"` to `"env"` variable in your Jupyter kernel file. See [here](https://jupyter-client.readthedocs.io/en/stable/kernels.html) for information about location and specification of Jupyter kernels.
+You can override this behavior by setting `ENV["COLUMNS"]` or `ENV["LINES"]` variables to hold the maximum width and height of output in characters respectively before using the `notebook` function.
+
+Alternatively you can add the following example entry `"COLUMNS": "1000", "LINES": "100"` to `"env"` variable in your Jupyter kernel file.
+In this way you set the maximum number of data frame rows to print to `100` and the maximum output width in characters to `1000` for every Julia session using this kernel. See [here](https://jupyter-client.readthedocs.io/en/stable/kernels.html) for information about location and specification of Jupyter kernels.
 
 ## The `DataFrame` Type
 


### PR DESCRIPTION
The way to change the way data frames are displayed in Jupyter Notebook is non-obvious so I propose to add the instructions to the manual.