### PR TITLE
WIP: make indexing and eachcol return views of data frame columns

### DIFF
--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -44,7 +44,7 @@ If it is performed a description explicitly mentions that the data is *copied*.
 For performance reasons, accessing, via `getindex` or `view`, a single `row` and multiple `cols` of a `DataFrame`, a `SubDataFrame` or a `DataFrameRow` always returns a `DataFrameRow` (which is a view-like type).
 
 `DataFrame`:
-* `df[col]` -> the vector contained in column `col`;
+* `df[col]` -> a view of the vector contained in column `col`;
 * `df[cols]` -> a freshly allocated `DataFrame` containing the copies of vectors contained in columns `cols`;
 * `df[row, col]` -> the value contained in row `row` of column `col`, the same as `df[col][row]`;
 * `df[CartesianIndex(row, col)]` -> the same as `df[row,col]`;

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -44,10 +44,10 @@ The return value can have two concrete types:
 
 * If the `eachcol` function is called with the `names` argument set to `true` then it returns a value of the
   `DataFrameColumns{<:AbstractDataFrame, Pair{Symbol, AbstractVector}}` type, which is an
-  iterator returning a pair containing the column name and the column vector.
+  iterator returning a pair containing the column name and the veiw of a column vector.
 * If the `eachcol` function is called with `names` argument set to `false` (the default) then it returns a value of the
   `DataFrameColumns{<:AbstractDataFrame, AbstractVector}` type, which is an
-  iterator returning the column vector only.
+  iterator returning the view of a column vector only.
 
 The `DataFrameRows` and `DataFrameColumns` types are subtypes of `AbstractVector` and support its interface
 with the exception that they are read only. Note that they are not exported and should not be constructed directly,

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -49,7 +49,7 @@ Columns can be accessed via `df.col` or `df[:col]`. The latter syntax is more fl
 
 ```jldoctest dataframe
 julia> df.A
-4-element Array{Int64,1}:
+4-element view(::Array{Int64,1}, :) with eltype Int64:
  1
  2
  3
@@ -273,7 +273,7 @@ we can observe that:
 
 ### Taking a Subset
 
-Specific subsets of a data frame can be extracted using the indexing syntax, similar to matrices. The colon `:` indicates that all items (rows or columns depending on its position) should be retained:
+Specific subsets of a data frame can be extracted using the indexing syntax, similar to matrices. The colon `:` indicates that all items (rows or columns depending on its position) should be retained, `Not` can be used for negation, and also regular expressions can be used for column selection:
 
 ```jldoctest dataframe
 julia> df[1:3, :]
@@ -328,7 +328,7 @@ julia> df[[3, 1], [:C]]
 │ 2   │ 1     │
 ```
 
-Do note that `df[[:A]]` and `df[:, [:A]]` return a `DataFrame` object, while `df[:A]` and `df[:, :A]` return a vector:
+Do note that `df[[:A]]` and `df[:, [:A]]` return a `DataFrame` object, while `df[:A]` and `df[:, :A]` return a vector view:
 
 ```jldoctest dataframe
 julia> df[[:A]]
@@ -351,7 +351,7 @@ julia> df[[:A]] == df[:, [:A]]
 true
 
 julia> df[:A]
-500-element Array{Int64,1}:
+500-element view(::Array{Int64,1}, :) with eltype Int64:
    1
    3
    5
@@ -369,23 +369,35 @@ julia> df[:A] == df[:, :A]
 true
 ```
 
-In the first cases, `[:A]` is a vector, indicating that the resulting object should be a `DataFrame`, since a vector can contain one or more column names. On the other hand, `:A` is a single symbol, indicating that a single column vector should be extracted.
+In the first cases, `[:A]` is a vector, indicating that the resulting object should be a `DataFrame`, since a vector can contain one or more column names. On the other hand, `:A` is a single symbol, indicating that a view of a single column vector should be extracted.
 
-It is also possible to use a regular expression as a selector of columns matching it:
+It is also possible to use a regular expression as a selector of columns matching it. Finally you can use `Not` to negate any column or row selection (here we give an example of negating selection of columns and of rows).
 ```jldoctest dataframe
-julia> df = DataFrame(x1=1, x2=2, y=3)
-1×3 DataFrame
+julia> df = DataFrame(x1=1:3, x2=11:13, y=21:23)
+3×3 DataFrame
 │ Row │ x1    │ x2    │ y     │
 │     │ Int64 │ Int64 │ Int64 │
 ├─────┼───────┼───────┼───────┤
-│ 1   │ 1     │ 2     │ 3     │
+│ 1   │ 1     │ 11    │ 21    │
+│ 2   │ 2     │ 12    │ 22    │
+│ 3   │ 3     │ 13    │ 23    │
 
 julia> df[r"x"]
-1×2 DataFrame
+3×2 DataFrame
 │ Row │ x1    │ x2    │
 │     │ Int64 │ Int64 │
 ├─────┼───────┼───────┤
-│ 1   │ 1     │ 2     │
+│ 1   │ 1     │ 11    │
+│ 2   │ 2     │ 12    │
+│ 3   │ 3     │ 13    │
+
+julia> df[Not(2), Not(r"y")]
+2×2 DataFrame
+│ Row │ x1    │ x2    │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 1     │ 11    │
+│ 2   │ 3     │ 13    │
 ```
 
 The indexing syntax can also be used to select rows based on conditions on variables:
@@ -513,7 +525,7 @@ On the other hand, in-place functions, whose names end with `!`, may mutate the 
 ```jldoctest dataframe
 julia> x = [3, 1, 2];
 
-julia> df = DataFrame(x=x)
+julia> df = DataFrame(x=x, copycols=false)
 3×1 DataFrame
 │ Row │ x     │
 │     │ Int64 │
@@ -562,7 +574,7 @@ or when a `DataFrame` created with `copycols=false` (or with the `DataFrame!` fu
 are in use.
 
 It is possible to have a direct access to a column `col` of a `DataFrame` `df`
-using the syntaxes `df.col`, `df[:col]`, via the [`eachcol`](@ref) function,
+using the syntaxes `df.col`, `df[:col]`, via the [`eachcol`](@ref) function
 by accessing a `parent` of a `view` of a column of a `DataFrame`,
 or simply by storing the reference to the column vector before the `DataFrame`
 was created with `copycols=false` (or with the `DataFrame!` function).

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1014,7 +1014,7 @@ function hcat!(df1::DataFrame, df2::DataFrame;
                makeunique::Bool=false, copycols::Bool=true)
     u = add_names(index(df1), index(df2), makeunique=makeunique)
     for i in 1:length(u)
-        df1[u[i]] = copycols ? copy(_columns(df2)) : _columns(df2)[i]
+        df1[u[i]] = copycols ? copy(_columns(df2)[i]) : _columns(df2)[i]
     end
     return df1
 end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1012,8 +1012,11 @@ end
 # definition required to avoid hcat! ambiguity
 function hcat!(df1::DataFrame, df2::DataFrame;
                makeunique::Bool=false, copycols::Bool=true)
-    invoke(hcat!, Tuple{DataFrame, AbstractDataFrame}, df1, df2,
-           makeunique=makeunique, copycols=copycols)::DataFrame
+    u = add_names(index(df1), index(df2), makeunique=makeunique)
+    for i in 1:length(u)
+        df1[u[i]] = copycols ? copy(_columns(df2)) : _columns(df2)[i]
+    end
+    return df1
 end
 
 hcat!(df::DataFrame, x::AbstractVector; makeunique::Bool=false, copycols::Bool=true) =

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -287,12 +287,12 @@ ncol(df::DataFrame) = length(index(df))
         throw(BoundsError("attempt to access a data frame with $(ncol(df)) " *
                           "columns at index $col_ind"))
     end
-    @inbounds cols[col_ind]
+    @inbounds view(cols[col_ind], :)
 end
 
 function Base.getindex(df::DataFrame, col_ind::Symbol)
     selected_column = index(df)[col_ind]
-    return _columns(df)[selected_column]
+    return view(_columns(df)[selected_column], :)
 end
 
 # df[MultiColumnIndex] => DataFrame

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -160,7 +160,9 @@ end
     df3 = hcat(df1, dfv, copycols=false)
     @test names(df3) == [:a, :b]
     @test df3.a === df1.a
-    @test df3.b === dfv.b
+    @test df3.b == dfv.b
+    @test df3.b isa SubArray
+    @test parent(df3.b) == parent(dfv.b)
 
     df3 = hcat(df1, x)
     @test names(df3) == [:a, :x1]
@@ -177,7 +179,8 @@ end
     df3 = hcat(df1, x, copycols=false)
     @test names(df3) == [:a, :x1]
     @test df3.a === df1.a
-    @test df3.x1 === x
+    @test df3.x1 == x
+    @test parent(df3.x1) === x
 
     df3 = hcat(x, df1)
     @test names(df3) == [:x1, :a]
@@ -194,7 +197,8 @@ end
     df3 = hcat(x, df1, copycols=false)
     @test names(df3) == [:x1, :a]
     @test df3.a === df1.a
-    @test df3.x1 === x
+    @test df3.x1 == x
+    @test parent(df3.x1) === x
 
     df3 = hcat(dfv, x, df1)
     @test names(df3) == [:b, :x1, :a]
@@ -215,8 +219,11 @@ end
     df3 = hcat(dfv, x, df1, copycols=false)
     @test names(df3) == [:b, :x1, :a]
     @test df3.a === df1.a
-    @test df3.b === dfv.b
-    @test df3.x1 === x
+    @test df3.b == dfv.b
+    @test df3.b isa SubArray
+    @test parent(df3.b) == parent(dfv.b)
+    @test df3.x1 == x
+    @test parent(df3.x1) === x
 end
 #
 # vcat

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -336,24 +336,24 @@ end
 @testset "vcat mixed coltypes" begin
     df = vcat(DataFrame([[1]], [:x]), DataFrame([[1.0]], [:x]))
     @test df == DataFrame([[1.0, 1.0]], [:x])
-    @test typeof.(eachcol(df)) == [Vector{Float64}]
+    @test all(isa.(eachcol(df), SubArray{Float64, 1}))
     df = vcat(DataFrame([[1]], [:x]), DataFrame([["1"]], [:x]))
     @test df == DataFrame([[1, "1"]], [:x])
-    @test typeof.(eachcol(df)) == [Vector{Any}]
+    @test all(isa.(eachcol(df), SubArray{Any, 1}))
     df = vcat(DataFrame([Union{Missing, Int}[1]], [:x]), DataFrame([[1]], [:x]))
     @test df == DataFrame([[1, 1]], [:x])
-    @test typeof.(eachcol(df)) == [Vector{Union{Missing, Int}}]
+    @test all(isa.(eachcol(df), SubArray{Union{Missing, Int}, 1}))
     df = vcat(DataFrame([CategoricalArray([1])], [:x]), DataFrame([[1]], [:x]))
     @test df == DataFrame([[1, 1]], [:x])
-    @test df[:x] isa Vector{Int}
+    @test df.x isa SubArray{Int, 1}
     df = vcat(DataFrame([CategoricalArray([1])], [:x]),
               DataFrame([Union{Missing, Int}[1]], [:x]))
     @test df == DataFrame([[1, 1]], [:x])
-    @test df[:x] isa Vector{Union{Int, Missing}}
+    @test df.x isa SubArray{Union{Int, Missing}, 1}
     df = vcat(DataFrame([CategoricalArray([1])], [:x]),
               DataFrame([CategoricalArray{Union{Int, Missing}}([1])], [:x]))
     @test df == DataFrame([[1, 1]], [:x])
-    @test df[:x] isa CategoricalVector{Union{Int, Missing}}
+    @test df.x isa CategoricalVector{Union{Int, Missing}}
     df = vcat(DataFrame([Union{Int, Missing}[1]], [:x]),
               DataFrame([["1"]], [:x]))
     @test df == DataFrame([[1, "1"]], [:x])

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -6,6 +6,7 @@ using Test, DataFrames
     df = DataFrame(a=1:3, b=4:6, c=7:9)
 
     @test df[1] == [1, 2, 3]
+    @test df[1] isa SubArray
     @test df[1] === eachcol(df)[1]
     @test df[1:2] == DataFrame(a=1:3, b=4:6)
     @test df[r"[ab]"] == DataFrame(a=1:3, b=4:6)


### PR DESCRIPTION
This fixes https://github.com/JuliaData/DataFrames.jl/issues/1844.

I open this in case there are any design comments. This is still WIP as I have to do two things:
* review documentation in detail to make sure it is updated (I will also make other changes to documentation as I read it if it is outdated in this PR to simplify my life)
* go though DataFrames.jl internals to make sure we do not rely on `df[:col]` returning the actual stored vector not its `view`