### PR TITLE
Fix combine with aggregation when skipmissing=true

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -591,7 +591,7 @@ function groupreduce!(res, f, op, condf, adjust,
     @inbounds for i in eachindex(incol, gd.groups)
         gix = gd.groups[i]
         x = incol[i]
-        if condf === nothing || condf(x)
+        if gix > 0 && (condf === nothing || condf(x))
             res[gix] = op(res[gix], f(x, gix))
             adjust !== nothing && (counts[gix] += 1)
         end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -770,12 +770,12 @@ Base.isless(::TestType, ::Int) = true
 Base.isless(::Int, ::TestType) = false
 Base.isless(::TestType, ::TestType) = false
 
-@testset "combine with aggregation functions" begin
+@testset "combine with aggregation functions" for skip in (false, true), sort in (false, true)
     Random.seed!(1)
-    df = DataFrame(a = rand(1:5, 20), x1 = rand(Int, 20), x2 = rand(Complex{Int}, 20))
+    df = DataFrame(a = rand([1:5;missing], 20), x1 = rand(Int, 20), x2 = rand(Complex{Int}, 20))
 
     for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length)
-        gd = groupby_checked(df, :a)
+        gd = groupby_checked(df, :a, skipmissing=skip, sort=sort)
 
         res = combine(gd, y = :x1 => f)
         expected = combine(gd, y = :x1 => x -> f(x))
@@ -785,7 +785,7 @@ Base.isless(::TestType, ::TestType) = false
         for T in (Union{Missing, Int}, Union{Int, Int8},
                   Union{Missing, Int, Int8})
             df.x3 = Vector{T}(df.x1)
-            gd = groupby_checked(df, :a)
+            gd = groupby_checked(df, :a, skipmissing=skip, sort=sort)
             res = combine(gd, y = :x3 => f)
             expected = combine(gd, y = :x3 => x -> f(x))
             @test res ≅ expected
@@ -796,7 +796,7 @@ Base.isless(::TestType, ::TestType) = false
 
         df.x3 = allowmissing(df.x1)
         df.x3[1] = missing
-        gd = groupby_checked(df, :a)
+        gd = groupby_checked(df, :a, skipmissing=skip, sort=sort)
         res = combine(gd, y = :x3 => f)
         expected = combine(gd, y = :x3 => x -> f(x))
         @test res ≅ expected
@@ -808,7 +808,7 @@ Base.isless(::TestType, ::TestType) = false
     end
     # Test complex numbers
     for f in (sum, prod, mean, var, std, first, last, length)
-        gd = groupby_checked(df, :a)
+        gd = groupby_checked(df, :a, skipmissing=skip, sort=sort)
 
         res = combine(gd, y = :x2 => f)
         expected = combine(gd, y = :x2 => x -> f(x))
@@ -821,7 +821,7 @@ Base.isless(::TestType, ::TestType) = false
                    (Union{Missing, Int}, false), (Union{Missing, Int}, true))
         df.x3 = CategoricalVector{T}(df.x1)
         m && (df.x3[1] = missing)
-        gd = groupby_checked(df, :a)
+        gd = groupby_checked(df, :a, skipmissing=skip, sort=sort)
         res = combine(gd, y = :x3 => f)
         expected = combine(gd, y = :x3 => x -> f(x))
         @test res ≅ expected
@@ -831,23 +831,21 @@ Base.isless(::TestType, ::TestType) = false
 
         res = combine(gd, y = :x3 => f∘skipmissing)
         expected = combine(gd, y = :x3 => x -> f(collect(skipmissing(x))))
-        @test res == expected
+        @test res ≅ expected
         @test typeof(res.y) == typeof(expected.y)
         if m
             gd[1].x3 = missing
             @test_throws ArgumentError combine(gd, y = :x3 => f∘skipmissing)
         end
     end
-    @test combine(gd, y = :x1 => maximum, z = :x2 => sum) ==
+    @test combine(gd, y = :x1 => maximum, z = :x2 => sum) ≅
         combine(gd, y = :x1 => x -> maximum(x), z = :x2 => x -> sum(x))
     # Test floating point corner cases
     df = DataFrame(a = [1, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6],
                    x1 = [0.0, 1.0, 2.0, NaN, NaN, NaN, Inf, Inf, Inf, 1.0, NaN, 0.0, -0.0])
 
-    for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length),
-        sort in (false, true),
-        skip in (false, true)
-        gd = groupby_checked(df, :a, sort=sort, skipmissing=skip)
+    for f in (sum, prod, maximum, minimum, mean, var, std, first, last, length)
+        gd = groupby_checked(df, :a, skipmissing=skip, sort=sort)
 
         res = combine(gd, y = :x1 => f)
         expected = combine(gd, y = :x1 => x -> f(x))
@@ -858,7 +856,7 @@ Base.isless(::TestType, ::TestType) = false
 
         df.x3 = allowmissing(df.x1)
         df.x3[1] = missing
-        gd = groupby_checked(df, :a, sort=sort, skipmissing=skip)
+        gd = groupby_checked(df, :a, skipmissing=skip, sort=sort)
         res = combine(gd, y = :x3 => f)
         expected = combine(gd, y = :x3 => x -> f(x))
         @test res ≅ expected
@@ -876,7 +874,7 @@ Base.isless(::TestType, ::TestType) = false
 
     # Test maximum when no promotion rule exists
     df = DataFrame(x = [1, 1, 2, 2], y = [1, TestType(), TestType(), TestType()])
-    gd = groupby_checked(df, :x)
+    gd = groupby_checked(df, :x, skipmissing=skip, sort=sort)
     for f in (maximum, minimum)
         res = combine(gd, z = :y => maximum)
         @test res.z isa Vector{Any}


### PR DESCRIPTION
`gix == 0` for missing values when skipmissing=true, but the code was not designed to handle this. Due to `@inbounds`, it is likely to go unnoticed.

I've checked using benchmark at https://github.com/JuliaData/DataFrames.jl/pull/1651 that this doesn't affect performance (since unfortunately SIMD isn't enabled anyway in this loop).