### PR TITLE
Reformat long error-throwing code lines

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -240,7 +240,7 @@ Base.propertynames(df::AbstractDataFrame, private::Bool=false) = names(df)
 ##############################################################################
 
 """
-    similar(df::DataFrame[, rows::Integer])
+    similar(df::AbstractDataFrame, rows::Integer=nrow(df))
 
 Create a new `DataFrame` with the same column names and column element types
 as `df`. An optional second argument can be provided to request a number of rows
@@ -265,7 +265,7 @@ function Base.:(==)(df1::AbstractDataFrame, df2::AbstractDataFrame)
     for idx in 1:size(df1, 2)
         coleq = df1[idx] == df2[idx]
         # coleq could be missing
-        !isequal(coleq, false) || return false
+        isequal(coleq, false) && return false
         eq &= coleq
     end
     return eq
@@ -477,7 +477,6 @@ function get_stats(col::AbstractVector, stats::AbstractVector{Symbol})
             d[:std] = try std(col, mean = m) catch end
         end
     end
-
 
     if :nunique in stats
         if eltype(col) <: Real

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -817,7 +817,7 @@ function Base.convert(::Type{Matrix{T}}, df::AbstractDataFrame) where T
             if err isa MethodError && err.f == convert &&
                !(T >: Missing) && any(ismissing, col)
                 throw(ArgumentError("cannot convert a DataFrame containing missing values to Matrix{$T} " *
-                      "(found for column $name)"))
+                                     "(found for column $name)"))
             else
                 rethrow(err)
             end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -405,7 +405,8 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
 
     if !allunique(ordered_names)
         duplicate_names = unique(ordered_names[nonunique(DataFrame(ordered_names = ordered_names))])
-        throw(ArgumentError("Duplicate names not allowed. Duplicated value(s) are: :$(join(duplicate_names, ", "))"))
+        throw(ArgumentError("Duplicate names not allowed. Duplicated value(s) are: " *
+                            ":$(join(duplicate_names, ", "))"))
     end
 
     # Put the summary stats into the return data frame
@@ -816,7 +817,8 @@ function Base.convert(::Type{Matrix{T}}, df::AbstractDataFrame) where T
         catch err
             if err isa MethodError && err.f == convert &&
                !(T >: Missing) && any(ismissing, col)
-                error("cannot convert a DataFrame containing missing values to Matrix{$T} (found for column $name)")
+                error("cannot convert a DataFrame containing missing values to Matrix{$T} " *
+                      "(found for column $name)")
             else
                 rethrow(err)
             end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -817,7 +817,7 @@ function Base.convert(::Type{Matrix{T}}, df::AbstractDataFrame) where T
             if err isa MethodError && err.f == convert &&
                !(T >: Missing) && any(ismissing, col)
                 throw(ArgumentError("cannot convert a DataFrame containing missing values to Matrix{$T} " *
-                                     "(found for column $name)"))
+                                    "(found for column $name)"))
             else
                 rethrow(err)
             end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -817,8 +817,8 @@ function Base.convert(::Type{Matrix{T}}, df::AbstractDataFrame) where T
         catch err
             if err isa MethodError && err.f == convert &&
                !(T >: Missing) && any(ismissing, col)
-                error("cannot convert a DataFrame containing missing values to Matrix{$T} " *
-                      "(found for column $name)")
+                throw(ArgumentError("cannot convert a DataFrame containing missing values to Matrix{$T} " *
+                      "(found for column $name)"))
             else
                 rethrow(err)
             end

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -82,7 +82,8 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
         if size(df, 2) == 0
             rowid = nothing
         else
-            size(df, 1) == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+            size(df, 1) == 1 || 
+                throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
 
@@ -215,7 +216,8 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
         if size(df, 2) == 0
             rowid = nothing
         else
-            size(df, 1) == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+            size(df, 1) == 1 || 
+                throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
 

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -81,8 +81,7 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
     if rowid !== nothing
         if size(df, 2) == 0
             rowid = nothing
-        else
-            size(df, 1) == 1 || 
+        elseif size(df, 1) != 1 
                 throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
@@ -215,8 +214,7 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
     if rowid !== nothing
         if size(df, 2) == 0
             rowid = nothing
-        else
-            size(df, 1) == 1 || 
+        elseif size(df, 1) != 1 
                 throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -82,7 +82,7 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
         if size(df, 2) == 0
             rowid = nothing
         elseif size(df, 1) != 1 
-                throw(ArgumentError("rowid may be passed only with a single row data frame"))
+            throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
 

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -215,7 +215,7 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
         if size(df, 2) == 0
             rowid = nothing
         elseif size(df, 1) != 1 
-                throw(ArgumentError("rowid may be passed only with a single row data frame"))
+            throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
 

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -518,8 +518,7 @@ function _show(io::IO,
     if rowid !== nothing
         if size(df, 2) == 0
             rowid = nothing
-        else
-            nrows == 1 || 
+        elseif nrows != 1 
                 throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -519,7 +519,7 @@ function _show(io::IO,
         if size(df, 2) == 0
             rowid = nothing
         elseif nrows != 1 
-                throw(ArgumentError("rowid may be passed only with a single row data frame"))
+            throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
     dsize = displaysize(io)

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -519,7 +519,8 @@ function _show(io::IO,
         if size(df, 2) == 0
             rowid = nothing
         else
-            nrows == 1 || throw(ArgumentError("rowid may be passed only with a single row data frame"))
+            nrows == 1 || 
+                throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
     dsize = displaysize(io)

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -171,7 +171,8 @@ function ordering(df::AbstractDataFrame, cols::AbstractVector,
     end
 
     if length(lt) != length(cols)
-        throw(ArgumentError("All ordering arguments must be 1 or the same length as the number of columns requested."))
+        throw(ArgumentError("All ordering arguments must be 1 or the same length " *
+                            "as the number of columns requested."))
     end
 
     if length(cols) == 1

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -157,7 +157,8 @@ Base.get(dfr::DataFrameRow, key::ColumnIndex, default) =
     haskey(dfr, key) ? dfr[key] : default
 Base.get(f::Base.Callable, dfr::DataFrameRow, key::ColumnIndex) =
     haskey(dfr, key) ? dfr[key] : f()
-Base.broadcastable(::DataFrameRow) = throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
+Base.broadcastable(::DataFrameRow) = 
+    throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 
 """
     copy(dfr::DataFrameRow)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -996,7 +996,8 @@ function readtable(io::IO,
     if !isempty(eltypes)
         for j in 1:length(eltypes)
             if !(eltypes[j] in [String, Bool, Float64, Int64])
-                throw(ArgumentError("Invalid eltype $(eltypes[j]) encountered.\nValid eltypes: $(String), Bool, Float64 or Int64"))
+                throw(ArgumentError("Invalid eltype $(eltypes[j]) encountered.\n" *
+                                    "Valid eltypes: $(String), Bool, Float64 or Int64"))
             end
         end
     end

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -38,7 +38,7 @@ ai = convert(Matrix{Int}, df)
 @test ai == Matrix{Int}(df)
 
 df[1,1] = missing
-@test_throws ErrorException convert(Matrix{Float64}, df)
+@test_throws ArgumentError convert(Matrix{Float64}, df)
 na = convert(Matrix{Union{Float64, Missing}}, df)
 naa = convert(Matrix{Any}, df)
 nai = convert(Matrix{Union{Int, Missing}}, df)


### PR DESCRIPTION
Make sure to limit error-throwing code lines within the width of 95 characters.