### PR TITLE
Deprecate get for AbstractDataFrame

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -217,6 +217,8 @@ function Base.size(df::AbstractDataFrame, i::Integer)
     end
 end
 
+Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0 || size(df, 2) == 0
+
 Base.lastindex(df::AbstractDataFrame) = ncol(df)
 Base.lastindex(df::AbstractDataFrame, i::Integer) = last(axes(df, i))
 Base.axes(df::AbstractDataFrame, i::Integer) = Base.OneTo(size(df, i))
@@ -275,14 +277,6 @@ function Base.isequal(df1::AbstractDataFrame, df2::AbstractDataFrame)
     end
     return true
 end
-
-##############################################################################
-##
-## Associative methods
-##
-##############################################################################
-
-Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0 || size(df, 2) == 0
 
 ##############################################################################
 ##

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -283,7 +283,6 @@ end
 ##############################################################################
 
 Base.haskey(df::AbstractDataFrame, key::Any) = haskey(index(df), key)
-Base.get(df::AbstractDataFrame, key::Any, default::Any) = haskey(df, key) ? df[key] : default
 Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0 || size(df, 2) == 0
 
 ##############################################################################

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -282,7 +282,6 @@ end
 ##
 ##############################################################################
 
-Base.haskey(df::AbstractDataFrame, key::Any) = haskey(index(df), key)
 Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0 || size(df, 2) == 0
 
 ##############################################################################
@@ -1139,7 +1138,7 @@ function _vcat(dfs::AbstractVector{<:AbstractDataFrame};
     all_cols = Vector{AbstractVector}(undef, length(header))
     for (i, name) in enumerate(header)
         newcols = map(dfs) do df
-            if haskey(df, name)
+            if haskey(index(df), name)
                 return df[name]
             else
                 Iterators.repeated(missing, nrow(df))

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -400,7 +400,7 @@ function Base.join(df1::AbstractDataFrame,
         indicatorcol = CategoricalArray{String,1}(refs, CategoricalPool{String,UInt8}(["left_only", "right_only", "both"]))
         unique_indicator = indicator
         try_idx = 0
-        while haskey(joined, unique_indicator)
+        while haskey(index(joined), unique_indicator)
             try_idx += 1
             unique_indicator = Symbol(string(indicator, "_", try_idx))
         end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -767,14 +767,14 @@ function insertcols!(df::DataFrame, col_ind::Int, name_col::Pair{Symbol, <:Abstr
     0 < col_ind <= ncol(df) + 1 || throw(BoundsError())
     size(df, 1) == length(item) || size(df, 2) == 0 || error("number of rows does not match")
 
-    if haskey(df, name)
+    if haskey(index(df), name)
         if makeunique
             k = 1
             while true
                 # we only make sure that new column name is unique
                 # if df originally had duplicates in names we do not fix it
                 nn = Symbol("$(name)_$k")
-                if !haskey(df, nn)
+                if !haskey(index(df), nn)
                     name = nn
                     break
                 end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1394,3 +1394,5 @@ import Base: convert
 @deprecate colwise(fns::Union{AbstractVector, Tuple}, d::AbstractDataFrame) [f(col) for f in fns, col in eachcol(d)]
 @deprecate colwise(f, gd::GroupedDataFrame) [[f(col) for col in eachcol(d)] for d in gd]
 @deprecate colwise(fns::Union{AbstractVector, Tuple}, gd::GroupedDataFrame) [[f(col) for f in fns, col in eachcol(d)] for d in gd]
+
+@deprecate Base.get(df::AbstractDataFrame, key::Any, default::Any) haskey(df, key) ? df[key] : default

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1399,4 +1399,4 @@ import Base: get
 @deprecate get(df::AbstractDataFrame, key::Any, default::Any) key in names(df) ? df[key] : default
 
 import Base: haskey
-haskey(df::AbstractDataFrame, key::Any) key in names(df)
+@deprecate haskey(df::AbstractDataFrame, key::Any) key in names(df)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1396,4 +1396,7 @@ import Base: convert
 @deprecate colwise(fns::Union{AbstractVector, Tuple}, gd::GroupedDataFrame) [[f(col) for f in fns, col in eachcol(d)] for d in gd]
 
 import Base: get
-@deprecate get(df::AbstractDataFrame, key::Any, default::Any) haskey(df, key) ? df[key] : default
+@deprecate get(df::AbstractDataFrame, key::Any, default::Any) key in names(df) ? df[key] : default
+
+import Base: haskey
+haskey(df::AbstractDataFrame, key::Any) key in names(df)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1395,4 +1395,5 @@ import Base: convert
 @deprecate colwise(f, gd::GroupedDataFrame) [[f(col) for col in eachcol(d)] for d in gd]
 @deprecate colwise(fns::Union{AbstractVector, Tuple}, gd::GroupedDataFrame) [[f(col) for f in fns, col in eachcol(d)] for d in gd]
 
-@deprecate Base.get(df::AbstractDataFrame, key::Any, default::Any) haskey(df, key) ? df[key] : default
+import Base: get
+@deprecate get(df::AbstractDataFrame, key::Any, default::Any) haskey(df, key) ? df[key] : default

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -67,11 +67,6 @@ end
 
 @testset "Associative methods" begin
     df = DataFrame(a=[1, 2], b=[3.0, 4.0])
-    @test haskey(df, :a)
-    @test !haskey(df, :c)
-    @test haskey(df, 1)
-    @test_throws MethodError haskey(df, 1.5)
-    @test_throws ArgumentError haskey(df, true)
     @test !isempty(df)
 
     dfv = view(df, 1:2, 1:2)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -72,12 +72,9 @@ end
     @test haskey(df, 1)
     @test_throws MethodError haskey(df, 1.5)
     @test_throws ArgumentError haskey(df, true)
-    @test get(df, :a, -1) === eachcol(df)[1]
-    @test get(df, :c, -1) == -1
     @test !isempty(df)
 
     dfv = view(df, 1:2, 1:2)
-    @test get(df, :a, -1) === eachcol(df)[1]
 
     @test empty!(df) === df
     @test isempty(eachcol(df))


### PR DESCRIPTION
I propose to deprecate `get` method for `AbstractDataFrame`. I think it is not used and in general it is confusing to have it since we moved from `AbstractDict` interpretation.