### PR TITLE
update tests to follow Tables.jl 0.2 rules

### DIFF
--- a/test/tables.jl
+++ b/test/tables.jl
@@ -120,6 +120,8 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test isequal(df.c, [missing, missing, missing])
 
         etu = EltypeUnknownIterator([nt, nt, nt])
+        @test_throws ArgumentError DataFrame(etu)
+        Tables.istable(EltypeUnknownIterator) = true
         df = DataFrame(etu)
         @test size(df) == (3, 3)
         @test df.a == [1, 1, 1]


### PR DESCRIPTION
New Tables.jl 0.2 rules made tests in test/tables.jl fail.