### PR TITLE
Deprecate empty!

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -694,11 +694,9 @@ Base.setindex!(df::DataFrame, v, ::Colon, col_inds) =
 
 ##############################################################################
 ##
-## Mutating AbstractDict methods
+## Mutating methods
 ##
 ##############################################################################
-
-Base.empty!(df::DataFrame) = (empty!(_columns(df)); empty!(index(df)); df)
 
 """
 Insert a column into a data frame in place.

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1400,3 +1400,6 @@ import Base: get
 
 import Base: haskey
 @deprecate haskey(df::AbstractDataFrame, key::Any) key in names(df)
+
+import Base: empty!
+@deprecate empty!(df::DataFrame) deletecols!(df, 1:ncol(df))

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -65,17 +65,7 @@ end
     @test size(similar(df, 2)) == size(missingdf)
 end
 
-@testset "Associative methods" begin
-    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
-    @test !isempty(df)
-
-    dfv = view(df, 1:2, 1:2)
-
-    @test empty!(df) === df
-    @test isempty(eachcol(df))
-    @test isempty(df)
-    @test isempty(DataFrame(a=[], b=[]))
-
+@testset "insertcols!" begin
     df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
     @test_throws BoundsError insertcols!(df, 5, :newcol => ["a", "b"], )
     @test_throws ErrorException insertcols!(df, 1, :newcol => ["a"])

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -203,4 +203,16 @@ df = DataFrame(Union{Int, Missing}, 2, 2)
     end
 end
 
+@testset "empty!" begin
+    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test !isempty(df)
+
+    dfv = view(df, 1:2, 1:2)
+
+    @test empty!(df) === df
+    @test isempty(eachcol(df))
+    @test isempty(df)
+    @test isempty(DataFrame(a=[], b=[]))
+end
+
 end # module


### PR DESCRIPTION
So that we can change it to be equivalent to `empty!.(eachcol(df))`.

Fix #1841.