### PR TITLE
Make DataFrameRow behave more like NamedTuple

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -161,6 +161,7 @@ Base.get(dfr::DataFrameRow, key::Union{Integer, Symbol}, default) =
     haskey(dfr, key) ? dfr[key] : default
 Base.get(f::Callable, dfr::DataFrameRow, key::Union{Integer, Symbol}) =
     haskey(dfr, key) ? getfield(dfr, key) : f()
+Base.broadcastable(::DataFrameRow) = throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 
 """
     copy(dfr::DataFrameRow)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -159,7 +159,7 @@ Base.pairs(r::DataFrameRow) = Base.Iterators.Pairs(r, keys(r))
 Base.map(f, r::DataFrameRow...) = map(f, copy.(r)...)
 Base.get(dfr::DataFrameRow, key::Union{Integer, Symbol}, default) =
     haskey(dfr, key) ? dfr[key] : default
-Base.get(f::Callable, dfr::DataFrameRow, key::Union{Integer, Symbol}) =
+Base.get(f::Base.Callable, dfr::DataFrameRow, key::Union{Integer, Symbol}) =
     haskey(dfr, key) ? getfield(dfr, key) : f()
 Base.broadcastable(::DataFrameRow) = throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -141,7 +141,7 @@ end
 
 # Computing the element type requires going over all columns,
 # so better let collect() do it only if necessary (widening)
-Base.IteratorEltype(::DataFrameRow) = Base.EltypeUnknown()
+Base.IteratorEltype(::Type{DataFrameRow}) = Base.EltypeUnknown()
 
 function Base.convert(::Type{Vector}, dfr::DataFrameRow)
     T = reduce(promote_type, eltypes(parent(dfr)))
@@ -155,12 +155,11 @@ Base.Vector{T}(dfr::DataFrameRow) where T = convert(Vector{T}, dfr)
 Base.keys(r::DataFrameRow) = Tuple(_names(r))
 Base.values(r::DataFrameRow) =
     ntuple(col -> parent(r)[row(r), parentcols(index(r), col)], length(r))
-Base.pairs(r::DataFrameRow) = Base.Iterators.Pairs(r, keys(r))
 Base.map(f, r::DataFrameRow, rs::DataFrameRow...) = map(f, copy(r), copy.(rs)...)
 Base.get(dfr::DataFrameRow, key::Union{Integer, Symbol}, default) =
     haskey(dfr, key) ? dfr[key] : default
 Base.get(f::Base.Callable, dfr::DataFrameRow, key::Union{Integer, Symbol}) =
-    haskey(dfr, key) ? getfield(dfr, key) : f()
+    haskey(dfr, key) ? dfr[key] : f()
 Base.broadcastable(::DataFrameRow) = throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 
 """

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -152,11 +152,11 @@ Base.convert(::Type{Vector{T}}, dfr::DataFrameRow) where T =
 Base.Vector(dfr::DataFrameRow) = convert(Vector, dfr)
 Base.Vector{T}(dfr::DataFrameRow) where T = convert(Vector{T}, dfr)
 
-Base.keys(r::DataFrameRow) = Tuple(names(r))
+Base.keys(r::DataFrameRow) = Tuple(_names(r))
 Base.values(r::DataFrameRow) =
     ntuple(col -> parent(r)[row(r), parentcols(index(r), col)], length(r))
 Base.pairs(r::DataFrameRow) = Base.Iterators.Pairs(r, keys(r))
-Base.map(f, r::DataFrameRow...) = map(f, copy.(r)...)
+Base.map(f, r::DataFrameRow, rs::DataFrameRow...) = map(f, copy(r), copy.(rs)...)
 Base.get(dfr::DataFrameRow, key::Union{Integer, Symbol}, default) =
     haskey(dfr, key) ? dfr[key] : default
 Base.get(f::Base.Callable, dfr::DataFrameRow, key::Union{Integer, Symbol}) =

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -141,7 +141,7 @@ end
 
 # Computing the element type requires going over all columns,
 # so better let collect() do it only if necessary (widening)
-Base.IteratorEltype(::Type{DataFrameRow}) = Base.EltypeUnknown()
+Base.IteratorEltype(::Type{<:DataFrameRow}) = Base.EltypeUnknown()
 
 function Base.convert(::Type{Vector}, dfr::DataFrameRow)
     T = reduce(promote_type, eltypes(parent(dfr)))

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -152,9 +152,15 @@ Base.convert(::Type{Vector{T}}, dfr::DataFrameRow) where T =
 Base.Vector(dfr::DataFrameRow) = convert(Vector, dfr)
 Base.Vector{T}(dfr::DataFrameRow) where T = convert(Vector{T}, dfr)
 
-Base.keys(r::DataFrameRow) = names(r)
+Base.keys(r::DataFrameRow) = Tuple(names(r))
 Base.values(r::DataFrameRow) =
     ntuple(col -> parent(r)[row(r), parentcols(index(r), col)], length(r))
+Base.pairs(r::DataFrameRow) = Base.Iterators.Pairs(r, keys(r))
+Base.map(f, r::DataFrameRow...) = map(f, copy.(r)...)
+Base.get(dfr::DataFrameRow, key::Union{Integer, Symbol}, default) =
+    haskey(dfr, key) ? dfr[key] : default
+Base.get(f::Callable, dfr::DataFrameRow, key::Union{Integer, Symbol}) =
+    haskey(dfr, key) ? getfield(dfr, key) : f()
 
 """
     copy(dfr::DataFrameRow)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -211,6 +211,7 @@ end
     @test values(r) == (2.0, 2.0, 0.0, 0.0)
     @test collect(pairs(r)) == [:x8 => 2.0, :x5 => 2.0, :x1 => 0.0, :x3 => 0.0]
 
+    r = deepcopy(ref_df)[1, :]
     @test map(identity, r[1:3]) == (a = 1, b = 2.0, c = "A")
     @test map((a,b) -> (a,b), r[1:3], r[1:3]) == (a = (1, 1), b = (2.0, 2.0), c = ("A", "A"))
     @test get(r, 1, 100) == 1

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -179,7 +179,7 @@ end
     df = deepcopy(ref_df)
     r = DataFrameRow(df, 1, :)
 
-    @test keys(r) == names(df)
+    @test keys(r) == Tuple(names(df))
     @test values(r) == (df[1, 1], df[1, 2], df[1, 3], df[1, 4])
     @test collect(pairs(r)) == [:a=>df[1, 1], :b=>df[1, 2], :c=>df[1, 3], :d=>df[1, 4]]
 
@@ -205,11 +205,22 @@ end
     @test size(r) == (4,)
     @test size(r, 1) == 4
     @test_throws BoundsError size(r, 2)
-    @test keys(r) == [:x8, :x5, :x1, :x3]
+    @test keys(r) == (:x8, :x5, :x1, :x3)
     r[:] = 0.0
     r[1:2] = 2.0
     @test values(r) == (2.0, 2.0, 0.0, 0.0)
     @test collect(pairs(r)) == [:x8 => 2.0, :x5 => 2.0, :x1 => 0.0, :x3 => 0.0]
+
+    @test map(identity, r[1:3]) == (a = 1, b = 2.0, c = "A")
+    @test map((a,b) -> (a,b), r[1:3], r[1:3]) == (a = (1, 1), b = (2.0, 2.0), c = ("A", "A"))
+    @test get(r, 1, 100) == 1
+    @test get(r, :a, 100) == 1
+    @test get(r, 10, 100) == 100
+    @test get(r, :z, 100) == 100
+    @test get(() -> 100,r, 1) == 1
+    @test get(() -> 100,r, :a) == 1
+    @test get(() -> 100,r, 10) == 100
+    @test get(() -> 100,r, :z) == 100
 end
 
 @testset "convert and copy" begin


### PR DESCRIPTION
This PR implements methods that make `DataFrameRow` behave like `NamedTuple` in standard operations.
This is breaking for:
* `keys` (as we return now a `Tuple` not a `Vector`),
* `pairs` as we return `Pairs` not a `Generator`
* `map` where we return a `NamedTuple` not a `Vector`
* `broadcastable` where we disallow `DataFrameRow` on RHS (in preparation for a future functionality to match `NamedTuple`)

I will write the tests after we decide:
* if we want it (or part of it)
* in case we want it do we go through a deprecation period or simply change it (these are small changes, the only code that would be broken is code that expects a vector and consequently mutates it, and now it will get a `Tuple` or `NamedTuple`)