### PR TITLE
Fix display of DataFrameRow with zero columns

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -82,7 +82,7 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
         if size(df, 2) == 0
             rowid = nothing
         else
-            nrows == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+            size(df, 1) == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
 
@@ -215,7 +215,7 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
         if size(df, 2) == 0
             rowid = nothing
         else
-            nrows == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+            size(df, 1) == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
 

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -78,8 +78,12 @@ end
 
 function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
                summary::Bool=true, rowid::Union{Int,Nothing}=nothing)
-    if rowid !== nothing && size(df, 1) != 1
-        throw(ArgumentError("rowid may be passed only with a single row data frame"))
+    if rowid !== nothing
+        if size(df, 2) == 0
+            rowid = nothing
+        else
+            nrows == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+        end
     end
 
     mxrow, mxcol = size(df)
@@ -207,8 +211,12 @@ function latex_escape(cell::AbstractString)
 end
 
 function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
-    if rowid !== nothing && size(df, 1) != 1
-        throw(ArgumentError("rowid may be passed only with a single row data frame"))
+    if rowid !== nothing
+        if size(df, 2) == 0
+            rowid = nothing
+        else
+            nrows == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+        end
     end
 
     mxrow, mxcol = size(df)

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -516,7 +516,11 @@ function _show(io::IO,
                rowid=nothing)
     nrows = size(df, 1)
     if rowid !== nothing
-        nrows == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+        if size(df, 2) == 0
+            rowid = nothing
+        else
+            nrows == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+        end
     end
     dsize = displaysize(io)
     availableheight = dsize[1] - 7

--- a/test/io.jl
+++ b/test/io.jl
@@ -117,4 +117,32 @@ end
     """
 end
 
+@testset "empty data frame and DataFrameRow" begin
+    df = DataFrame(a = [1,2], b = [1.0, 2.0])
+
+    @test sprint(show, "text/csv", df[2:1]) == ""
+    @test sprint(show, "text/tab-separated-values", df[2:1]) == ""
+    @test sprint(show, "text/html", df[2:1]) ==
+          "<table class=\"data-frame\"><thead><tr><th></th></tr><tr><th></th></tr>" *
+          "</thead><tbody><p>0 rows × 0 columns</p></tbody></table>"
+    @test sprint(show, "text/latex", df[2:1]) ==
+          "\\begin{tabular}{r|}\n\t& \\\\\n\t\\hline\n\t& \\\\\n\t\\hline\n\\end{tabular}\n"
+
+    @test sprint(show, "text/csv", @view df[2:1]) == ""
+    @test sprint(show, "text/tab-separated-values", @view df[2:1]) == ""
+    @test sprint(show, "text/html", @view df[2:1]) ==
+          "<table class=\"data-frame\"><thead><tr><th></th></tr><tr><th></th></tr>" *
+          "</thead><tbody><p>0 rows × 0 columns</p></tbody></table>"
+    @test sprint(show, "text/latex", @view df[2:1]) ==
+          "\\begin{tabular}{r|}\n\t& \\\\\n\t\\hline\n\t& \\\\\n\t\\hline\n\\end{tabular}\n"
+
+    @test sprint(show, "text/csv", df[1, 2:1]) == ""
+    @test sprint(show, "text/tab-separated-values", df[1, 2:1]) == ""
+    @test sprint(show, "text/html", df[1, 2:1]) ==
+          "<p>DataFrameRow</p><table class=\"data-frame\"><thead><tr><th></th></tr>" *
+          "<tr><th></th></tr></thead><tbody><p>0 rows × 0 columns</p></tbody></table>"
+    @test sprint(show, "text/latex", df[1, 2:1]) ==
+          "\\begin{tabular}{r|}\n\t& \\\\\n\t\\hline\n\t& \\\\\n\t\\hline\n\\end{tabular}\n"
+end
+
 end # module

--- a/test/show.jl
+++ b/test/show.jl
@@ -361,9 +361,9 @@ end
 
 @testset "Test empty data frame and DataFrameRow" begin
     df = DataFrame(x = [float(pi)])
-    @test sprint(show, df[2:1]) =="0×0 DataFrame\n"
-    @test sprint(show, @view df[2:1]) =="0×0 SubDataFrame\n"
-    @test sprint(show, df[1, 2:1]) =="DataFrameRow"
+    @test sprint(show, df[2:1]) == "0×0 DataFrame\n"
+    @test sprint(show, @view df[2:1]) == "0×0 SubDataFrame\n"
+    @test sprint(show, df[1, 2:1]) == "DataFrameRow"
 end
 
 end # module

--- a/test/show.jl
+++ b/test/show.jl
@@ -359,4 +359,11 @@ end
         │ 1   │ 3.141592653589793 │"""
 end
 
+@testset "Test empty data frame and DataFrameRow" begin
+    df = DataFrame(x = [float(pi)])
+    @test sprint(show, df[2:1]) =="0×0 DataFrame\n"
+    @test sprint(show, @view df[2:1]) =="0×0 SubDataFrame\n"
+    @test sprint(show, df[1, 2:1]) =="DataFrameRow"
+end
+
 end # module


### PR DESCRIPTION
Currently trying to display `DataFrameRow` with zero columns throws an error.
This PR fixes this and adds some extra tests for zero columns data frames.