### PR TITLE
allow to create columns using : as row selector

### DIFF
--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -122,6 +122,8 @@ so it is unsafe to use it afterwards (the column length correctness will be pres
 * `df[CartesianIndex(row, col)] = v` -> the same as `df[row, col] = v`;
 * `df[row, cols] = v` -> set row `row` of columns `cols` in-place; the same as `dfr = df[row, cols]; dfr[:] = v`;
 * `df[rows, col] = v` -> set rows `rows` of column `col` in-place; `v` must be an `AbstractVector`;
+                         if `rows` is `:` and `col` is a `Symbol` that is not present in `df` then a new column
+                         in `df` is created and holds a `copy` of `v`; equivalent to `df.col = copy(v)` if `col` is a valid identifier;
 * `df[rows, cols] = v` -> set rows `rows` of columns `cols` in-place; `v` must be an `AbstractMatrix` or an `AbstractDataFrame`
                       (in this case column names must match);
 * `df[!, col] = v` -> replaces `col` with `v` without copying
@@ -185,7 +187,11 @@ Additional rules:
 * in the `df[CartesianIndex(row, col)] .= v`, `df[row, col] .= v` syntaxes `v` is broadcasted into the contents of `df[row, col]` (this is consistent with Julia Base);
 * in the `df[row, cols] .= v` syntaxes the assignment to `df` is performed in-place;
 * in the `df[rows, col] .= v` and `df[rows, cols] .= v` syntaxes the assignment to `df` is performed in-place;
-* in the `df[!, col] .= v` syntax column `col` is replaced by a freshly allocated vector; if `col` is `Symbol` and it is missing from `df` then a new column is added; the length of the column is always the value of `nrow(df)` before the assignment takes place;
+  if `rows` is `:` and `col` is `Symbol` and it is missing from `df` then a new column is allocated and added;
+  the length of the column is always the value of `nrow(df)` before the assignment takes place;
+* in the `df[!, col] .= v` syntax column `col` is replaced by a freshly allocated vector;
+  if `col` is `Symbol` and it is missing from `df` then a new column is allocated added;
+  the length of the column is always the value of `nrow(df)` before the assignment takes place;
 * the `df[!, cols] .= v` syntax replaces existing columns `cols` in data frame `df` with freshly allocated vectors;
 * `df.col .= v` syntax is allowed and performs in-place assignment to an existing vector `df.col`.
 * in the `sdf[CartesianIndex(row, col)] .= v`, `sdf[row, col] .= v` and `sdf[row, cols] .= v` syntaxes the assignment to `sdf` is performed in-place;

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -135,10 +135,6 @@ so it is unsafe to use it afterwards (the column length correctness will be pres
                        `v` must be an `AbstractMatrix` or an `AbstractDataFrame`
                        (in the latter case column names must match);
 
-Note that `df[!, col] = v`, `df.col = v` and `df[:, col] = v` can be used to add a new column to a `DataFrame`.
-The difference is that `df[:, col] = v` copies `v` before adding it to `df` and `df[!, col] = v` and `df.col = v`
-add `v` without copying it.
-
 `setindex!` on `SubDataFrame`:
 * `sdf[row, col] = v` -> set value of `col` in row `row` to `v` in-place;
 * `sdf[CartesianIndex(row, col)] = v` -> the same as `sdf[row, col] = v`;

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -135,9 +135,9 @@ so it is unsafe to use it afterwards (the column length correctness will be pres
                        `v` must be an `AbstractMatrix` or an `AbstractDataFrame`
                        (in the latter case column names must match);
 
-Note that only `df[!, col] = v` and `df.col = v` can be used to add a new column to a `DataFrame`.
-In particular as `df[:, col] = v` is an in-place operation it does not add a column `v` to a `DataFrame` if `col` is missing
-(an error is thrown if such operation is attempted).
+Note that `df[!, col] = v`, `df.col = v` and `df[:, col] = v` can be used to add a new column to a `DataFrame`.
+The difference is that `df[:, col] = v` copies `v` before adding it to `df` and `df[!, col] = v` and `df.col = v`
+add `v` without copying it.
 
 `setindex!` on `SubDataFrame`:
 * `sdf[row, col] = v` -> set value of `col` in row `row` to `v` in-place;

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -525,6 +525,10 @@ for T in (:AbstractVector, :Not, :Colon)
                                   v::AbstractVector,
                                   row_inds::$T,
                                   col_ind::ColumnIndex)
+        if row_inds isa Colon && !haskey(index(df), col_ind)
+            df[!, col_ind] = copy(v)
+            return df
+        end
         x = df[!, col_ind]
         try
             x[row_inds] = v

--- a/src/other/broadcasting.jl
+++ b/src/other/broadcasting.jl
@@ -96,6 +96,14 @@ Base.maybeview(df::AbstractDataFrame, idx::CartesianIndex{2}) = df[idx]
 Base.maybeview(df::AbstractDataFrame, row::Integer, col::ColumnIndex) = df[row, col]
 Base.maybeview(df::AbstractDataFrame, rows, cols) = view(df, rows, cols)
 
+function Base.dotview(df::DataFrame, ::Colon, cols::ColumnIndex)
+    haskey(index(df), cols) && return view(df, :, cols)
+    if !(cols isa Symbol)
+        throw(ArgumentError("creating new columns using an integer index by broadcasting is disallowed"))
+    end
+    LazyNewColDataFrame(df, cols)
+end
+
 function Base.dotview(df::DataFrame, ::typeof(!), cols)
     if !(cols isa ColumnIndex)
         return ColReplaceDataFrame(df, index(df)[cols])

--- a/src/other/broadcasting.jl
+++ b/src/other/broadcasting.jl
@@ -109,7 +109,7 @@ function Base.dotview(df::DataFrame, ::typeof(!), cols)
         return ColReplaceDataFrame(df, index(df)[cols])
     end
     if !(cols isa Symbol) && cols > ncol(df)
-        throw(ArgumentError("creating new columns using an integer index by broadcasting is disallowed"))
+        throw(ArgumentError("creating new columns using an integer index is disallowed"))
     end
     LazyNewColDataFrame(df, cols)
 end

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -1500,6 +1500,13 @@ end
     @test_throws MethodError df[:, 1] .= z
 
     df = DataFrame(ones(3, 4))
+    z = "abc"
+    df[:, :z] .= z
+    @test df.z == fill("abc", 3)
+    @test_throws ArgumentError df[:, 6] .= z
+    @test_throws MethodError df[:, 1] .= z
+
+    df = DataFrame(ones(3, 4))
     z = fill("abc", 1, 1, 1)
     @test_throws DimensionMismatch df[:, :z] .= z
 end

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -1490,4 +1490,14 @@ end
     @test @views typeof(df[!, 1:2]) <: SubDataFrame
 end
 
+@testset "broadcasting of df[:, col] = vector" begin
+    df = DataFrame(ones(3, 4))
+    z = ["a", "b", "c"]
+    df[:, :z] .= z
+    @test df.z == z
+    @test df.z !== z
+    @test_throws ArgumentError df[:, 6] .= z
+    @test_throws MethodError df[:, 1] .= z
+end
+
 end # module

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -1490,7 +1490,7 @@ end
     @test @views typeof(df[!, 1:2]) <: SubDataFrame
 end
 
-@testset "broadcasting of df[:, col] = vector" begin
+@testset "broadcasting of df[:, col] = value" begin
     df = DataFrame(ones(3, 4))
     z = ["a", "b", "c"]
     df[:, :z] .= z
@@ -1498,6 +1498,10 @@ end
     @test df.z !== z
     @test_throws ArgumentError df[:, 6] .= z
     @test_throws MethodError df[:, 1] .= z
+
+    df = DataFrame(ones(3, 4))
+    z = fill("abc", 1, 1, 1)
+    @test_throws DimensionMismatch df[:, :z] .= z
 end
 
 end # module

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -890,6 +890,8 @@ end
     @test df == DataFrame(a=1,b=2)
 
     # `df[rows, col] = v` -> set rows `rows` of column `col` in-place; `v` must be an `AbstractVector`
+    # the exception is `df[:, col] = v`, when col is not present in df, in which case `v` is copied
+    # and column `col` is created
 
     df = DataFrame(a=1:3, b=4:6, c=7:9)
     x = df.a
@@ -903,17 +905,23 @@ end
     @test_throws ArgumentError df[1:3, :z] = ["a", "b", "c"]
     @test_throws BoundsError df[1:3, 4] = ["a", "b", "c"]
 
+    df = DataFrame(a=1:3, b=4:6, c=7:9)
+    x = df.a
+    df[:, 1] = 10:12
+    @test df == DataFrame(a=10:12, b=4:6, c=7:9)
+    @test df.a === x
+
+    y = ["a", "b", "c"]
+    df[:, :y] = y
+    @test df.y == y
+    @test df.y !== y
+
+    @test_throws MethodError df[:, 1] = ["a", "b", "c"]
     # TODO: enable these tests after deprecation period
-    # df = DataFrame(a=1:3, b=4:6, c=7:9)
-    # x = df.a
-    # df[:, 1] = 10:12
-    # @test df == DataFrame(a=10:12, b=4:6, c=7:9)
-    # @test df.a === x
-    # @test_throws MethodError df[:, 1] = ["a", "b", "c"]
     # @test_throws ArgumentError df[:, 1] = [1]
     # @test_throws ArgumentError df[:, 1] = 1
-    # @test_throws ArgumentError df[:, :z] = ["a", "b", "c"]
-    # @test_throws BoundsError df[:, 4] = ["a", "b", "c"]
+    # @test_throws BoundsError df[:, 5] = ["a", "b", "c"]
+    @test_throws ArgumentError df[:, 10] = ["a", "b", "c"]
 
     # `df[rows, cols] = v` -> set rows `rows` of columns `cols` in-place;
     #                         `v` must be an `AbstractMatrix` or an `AbstractDataFrame`


### PR DESCRIPTION
Allow `df[:, col] = vector` and `df[:, col] .= v` to create a column if `col` is not present in `df`. A fresh vector is always allocated.

Given the comments on Slack I am convinced we can add this without harm, but there is no rush (though personally I would prefer to settle this PR before 1.0, as I would prefer not to mess with `getindex`/`setindex!`/broadcasting assignment after 1.0 if possible).

CC @oxinabox @nalimilan @pdeffebach 