### PR TITLE
fix constructor with zero rows

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1419,6 +1419,10 @@ Otherwise if `columns=:equal` then `row` must contain exactly the same columns a
 As a special case, if `df` has no columns and `row` is a `NamedTuple` or `DataFrameRow`,
 columns are created for all values in `row`, using their names and order.
 
+Please note that `push!` must not be used on a `DataFrame` that contains columns
+that are aliases (equal when compared with `===`) as it will silently produce
+a wrong result in such a situation.
+
 # Examples
 ```jldoctest
 julia> df = DataFrame(A=1:3, B=1:3)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1302,6 +1302,10 @@ An error is thrown if conversion fails: this is the case in particular if a colu
 in `df2` contains `missing` values but the corresponding column in `df1` does not
 accept them.
 
+Please note that `append!` must not be used on a `DataFrame` that contains columns
+that are aliases (equal when compared with `===`) as it will silently produce
+a wrong result in such a situation.
+
 !!! note
     Use [`vcat`](@ref) instead of `append!` when more flexibility is needed.
     Since `vcat` does not operate in place, it is able to use promotion to find

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -103,9 +103,7 @@ struct DataFrame <: AbstractDataFrame
         end
         lengths = [isa(col, AbstractArray) ? length(col) : 1 for col in columns]
         minlen, maxlen = extrema(lengths)
-        if minlen == 0 && maxlen == 0
-            return new(columns, colindex)
-        elseif minlen != maxlen || minlen == maxlen == 1
+        if minlen != maxlen || minlen == maxlen == 1
             # recycle scalars
             for i in 1:length(columns)
                 isa(columns[i], AbstractArray) && continue

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1221,4 +1221,16 @@ end
     @test size(DataFrame()) == (0,0)
 end
 
+@testset "0-row DataFrame corner cases"
+    df = DataFrame(a=1:0)
+    @test df.a isa Vector{Int}
+    v = Int[]
+    df = DataFrame(a=v, b=v)
+    @test df.a !== df.b
+    df = DataFrame(a=v, b=v, copycols=true)
+    @test df.a !== df.b
+    df = DataFrame(a=v, b=v, copycols=false)
+    @test df.a === df.b
+end
+
 end # module

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1221,7 +1221,7 @@ end
     @test size(DataFrame()) == (0,0)
 end
 
-@testset "0-row DataFrame corner cases"
+@testset "0-row DataFrame corner cases" begin
     df = DataFrame(a=1:0)
     @test df.a isa Vector{Int}
     v = Int[]


### PR DESCRIPTION
Fixes #1800.

Additionally fixes a bug under which `0`-length ranges were not converted to a vector. This should be merged before 0.18.2 release.