### PR TITLE
clean up after deletecols! removal

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -30,8 +30,8 @@ export AbstractDataFrame,
        categorical!,
        combine,
        completecases,
-       deletecols!,
-       deletecols,
+       deletecols!, # TODO: remove export after deprecation period
+       deletecols,  # TODO: remove export after deprecation period
        deleterows!,
        describe,
        disallowmissing!,

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -30,8 +30,6 @@ export AbstractDataFrame,
        categorical!,
        combine,
        completecases,
-       deletecols!, # TODO: remove export after deprecation period
-       deletecols,  # TODO: remove export after deprecation period
        deleterows!,
        describe,
        disallowmissing!,

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -397,8 +397,8 @@ function Base.join(df1::AbstractDataFrame,
     if indicator !== nothing
         refs = UInt8.(coalesce.(joined[df1_ind], false) .+
                       2 .* coalesce.(joined[df2_ind], false))
-        pool = CategoricalPool{String,UInt8}(["left_only", "right_only", "both"]
-        indicatorcol = CategoricalArray{String,1}(refs, pool))
+        pool = CategoricalPool{String,UInt8}(["left_only", "right_only", "both"])
+        indicatorcol = CategoricalArray{String,1}(refs, pool)
         unique_indicator = indicator
         try_idx = 0
         while hasproperty(joined, unique_indicator)

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -406,8 +406,11 @@ function Base.join(df1::AbstractDataFrame,
         end
         joined[unique_indicator] = indicatorcol
 
-        deletecols!(joined, Symbol(indicator_cols[1]))
-        deletecols!(joined, Symbol(indicator_cols[2]))
+        for colname in indicator_cols
+            i = index(joined)[Symbol(colname)]
+            splice!(_columns(joined), i)
+            delete!(index(joined), i)
+        end
     end
 
     return joined

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -306,9 +306,11 @@ function Base.join(df1::AbstractDataFrame,
             end
         end
         df1 = copy(df1, copycols=false)
-        df1[Symbol(indicator_cols[1])] = trues(nrow(df1))
+        df1_ind = Symbol(indicator_cols[1])
+        df1[df1_ind] = trues(nrow(df1))
         df2 = copy(df2, copycols=false)
-        df2[Symbol(indicator_cols[2])] = trues(nrow(df2))
+        df2_ind = Symbol(indicator_cols[2])
+        df2[df2_ind] = trues(nrow(df2))
     end
 
     if kind == :cross
@@ -393,11 +395,10 @@ function Base.join(df1::AbstractDataFrame,
     end
 
     if indicator !== nothing
-        left = joined[Symbol(indicator_cols[1])]
-        right = joined[Symbol(indicator_cols[2])]
-
-        refs = UInt8[coalesce(l, false) + 2 * coalesce(r, false) for (l, r) in zip(left, right)]
-        indicatorcol = CategoricalArray{String,1}(refs, CategoricalPool{String,UInt8}(["left_only", "right_only", "both"]))
+        refs = UInt8.(coalesce.(joined[df1_ind], false) .+
+                      2 .* coalesce.(joined[df2_ind], false))
+        pool = CategoricalPool{String,UInt8}(["left_only", "right_only", "both"]
+        indicatorcol = CategoricalArray{String,1}(refs, pool))
         unique_indicator = indicator
         try_idx = 0
         while hasproperty(joined, unique_indicator)
@@ -405,12 +406,7 @@ function Base.join(df1::AbstractDataFrame,
             unique_indicator = Symbol(string(indicator, "_", try_idx))
         end
         joined[unique_indicator] = indicatorcol
-
-        for colname in indicator_cols
-            i = index(joined)[Symbol(colname)]
-            splice!(_columns(joined), i)
-            delete!(index(joined), i)
-        end
+        select!(joined, Not([df1_ind, df2_ind]))
     end
 
     return joined

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1362,6 +1362,15 @@ import Base: show
 @deprecate showall(io::IO, df::GroupedDataFrame) show(io, df, allgroups=true)
 @deprecate showall(df::GroupedDataFrame) show(df, allgroups=true)
 
+import Base: delete!, insert!, merge!
+
+@deprecate delete!(df::AbstractDataFrame, cols::Any) select!(df, Not(cols))
+@deprecate insert!(df::DataFrame, col_ind::Int, item, name::Symbol; makeunique::Bool=false) insertcols!(df, col_ind, name => item; makeunique=makeunique)
+@deprecate merge!(df1::DataFrame, df2::AbstractDataFrame) (foreach(col -> df1[col] = df2[col], names(df2)); df1)
+
+ import Base: setindex!
+@deprecate setindex!(df::DataFrame, x::Nothing, col_ind::Int) select!(df, Not(col_ind))
+
 import Base: map
 @deprecate map(f::Function, sdf::SubDataFrame) f(sdf)
 @deprecate map(f::Union{Function,Type}, dfc::DataFrameColumns{<:AbstractDataFrame, Pair{Symbol, AbstractVector}}) mapcols(f, dfc.df)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1368,7 +1368,7 @@ import Base: delete!, insert!, merge!
 @deprecate insert!(df::DataFrame, col_ind::Int, item, name::Symbol; makeunique::Bool=false) insertcols!(df, col_ind, name => item; makeunique=makeunique)
 @deprecate merge!(df1::DataFrame, df2::AbstractDataFrame) (foreach(col -> df1[col] = df2[col], names(df2)); df1)
 
- import Base: setindex!
+import Base: setindex!
 @deprecate setindex!(df::DataFrame, x::Nothing, col_ind::Int) select!(df, Not(col_ind))
 
 import Base: map

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1362,14 +1362,6 @@ import Base: show
 @deprecate showall(io::IO, df::GroupedDataFrame) show(io, df, allgroups=true)
 @deprecate showall(df::GroupedDataFrame) show(df, allgroups=true)
 
-import Base: delete!, insert!, merge!
-@deprecate delete!(df::AbstractDataFrame, cols::Any) deletecols!(df, cols)
-@deprecate insert!(df::DataFrame, col_ind::Int, item, name::Symbol; makeunique::Bool=false) insertcols!(df, col_ind, name => item; makeunique=makeunique)
-@deprecate merge!(df1::DataFrame, df2::AbstractDataFrame) (foreach(col -> df1[col] = df2[col], names(df2)); df1)
-
-import Base: setindex!
-@deprecate setindex!(df::DataFrame, x::Nothing, col_ind::Int) deletecols!(df, col_ind)
-
 import Base: map
 @deprecate map(f::Function, sdf::SubDataFrame) f(sdf)
 @deprecate map(f::Union{Function,Type}, dfc::DataFrameColumns{<:AbstractDataFrame, Pair{Symbol, AbstractVector}}) mapcols(f, dfc.df)
@@ -1404,7 +1396,7 @@ import Base: haskey
 @deprecate haskey(df::AbstractDataFrame, key::Any) key in 1:ncol(df) || key in names(df)
 
 import Base: empty!
-@deprecate empty!(df::DataFrame) deletecols!(df, 1:ncol(df))
+@deprecate empty!(df::DataFrame) select!(df, Int[])
 
 @deprecate deletecols!(df::DataFrame, inds) select!(df, Not(inds))
 @deprecate deletecols(df::DataFrame, inds; copycols::Bool=true) select(df, Not(inds), copycols=copycols)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1400,4 +1400,3 @@ import Base: empty!
 
 @deprecate deletecols!(df::DataFrame, inds) select!(df, Not(inds))
 @deprecate deletecols(df::DataFrame, inds; copycols::Bool=true) select(df, Not(inds), copycols=copycols)
-@deprecate deletecols(df::DataFrame, inds) select(df, Not(inds))


### PR DESCRIPTION
I have forgotten to clean-up some code after `deletecols!` removal.

I also propose to remove old `insert!`, `delete!` and `merge!` deprecations.