### PR TITLE
Improve nonunique

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -878,7 +878,7 @@ function nonunique(df::AbstractDataFrame)
     return res
 end
 
-nonunique(df::AbstractDataFrame, cols::Union{Integer, Symbol}) =
+nonunique(df::AbstractDataFrame, cols) =
     if cols isa Union{Integer, Symbol}
         if cols isa Bool
             throw(ArgumentError("invalid index: $cols of type Bool"))

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1567,3 +1567,5 @@ end
 function permutecols!(df::DataFrame, p::AbstractVector{Symbol})
     permutecols!(df, index(df)[p])
 end
+
+nonunique(df::DataFrame, cols) = nonunique(select(df, cols, copycols=false))

--- a/test/duplicates.jl
+++ b/test/duplicates.jl
@@ -10,6 +10,7 @@ const ≅ = isequal
     @test udf == unique(df)
     unique!(df)
     @test df == udf
+    @test_throws ArgumentError unique(df, true)
 
     pdf = DataFrame(a = CategoricalArray(["a", "a", missing, missing, "b", missing, "a", missing]),
                     b = CategoricalArray(["a", "b", missing, missing, "b", "a", "a", "a"]))
@@ -20,6 +21,24 @@ const ≅ = isequal
     @test updf ≅ unique(pdf)
     unique!(pdf)
     @test pdf ≅ updf
+    @test_throws ArgumentError unique(pdf, true)
+
+    df = view(DataFrame(a = [1, 2, 3, 3, 4]), :, :)
+    udf = DataFrame(a = [1, 2, 3, 4])
+    @test nonunique(df) == [false, false, false, true, false]
+    @test udf == unique(df)
+    @test_throws ArgumentError unique!(df)
+    @test_throws ArgumentError unique(df, true)
+
+    pdf = view(DataFrame(a = CategoricalArray(["a", "a", missing, missing, "b", missing, "a", missing]),
+                         b = CategoricalArray(["a", "b", missing, missing, "b", "a", "a", "a"])), :,  :)
+    updf = DataFrame(a = CategoricalArray(["a", "a", missing, "b", missing]),
+                    b = CategoricalArray(["a", "b", missing, "b", "a"]))
+    @test nonunique(pdf) == [false, false, false, true, false, false, true, true]
+    @test nonunique(updf) == falses(5)
+    @test updf ≅ unique(pdf)
+    @test_throws ArgumentError unique!(pdf)
+    @test_throws ArgumentError unique(pdf, true)
 end
 
 end # module


### PR DESCRIPTION
A small PR with the following changes in `nonunique`:
* return `BitVector` instead of `Vector{Bool}`
* correctly handle passing `true` as `cols` (it should error)
* make the operation faster for `DataFrame` (as in the old implementation we were performing an unnecessary copy)
* improve code coverage