### PR TITLE
Simplify fallback

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -20,9 +20,6 @@ function DataFrame(x::T; copycols::Bool=true) where {T}
     if x isa AbstractVector && all(col -> isa(col, AbstractVector), x)
         return DataFrame(Vector{AbstractVector}(x), copycols=copycols)
     end
-    if Tables.istable(T)
-        return fromcolumns(Tables.columns(x), copycols=copycols)
-    end
     if x isa AbstractVector || x isa Tuple
         if all(v -> v isa Pair{Symbol, <:AbstractVector}, x)
             return DataFrame(AbstractVector[last(v) for v in x], [first(v) for v in x],

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -103,7 +103,7 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test isequal(df, DataFrame(Tables.columntable(df)))
 
         dn = DuplicateNamesTable()
-        @test_throws ErrorException (dn |> DataFrame)
+        @test_throws ArgumentError (dn |> DataFrame)
 
         dn = DuplicateNamesColumnTable()
         @test_throws ArgumentError (dn |> DataFrame)


### PR DESCRIPTION
Because we're now calling `if x isa AbstractVector || x isa Tuple`, we don't need the initial `istable` check, so we can simplify things a little here.