### PR TITLE
First proposal of consistency checks

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -78,10 +78,11 @@ end
 
 function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
                summary::Bool=true, rowid::Union{Int,Nothing}=nothing)
+    _check_consistency(df)
     if rowid !== nothing
         if size(df, 2) == 0
             rowid = nothing
-        elseif size(df, 1) != 1 
+        elseif size(df, 1) != 1
             throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
@@ -211,10 +212,11 @@ function latex_escape(cell::AbstractString)
 end
 
 function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
+    _check_consistency(df)
     if rowid !== nothing
         if size(df, 2) == 0
             rowid = nothing
-        elseif size(df, 1) != 1 
+        elseif size(df, 1) != 1
             throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end
@@ -335,6 +337,7 @@ function printtable(io::IO,
                     separator::Char = ',',
                     quotemark::Char = '"',
                     missingstring::AbstractString = "missing")
+    _check_consistency(df)
     n, p = size(df)
     etypes = eltypes(df)
     if header

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -296,6 +296,8 @@ function Base.join(df1::AbstractDataFrame,
                    kind::Symbol = :inner, makeunique::Bool=false,
                    indicator::Union{Nothing, Symbol} = nothing,
                    validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false))
+    _check_consistency(df1)
+    _check_consistency(df2)
     if indicator !== nothing
         indicator_cols = ["_left", "_right"]
         for i in 1:2

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -514,11 +514,12 @@ function _show(io::IO,
                rowlabel::Symbol = :Row,
                summary::Bool = true,
                rowid=nothing)
+    _check_consistency(df)
     nrows = size(df, 1)
     if rowid !== nothing
         if size(df, 2) == 0
             rowid = nothing
-        elseif nrows != 1 
+        elseif nrows != 1
             throw(ArgumentError("rowid may be passed only with a single row data frame"))
         end
     end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -291,9 +291,10 @@ function _check_consistency(df::DataFrame)
     ncols == 0 && return nothing
     nrows = length(cols[1])
     for i in 2:length(cols)
-        @assert length(cols[i]) == nrows "Length of column $(names(df)[i]) ($(length(df[!, i])))" *
+        @assert length(cols[i]) == nrows "Data frame is corrupt: length of column :$(names(df)[i]) ($(length(df[!, i])))" *
                                          " does not match length of column 1 ($(length(df[!, 1]))). " *
-                                         "It is likely caused by unintended resizing of the column."
+                                         "The column vector has likely been resized unintentionally " *
+                                         "(either directly or because it is shared with another data frame)."
     end
     nothing
 end
@@ -1177,7 +1178,7 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple}; columns
         for col in _columns(df)
             resize!(col, nrows)
         end
-        @error "Error adding value to column $(names(df)[current_col])."
+        @error "Error adding value to column :$(names(df)[current_col])."
         rethrow(err)
     end
     df
@@ -1291,7 +1292,7 @@ function Base.push!(df::DataFrame, row::Any)
         for col in _columns(df)
             resize!(col, nrows)
         end
-        @error "Error adding value to column $(names(df)[current_col])."
+        @error "Error adding value to column :$(names(df)[current_col])."
         rethrow(err)
     end
     df

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -250,42 +250,43 @@ function Base.push!(df::DataFrame, dfr::DataFrameRow; columns::Symbol=:equal)
     if !(columns in (:equal, :intersect))
         throw(ArgumentError("`columns` keyword argument must be `:equal` or `:intersect`"))
     end
-    if ncol(df) == 0
+    nrows, ncols = size(df)
+    targetrows = nrows + 1
+    if ncols == 0
         for (n, v) in pairs(dfr)
             setproperty!(df, n, fill!(Tables.allocatecolumn(typeof(v), 1), v))
         end
         return df
     end
 
-    if parent(dfr) === df && index(dfr) isa Index
-        # in this case we are sure that all we do is safe
-        r = row(dfr)
-        for col in _columns(df)
-            # use a barrier function to improve performance
-            pushhelper!(col, r)
-        end
-    else
-        # DataFrameRow can contain duplicate columns and we disallow this
-        # corner case when push!-ing
-        # Only check for equal lengths, as an error will be thrown below if some names don't match
-        if columns === :equal
-            msg = "Number of columns of `row` does not match `DataFrame` column count."
-            size(df, 2) == length(dfr) || throw(ArgumentError(msg))
-        end
-        i = 1
-        for nm in _names(df)
-            try
-                push!(df[!, i], dfr[nm])
-            catch
-                #clean up partial row
-                for j in 1:(i - 1)
-                    pop!(df[!, j])
-                end
-                msg = "Error adding value to column :$nm."
-                throw(ArgumentError(msg))
+    try
+        if parent(dfr) === df && index(dfr) isa Index
+            # in this case we are sure that all we do is safe
+            r = row(dfr)
+            for col in _columns(df)
+                # use a barrier function to improve performance
+                pushhelper!(col, r)
             end
-            i += 1
+        else
+            # DataFrameRow can contain duplicate columns and we disallow this
+            # corner case when push!-ing
+            # Only check for equal lengths, as an error will be thrown below if some names don't match
+            if columns === :equal
+                msg = "Number of columns of `row` does not match `DataFrame` column count."
+                ncols == length(dfr) || throw(ArgumentError(msg))
+            end
+            for (col, nm) in zip(_columns(df), _names(df))
+                push!(col, dfr[nm])
+            end
         end
+        for col in _columns(df)
+            @assert length(col) == targetrows
+        end
+    catch err
+        for col in _columns(df)
+            resize!(col, nrows)
+        end
+        rethrow(err)
     end
     df
 end

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -134,6 +134,7 @@ julia> for g in gd
 """
 function groupby(df::AbstractDataFrame, cols::AbstractVector;
                  sort::Bool = false, skipmissing::Bool = false)
+    _check_consistency(df)
     intcols = convert(Vector{Int}, index(df)[cols])
     sdf = df[!, intcols]
     df_groups = group_rows(sdf, false, sort, skipmissing)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -156,7 +156,7 @@ end
     @test df == dfb
 
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, (33.33,"pear"))
+    @test_throws InexactError push!(dfb, (33.33,"pear"))
     @test dfc == dfb
 
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
@@ -164,11 +164,11 @@ end
     @test dfc == dfb
 
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, ("coconut",22))
+    @test_throws MethodError push!(dfb, ("coconut",22))
     @test dfc == dfb
 
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, (11,22))
+    @test_throws MethodError push!(dfb, (11,22))
     @test dfc == dfb
 
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
@@ -190,7 +190,7 @@ end
 
     df0= DataFrame( first=[1,2], second=["apple","orange"] )
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, (second=3, first=3))
+    @test_throws MethodError push!(dfb, (second=3, first=3))
     @test df0 == dfb
 
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
@@ -199,22 +199,22 @@ end
 
     df0= DataFrame( first=[1,2], second=["apple","orange"] )
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, Dict(:first=>true, :second=>false))
+    @test_throws MethodError push!(dfb, Dict(:first=>true, :second=>false))
     @test df0 == dfb
 
     df0= DataFrame( first=[1,2], second=["apple","orange"] )
     dfb= DataFrame( first=[1,2], second=["apple","orange"] )
-    @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>"stuff"))
+    @test_throws MethodError push!(dfb, Dict(:first=>"chicken", :second=>"stuff"))
     @test df0 == dfb
 
     df0=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
     dfb=DataFrame( first=[1,2,3], second=["apple","orange","pear"] )
-    @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
+    @test_throws MethodError push!(dfb, Dict(:first=>"chicken", :second=>1))
     @test df0 == dfb
 
     df0=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
     dfb=DataFrame( first=["1","2","3"], second=["apple","orange","pear"] )
-    @test_throws ArgumentError push!(dfb, Dict(:first=>"chicken", :second=>1))
+    @test_throws MethodError push!(dfb, Dict(:first=>"chicken", :second=>1))
     @test df0 == dfb
 
     df = DataFrame(x=1)
@@ -226,12 +226,43 @@ end
     @test df[!, :x] == [1, 3, 5] && df[!, :y] == [2, 4, 6]
 
     df = DataFrame(x=1, y=2)
-    @test_throws ArgumentError push!(df, Dict(:x=>1, "y"=>2))
+    @test_throws KeyError push!(df, Dict(:x=>1, "y"=>2))
     @test df == DataFrame(x=1, y=2)
 
     df = DataFrame()
     @test push!(df, (a=1, b=true)) === df
     @test df == DataFrame(a=1, b=true)
+
+    df = DataFrame()
+    df.a = [1,2,3]
+    df.b = df.a
+    dfc = copy(df)
+    @test_throws AssertionError push!(df, [1,2])
+    @test df == dfc
+    @test_throws AssertionError push!(df, (a=1,b=2))
+    @test df == dfc
+    @test_throws AssertionError push!(df, Dict(:a=>1, :b=>2))
+    @test df == dfc
+    @test_throws AssertionError push!(df, df[1, :])
+    @test df == dfc
+    @test_throws AssertionError push!(df, dfc[1, :])
+    @test df == dfc
+
+    df = DataFrame()
+    df.a = [1,2,3,4]
+    df.b = df.a
+    df.c = [1,2,3,4]
+    dfc = copy(df)
+    @test_throws AssertionError push!(df, [1,2,3])
+    @test df == dfc
+    @test_throws AssertionError push!(df, (a=1,b=2,c=3))
+    @test df == dfc
+    @test_throws AssertionError push!(df, Dict(:a=>1, :b=>2, :c=>3))
+    @test df == dfc
+    @test_throws AssertionError push!(df, df[1, :])
+    @test df == dfc
+    @test_throws AssertionError push!(df, dfc[1, :])
+    @test df == dfc
 end
 
 @testset "select! Not" begin
@@ -976,6 +1007,24 @@ end
     df4 = append!(df3, DataFrame())
     @test df4 === df3
     @test df4 == df
+
+    df = DataFrame()
+    df.a = [1,2,3]
+    df.b = df.a
+    dfc = copy(df)
+    @test_throws AssertionError append!(df, dfc)
+    @test df == dfc
+
+    df = DataFrame()
+    df.a = [1,2,3,4]
+    df.b = df.a
+    df.c = [1,2,3,4]
+    dfc = copy(df)
+    @test_throws AssertionError append!(df, dfc)
+    @test df == dfc
+
+    names!(df, [:a, :b, :z])
+    @test_throws ErrorException append!(df, dfc)
 end
 
 @testset "test categorical!" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -68,6 +68,16 @@ end
     @test parent(gd) === df
 end
 
+@testset "consistency" begin
+    df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8], c = 1:4)
+    push!(df.c, 5)
+    @test_throws AssertionError gd = groupby(df, :a)
+
+    df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8], c = 1:4)
+    push!(DataFrames._columns(df), df[:, :a])
+    @test_throws AssertionError gd = groupby(df, :a)
+end
+
 @testset "accepted columns" begin
     df = DataFrame(A=[1,1,1,2,2,2], B=[1,2,1,2,1,2], C=1:6)
     @test groupby(df, [1,2]) == groupby(df, 1:2) == groupby(df, [:A, :B])

--- a/test/io.jl
+++ b/test/io.jl
@@ -145,4 +145,20 @@ end
           "\\begin{tabular}{r|}\n\t& \\\\\n\t\\hline\n\t& \\\\\n\t\\hline\n\\end{tabular}\n"
 end
 
+@testset "consistency" begin
+    df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8], c = 1:4)
+    push!(df.c, 5)
+    @test_throws AssertionError sprint(show, "text/html", df)
+    @test_throws AssertionError sprint(show, "text/latex", df)
+    @test_throws AssertionError sprint(show, "text/csv", df)
+    @test_throws AssertionError sprint(show, "text/tab-separated-values", df)
+
+    df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8], c = 1:4)
+    push!(DataFrames._columns(df), df[:, :a])
+    @test_throws AssertionError sprint(show, "text/html", df)
+    @test_throws AssertionError sprint(show, "text/latex", df)
+    @test_throws AssertionError sprint(show, "text/csv", df)
+    @test_throws AssertionError sprint(show, "text/tab-separated-values", df)
+end
+
 end # module

--- a/test/join.jl
+++ b/test/join.jl
@@ -673,4 +673,21 @@ end
                                      validate=(false, true))
 end
 
+@testset "consistency" begin
+    # Join on symbols or vectors of symbols
+    cname = copy(name)
+    cjob = copy(job)
+    push!(cname[!, 1], cname[1, 1])
+    @test_throws AssertionError join(cname, cjob, on = :ID)
+
+    cname = copy(name)
+    cjob = copy(job)
+    push!(cjob[!, 1], cjob[1, 1])
+    @test_throws AssertionError join(cname, cjob, on = :ID)
+
+    cname = copy(name)
+    push!(DataFrames._columns(cname), cname[:, 1])
+    @test_throws AssertionError join(cname, cjob, on = :ID)
+end
+
 end # module

--- a/test/show.jl
+++ b/test/show.jl
@@ -366,4 +366,14 @@ end
     @test sprint(show, df[1, 2:1]) == "DataFrameRow"
 end
 
+@testset "consistency" begin
+    df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8], c = 1:4)
+    push!(df.c, 5)
+    @test_throws AssertionError sprint(show, df)
+
+    df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8], c = 1:4)
+    push!(DataFrames._columns(df), df[:, :a])
+    @test_throws AssertionError sprint(show, df)
+end
+
 end # module


### PR DESCRIPTION
This fixes https://github.com/JuliaData/DataFrames.jl/issues/1885 and https://github.com/JuliaData/DataFrames.jl/issues/1845.

What it does:
* sanitizes `push!` and `append!`, as I concluded that it is best to do more strict checks there (as we do dynamic dispatch there anyway)
* adds consistency checks to `join`, `groupby` and `_show`

(this also lead to a bit different approach to error throwing)

Consistency check for 10000 column costs ~200 microseconds so I think it is acceptable. But please comment on this.

Also please comment where else you think it is worth to add consistency checks.