### PR TITLE
Cleanup tests

### DIFF
--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -53,7 +53,7 @@ end
     @test (df1 ./ df2) == DataFrame(ones(size(refdf)))
 end
 
-@testset "broadcasting of AbstractDataFrame objects errors" begin
+@testset "broadcasting of AbstractDataFrame objects thrown exceptions" begin
     df = copy(refdf)
     dfv = view(df, :, 2:ncol(df))
 

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -427,7 +427,7 @@ end
     @test_throws ArgumentError reduce(vcat, (df1, df2, df2), cols=[:C, :C])
 end
 
-@testset "vcat errors" begin
+@testset "vcat thrown exceptions" begin
     df1 = DataFrame(A = 1:3, B = 1:3)
     df2 = DataFrame(A = 1:3)
     # right missing 1 column

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -322,7 +322,7 @@ end
     @test DataFrame(a = 1, b = 1:5) == DataFrame(a = fill(1, 5), b = collect(1:5))
 end
 
-@testset "constructor errors" begin
+@testset "constructor thrown exceptions" begin
     @test_throws DimensionMismatch DataFrame(a=1, b=[])
     @test_throws DimensionMismatch DataFrame(Any[collect(1:10)], DataFrames.Index([:A, :B]))
     @test_throws DimensionMismatch DataFrame(A = rand(2,2))

--- a/test/index.jl
+++ b/test/index.jl
@@ -192,7 +192,7 @@ si7 = SubIndex(i, Not(1:2))
     @test names(dfr3) == [:c, :b]
 end
 
-@testset "fuzzy matching and ArgumentError" begin
+@testset "fuzzy matching" begin
     i = Index()
     push!(i, :x1)
     push!(i, :x12)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -173,4 +173,33 @@ end
     @test_throws ErrorException columnindex(df, "x1")
 end
 
+@testset "eachrow and eachcol integration" begin
+     df = DataFrame(rand(3,4), [:a, :b, :c, :d])
+
+     df2 = DataFrame(eachrow(df))
+     @test df == df2
+     @test !any(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+
+     df2 = DataFrame!(eachrow(df))
+     @test df == df2
+     @test !any(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+
+     df2 = DataFrame(eachcol(df, true))
+     @test df == df2
+     @test !any(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+
+     df2 = DataFrame!(eachcol(df, true))
+     @test df == df2
+     @test all(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+
+     df2 = DataFrame(eachcol(df))
+     @test names(df2) == [:x1, :x2, :x3, :x4]
+     @test all(((a,b),) -> a == b, zip(eachcol(df), eachcol(df2)))
+     @test !any(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+
+     df2 = DataFrame(eachcol(df))
+     @test names(df2) == [:x1, :x2, :x3, :x4]
+     @test !any(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+end
+
 end # module


### PR DESCRIPTION
What I have changed:
* added tests for `DataFrame` constructors from `eachrow` and `eachcol` as they were missing
* removed `"error"` word from testset names, so that they do not produce false positives when parsing log files.