### PR TITLE
Improve documentation generation

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,5 +2,5 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.19"
+Documenter = "~0.23"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
     doctest = false,
     clean = false,
     sitename = "DataFrames.jl",
-    format = :html,
+    format = Documenter.HTML(),
     pages = Any[
         "Introduction" => "index.md",
         "User Guide" => Any[
@@ -24,7 +24,7 @@ makedocs(
             "Reshaping" => "man/reshaping_and_pivoting.md",
             "Sorting" => "man/sorting.md",
             "Categorical Data" => "man/categorical.md",
-            "Missing Data" => "man/missing.md", 
+            "Missing Data" => "man/missing.md",
             "Data manipulation frameworks" => "man/querying_frameworks.md"
         ],
         "API" => Any[
@@ -42,7 +42,6 @@ deploydocs(
     # options
     repo = "github.com/JuliaData/DataFrames.jl.git",
     target = "build",
-    julia = "1.0",
     deps = nothing,
     make = nothing,
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,7 +14,7 @@ Please report bugs by
 [opening an issue](https://github.com/JuliaData/DataFrames.jl/issues/new).
 
 You can follow
-the [**source**]() links throughout the documentation to jump right to the
+the **source** links throughout the documentation to jump right to the
 source files on GitHub to make pull requests for improving the documentation and function
 capabilities.
 

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -33,7 +33,6 @@ allowmissing!
 categorical!
 completecases
 copy
-DataFrame
 DataFrame!
 deleterows!
 describe


### PR DESCRIPTION
Fixes #1891

The original reason for this PR is #1891. The problem I have is that locally the documentation of the functions mentioned there is generated correctly, but it is broken on GitHub for some strange reason.

So I have started to look at documentation generation mechanics and fixed some deprecations. Currently when I build documentation locally I get the following output (sorry that it is long, but maybe something important is lurking there). I will ask the questions I have below the output.

```
julia> include("make.jl")
[ Info: SetupBuildDirectory: setting up build directory.
[ Info: Doctest: skipped.
[ Info: ExpandTemplates: expanding markdown templates.
┌ Warning: duplicate docs found for 'DataFrame' in `@docs` block in src\lib\types.md:112-122
│ ```@docs
│ AbstractDataFrame
│ DataFrame
│ DataFrameRow
│ GroupedDataFrame
│ SubDataFrame
│ DataFrameRows
│ DataFrameColumns
│ RepeatedVector
│ StackedVector
│ ```
└ @ Documenter.Expanders C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Expanders.jl:313
[ Info: CrossReferences: building cross-references.
┌ Warning: no doc found for reference '[`sum`](@ref)' in src\lib\functions.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`isequal`](@ref)' in src\lib\functions.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`sum`](@ref)' in src\lib\functions.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`skipmissing`](@ref)' in src\lib\functions.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`unique`](@ref)' in src\lib\functions.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`size`](@ref)' in src\lib\functions.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`size`](@ref)' in src\lib\functions.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`summary`](@ref)' in src\lib\types.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`first`](@ref)' in src\lib\types.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
┌ Warning: no doc found for reference '[`last`](@ref)' in src\lib\types.md.
└ @ Documenter.CrossReferences C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\CrossReferences.jl:160
[ Info: CheckDocument: running document checks.
┌ Warning: 24 docstrings potentially missing:
│
│     DataFrames.showrowindices :: Tuple{IO,AbstractDataFrame,AbstractArray{Int64,1},Array{Int64,1},Int64,Int64,Any}
│     DataFrames.@csv2_str :: Tuple{Any,Vararg{Any,N} where N}
│     DataFrames.@csv_str :: Tuple{Any,Vararg{Any,N} where N}
│     Base.parent :: Tuple{GroupedDataFrame}
│     Base.first :: Tuple{AbstractDataFrame}
│     Base.first :: Tuple{AbstractDataFrame,Integer}
│     DataFrames.getprintedwidth :: Tuple{Array{Int64,1}}
│     Base.last :: Tuple{AbstractDataFrame}
│     Base.last :: Tuple{AbstractDataFrame,Integer}
│     DataFrames.writetable :: Tuple{AbstractString,AbstractDataFrame}
│     DataFrames.@wsv_str :: Tuple{Any,Vararg{Any,N} where N}
│     Base.issorted :: Union{Tuple{AbstractDataFrame}, Tuple{AbstractDataFrame,Any}}
│     Base.unique
│     DataFrames.ourshow :: Tuple{IO,Any}
│     DataFrames.@tsv_str :: Tuple{Any,Vararg{Any,N} where N}
│     DataFrames.compacttype :: Union{Tuple{Type}, Tuple{Type,Int64}}
│     DataFrames.showrows :: Union{Tuple{IO,AbstractDataFrame,AbstractArray{Int64,1},AbstractArray{Int64,1},Array{Int64,1}}, Tuple{IO,AbstractDataFrame,AbstractArray{Int64,1},AbstractArray{Int64,1},Array{Int64,1},Bool}, Tuple{IO,AbstractDataFrame,AbstractArray{Int64,1},AbstractArray{Int64,1},Array{Int64,1},Bool,Bool}, Tuple{IO,AbstractDataFrame,AbstractArray{Int64,1},AbstractArray{Int64,1},Array{Int64,1},Bool,Bool,Symbol}, Tuple{IO,AbstractDataFrame,AbstractArray{Int64,1},AbstractArray{Int64,1},Array{Int64,1},Bool,Bool,Symbol,Bool}, Tuple{IO,AbstractDataFrame,AbstractArray{Int64,1},AbstractArray{Int64,1},Array{Int64,1},Bool,Bool,Symbol,Bool,Any}}
│     DataFrames.inlinetable :: Tuple{AbstractString}
│     DataFrames.gennames :: Tuple{Integer}
│     Base.similar :: Union{Tuple{AbstractDataFrame}, Tuple{AbstractDataFrame,Integer}}
│     DataFrames.readtable :: Tuple{AbstractString}
│     Base.sortperm :: Tuple{AbstractDataFrame,Any}
│     DataFrames.getmaxwidths :: Union{Tuple{AbstractDataFrame,IO,AbstractArray{Int64,1},AbstractArray{Int64,1},Symbol}, Tuple{AbstractDataFrame,IO,AbstractArray{Int64,1},AbstractArray{Int64,1},Symbol,Any}}
│     DataFrames.getchunkbounds :: Tuple{Array{Int64,1},Bool,Int64}
└ @ Documenter.DocChecks C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\DocChecks.jl:63
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
┌ Warning: invalid local link: unresolved path in lib\functions.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\functions.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\functions.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\functions.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\functions.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\functions.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\functions.md
│   link = "lib/@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\types.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\types.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Warning: invalid local link: unresolved path in lib\types.md
│   link = "@ref"
└ @ Documenter.Writers.HTMLWriter C:\Users\bogum\.julia\packages\Documenter\oEuOX\src\Writers\HTMLWriter.jl:1173
┌ Info: Deployment criteria:
│ - ✔ ENV["TRAVIS_REPO_SLUG"]="" occurs in repo="github.com/JuliaData/DataFrames.jl.git"
│ - ✘ ENV["TRAVIS_PULL_REQUEST"]="" is "false"
│ - ✔ ENV["TRAVIS_TAG"]="" is (i) empty or (ii) a valid VersionNumber
│ - ✘ ENV["TRAVIS_BRANCH"]="" matches devbranch="master" (if tag is empty)
│ - ✘ ENV["DOCUMENTER_KEY"] exists
│ - ✔ ENV["TRAVIS_EVENT_TYPE"]="" is not "cron"
└ Deploying: ✘
```

Questions (maybe @mortenpi or @fredrikekre could give advice how to fix it - thank you for your support in advance 😄):

Question 1: why do I get different results locally and on remote when building the documentation (as I have said - the original problem locally is not present, but some other problems pop up that are not present on remote). What I should do to ensure that both are identical (as this is essential for testing for me)

Question 2: how can I check what documentation is generated remotely on GitHub during CI (but before merging the PR)

Question 3: I have a warning `Warning: duplicate docs found for 'DataFrame' in `@docs` block in src\lib\types.md:112-122` but I cannot see these duplicate docs - what is the reason of this warning?

Question 4: I get warnings like (this is one example, there are many) `Warning: no doc found for reference '[`isequal`](@ref)' in src\lib\functions.md.` - this is a reference to Base - how to make it work in a package? (so that I get a cross-reference from a package to Base)

Question 5: I get warnings `Warning: 24 docstrings potentially missing:` - how can I indicate to Documenter.jl that I do not intend to write a documentation of some function (this is mostly needed for unexported or deprecated functionality or the functionality that extends Base; I know we have still some docstrings missing where they are needed 😢 - these will get added)

Question 6: I get warnings like `Warning: invalid local link: unresolved path in lib\functions.md
│   link = "@ref"` - how can I check which link is actually invalid (there are hundreds of them in the generated file)

(sorry for the laundry list - if the answer is "read the Documenter.jl documentation" then please say so I will go through it again 😄 - I did it once, and did not notice the answers for these question)