### PR TITLE
Fix path to iris.csv

### DIFF
--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -5,7 +5,7 @@ Reshape data from wide to long format using the `stack` function:
 ```jldoctest reshape
 julia> using DataFrames, CSV
 
-julia> iris = CSV.read(joinpath(dirname(pathof(DataFrames)), "../test/data/iris.csv"));
+julia> iris = CSV.read(joinpath(dirname(pathof(DataFrames)), "../docs/src/assets/iris.csv"));
 
 julia> first(iris, 6)
 6×5 DataFrame


### PR DESCRIPTION
This occurrence had been missed in a previous fix apparently.