### PR TITLE
Speed up getindex with AbstractVector{Bool} row selection

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -351,7 +351,7 @@ end
     end
     selected_columns = index(df)[col_inds]
     # Computing integer indices once for all columns is faster
-    selected_rows = T === Bool ? selected_rows = findall(row_inds) : row_inds
+    selected_rows = T === Bool ? findall(row_inds) : row_inds
     new_columns = AbstractVector[dv[selected_rows] for dv in _columns(df)[selected_columns]]
     return DataFrame(new_columns, Index(_names(df)[selected_columns]), copycols=false)
 end
@@ -376,7 +376,7 @@ end
                           "rows at index $row_inds"))
     end
     # Computing integer indices once for all columns is faster
-    selected_rows = T === Bool ? selected_rows = findall(row_inds) : row_inds
+    selected_rows = T === Bool ? findall(row_inds) : row_inds
     new_columns = AbstractVector[dv[selected_rows] for dv in _columns(df)]
     return DataFrame(new_columns, copy(index(df)), copycols=false)
 end


### PR DESCRIPTION
Computing the integer indices before indexing into the vectors is faster: since the array indexing code does that anyway, doing it manually avoids repeating the operation for each column.

```julia
using DataFrames, BenchmarkTools
df = DataFrame(rand(10_000, 100));
inds = rand(Bool, nrow(df));
@btime df[inds, :];
@btime df[inds, 1:10];
@btime df[inds, 1:2];
@btime df[inds, [1]];

# git master
julia> @btime df[inds, :];
  4.039 ms (517 allocations: 3.85 MiB)

julia> @btime df[inds, 1:10];
  397.159 μs (76 allocations: 395.48 KiB)

julia> @btime df[inds, 1:2];
  79.435 μs (36 allocations: 80.55 KiB)

julia> @btime df[inds, [1]];
  40.242 μs (34 allocations: 41.34 KiB)

# This PR
julia> @btime df[inds, :];
  1.372 ms (419 allocations: 3.87 MiB)

julia> @btime df[inds, 1:10];
  135.309 μs (68 allocations: 433.06 KiB)

julia> @btime df[inds, 1:2];
  68.609 μs (36 allocations: 119.38 KiB)

julia> @btime df[inds, [1]];
  59.974 μs (35 allocations: 80.33 KiB)

# Alternative using LogicalIndex
julia> @btime df[inds, :];
  3.752 ms (418 allocations: 3.84 MiB)

julia> @btime df[inds, 1:10];
  369.710 μs (67 allocations: 394.58 KiB)

julia> @btime df[inds, 1:2];
  76.246 μs (35 allocations: 80.39 KiB)

julia> @btime df[inds, [1]];
  40.101 μs (34 allocations: 41.28 KiB)
```