### PR TITLE
make categorical! accept missing values when converting

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1205,8 +1205,8 @@ end
     categorical!(df::DataFrame; compress::Bool=false)
 
 Change columns selected by `cname` or `cnames` in data frame `df`
-to `CategoricalVector`. If no columns are indicated then all columns that have
-an `Union{AbstractString, Missing}` element type type will be converted to categorical.
+to `CategoricalVector`. If no columns are indicated then all columns whose element type
+is a subtype of `Union{AbstractString, Missing}` will be converted to categorical.
 
 If the `compress` keyword argument is set to `true` then the created `CategoricalVector`s
 will be compressed.

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1206,7 +1206,7 @@ end
 
 Change columns selected by `cname` or `cnames` in data frame `df`
 to `CategoricalVector`. If no columns are indicated then all columns that have
-an `AbstractString` element type type will be converted to categorical.
+an `Union{AbstractString, Missing}` element type type will be converted to categorical.
 
 If the `compress` keyword argument is set to `true` then the created `CategoricalVector`s
 will be compressed.
@@ -1279,7 +1279,7 @@ end
 
 function categorical!(df::DataFrame; compress::Bool=false)
     for i in 1:size(df, 2)
-        if eltype(df[i]) <: AbstractString
+        if eltype(df[i]) <: Union{AbstractString, Missing}
             df[i] = categorical(df[i], compress)
         end
     end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -774,6 +774,10 @@ DRT = CategoricalArrays.DefaultRefType
                    CategoricalArrays.CategoricalValue{Bool,UInt8},
                    CategoricalArrays.CategoricalValue{Int,UInt8},
                    CategoricalArrays.CategoricalString{UInt8}]))
+
+    df = DataFrame([["a", missing]])
+    categorical!(df)
+    @test df.x1 isa CategoricalVector{Union{Missing, String}}
 end
 
 @testset "unstack promotion to support missing values" begin


### PR DESCRIPTION
A small change how `categorical!` without specified columns works. I recommend to allow automatic conversion of columns with eltype `Union{AbstractString,Missing}` (and not only `AbstractString` as currently). 