### PR TITLE
fix deprecation warning for DataFrame constructor

### DIFF
--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,6 +1,6 @@
 import Base: @deprecate
 
-@deprecate DataFrame(t::Type, nrows::Integer, ncols::Integer) DataFrame(Matrix{t}(undef, nrows, ncols))
+@deprecate DataFrame(t::Type, nrows::Integer, ncols::Integer) DataFrame([Vector{t}(undef, nrows) for i in 1:ncols])
 
 @deprecate DataFrame(column_eltypes::AbstractVector{<:Type},
                      nrows::Integer) DataFrame(column_eltypes, Symbol.('x' .* string.(1:length(column_eltypes))), nrows)


### PR DESCRIPTION
A small fix needed due to problem described in https://discourse.julialang.org/t/subsetting-uninitialized-arrays/25449.