### PR TITLE
Fix map(f, ::GroupedDataFrame) when there are no groups

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -291,6 +291,10 @@ function Base.map(f::Any, gd::GroupedDataFrame)
     if length(gd) > 0
         idx, valscat = _combine(f, gd)
         parent = hcat!(gd.parent[idx, gd.cols], valscat, makeunique=true)
+        if length(idx) == 0
+            return GroupedDataFrame(parent, collect(1:length(gd.cols)), idx,
+                                    Int[], Int[], Int[])
+        end
         starts = Vector{Int}(undef, length(gd))
         ends = Vector{Int}(undef, length(gd))
         starts[1] = 1
@@ -704,7 +708,7 @@ function _combine(f::Union{AbstractVector{<:Pair}, Tuple{Vararg{Pair}},
                     Symbol('x', i)
                 for i in 1:length(f)]
     end
-    valscat = DataFrame(collect(outcols), nams, makeunique=true)
+    valscat = DataFrame(collect(AbstractVector, outcols), nams, makeunique=true)
     return idx, valscat
 end
 
@@ -734,7 +738,7 @@ function _combine(f::Any, gd::GroupedDataFrame)
          !isa(firstres, Union{AbstractDataFrame, NamedTuple, DataFrameRow, AbstractMatrix}))
          nms = [Symbol(names(gd.parent)[index(gd.parent)[first(f)]], '_', funname(fun))]
     end
-    valscat = DataFrame(collect(outcols), collect(Symbol, nms))
+    valscat = DataFrame(collect(AbstractVector, outcols), collect(Symbol, nms))
     return idx, valscat
 end
 

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -11,7 +11,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
     keys = join(string.(keynames), ", ")
 
     keystr = length(gd.cols) > 1 ? "keys" : "key"
-    groupstr = N > 1 ? "groups" : "group"
+    groupstr = N == 1 ? "group" : "groups"
     summary && print(io, "$(typeof(gd).name) with $N $groupstr based on $keystr: $keys")
     if allgroups
         for i = 1:N

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -431,6 +431,13 @@ end
     @test isempty(gd2.idx)
     @test isempty(gd2.starts)
     @test isempty(gd2.ends)
+    gd2 = map(d -> DataFrame(X=Int[]), gd)
+    @test length(gd2) == 0
+    @test gd.cols == [1]
+    @test isempty(gd2.groups)
+    @test isempty(gd2.idx)
+    @test isempty(gd2.starts)
+    @test isempty(gd2.ends)
 end
 
 @testset "grouping with missings" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -420,6 +420,17 @@ end
     res = map(df -> sum(df.x), gd)
     @test length(res) == 0
     @test res.parent == DataFrame(x=[])
+
+    # Test with zero groups in output
+    df = DataFrame(A = [1, 2])
+    gd = groupby_checked(df, :A)
+    gd2 = map(d -> DataFrame(), gd)
+    @test length(gd2) == 0
+    @test gd.cols == [1]
+    @test isempty(gd2.groups)
+    @test isempty(gd2.idx)
+    @test isempty(gd2.starts)
+    @test isempty(gd2.ends)
 end
 
 @testset "grouping with missings" begin


### PR DESCRIPTION
Also fix a bug when the user-provided function returns an empty `DataFrame` with no columns.