### PR TITLE
Allow rename when selecting

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -150,21 +150,21 @@ rename(f::Function, df::AbstractDataFrame)
 
 * `::AbstractDataFrame` : the updated result
 
-New names are processed sequentially. A new name must not already exist in the `DataFrame`
-at the moment an attempt to rename a column is performed.
+Each name is changed at most once. Permutation of names is allowed.
 
 **Examples**
 
 ```julia
 df = DataFrame(i = 1:10, x = rand(10), y = rand(["a", "b", "c"], 10))
 rename(df, :i => :A, :x => :X)
+rename(df, :x => :y, :y => :x)
 rename(df, [:i => :A, :x => :X])
 rename(df, Dict(:i => :A, :x => :X))
 rename(x -> Symbol(uppercase(string(x))), df)
 rename(df) do x
     Symbol(uppercase(string(x)))
 end
-rename!(df, Dict(:i =>: A, :x => :X))
+rename!(df, Dict(:i => :A, :x => :X))
 ```
 
 """

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -48,7 +48,7 @@ end
 function rename!(x::Index, nms)
     xbackup = copy(x)
     processedfrom = Set{Symbol}()
-    processedto = Set(Symbol[])
+    processedto = Set{Symbol}()
     toholder = Dict{Symbol,Int}()
     for (from, to) in nms
         if from ∈ processedfrom

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -52,12 +52,12 @@ function rename!(x::Index, nms)
     toholder = Dict{Symbol,Int}()
     for (from, to) in nms
         if from ∈ processedfrom
-            copy!(x.lookup, xbackup.lookup)
+            merge!(empty!(x.lookup), xbackup.lookup)
             x.names .= xbackup.names
             throw(ArgumentError("Tried renaming $from multiple times."))
         end
         if to ∈ processedto
-            copy!(x.lookup, xbackup.lookup)
+            merge!(empty!(x.lookup), xbackup.lookup)
             x.names .= xbackup.names
             throw(ArgumentError("Tried renaming to $to multiple times."))
         end
@@ -65,7 +65,7 @@ function rename!(x::Index, nms)
         push!(processedto, to)
         from == to && continue # No change, nothing to do
         if !haskey(xbackup, from)
-            copy!(x.lookup, xbackup.lookup)
+            merge!(empty!(x.lookup), xbackup.lookup)
             x.names .= xbackup.names
             throw(ArgumentError("Tried renaming $from to $to, when $from does not exist in the Index."))
         end
@@ -77,7 +77,7 @@ function rename!(x::Index, nms)
         x.names[col] = to
     end
     if !isempty(toholder)
-        copy!(x.lookup, xbackup.lookup)
+        merge!(empty!(x.lookup), xbackup.lookup)
         x.names .= xbackup.names
         throw(ArgumentError("Tried renaming to $(first(keys(toholder))), when it already exists in the Index."))
     end

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -47,7 +47,7 @@ end
 
 function rename!(x::Index, nms)
     xbackup = copy(x)
-    processedfrom = Set(Symbol[])
+    processedfrom = Set{Symbol}()
     processedto = Set(Symbol[])
     toholder = Dict{Symbol,Int}()
     for (from, to) in nms

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -46,13 +46,40 @@ function names!(x::Index, nms::Vector{Symbol}; makeunique::Bool=false)
 end
 
 function rename!(x::Index, nms)
+    xbackup = copy(x)
+    processedfrom = Set(Symbol[])
+    processedto = Set(Symbol[])
+    toholder = Dict{Symbol,Int}()
     for (from, to) in nms
-        from == to && continue # No change, nothing to do
-        if haskey(x, to)
-            error("Tried renaming $from to $to, when $to already exists in the Index.")
+        if from ∈ processedfrom
+            copy!(x.lookup, xbackup.lookup)
+            x.names .= xbackup.names
+            throw(ArgumentError("Tried renaming $from multiple times."))
         end
-        x.lookup[to] = col = pop!(x.lookup, from)
+        if to ∈ processedto
+            copy!(x.lookup, xbackup.lookup)
+            x.names .= xbackup.names
+            throw(ArgumentError("Tried renaming to $to multiple times."))
+        end
+        push!(processedfrom, from)
+        push!(processedto, to)
+        from == to && continue # No change, nothing to do
+        if !haskey(xbackup, from)
+            copy!(x.lookup, xbackup.lookup)
+            x.names .= xbackup.names
+            throw(ArgumentError("Tried renaming $from to $to, when $from does not exist in the Index."))
+        end
+        if haskey(x, to)
+            toholder[to] = x.lookup[to]
+        end
+        col = haskey(toholder, from) ? pop!(toholder, from) : pop!(x.lookup, from)
+        x.lookup[to] = col
         x.names[col] = to
+    end
+    if !isempty(toholder)
+        copy!(x.lookup, xbackup.lookup)
+        x.names .= xbackup.names
+        throw(ArgumentError("Tried renaming to $(first(keys(toholder))), when it already exists in the Index."))
     end
     return x
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -617,6 +617,36 @@ end
     @test d.b === df.b
 end
 
+@testset "select! rename" begin
+    df = DataFrame(a=1, b=2, c=3, d=4, e=5)
+    dfa = df.a
+    dfb = df.b
+    dfc = df.c
+    dfd = df.d
+    dfe = df.e
+
+    d = copy(df, copycols=false)
+    select!(d, [:a=>:b])
+    @test names(d) == [:b]
+    @test d.b === dfa
+
+    d = copy(df, copycols=false)
+    select!(d, [:b=>:a, :a=>:b, :e])
+    @test names(d) == [:a, :b, :e]
+    @test d.b === dfa
+    @test d.a === dfb
+    @test d.e === dfe
+
+    d = copy(df, copycols=false)
+    select!(d, [:a=>:aa, :b=>:bb, :c=>:cc, :d=>:dd, :e=>:ee])
+    @test names(d) == [:aa, :bb, :cc, :dd, :ee]
+    @test d.aa === dfa
+    @test d.bb === dfb
+    @test d.cc === dfc
+    @test d.dd === dfd
+    @test d.ee === dfe
+end
+
 @testset "select" begin
     df = DataFrame(a=1, b=2, c=3, d=4, e=5)
     @test_throws BoundsError select(df, 0)
@@ -817,6 +847,36 @@ end
     @test d isa SubDataFrame
     @test names(d) == [:b]
     @test d.b === df.b
+end
+
+@testset "select rename" begin
+    df = DataFrame(a=1, b=2, c=3, d=4, e=5)
+
+    d = select(df, [:a=>:b])
+    @test names(d) == [:b]
+    @test d.b !== df.a
+    @test d.b == df.a
+
+    d = select(df, [:b=>:a, :a=>:b, :e])
+    @test names(d) == [:a, :b, :e]
+    @test d.b !== df.a
+    @test d.a !== df.b
+    @test d.e !== df.e
+    @test d.b == df.a
+    @test d.a == df.b
+    @test d.e == df.e
+
+    d = select(df, [:e, :b=>:a, :c], copycols=false)
+    @test names(d) == [:e, :a, :c]
+    @test d.e === df.e
+    @test d.a === df.b
+    @test d.c === df.c
+
+    d = select(df, [:e=>:a, :b, :a=>:c], copycols=false)
+    @test names(d) == [:a, :b, :c]
+    @test d.a === df.e
+    @test d.b === df.b
+    @test d.c === df.a
 end
 
 @testset "deleterows!" begin
@@ -1552,6 +1612,17 @@ end
     @test df[:, :][!, :x] !== x
     @test df[:, [:y,:x]][!, :x] == x
     @test df[:, [:y,:x]][!, :x] !== x
+end
+
+@testset "test getindex with rename" begin
+    x = [1,3]
+    y = [2,4]
+    df = DataFrame(x=x, y=y, copycols=false)
+    @test df[!, [:x=>:t]].t === x
+    @test df[:, [:x=>:t]].t == x
+    @test df[:, [:x=>:t]].t !== x
+    @test df[1:1, [:x=>:t]].t == x[1:1]
+    @test df[Not(2), [:x=>:t]].t == x[Not(2)]
 end
 
 @testset "test corner case of getindex" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1127,6 +1127,33 @@ end
     @test names(df) == [:A_4, :B_4]
     @test rename!(x->Symbol(lowercase(string(x))), df) === df
     @test names(df) == [:a_4, :b_4]
+
+    df = DataFrame(A = 1:3, B = 'A':'C', C = [:x, :y, :z])
+    @test rename!(df, :A => :B, :B => :A) === df
+    @test names(df) == [:B, :A, :C]
+    @test rename!(df, :A => :B, :B => :A, :C => :D) === df
+    @test names(df) == [:A, :B, :D]
+    @test rename!(df, :A => :B, :B => :C, :D => :A) === df
+    @test names(df) == [:B, :C, :A]
+    @test rename!(df, :A => :C, :B => :A, :C => :B) === df
+    @test names(df) == [:A, :B, :C]
+    @test rename!(df, :A => :A, :B => :B, :C => :C) === df
+    @test names(df) == [:A, :B, :C]
+
+    @test_throws ArgumentError rename!(df, :X => :Y)
+    @test names(df) == [:A, :B, :C]
+    @test_throws ArgumentError rename!(df, :A => :X, :X => :Y)
+    @test names(df) == [:A, :B, :C]
+    @test_throws ArgumentError rename!(df, :A => :B)
+    @test names(df) == [:A, :B, :C]
+    @test_throws ArgumentError rename!(df, :A => :X, :A => :X)
+    @test names(df) == [:A, :B, :C]
+    @test_throws ArgumentError rename!(df, :A => :X, :B => :X)
+    @test names(df) == [:A, :B, :C]
+    @test_throws ArgumentError rename!(df, :A => :B, :B => :A, :C => :B)
+    @test names(df) == [:A, :B, :C]
+    @test_throws ArgumentError rename!(df, :A => :B, :B => :A, :A => :X)
+    @test names(df) == [:A, :B, :C]
 end
 
 @testset "size" begin


### PR DESCRIPTION
Based on the previous pr https://github.com/JuliaData/DataFrames.jl/pull/1974.

Now it supports
```julia
julia> df = DataFrame(A = 1:3, B = 'A':'C', C = [:x, :y, :z])
3×3 DataFrame
│ Row │ A     │ B    │ C      │
│     │ Int64 │ Char │ Symbol │
├─────┼───────┼──────┼────────┤
│ 1   │ 1     │ 'A'  │ x      │
│ 2   │ 2     │ 'B'  │ y      │
│ 3   │ 3     │ 'C'  │ z      │

julia> df[:, [:B, :C=>:A]]
3×2 DataFrame
│ Row │ B    │ A      │
│     │ Char │ Symbol │
├─────┼──────┼────────┤
│ 1   │ 'A'  │ x      │
│ 2   │ 'B'  │ y      │
│ 3   │ 'C'  │ z      │
```