### PR TITLE
Avoid a copy when materializing some TableTraits sources

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -17,6 +17,10 @@ fromcolumns(x; copycols::Bool=true) =
               copycols=copycols)
 
 function DataFrame(x::T; copycols::Bool=true) where {T}
+    if TableTraits.supports_get_columns_copy_using_missing(x)
+        y = TableTraits.get_columns_copy_using_missing(x)
+        return DataFrame(values(y), keys(y); copycols=false)
+    end
     if x isa AbstractVector && all(col -> isa(col, AbstractVector), x)
         return DataFrame(Vector{AbstractVector}(x), copycols=copycols)
     end


### PR DESCRIPTION
This is a temporary, partial solution for #1809, until there is a way to handle this situation with Tables.jl. For now it fixes a performance regression for some cases described in #1809 (but not all of them). Would be great if this could be put into a patch release soon!