### PR TITLE
add skipmissing to by

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1069,7 +1069,7 @@ by(d::AbstractDataFrame, cols::Any, f::Any;
     combine(f, groupby(d, cols, sort=sort, skipmissing=skipmissing))
 by(f::Any, d::AbstractDataFrame, cols::Any;
    sort::Bool=false, skipmissing::Bool=false) =
-    by(d, cols, f, sort=sor, skipmissing=skipmissingt)
+    by(d, cols, f, sort=sort, skipmissing=skipmissingt)
 by(d::AbstractDataFrame, cols::Any, f::Pair;
    sort::Bool=false, skipmissing::Bool=false) =
     combine(f, groupby(d, cols, sort=sort, skipmissing=skipmissing))

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -33,8 +33,8 @@ Base.parent(gd::GroupedDataFrame) = getfield(gd, :parent)
 A view of an `AbstractDataFrame` split into row groups
 
 ```julia
-groupby(d::AbstractDataFrame, cols; sort = false, skipmissing = false)
-groupby(cols; sort = false, skipmissing = false)
+groupby(d::AbstractDataFrame, cols; sort=false, skipmissing=false)
+groupby(cols; sort=false, skipmissing=false)
 ```
 
 ### Arguments
@@ -928,10 +928,14 @@ function _combine_with_first!(first::Union{AbstractDataFrame,
 end
 
 """
-    by(df::AbstractDataFrame, keys, cols => f...; sort::Bool = false)
-    by(df::AbstractDataFrame, keys; (colname = cols => f)..., sort::Bool = false)
-    by(df::AbstractDataFrame, keys, f; sort::Bool = false)
-    by(f, df::AbstractDataFrame, keys; sort::Bool = false)
+    by(df::AbstractDataFrame, keys, cols=>f...;
+       sort::Bool=false, skipmissing::Bool=false)
+    by(df::AbstractDataFrame, keys; (colname = cols => f)...,
+       sort::Bool=false, skipmissing::Bool=false)
+    by(df::AbstractDataFrame, keys, f;
+       sort::Bool=false, skipmissing::Bool=false)
+    by(f, df::AbstractDataFrame, keys;
+       sort::Bool=false, skipmissing::Bool=false)
 
 Split-apply-combine in one step: apply `f` to each grouping in `df`
 based on grouping columns `keys`, and return a `DataFrame`.
@@ -978,6 +982,8 @@ operating on a single column and returning a single value or vector, the functio
 appended to the input colummn name; for other functions, columns are called `x1`, `x2`
 and so on. The resulting data frame will be sorted on `keys` if `sort=true`.
 Otherwise, ordering of rows is undefined.
+Additionally if `skipmissing=true` then the resulting data frame will not contain groups
+with `missing` values in one of the `keys` columns.
 
 Optimized methods are used when standard summary functions (`sum`, `prod`,
 `minimum`, `maximum`, `mean`, `var`, `std`, `first`, `last` and `length)

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1069,7 +1069,7 @@ by(d::AbstractDataFrame, cols::Any, f::Any;
     combine(f, groupby(d, cols, sort=sort, skipmissing=skipmissing))
 by(f::Any, d::AbstractDataFrame, cols::Any;
    sort::Bool=false, skipmissing::Bool=false) =
-    by(d, cols, f, sort=sort, skipmissing=skipmissingt)
+    by(d, cols, f, sort=sort, skipmissing=skipmissing)
 by(d::AbstractDataFrame, cols::Any, f::Pair;
    sort::Bool=false, skipmissing::Bool=false) =
     combine(f, groupby(d, cols, sort=sort, skipmissing=skipmissing))

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -136,7 +136,7 @@ julia> for g in gd
 
 """
 function groupby(df::AbstractDataFrame, cols::AbstractVector;
-                 sort::Bool = false, skipmissing::Bool = false)
+                 sort::Bool=false, skipmissing::Bool=false)
     _check_consistency(df)
     intcols = convert(Vector{Int}, index(df)[cols])
     sdf = df[!, intcols]
@@ -1064,16 +1064,21 @@ julia> by(df, :a, (:b, :c) => x -> (minb = minimum(x.b), sumc = sum(x.c)))
 ```
 
 """
-by(d::AbstractDataFrame, cols::Any, f::Any; sort::Bool = false) =
-    combine(f, groupby(d, cols, sort = sort))
-by(f::Any, d::AbstractDataFrame, cols::Any; sort::Bool = false) =
-    by(d, cols, f, sort = sort)
-by(d::AbstractDataFrame, cols::Any, f::Pair; sort::Bool = false) =
-    combine(f, groupby(d, cols, sort = sort))
-by(d::AbstractDataFrame, cols::Any, f::Pair...; sort::Bool = false) =
-    combine(f, groupby(d, cols, sort = sort))
-by(d::AbstractDataFrame, cols::Any; sort::Bool = false, f...) =
-    combine(values(f), groupby(d, cols, sort = sort))
+by(d::AbstractDataFrame, cols::Any, f::Any;
+   sort::Bool=false, skipmissing::Bool=false) =
+    combine(f, groupby(d, cols, sort=sort, skipmissing=skipmissing))
+by(f::Any, d::AbstractDataFrame, cols::Any;
+   sort::Bool=false, skipmissing::Bool=false) =
+    by(d, cols, f, sort=sor, skipmissing=skipmissingt)
+by(d::AbstractDataFrame, cols::Any, f::Pair;
+   sort::Bool=false, skipmissing::Bool=false) =
+    combine(f, groupby(d, cols, sort=sort, skipmissing=skipmissing))
+by(d::AbstractDataFrame, cols::Any, f::Pair...;
+   sort::Bool=false, skipmissing::Bool=false) =
+    combine(f, groupby(d, cols, sort=sort, skipmissing=skipmissing))
+by(d::AbstractDataFrame, cols::Any;
+   sort::Bool=false, skipmissing::Bool=false, f...) =
+    combine(values(f), groupby(d, cols, sort=sort, skipmissing=skipmissing))
 
 #
 # Aggregate convenience functions

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -982,7 +982,7 @@ operating on a single column and returning a single value or vector, the functio
 appended to the input colummn name; for other functions, columns are called `x1`, `x2`
 and so on. The resulting data frame will be sorted on `keys` if `sort=true`.
 Otherwise, ordering of rows is undefined.
-Additionally if `skipmissing=true` then the resulting data frame will not contain groups
+If `skipmissing=true` then the resulting data frame will not contain groups
 with `missing` values in one of the `keys` columns.
 
 Optimized methods are used when standard summary functions (`sum`, `prod`,

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1177,7 +1177,7 @@ end
     df = DataFrame(a=[2, 2, missing, missing, 1, 1, 3, 3], b=1:8)
     for dosort in (false, true), doskipmissing in (false, true)
         @test by(df, :x1, :b=>sum, sort=dosort, skipmissing=doskipmissing) ≅
-            combine(groupby(df, :x1), :b=>sum, sort=dosort, skipmissing=doskipmissing)
+            combine(groupby(df, :x1, sort=dosort, skipmissing=doskipmissing), :b=>sum)
     end
 end
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1173,4 +1173,11 @@ end
     @test groupvars(gd2) == [:A]
 end
 
+@testset "by skipmissing and sort" begin
+    df = DataFrame(a=[2, 2, missing, missing, 1, 1, 3, 3], b=1:8)
+    for dosort in (false, true), doskipmissing in (false, true)
+        @test by(df, :x1, :b=>sum) ≅ combine(groupby(df, :x1), :b=>sum)
+    end
+end
+
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1176,8 +1176,8 @@ end
 @testset "by skipmissing and sort" begin
     df = DataFrame(a=[2, 2, missing, missing, 1, 1, 3, 3], b=1:8)
     for dosort in (false, true), doskipmissing in (false, true)
-        @test by(df, :x1, :b=>sum, sort=dosort, skipmissing=doskipmissing) ≅
-            combine(groupby(df, :x1, sort=dosort, skipmissing=doskipmissing), :b=>sum)
+        @test by(df, :a, :b=>sum, sort=dosort, skipmissing=doskipmissing) ≅
+            combine(groupby(df, :a, sort=dosort, skipmissing=doskipmissing), :b=>sum)
     end
 end
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1176,7 +1176,8 @@ end
 @testset "by skipmissing and sort" begin
     df = DataFrame(a=[2, 2, missing, missing, 1, 1, 3, 3], b=1:8)
     for dosort in (false, true), doskipmissing in (false, true)
-        @test by(df, :x1, :b=>sum) ≅ combine(groupby(df, :x1), :b=>sum)
+        @test by(df, :x1, :b=>sum, sort=dosort, skipmissing=doskipmissing) ≅
+            combine(groupby(df, :x1), :b=>sum, sort=dosort, skipmissing=doskipmissing)
     end
 end
 


### PR DESCRIPTION
This change makes `by` and `groupby` consistent.
It is marginally breaking as someone in `by` could have wanted to create column named `skipmissing` (a similar problem we now have with `sort`), but I think it is OK to go with it without deprecation period.