### PR TITLE
Remove dump method

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -13,7 +13,7 @@ type in that it allows indexing by a key (the columns).
 The following are normally implemented for AbstractDataFrames:
 
 * [`describe`](@ref) : summarize columns
-* [`dump`](@ref) : show structure
+* [`summary`](@ref) : show number of rows and columns
 * `hcat` : horizontal concatenation
 * `vcat` : vertical concatenation
 * [`repeat`](@ref) : repeat rows
@@ -319,16 +319,6 @@ Base.last(df::AbstractDataFrame) = df[nrow(df), :]
 Get a data frame with the `n` last rows of `df`.
 """
 Base.last(df::AbstractDataFrame, n::Integer) = df[max(1,nrow(df)-n+1):nrow(df), :]
-
-# get the structure of a df
-function Base.dump(io::IOContext, df::AbstractDataFrame, n::Int, indent)
-    println(io, typeof(df), "  $(nrow(df)) observations of $(ncol(df)) variables")
-    if n > 0
-        for (name, col) in eachcol(df, true)
-            println(io, indent, "  ", name, ": ", col)
-        end
-    end
-end
 
 
 """

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -70,8 +70,7 @@ df = DataFrame()
 v = ["x","y","z"][rand(1:3, 10)]
 df1 = DataFrame(Any[collect(1:10), v, rand(10)], [:A, :B, :C])
 df2 = DataFrame(A = 1:10, B = v, C = rand(10))
-dump(df1)
-dump(df2)
+summary(df1)
 describe(df2)
 first(df1, 10)
 df1[:A] + df2[:C]

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -6,7 +6,7 @@ on an `AbstractDataFrame` if a collections of rows and columns are specified.
 
 A `SubDataFrame` is an `AbstractDataFrame`, so expect that most
 DataFrame functions should work. Such methods include `describe`,
-`dump`, `nrow`, `size`, `by`, `stack`, and `join`.
+`summary`, `nrow`, `size`, `by`, `stack`, and `join`.
 
 Indexing is just like a `DataFrame` except that it is possible to create a
 `SubDataFrame` with duplicate columns. All such columns will have a reference

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -903,13 +903,6 @@ end
     @test last(df, 1) == DataFrame(A = 10)
 end
 
-@testset "misc" begin
-    df = DataFrame([collect('A':'C')])
-    @test sprint(dump, df) == "DataFrame  3 observations of 1 variables\n  x1: ['A', 'B', 'C']\n\n"
-    df = DataFrame(A = 1:12, B = repeat('A':'C', inner=4))
-    # @test DataFrames.without(df, 1) == DataFrame(B = repeat('A':'C', inner=4))
-end
-
 @testset "column conversions" begin
     df = DataFrame([collect(1:10), collect(1:10)])
     @test !isa(df[1], Vector{Union{Int, Missing}})

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -161,15 +161,6 @@ end
     @test names(df) == names(x)[[4,2]]
 end
 
-@testset "dump" begin
-    y = 1.0:10.0
-    df = view(DataFrame(y=y), 2:6, :)
-    refstr = string("SubDataFrame{DataFrame,DataFrames.Index,",
-                    "UnitRange{$Int}}  5 observations of 1 variables\n",
-                    "  y: [2.0, 3.0, 4.0, 5.0, 6.0]\n\n")
-    @test sprint(dump, df) == refstr
-end
-
 @testset "deleterows!" begin
     y = 1.0:10.0
     df = view(DataFrame(y=y), 2:6, :)


### PR DESCRIPTION
This is an abuse of `dump`, which is supposed to always print the internals.
`summary(df)` can be used instead.