### PR TITLE
fix a typo in append!

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1135,7 +1135,7 @@ function Base.append!(df1::DataFrame, df2::AbstractDataFrame)
         for col in _columns(df1)
             resize!(col, nrows)
         end
-        @error "Error adding value to column $(names(df)[current_col])."
+        @error "Error adding value to column $(names(df1)[current_col])."
         rethrow(err)
     end
     return df1


### PR DESCRIPTION
Fixes a problem with error message generation:

Current:
```
julia> df = DataFrame()
0×0 DataFrame


julia> df.a = df.b = [1]
1-element Array{Int64,1}:
 1

julia> append!(df, df)
┌ Error: Exception while generating log record in module DataFrames at C:\Users\bogum\.julia\dev\DataFrames\src\dataframe\dataframe.jl:1138
│   exception =
│    UndefVarError: df not defined
│    Stacktrace:
│     [1] macro expansion at .\logging.jl:319 [inlined]
│     [2] append!(::DataFrame, ::DataFrame)
│     [3] top-level scope at none:0
│     [4] eval(::Module, ::Any) at .\boot.jl:328
│     [5] eval_user_input(::Any, ::REPL.REPLBackend) at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:85
│     [6] macro expansion at C:\cygwin\home\Administrator\buildbot\worker\package_win64\build\usr\share\julia\stdlib\v1.1\REPL\src\REPL.jl:117 [inlined]
│     [7] (::getfield(REPL, Symbol("##26#27")){REPL.REPLBackend})() at .\task.jl:259
└ @ DataFrames
ERROR: AssertionError: length(col) == targetrows
Stacktrace:
 [1] append!(::DataFrame, ::DataFrame)
 [2] top-level scope at none:0
```

after the change:
```
julia> append!(df, df)
┌ Error: Error adding value to column b.
└ @ DataFrames
ERROR: AssertionError: length(col) == targetrows
Stacktrace:
 [1] append!(::DataFrame, ::DataFrame)
 [2] top-level scope at none:0
```