### PR TITLE
fix push! error message

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1498,7 +1498,7 @@ function Base.push!(df::DataFrame, row::Any)
             for j in 1:(i - 1)
                 pop!(_columns(df)[j])
             end
-            msg = "Error adding $t to column :$(_names(df)[i]). Possible type mis-match."
+            msg = "Error adding $(repr(t)) to column :$(_names(df)[i]). Possible type mis-match."
             throw(ArgumentError(msg))
         end
         i += 1


### PR DESCRIPTION
This fixes a problem with printing `push!` error message when `t` is `nothing`.