### PR TITLE
Fix the constructor to no longer mask error messages

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -31,11 +31,7 @@ function DataFrame(x::T; copycols::Bool=true) where {T}
                              copycols=copycols)
         end
     end
-    try
-        return fromcolumns(Tables.columns(x), copycols=copycols)
-    catch e
-        throw(ArgumentError("unable to construct DataFrame from $(typeof(x))"))
-    end
+    return fromcolumns(Tables.columns(x), copycols=copycols)
 end
 
 Base.append!(df::DataFrame, x) = append!(df, DataFrame(x, copycols=false))

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -103,7 +103,7 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test isequal(df, DataFrame(Tables.columntable(df)))
 
         dn = DuplicateNamesTable()
-        @test_throws ArgumentError (dn |> DataFrame)
+        @test_throws ErrorException (dn |> DataFrame)
 
         dn = DuplicateNamesColumnTable()
         @test_throws ArgumentError (dn |> DataFrame)


### PR DESCRIPTION
Fixes #1820.

Any chance that a bug fix release could be tagged soon? The problem that is fixed with this PR and https://github.com/JuliaData/DataFrames.jl/issues/1809 are causing a lot of trouble for our work right now, and it would be good to get a new release out that fixes those two regressions.