### PR TITLE
fix deprecation for setindex! using 1-row DataFrame

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.19.2"
+version = "0.19.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1434,7 +1434,8 @@ function Base.setindex!(df::DataFrame, new_df::DataFrame, col_inds::AbstractVect
     setindex!(df, new_df, findall(col_inds))
 end
 @deprecate setindex!(df::DataFrame, new_df::DataFrame,
-                     col_inds::AbstractVector{<:ColumnIndex}) foreach(((j, colind),) -> (df[!, colind] = new_df[!, j]), enumerate(col_inds))
+                     col_inds::AbstractVector{<:ColumnIndex}) foreach(((j, colind),) -> (df[!, colind] = new_df[!, j]),
+                                                                      enumerate(col_inds))
 
 # df[MultiColumnIndex] = AbstractVector (REPEATED FOR EACH COLUMN)
 @deprecate setindex!(df::DataFrame, v::AbstractVector,
@@ -1467,9 +1468,11 @@ end
 
 # df[SingleRowIndex, MultiColumnIndex] = 1-Row DataFrame
 @deprecate setindex!(df::DataFrame, new_df::DataFrame, row_ind::Integer,
-                     col_inds::AbstractVector{Bool}) (foreach(c -> (df[row_ind, c] = new_df[1, c]), findall(col_inds)); df)
+                     col_inds::AbstractVector{Bool}) (foreach(((i, c),) -> (df[row_ind, c] = new_df[1, i]),
+                                                              enumerate(findall(col_inds))); df)
 @deprecate setindex!(df::DataFrame, new_df::DataFrame, row_ind::Integer,
-                     col_inds::AbstractVector{<:ColumnIndex}) (foreach(c -> (df[row_ind, c] = new_df[1, c]), col_inds); df)
+                     col_inds::AbstractVector{<:ColumnIndex}) (foreach(((i, c),) -> (df[row_ind, c] = new_df[1, i]),
+                                                                       enumerate(col_inds)); df)
 
 # df[SingleRowIndex, MultiColumnIndex] = Single Item
 @deprecate setindex!(df::DataFrame, v::Any, row_ind::Integer,

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -386,6 +386,15 @@ end
         # vector broadcasting assignment of subtables
         df[1:2, 1:2] = [3,2]
         df[[true,false,false,true], 2:3] = [2,3]
+
+        # test of 1-row DataFrame assignment
+        df = DataFrame([1 2 3])
+        df[1, 2:3] = DataFrame([11 12])
+        @test df == DataFrame([1 11 12])
+
+        df = DataFrame([1 2 3])
+        df[1, [false, true, true]] = DataFrame([11 12])
+        @test df == DataFrame([1 11 12])
     end
 
     @testset "old test/dataframes.jl tests" begin


### PR DESCRIPTION
This fixes https://discourse.julialang.org/t/overwrite-partial-dataframe-row-with-new-array/27953.

@nalimilan After this is merged we should tag a release. Ideally I would also merge https://github.com/JuliaData/DataFrames.jl/pull/1925 and https://github.com/JuliaData/DataFrames.jl/pull/1899 if they could be ready relatively soon (I have time to work on it) and then tag 0.20.0 release (this is my preferred option if you have time to have a look, especially at #1899 which is large). Otherwise we should just pick this PR over 0.19.3 and tag 0.19.4 with only this fix.