### PR TITLE
allow more flexible cols in groupby and in particular handle empty cols

### DIFF
--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -54,7 +54,7 @@ for each grouping into `df`.
 Within each group, the order of rows in `df` is preserved.
 
 `cols` can be any valid data frame indexing expression.
-In particular if it is an empty vector then a single group `GroupedDataFrame`
+In particular if it is an empty vector then a single-group `GroupedDataFrame`
 is created.
 
 A `GroupedDataFrame` also supports

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1125,8 +1125,9 @@ Split-apply-combine that applies a set of functions over columns of an
 `AbstractDataFrame` or [`GroupedDataFrame`](@ref)
 
 ```julia
-aggregate(df::AbstractDataFrame, cols, fs)
-aggregate(gd::GroupedDataFrame, fs)
+aggregate(df::AbstractDataFrame, fs)
+aggregate(df::AbstractDataFrame, cols, fs; sort=false, skipmissing=false)
+aggregate(gd::GroupedDataFrame, fs; sort=false)
 ```
 
 ### Arguments
@@ -1136,6 +1137,8 @@ aggregate(gd::GroupedDataFrame, fs)
 * `cols` : a column indicator (`Symbol`, `Int`, `Vector{Symbol}`, etc.)
 * `fs` : a function or vector of functions to be applied to vectors
   within groups; expects each argument to be a column vector
+* `sort` : whether to sort rows according to the values of the grouping columns
+* `skipmissing` : whether to skip rows with `missing` values in one of the grouping columns `cols`
 
 Each `fs` should return a value or vector. All returns must be the
 same length.
@@ -1201,11 +1204,9 @@ function aggregate(gd::GroupedDataFrame, fs::AbstractVector; sort::Bool=false)
 end
 
 # Groups DataFrame by cols before applying aggregate
-function aggregate(d::AbstractDataFrame,
-                   cols::Union{S, AbstractVector{S}},
-                   fs::Any;
-                   sort::Bool=false) where {S<:ColumnIndex}
-    aggregate(groupby(d, cols, sort=sort), fs)
+function aggregate(d::AbstractDataFrame, cols, fs::Any;
+                   sort::Bool=false, skipmissing::Bool=false)
+    aggregate(groupby(d, cols, sort=sort, skipmissing=skipmissing), fs)
 end
 
 function funname(f)

--- a/test/data.jl
+++ b/test/data.jl
@@ -120,7 +120,7 @@ const ≅ = isequal
 
     df = DataFrame(a = [3, missing, 1], b = [100, 200, 300])
     for dosort in (true, false), doskipmissing in (true, false)
-        @test aggregate(df, :a, sum, sort=dosort, skipmissing=doskipmissing) ==
+        @test aggregate(df, :a, sum, sort=dosort, skipmissing=doskipmissing) ≅
               aggregate(groupby(df, :a, sort=dosort, skipmissing=doskipmissing), sum)
     end
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -118,6 +118,12 @@ const ≅ = isequal
     adf′ = aggregate(groupby(df7, 2), [sum, length], sort=true)
     @test adf ≅ adf′
 
+    df = DataFrame(a = [3, missing, 1], b = [100, 200, 300])
+    for dosort in (true, false), doskipmissing in (true, false)
+        @test aggregate(df, :a, sum, sort=dosort, skipmissing=doskipmissing) ==
+              aggregate(groupby(df, :a, sort=dosort, skipmissing=doskipmissing), sum)
+    end
+
     # Check column names
     anonf = x -> sum(x)
     adf = aggregate(df7, :d2, [mean, anonf])

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1227,7 +1227,7 @@ end
     @test gdf[1:1] == gdf
 
     @test map(nrow, gdf) == groupby_checked(DataFrame(x1=4), [])
-    @test map(:x3 => identity, gdf) == groupby_checked(DataFrame(x3_identity=[1,2,3]), [])
+    @test map(:x2 => identity, gdf) == groupby_checked(DataFrame(x2_identity=[1,2,3]), [])
     @test aggregate(df, sum) == aggregate(df, [], sum) == aggregate(df, 1:0, sum)
     @test aggregate(df, sum) == aggregate(df, [], sum, sort=true, skipmissing=true)
     @test DataFrame(gdf) == df

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1210,7 +1210,7 @@ end
     @test groupvars(gdf) == [:y]
     @test groupindices(gdf) == [1,2,3]
 
-    gdf = groupby(df, [])
+    gdf = groupby_checked(df, [])
     @test groupvars(gdf) == []
     @test groupindices(gdf) == [1,1,1]
 
@@ -1220,14 +1220,14 @@ end
 
     @test by(df, [], a=:x1=>sum, b=:x2=>length) == DataFrame(a=5, b=3)
 
-    gdf = groupby(df, [])
+    gdf = groupby_checked(df, [])
     @test gdf[1] == df
     @test_throws BoundsError gdf[2]
     @test gdf[:] == gdf
     @test gdf[1:1] == gdf
 
-    @test map(nrow, gdf) == groupby(DataFrame(x1=4), [])
-    @test map(:x3 => identity, gdf) == groupby(DataFrame(x3_identity=[1,2,3]), [])
+    @test map(nrow, gdf) == groupby_checked(DataFrame(x1=4), [])
+    @test map(:x3 => identity, gdf) == groupby_checked(DataFrame(x3_identity=[1,2,3]), [])
     @test aggregate(df, sum) == aggregate(df, [], sum) == aggregate(df, 1:0, sum)
     @test aggregate(df, sum) == aggregate(df, [], sum, sort=true, skipmissing=true)
     @test DataFrame(gdf) == df

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1200,4 +1200,25 @@ end
     end
 end
 
+@testset "non standard cols arguments" begin
+    df = DataFrame(x1=[1,2,2], x2=[1,1,2], y=[1,2,3])
+    gdf = groupby(df, r"x")
+    @test groupvars(gdf) == [:x1, :x2]
+    @test groupindices(gdf) == [1,2,3]
+
+    gdf = groupby(df, Not(r"x"))
+    @test groupvars(gdf) == [:y]
+    @test groupindices(gdf) == [1,2,3]
+
+    gdf = groupby(df, [])
+    @test groupvars(gdf) == Symbol[]
+    @test groupindices(gdf) == [1,1,1]
+
+    gdf = groupby(df, r"z")
+    @test groupvars(gdf) == Symbol[]
+    @test groupindices(gdf) == [1,1,1]
+
+    @test by(df, [], a=:x1=>sum, b=:x2=>length) == DataFrame(a=5, b=3)
+end
+
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1226,8 +1226,8 @@ end
     @test gdf[:] == gdf
     @test gdf[1:1] == gdf
 
-    @test map(nrow, gdf) == groupby_checked(DataFrame(x1=4), [])
-    @test map(:x2 => identity, gdf) == groupby_checked(DataFrame(x2_identity=[1,2,3]), [])
+    @test map(nrow, gdf) == groupby_checked(DataFrame(x1=3), [])
+    @test map(:x2 => identity, gdf) == groupby_checked(DataFrame(x2_identity=[1,1,2]), [])
     @test aggregate(df, sum) == aggregate(df, [], sum) == aggregate(df, 1:0, sum)
     @test aggregate(df, sum) == aggregate(df, [], sum, sort=true, skipmissing=true)
     @test DataFrame(gdf) == df

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1201,7 +1201,7 @@ end
 end
 
 @testset "non standard cols arguments" begin
-    df = DataFrame(x1=[1,2,2], x2=[1,1,2], y=[1,2,3])
+    df = DataFrame(x1=Int64[1,2,2], x2=Int64[1,1,2], y=Int64[1,2,3])
     gdf = groupby_checked(df, r"x")
     @test groupvars(gdf) == [:x1, :x2]
     @test groupindices(gdf) == [1,2,3]

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1232,7 +1232,7 @@ end
     @test aggregate(df, sum) == aggregate(df, [], sum, sort=true, skipmissing=true)
     @test DataFrame(gdf) == df
 
-    @test sprint(show, gdf) == """
+    @test sprint(show, groupby(df, [])) == """
     GroupedDataFrame with 1 group based on key:
     First Group (3 rows):
     │ Row │ x1    │ x2    │ y     │

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1219,6 +1219,28 @@ end
     @test groupindices(gdf) == [1,1,1]
 
     @test by(df, [], a=:x1=>sum, b=:x2=>length) == DataFrame(a=5, b=3)
+
+    gdf = groupby(df, [])
+    @test gdf[1] == df
+    @test_throws BoundsError gdf[2]
+    @test gdf[:] == gdf
+    @test gdf[1:1] == gdf
+
+    @test map(nrow, gdf) == groupby(DataFrame(x1=4), [])
+    @test map(:x3 => identity, gdf) == groupby(DataFrame(x3_identity=[1,2,3]), [])
+    @test aggregate(df, sum) == aggregate(df, [], sum) == aggregate(df, 1:0, sum)
+    @test aggregate(df, sum) == aggregate(df, [], sum, sort=true, skipmissing=true)
+    @test DataFrame(gdf) == df
+
+    @test sprint(show, df) == """
+    GroupedDataFrame with 1 group based on key:
+    First Group (3 rows):
+    │ Row │ x1    │ x2    │ y     │
+    │     │ Int64 │ Int64 │ Int64 │
+    ├─────┼───────┼───────┼───────┤
+    │ 1   │ 1     │ 1     │ 1     │
+    │ 2   │ 2     │ 1     │ 2     │
+    │ 3   │ 2     │ 2     │ 3     │"""
 end
 
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1232,15 +1232,10 @@ end
     @test aggregate(df, sum) == aggregate(df, [], sum, sort=true, skipmissing=true)
     @test DataFrame(gdf) == df
 
-    @test sprint(show, groupby(df, [])) == """
-    GroupedDataFrame with 1 group based on key:
-    Group 1 (3 rows):
-    │ Row │ x1    │ x2    │ y     │
-    │     │ Int64 │ Int64 │ Int64 │
-    ├─────┼───────┼───────┼───────┤
-    │ 1   │ 1     │ 1     │ 1     │
-    │ 2   │ 2     │ 1     │ 2     │
-    │ 3   │ 2     │ 2     │ 3     │"""
+    @test sprint(show, groupby(df, [])) == "GroupedDataFrame with 1 group based on key: \n" *
+        "Group 1 (3 rows): \n│ Row │ x1    │ x2    │ y     │\n│     │ Int64 │ Int64 │ Int64 │\n" *
+        "├─────┼───────┼───────┼───────┤\n│ 1   │ 1     │ 1     │ 1     │\n" *
+        "│ 2   │ 2     │ 1     │ 2     │\n│ 3   │ 2     │ 2     │ 3     │"
 end
 
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1232,7 +1232,7 @@ end
     @test aggregate(df, sum) == aggregate(df, [], sum, sort=true, skipmissing=true)
     @test DataFrame(gdf) == df
 
-    @test sprint(show, df) == """
+    @test sprint(show, gdf) == """
     GroupedDataFrame with 1 group based on key:
     First Group (3 rows):
     │ Row │ x1    │ x2    │ y     │

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1234,7 +1234,7 @@ end
 
     @test sprint(show, groupby(df, [])) == """
     GroupedDataFrame with 1 group based on key:
-    First Group (3 rows):
+    Group 1 (3 rows):
     │ Row │ x1    │ x2    │ y     │
     │     │ Int64 │ Int64 │ Int64 │
     ├─────┼───────┼───────┼───────┤

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1232,7 +1232,7 @@ end
     @test aggregate(df, sum) == aggregate(df, [], sum, sort=true, skipmissing=true)
     @test DataFrame(gdf) == df
 
-    @test sprint(show, groupby(df, [])) == "GroupedDataFrame with 1 group based on key: \n" *
+    @test sprint(show, groupby_checked(df, [])) == "GroupedDataFrame with 1 group based on key: \n" *
         "Group 1 (3 rows): \n│ Row │ x1    │ x2    │ y     │\n│     │ Int64 │ Int64 │ Int64 │\n" *
         "├─────┼───────┼───────┼───────┤\n│ 1   │ 1     │ 1     │ 1     │\n" *
         "│ 2   │ 2     │ 1     │ 2     │\n│ 3   │ 2     │ 2     │ 3     │"


### PR DESCRIPTION
Allow more flexible `cols` in `groupby` and `by` (e.g. `Regex`, `Not`, `All`).
In particular also correctly handle the case when cols produces an empty selection of columns. In this case we create a single group having all columns.