### PR TITLE
fix a bug in select!

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -821,6 +821,7 @@ function select!(df::DataFrame, inds::AbstractVector{Int})
     copy!(_columns(df), _columns(df)[inds])
     x = index(df)
     copy!(_names(x), _names(df)[inds])
+    empty!(x.lookup)
     for (i, n) in enumerate(x.names)
         x.lookup[n] = i
     end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -406,6 +406,7 @@ end
     @test names(d) == [:b, :d]
     select!(d, Not(:b))
     @test d == DataFrame(d=4)
+    DataFrames._check_consistency(d)
 
     d = copy(df)
     select!(d, Not(r"[aec]"))


### PR DESCRIPTION
`lookup` of `Index` was not cleaned by `select!` before reassignment. This PR fixes this.