### PR TITLE
Fix handling of hash collisions in row_group_slots

### DIFF
--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -131,8 +131,8 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
                 elseif rhashes[i] == rhashes[g_row] # occupied slot, check if miss or hit
                     if isequal_row(cols, i, g_row) # hit
                         gix = groups !== nothing ? groups[g_row] : 0
+                        break
                     end
-                    break
                 end
                 slotix = slotix & szm1 + 1 # check the next slot
                 probe += 1

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -51,12 +51,23 @@ function groupby_checked(df::AbstractDataFrame, keys, args...; kwargs...)
 
         # correct start-end relations
         for i in eachindex(se)
+            firstkeys = gd.parent[gd.idx[se[i][1]], gd.cols]
+            # all grouping keys must be equal within a group
+            @assert all(j -> gd.parent[gd.idx[j], gd.cols] ≅ firstkeys, se[i][1]:se[i][2])
             @assert se[i][1] <= se[i][2]
             if i > 1
                 # the blocks returned by groupby must be continuous
                 @assert se[i-1][2] + 1 == se[i][1]
             end
         end
+
+        # all grouping keys must be equal within a group
+        for (s, e) in zip(gd.starts, gd.ends)
+            firstkeys = gd.parent[gd.idx[s], gd.cols]
+            @assert all(j -> gd.parent[gd.idx[j], gd.cols] ≅ firstkeys, s:e)
+        end
+        # all groups have different grouping keys
+        @test allunique(eachrow(gd.parent[gd.idx[gd.starts], gd.cols]))
     end
 
     gd

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -608,6 +608,13 @@ end
     end
 end
 
+@testset "grouping with hash collisions" begin
+    # Hash collisions are almost certain on 32-bit
+    df = DataFrame(A=1:2_000_000)
+    gd = groupby_checked(df, :A)
+    @test DataFrame(df) == df
+end
+
 @testset "by, combine and map with pair interface" begin
     vexp = x -> exp.(x)
     Random.seed!(1)


### PR DESCRIPTION
Original code was correct but JuliaData/DataTables.jl#79 incorrectly moved `break` outside of the `if`.

Fixes #1978.