### PR TITLE
remove InteractiveUtils load

### DIFF
--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -1,6 +1,6 @@
 module TestConversions
 
-using Test, DataFrames, InteractiveUtils
+using Test, DataFrames
 using DataStructures: OrderedDict, SortedDict
 const ≅ = isequal
 


### PR DESCRIPTION
Loading `InteractiveUtils` is not needed and it causes tests to fail on nightly