### PR TITLE
disallow Base.Generator in setindex! to DataFrameRow

### DIFF
--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -152,7 +152,7 @@ Note that `sdf[!, col] = v`, `sdf[!, cols] = v` and `sdf.col = v` are not allowe
                     equivalent to `dfr.col = v` if `col` is a valid identifier;
 * `dfr[cols] = v` -> set values of entries in columns `cols` in `dfr` by elements of `v` in place;
                      `v` can be:
-                     1) a `Tuple`, an `AbstractArray` or a `Base.Generator`,
+                     1) a `Tuple` or an `AbstractArray`,
                         in which cases it must have a number of elements equal to `length(dfr)`,
                      2) an `AbstractDict`, in which case column names must match,
                      3) a `NamedTuple` or `DataFrameRow`, in which case column names and order must match;

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -504,7 +504,7 @@ end
 
 for T in (:AbstractVector, :Regex, :Not, :Between, :All, :Colon)
     @eval function Base.setindex!(df::DataFrame,
-                                  v::Union{Tuple, AbstractArray, Base.Generator},
+                                  v::Union{Tuple, AbstractArray},
                                   row_ind::Integer,
                                   col_inds::$T)
         idxs = index(df)[col_inds]
@@ -663,7 +663,7 @@ function insertcols!(df::DataFrame, col_ind::Int, name_col::Pair{Symbol, <:Abstr
     name, item = name_col
     if !(0 < col_ind <= ncol(df) + 1)
         throw(BoundsError("attempt to insert a column to a data frame with $(ncol(df)) columns at index $col_ind"))
-    end  
+    end
     if !(size(df, 1) == length(item) || size(df, 2) == 0)
         throw(DimensionMismatch("length of new column ($(length(item))) must match the number of rows in data frame ($(nrow(df)))"))
     end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1169,7 +1169,7 @@ end
 
     # * `dfr[cols] = v` -> set values of entries in columns `cols` in `dfr` by elements of `v` in place;
     #                      `v` can be:
-    #                      1) a `Tuple`, an `AbstractArray` or a `Base.Generator`,
+    #                      1) a `Tuple` an `AbstractArray`
     #                         in which cases it must have a number of elements equal to `length(dfr)`,
     #                      2) an `AbstractDict`, in which case column names must match,
     #                      3) a `NamedTuple` or `DataFrameRow`, in which case column names and order must match;
@@ -1203,12 +1203,7 @@ end
 
     df = DataFrame(a=1,b=2)
     dfr = df[1, :]
-    dfr[:] = (i for i in 10:11, _ in 1:1, _ in 1:1)
-    @test df == DataFrame(a=10,b=11)
-    df = DataFrame(a=1,b=2)
-    dfr = df[1, :]
-    @test_throws DimensionMismatch dfr[:] = (i for i in 10:12, _ in 1:1, _ in 1:1)
-    @test df == DataFrame(a=1,b=2)
+    @test_throws MethodError dfr[:] = (i for i in 10:11, _ in 1:1, _ in 1:1)
 
     df = DataFrame(a=1,b=2)
     dfr = df[1, :]
@@ -1286,12 +1281,7 @@ end
 
     df = DataFrame(a=1, b=2, c=3)
     dfr = df[1, :]
-    dfr[Not(3)] = (i for i in 10:11, _ in 1:1, _ in 1:1)
-    @test df == DataFrame(a=10,b=11, c=3)
-    df = DataFrame(a=1, b=2, c=3)
-    dfr = df[1, :]
-    @test_throws DimensionMismatch dfr[Not(3)] = (i for i in 11:13, _ in 1:1, _ in 1:1)
-    @test df == DataFrame(a=1, b=2, c=3)
+    @test_throws MethodError dfr[Not(3)] = (i for i in 10:11, _ in 1:1, _ in 1:1)
 
     df = DataFrame(a=1, b=2, c=3)
     dfr = df[1, :]

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1169,7 +1169,7 @@ end
 
     # * `dfr[cols] = v` -> set values of entries in columns `cols` in `dfr` by elements of `v` in place;
     #                      `v` can be:
-    #                      1) a `Tuple` an `AbstractArray`
+    #                      1) a `Tuple` or an `AbstractArray`
     #                         in which cases it must have a number of elements equal to `length(dfr)`,
     #                      2) an `AbstractDict`, in which case column names must match,
     #                      3) a `NamedTuple` or `DataFrameRow`, in which case column names and order must match;


### PR DESCRIPTION
To make it consistent with `push!`