### PR TITLE
allow scalar broadcasting into an empty data frame

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.19.0"
+version = "0.19.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -186,3 +186,10 @@ Note that `sdf[!, col] .= v` and `sdf[!, cols] .= v` syntaxes are not allowed as
 
 If column indexing using `Symbol` names in `cols` is performed, the order of columns in the operation is specified
 by the order of names.
+
+The `df[!, col] .= v` syntax follows several convinence special rules:
+* if `ncol(df) == 0` then it is allowed to add a column `v` as a freshly allocated column `col`;
+  the length of this column is equal to `length(v)` if `v` is a vector and `1` if it is a scalar or
+  a scalar broadcasting operation;
+* if `ncol(df) > 0` and `nrow(df) == 0` then it is allowed to add a column only if `v` is a scalar;
+  the length of this column is `0` and type the same as `typeof(v)`;

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -129,7 +129,7 @@ In particular a description explicitly mentions if the assignment is *in-place*.
                       (with the exception that if `v` is an `AbstractRange` it gets converted to a `Vector`);
                       also if `col` is a `Symbol` that is not present in `df` then a new column in `df` is created and holds `v`;
                       equivalent to `df.col = v` if `col` is a valid identifier;
-                      this operation is allowed if the following condition is met `ncol(df) == 0 || length(v) == nrow(df)`;
+                      this is allowed if `ncol(df) == 0 || length(v) == nrow(df)`;
 * `df[!, cols] = v` -> is currently disallowed, but is planned to be supported in the future;
 
 Note that only `df[!, col] = v` and `df.col = v` can be used to add a new column to a `DataFrame`.

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -129,6 +129,7 @@ In particular a description explicitly mentions if the assignment is *in-place*.
                       (with the exception that if `v` is an `AbstractRange` it gets converted to a `Vector`);
                       also if `col` is a `Symbol` that is not present in `df` then a new column in `df` is created and holds `v`;
                       equivalent to `df.col = v` if `col` is a valid identifier;
+                      this operation is allowed if the following condition is met `ncol(df) == 0 || length(v) == nrow(df)`;
 * `df[!, cols] = v` -> is currently disallowed, but is planned to be supported in the future;
 
 Note that only `df[!, col] = v` and `df.col = v` can be used to add a new column to a `DataFrame`.

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -172,7 +172,7 @@ In such an operation `AbstractDataFrame` is considered as two-dimensional and `D
     `DataFrameRow` is considered to be column-oriented.
 
 Additional rules:
-* in the `df[CartesianIndex(row, col)] .= v`, `df[row, col] .= v` syntaxes we broadcast `v` into the contents of `df[row, col]` (this is consistent with Base behavior);
+* in the `df[CartesianIndex(row, col)] .= v`, `df[row, col] .= v` syntaxes `v` is broadcasted into the contents of `df[row, col]` (this is consistent with Julia Base);
 * in the `df[row, cols] .= v` syntaxes the assignment to `df` is performed in-place;
 * in the `df[rows, col] .= v` and `df[rows, cols] .= v` syntaxes the assignment to `df` is performed in-place;
 * in the `df[!, col] .= v` syntax column `col` is replaced by a freshly allocated vector; if `col` is `Symbol` and it is missing from `df` then a new column is added; the length of the column is always the value of `nrow(df)` before the assignment takes place;

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -172,7 +172,8 @@ In such an operation `AbstractDataFrame` is considered as two-dimensional and `D
     `DataFrameRow` is considered to be column-oriented.
 
 Additional rules:
-* in the `df[CartesianIndex(row, col)] .= v`, `df[row, col] .= v` and `df[row, cols] .= v` syntaxes the assignment to `df` is performed in-place;
+* in the `df[CartesianIndex(row, col)] .= v`, `df[row, col] .= v` syntaxes we broadcast `v` into the contents of `df[row, col]` (this is consistent with Base behavior);
+* in the `df[row, cols] .= v` syntaxes the assignment to `df` is performed in-place;
 * in the `df[rows, col] .= v` and `df[rows, cols] .= v` syntaxes the assignment to `df` is performed in-place;
 * in the `df[!, col] .= v` syntax column `col` is replaced by a freshly allocated vector; if `col` is `Symbol` and it is missing from `df` then a new column is added;
 * `df[!, cols] = v` syntax is currently disallowed, but is planned to be supported in the future;

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -175,7 +175,7 @@ Additional rules:
 * in the `df[CartesianIndex(row, col)] .= v`, `df[row, col] .= v` syntaxes we broadcast `v` into the contents of `df[row, col]` (this is consistent with Base behavior);
 * in the `df[row, cols] .= v` syntaxes the assignment to `df` is performed in-place;
 * in the `df[rows, col] .= v` and `df[rows, cols] .= v` syntaxes the assignment to `df` is performed in-place;
-* in the `df[!, col] .= v` syntax column `col` is replaced by a freshly allocated vector; if `col` is `Symbol` and it is missing from `df` then a new column is added;
+* in the `df[!, col] .= v` syntax column `col` is replaced by a freshly allocated vector; if `col` is `Symbol` and it is missing from `df` then a new column is added; the length of the column is always the value of `nrow(df)` before the assignment takes place;
 * `df[!, cols] = v` syntax is currently disallowed, but is planned to be supported in the future;
 * `df.col .= v` syntax is allowed and performs in-place assignment to an existing vector `df.col`.
 * in the `sdf[CartesianIndex(row, col)] .= v`, `sdf[row, col] .= v` and `sdf[row, cols] .= v` syntaxes the assignment to `sdf` is performed in-place;
@@ -187,10 +187,3 @@ Note that `sdf[!, col] .= v` and `sdf[!, cols] .= v` syntaxes are not allowed as
 
 If column indexing using `Symbol` names in `cols` is performed, the order of columns in the operation is specified
 by the order of names.
-
-The `df[!, col] .= v` syntax follows several convinence special rules:
-* if `ncol(df) == 0` then it is allowed to add a column `v` as a freshly allocated column `col`;
-  the length of this column is equal to `length(v)` if `v` is a vector and `1` if it is a scalar or
-  a scalar broadcasting operation;
-* if `ncol(df) > 0` and `nrow(df) == 0` then it is allowed to add a column only if `v` is a scalar;
-  the length of this column is `0` and type the same as `typeof(v)`;

--- a/src/other/broadcasting.jl
+++ b/src/other/broadcasting.jl
@@ -84,7 +84,7 @@ end
 # in this case we inherit it from the right hand side
 Base.axes(x::LazyNewColDataFrame) = (Base.OneTo(nrow(x.df)),)
 
-function Base.materialize!(dest::LazyNewColDataFrame,
+function Base.Broadcast.materialize!(dest::LazyNewColDataFrame,
                            bc::Base.Broadcast.Broadcasted{Style}) where {Style}
     ibc = Base.Broadcast.instantiate(bc)
     if length(axes(ibc)) == 1 && length(axes(ibc)[1]) == 0
@@ -101,7 +101,7 @@ function Base.materialize!(dest::LazyNewColDataFrame,
     end
 end
 
-function Base.materialize!(dest::LazyNewColDataFrame, x)
+function Base.Broadcast.materialize!(dest::LazyNewColDataFrame, x)
     if length(axes(x)) == 1 && length(axes(x)[1]) == 0
         throw(ArgumentError("Cannot broadcast over an empty container"))
     end

--- a/src/other/broadcasting.jl
+++ b/src/other/broadcasting.jl
@@ -78,8 +78,6 @@ struct LazyNewColDataFrame{T}
     col::T
 end
 
-# we allow LazyNewColDataFrame also for data frames
-# that are empty, ie. `nrow(df) == 0`; in this case we create a 0 length column
 Base.axes(x::LazyNewColDataFrame) = (Base.OneTo(nrow(x.df)),)
 
 # ColReplaceDataFrame is reserved for future extensions if we decide to allow df[!, cols] .= v

--- a/src/other/broadcasting.jl
+++ b/src/other/broadcasting.jl
@@ -165,7 +165,7 @@ function Base.copyto!(lazydf::LazyNewColDataFrame, bc::Base.Broadcast.Broadcaste
         else
             col_tmp = Base.Broadcast.materialize(bc)
         end
-        if col_tmp isa AbstractVector
+        if col_tmp isa AbstractArray && ndims(col_tmp) == 1
             col = col_tmp
         else
             @assert nrow(lazydf.df) < 2

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -630,7 +630,7 @@ end
     @test df == DataFrame(a=Int[], b=Float64[])
     @test eltype(df.b) == Float64
     df[!, :a] .= 10.0
-    @test df == DataFrame(a=Int[])
+    @test df == DataFrame(a=Float64[], b=Float64[])
     @test eltype(df.a) == Float64
 end
 
@@ -1100,7 +1100,7 @@ end
     @test df == refdf
     @test_throws ArgumentError df[!, 10] .= [1,2,3]
     @test df == refdf
-    @test_throws DimensionMismatch df[!, 10] .= [1 2 3]
+    @test_throws ArgumentError df[!, 10] .= [1 2 3]
     @test df == refdf
 
     df = copy(refdf)

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -737,9 +737,11 @@ end
 
 @testset "scalar on assignment side" begin
     df = DataFrame(rand(2, 3))
-    df[1, 1] .= df[1, 1] .- df[1, 1]
+    @test_throws MethodError df[1, 1] .= df[1, 1] .- df[1, 1]
+    df[1, 1:1] .= df[1, 1] .- df[1, 1]
     @test df[1, 1] == 0
-    df[1, 2] .-= df[1, 2]
+    @test_throws MethodError df[1, 2] .-= df[1, 2]
+    df[1:1, 2] .-= df[1, 2]
     @test df[1, 2] == 0
 end
 
@@ -983,26 +985,20 @@ end
 @testset "additional checks of post-! broadcasting rules" begin
     df = copy(refdf)
     v1 = df[!, 1]
-    df[CartesianIndex(1, 1)] .= VERSION >= v"1.1.0" ? 'd' : Ref('d')
-    @test v1 == [100.0, 2.5, 3.5]
+    @test_throws MethodError df[CartesianIndex(1, 1)] .= 1
     @test_throws MethodError df[CartesianIndex(1, 1)] .= "d"
-    @test v1 == [100.0, 2.5, 3.5]
     @test_throws DimensionMismatch df[CartesianIndex(1, 1)] .= [1,2]
 
     df = copy(refdf)
     v1 = df[!, 1]
-    df[1, 1] .= VERSION >= v"1.1.0" ? 'd' : Ref('d')
-    @test v1 == [100.0, 2.5, 3.5]
+    @test_throws MethodError df[1, 1] .= 1
     @test_throws MethodError df[1, 1] .= "d"
-    @test v1 == [100.0, 2.5, 3.5]
     @test_throws DimensionMismatch df[1, 1] .= [1, 2]
 
     df = copy(refdf)
     v1 = df[!, 1]
-    df[1, :x1] .= VERSION >= v"1.1.0" ? 'd' : Ref('d')
-    @test v1 == [100.0, 2.5, 3.5]
+    @test_throws MethodError df[1, :x1] .= 1
     @test_throws MethodError df[1, :x1] .= "d"
-    @test v1 == [100.0, 2.5, 3.5]
     @test_throws DimensionMismatch df[1, :x1] .= [1, 2]
 
     df = copy(refdf)
@@ -1153,26 +1149,20 @@ end
 
     df = view(copy(refdf), :, :)
     v1 = df[!, 1]
-    df[CartesianIndex(1, 1)] .= VERSION >= v"1.1.0" ? 'd' : Ref('d')
-    @test v1 == [100.0, 2.5, 3.5]
+    @test_throws MethodError df[CartesianIndex(1, 1)] .= 1
     @test_throws MethodError df[CartesianIndex(1, 1)] .= "d"
-    @test v1 == [100.0, 2.5, 3.5]
     @test_throws DimensionMismatch df[CartesianIndex(1, 1)] .= [1,2]
 
     df = view(copy(refdf), :, :)
     v1 = df[!, 1]
-    df[1, 1] .= VERSION >= v"1.1.0" ? 'd' : Ref('d')
-    @test v1 == [100.0, 2.5, 3.5]
+    @test_throws MethodError df[1, 1] .= 1
     @test_throws MethodError df[1, 1] .= "d"
-    @test v1 == [100.0, 2.5, 3.5]
     @test_throws DimensionMismatch df[1, 1] .= [1, 2]
 
     df = view(copy(refdf), :, :)
     v1 = df[!, 1]
-    df[1, :x1] .= VERSION >= v"1.1.0" ? 'd' : Ref('d')
-    @test v1 == [100.0, 2.5, 3.5]
+    @test_throws MethodError df[1, :x1] .= 1
     @test_throws MethodError df[1, :x1] .= "d"
-    @test v1 == [100.0, 2.5, 3.5]
     @test_throws DimensionMismatch df[1, :x1] .= [1, 2]
 
     df = view(copy(refdf), :, :)
@@ -1318,6 +1308,20 @@ end
     @test a == [2, 3, 4]
     @test df.a == [3, 4, 5]
     @test df.a !== a
+end
+
+@testset "add new correct rules for df[row, col] .= v broadcasting" begin
+    df = DataFrame(a=1)
+    @test_throws MethodError df[1,1] .= 10
+    @test_throws MethodError df[1,:a] .= 10
+    @test_throws MethodError df[CartesianIndex(1,1)] .= 10
+    df = DataFrame(a=[[1,2,3]])
+    df[1,1] .= 10
+    @test df == DataFrame(a=[[10,10,10]])
+    df[1,:a] .= 100
+    @test df == DataFrame(a=[[100,100,100]])
+    df[CartesianIndex(1,1)] .= 1000
+    @test df == DataFrame(a=[[1000,1000,1000]])
 end
 
 end # module

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -683,7 +683,7 @@ end
 
     df[!, :b] .= c[1]
     @test nrow(df) == 0
-    @test df.b isa CategoricalVector
+    @test df.b isa CategoricalVector{String}
 end
 
 @testset "test categorical values" begin

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -629,7 +629,7 @@ end
     df[!, :b] .= 1.0
     @test df == DataFrame(a=Int[], b=Float64[])
     @test eltype(df.b) == Float64
-    df[!, :a] = 10.0
+    df[!, :a] .= 10.0
     @test df == DataFrame(a=Int[])
     @test eltype(df.a) == Float64
 end

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -603,6 +603,7 @@ end
 @testset "empty data frame corner case" begin
     df = DataFrame()
     @test_throws ArgumentError df[!, 1] .= 1
+    @test_throws ArgumentError df[!, 2] .= 1
     @test_throws ArgumentError df[!, :a] .= [1]
     @test_throws ArgumentError df[!, [:a,:b]] .= [1]
     @test df == DataFrame()
@@ -615,11 +616,22 @@ end
     @test_throws DimensionMismatch df .= ones(1,2)
     @test_throws DimensionMismatch df .= ones(1,1,1)
 
-    @test_throws ArgumentError df[!, :a] .= 1
+    @test_throws ArgumentError df[!, :a] .= [1]
     @test_throws ArgumentError df[!, [:a, :b]] .= 1
 
     df = DataFrame(a=[])
-    @test_throws ArgumentError df[!, :b] .= 1
+    @test_throws ArgumentError df[!, :b] .= sin.(1)
+
+    df = DataFrame()
+    df[!, :a] .= 1
+    @test df == DataFrame(a=Int[])
+    @test eltype(df.a) == Int
+    df[!, :b] .= 1.0
+    @test df == DataFrame(a=Int[], b=Float64[])
+    @test eltype(df.b) == Float64
+    df[!, :a] = 10.0
+    @test df == DataFrame(a=Int[])
+    @test eltype(df.a) == Float64
 end
 
 @testset "test categorical values" begin


### PR DESCRIPTION
Fix #1889
@grahamgill - in tests you can see what will be allowed and what will be still disallowed.