### PR TITLE
add groupindices for AbstractVectors

### DIFF
--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1190,6 +1190,17 @@ end
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 2, 1, 2, 1, missing]
     @test groupvars(gd2) == [:A]
+
+    A = [missing, :A, :B, :A, :B, missing]
+    @inferred groupindices(A)
+    @test groupindices(A) ≅ [missing, 1, 2, 1, 2, missing]
+    @test_throws DimensionMismatch groupindices([1, 2], [1, 3, 4])
+    @test_throws ArgumentError groupindices([1, 2], 1)
+    @test_throws ArgumentError groupindices()
+
+    B = [1, 1, 1, 1, 1, 1]
+    @inferred groupindices(A, B)
+    @test groupindices(A, B) ≅ [missing, 1, 2, 1, 2, missing]
 end
 
 @testset "by skipmissing and sort" begin


### PR DESCRIPTION
This pull request adds `groupindices` for multiple vectors. It corresponds loosely to functions such as [interaction](https://www.rdocumentation.org/packages/base/versions/3.6.1/topics/interaction) in R and [group](https://www.stata.com/support/faqs/data-management/creating-group-identifiers/) in Stata.

On the one hand, it's a bit weird to have something like this `DataFrames` since it does not act or return Dataframes. On the other hand, defining this function in this package allows one to benefit from the code performance of `row_group_slots` (and its future improvement).

Another point is that maybe the function should return a PooledArray. This is because functions that use the result of `groupindices` typically do a grouping operation, and therefore are interested in the group structure of the array. In this case, the function could be written
```julia
function groupindices(cols...)
    if !isa(cols, Tuple{Vararg{AbstractVector}})
        throw(ArgumentError("Arguments of groupindices should be AbstractVectors"))
    end
    if isempty(cols)
        throw(ArgumentError("groupindices was called without argument")) 
    end
    n = length(first(cols))
    if any(length(col) != n for col in cols)
        throw(DimensionMismatch("Arguments of groupindices should have the same length"))
    end
    groups = Vector{Int}(undef, n)
    ngroups, rhashes, gslots, sorted = row_group_slots(cols, Val(false), groups, true)
    pool = zeros(Union{Int, Missing}, ngroups)
    for x in groups
        p = pool[x]
        if !ismissing(p) && p == 0
            pool[x] = x == 1 ? missing : x - 1
        end
    end
    if !ismissing(pool[1])
        # no missing value was found
        deleteat!(pool, 1)
        groups .-= 1
    end
    invpool = Dict{Union{Int, Missing}, Int}(pool[i] => i for i in eachindex(pool))
    PooledArray(PooledArrays.RefArray(groups), invpool, pool)
end
```