### PR TITLE
Make push! more strict

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1191,7 +1191,7 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple}; columns
 end
 
 """
-    push!(df::DataFrame, row)
+    push!(df::DataFrame, row::Union{Tuple, AbstractArray, Base.Generator})
     push!(df::DataFrame, row::Union{DataFrameRow, NamedTuple, AbstractDict};
           columns::Symbol=:intersect)
 
@@ -1201,8 +1201,9 @@ Column types of `df` are preserved, and new values are converted if necessary.
 An error is thrown if conversion fails.
 
 If `row` is neither a `DataFrameRow`, `NamedTuple` nor `AbstractDict` then
-it is assumed to be an iterable and columns are matched by order of appearance.
-In this case `row` must contain the same number of elements as the number of columns in `df`.
+it must be a `Tuple`, an `AbstractArray`, or a `Base.Generator`
+and columns are matched by order of appearance. In this case `row` must contain
+the same number of elements as the number of columns in `df`.
 
 If `row` is a `DataFrameRow`, `NamedTuple` or `AbstractDict` then
 values in `row` are matched to columns in `df` based on names (order is ignored).
@@ -1277,6 +1278,10 @@ julia> push!(df, Dict(:A=>1.0, :B=>2.0))
 ```
 """
 function Base.push!(df::DataFrame, row::Any)
+    if ! row isa Union{Tuple, AbstractArray, Base.Generator}
+        Base.depwarn("In the future push! will not allow passing collections of type" *
+                     "$(typeof(row)) to be pushed into a DataFrame", :push!)
+    end
     nrows, ncols = size(df)
     if length(row) != ncols
         msg = "Length of `row` does not match `DataFrame` column count."

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1278,7 +1278,7 @@ julia> push!(df, Dict(:A=>1.0, :B=>2.0))
 ```
 """
 function Base.push!(df::DataFrame, row::Any)
-    if ! row isa Union{Tuple, AbstractArray, Base.Generator}
+    if !(row isa Union{Tuple, AbstractArray, Base.Generator})
         Base.depwarn("In the future push! will not allow passing collections of type" *
                      "$(typeof(row)) to be pushed into a DataFrame", :push!)
     end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1166,7 +1166,7 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple}; columns
     if columns === :equal && length(row) != ncols
         # TODO: add tests for this case after the deprecation period
         Base.depwarn("In the future push! will require that `row` has the same number" *
-                      " of elements as is the number of columns in `df`." *
+                      " of elements as is the number of columns in `df`. " *
                       "Use `columns=:intersect` to disable this check.", :push!)
     end
     current_col = 0

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1191,7 +1191,7 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple}; columns
 end
 
 """
-    push!(df::DataFrame, row::Union{Tuple, AbstractArray, Base.Generator})
+    push!(df::DataFrame, row::Union{Tuple, AbstractArray})
     push!(df::DataFrame, row::Union{DataFrameRow, NamedTuple, AbstractDict};
           columns::Symbol=:intersect)
 
@@ -1201,7 +1201,7 @@ Column types of `df` are preserved, and new values are converted if necessary.
 An error is thrown if conversion fails.
 
 If `row` is neither a `DataFrameRow`, `NamedTuple` nor `AbstractDict` then
-it must be a `Tuple`, an `AbstractArray`, or a `Base.Generator`
+it must be a `Tuple` or an `AbstractArray`
 and columns are matched by order of appearance. In this case `row` must contain
 the same number of elements as the number of columns in `df`.
 
@@ -1278,7 +1278,7 @@ julia> push!(df, Dict(:A=>1.0, :B=>2.0))
 ```
 """
 function Base.push!(df::DataFrame, row::Any)
-    if !(row isa Union{Tuple, AbstractArray, Base.Generator})
+    if !(row isa Union{Tuple, AbstractArray})
         Base.depwarn("In the future push! will not allow passing collections of type" *
                      " $(typeof(row)) to be pushed into a DataFrame", :push!)
     end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -441,7 +441,7 @@ function insert_single_column!(df::DataFrame,
         else
             if ncol(df) + 1 == Int(col_ind)
                 Base.depwarn("In the future setindex! will disallow adding columns" *
-                             "to a DataFrame using integer index. " *
+                             " to a DataFrame using integer index. " *
                              "Use a Symbol to specify a column name instead.", :setindex!)
                 push!(index(df), nextcolname(df))
                 push!(_columns(df), dv)
@@ -1166,7 +1166,7 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple}; columns
     if columns === :equal && length(row) != ncols
         # TODO: add tests for this case after the deprecation period
         Base.depwarn("In the future push! will require that `row` has the same number" *
-                      "of elements as is the number of columns in `df`." *
+                      " of elements as is the number of columns in `df`." *
                       "Use `columns=:intersect` to disable this check.", :push!)
     end
     current_col = 0
@@ -1280,7 +1280,7 @@ julia> push!(df, Dict(:A=>1.0, :B=>2.0))
 function Base.push!(df::DataFrame, row::Any)
     if !(row isa Union{Tuple, AbstractArray, Base.Generator})
         Base.depwarn("In the future push! will not allow passing collections of type" *
-                     "$(typeof(row)) to be pushed into a DataFrame", :push!)
+                     " $(typeof(row)) to be pushed into a DataFrame", :push!)
     end
     nrows, ncols = size(df)
     if length(row) != ncols

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -267,7 +267,7 @@ end
     df = DataFrame(a=1, b=2)
     push!(df, [1 2])
     @test df == DataFrame(a=[1, 1], b=[2, 2])
-    push!(df, (i for i in 1:2))
+    push!(df, (1, 2))
     @test df == DataFrame(a=[1, 1, 1], b=[2, 2, 2])
 
     @test_logs (:warn, r"In the future push! will not allow passing collections of type") push!(df, "ab")

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -266,9 +266,9 @@ end
 
     df = DataFrame(a=1, b=2)
     push!(df, [1 2])
-    @test df = DataFrame(a=[1, 1], b=[2, 2])
+    @test df == DataFrame(a=[1, 1], b=[2, 2])
     push!(df, (i for i in 1:2))
-    @test df = DataFrame(a=[1, 1, 1], b=[2, 2, 2])
+    @test df == DataFrame(a=[1, 1, 1], b=[2, 2, 2])
 
     @test_logs (:warn, r"In the future push! will not allow passing collections of type") push!(df, "ab")
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -263,6 +263,14 @@ end
     @test df == dfc
     @test_throws AssertionError push!(df, dfc[1, :])
     @test df == dfc
+
+    df = DataFrame(a=1, b=2)
+    push!(df, [1 2])
+    @test df = DataFrame(a=[1, 1], b=[2, 2])
+    push!(df, (i for i in 1:2))
+    @test df = DataFrame(a=[1, 1, 1], b=[2, 2, 2])
+
+    @test_logs (:warn, r"In the future push! will not allow passing collections of type") push!(df, "ab")
 end
 
 @testset "select! Not" begin


### PR DESCRIPTION
This is a deprecation PR for now.
Note that we still allow `AbstractArray`s (not only `AbstractVector`s) as this is what base allows:
```
julia> x = ones(2,2)
2×2 Array{Float64,2}:
 1.0  1.0
 1.0  1.0

julia> x[:, 1] = zeros(1,1,1,2)
1×1×1×2 Array{Float64,4}:
[:, :, 1, 1] =
 0.0

[:, :, 1, 2] =
 0.0

julia> x
2×2 Array{Float64,2}:
 0.0  1.0
 0.0  1.0
```