### PR TITLE
Change eltype to true eltype in describe

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -435,6 +435,10 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
             d[:last] = isempty(col) ? nothing : last(col)
         end
 
+        if :eltype in predefined_funs
+            d[:eltype] = eltype(col)
+        end
+
         return d
     end
 
@@ -483,10 +487,6 @@ function get_stats(col::AbstractVector, stats::AbstractVector{Symbol})
         else
             d[:nunique] = try length(unique(col)) catch end
         end
-    end
-
-    if :eltype in stats
-        d[:eltype] = eltype(col)
     end
 
     return d

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -876,8 +876,8 @@ end
                                 nmissing = [nothing, 1, nothing, 1, nothing, nothing],
                                 first = [1, 1, "a", "a", Date(2000), 1],
                                 last = [4, missing, "d", missing, Date(2004), 2],
-                                eltype = [Int, Int, String, String, Date,
-                                          eltype(df[!, :catarray])])
+                                eltype = [Int, Union{Missing, Int}, String,
+                                          Union{Missing, String}, Date, CategoricalValue{Int, UInt32}])
 
     default_fields = [:mean, :min, :median, :max, :nunique, :nmissing, :eltype]
 


### PR DESCRIPTION
Fixes #1765.

Actually I think that it is better to print true `eltype` not a stripped one. It is a bit more verbose, but is explicit and in this case it is not a problem (someone wants `eltype` in `describe` so one gets it verbatim).