### PR TITLE
disallow GroupedDataFrame broadcasting

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -15,6 +15,9 @@ struct GroupedDataFrame{T<:AbstractDataFrame}
     ends::Vector{Int}    # ends of groups
 end
 
+Base.broadcastable(::GroupedDataFrame) =
+    throw(ArgumentError("broadcasting over `GroupedDataFrame`s is reserved"))
+
 """
     parent(gd::GroupedDataFrame)
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -66,6 +66,7 @@ end
     df = DataFrame(a = [1, 1, 2, 2], b = [5, 6, 7, 8])
     gd = groupby(df, :a)
     @test parent(gd) === df
+    @test_throws ArgumentError identity.(gd)
 end
 
 @testset "consistency" begin


### PR DESCRIPTION
I do not do deprecation period, as the old behavior was unintended.