### PR TITLE
Add reference to DataFrames Tutorial in index.md

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,8 @@ This resource aims to teach you everything you need
 to know to get up and running with tabular data manipulation using the DataFrames.jl package
 and the Julia language.
 
+This documentation is always updated. There is available also a [DataFrames Tutorial in NoteBooks](https://github.com/bkamins/Julia-DataFrames-Tutorial/). That tutorial is not guarantee that be completely updated, but it is a good complementary resource to learn about DataFrames usage. 
+
 If there is something you expect DataFrames to be capable of, but
 cannot figure out how to do, please reach out with questions in Domains/Data on
 [Discourse](https://discourse.julialang.org/new-topic?title=[DataFrames%20Question]:%20&body=%23%20Question:%0A%0A%23%20Dataset%20(if%20applicable):%0A%0A%23%20Minimal%20Working%20Example%20(if%20applicable):%0A&category=Domains/Data&tags=question).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ This resource aims to teach you everything you need
 to know to get up and running with tabular data manipulation using the DataFrames.jl package
 and the Julia language.
 
-This documentation is always updated. There is available also a [DataFrames Tutorial in NoteBooks](https://github.com/bkamins/Julia-DataFrames-Tutorial/). That tutorial is not guarantee that be completely updated, but it is a good complementary resource to learn about DataFrames usage. 
+This documentation is always updated. There is available also a [DataFrames Tutorial in NoteBooks](https://github.com/bkamins/Julia-DataFrames-Tutorial/). That tutorial is a good complementary resource to learn about DataFrames usage, and it illustrates its usage in conjunction with other packages.
 
 If there is something you expect DataFrames to be capable of, but
 cannot figure out how to do, please reach out with questions in Domains/Data on

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ This resource aims to teach you everything you need
 to know to get up and running with tabular data manipulation using the DataFrames.jl package
 and the Julia language.
 
-This documentation is always updated. There is available also a [DataFrames Tutorial in NoteBooks](https://github.com/bkamins/Julia-DataFrames-Tutorial/). That tutorial is a good complementary resource to learn about DataFrames usage, and it illustrates its usage in conjunction with other packages.
+This documentation is always updated. There is available also a [DataFrames Tutorial using Jupyter Notebooks](https://github.com/bkamins/Julia-DataFrames-Tutorial/). That tutorial is a good complementary resource to learn about DataFrames.jl, and it illustrates its usage in conjunction with other packages.
 
 If there is something you expect DataFrames to be capable of, but
 cannot figure out how to do, please reach out with questions in Domains/Data on

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -3,10 +3,10 @@
 Welcome to the DataFrames documentation!
 
 This resource aims to teach you everything you need
-to know to get up and running with tabular data manipulation using the DataFrames.jl package
-and the Julia language.
-
-This documentation is always updated. There is available also a [DataFrames Tutorial using Jupyter Notebooks](https://github.com/bkamins/Julia-DataFrames-Tutorial/). That tutorial is a good complementary resource to learn about DataFrames.jl, and it illustrates its usage in conjunction with other packages.
+to know to get up and running with tabular data manipulation using the DataFrames.jl package.
+For more illustrations of its usage in conjunction with other packages, the
+[DataFrames Tutorial using Jupyter Notebooks](https://github.com/bkamins/Julia-DataFrames-Tutorial/)
+is a good complementary resource.
 
 If there is something you expect DataFrames to be capable of, but
 cannot figure out how to do, please reach out with questions in Domains/Data on


### PR DESCRIPTION
I think that the website [https://github.com/bkamins/Julia-DataFrames-Tutorial/](https://github.com/bkamins/Julia-DataFrames-Tutorial/) is a very useful resource, and it could be good to mention it in the documentation.