### PR TITLE
Documenting the difference betwen df[!, :col] and df[:, :col]

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -47,7 +47,9 @@ julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
 
 Columns can be directly (i.e. without copying) accessed via `df.col` or `df[!, :col]`. The latter syntax is more flexible as it allows passing a variable holding the name of the column, and not only a literal name. Note that column names are symbols (`:col` or `Symbol("col")`) rather than strings (`"col"`). Columns can also be accessed using an integer index specifying their position. 
 
-Since `df[!, :col]` does not make a copy, changing the elements of the column returned by this syntax will affect the values stored in the original `df`. Use the `df[:, :col]` syntax to get a copy of the column, which can be modified without changing `df`.
+Since `df[!, :col]` does not make a copy, changing the elements of the column returned by this syntax will affect the values stored in the original `df`. 
+
+To get a copy of the column use `df[:, :col]`. Changing the column returned by this syntax does not change `df`.
 
 ```jldoctest dataframe
 julia> df.A

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -47,7 +47,7 @@ julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
 
 Columns can be directly (i.e. without copying) accessed via `df.col` or `df[!, :col]`. The latter syntax is more flexible as it allows passing a variable holding the name of the column, and not only a literal name. Note that column names are symbols (`:col` or `Symbol("col")`) rather than strings (`"col"`). Columns can also be accessed using an integer index specifying their position. 
 
-Notice that, changing the elements of the column returned by `df[!, :col]` will affect the values stored in the original `df`. To get a copy of the column use `df[:, :col]`. Changing the column returned by `df[:, :col]` does not change `df`.
+Since `df[!, :col]` does not make a copy, changing the elements of the column returned by this syntax will affect the values stored in the original `df`. Use the `df[:, :col]` syntax to get a copy of the column, which can be modified without changing `df`.
 
 ```jldoctest dataframe
 julia> df.A
@@ -60,13 +60,31 @@ julia> df.A
 julia> df.A === df[!, :A]
 true
 
+julia> df.A === df[:, :A]
+false
+
+julia> df.A == df[:, :A]
+true
+
 julia> df.A === df[!, 1]
+true
+
+julia> df.A === df[:, 1]
+false
+
+julia> df.A == df[:, 1]
 true
 
 julia> firstcolumn = :A
 :A
 
 julia> df[!, firstcolumn] === df.A
+true
+
+julia> df[:, firstcolumn] === df.A
+false
+
+julia> df[:, firstcolumn] == df.A
 true
 ```
 

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -45,7 +45,9 @@ julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
 
 ```
 
-Columns can be directly (i.e. without copying) accessed via `df.col` or `df[!, :col]`. The latter syntax is more flexible as it allows passing a variable holding the name of the column, and not only a literal name. Note that column names are symbols (`:col` or `Symbol("col")`) rather than strings (`"col"`). Columns can also be accessed using an integer index specifying their position.
+Columns can be directly (i.e. without copying) accessed via `df.col` or `df[!, :col]`. The latter syntax is more flexible as it allows passing a variable holding the name of the column, and not only a literal name. Note that column names are symbols (`:col` or `Symbol("col")`) rather than strings (`"col"`). Columns can also be accessed using an integer index specifying their position. 
+
+`Notice that, changing the elements of the array returned by `df[!, :col]` will affect the original `df`, while `df[:, :col]` returns a copy of the array, and changing it doesn't change `df` values.
 
 ```jldoctest dataframe
 julia> df.A

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -47,7 +47,7 @@ julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
 
 Columns can be directly (i.e. without copying) accessed via `df.col` or `df[!, :col]`. The latter syntax is more flexible as it allows passing a variable holding the name of the column, and not only a literal name. Note that column names are symbols (`:col` or `Symbol("col")`) rather than strings (`"col"`). Columns can also be accessed using an integer index specifying their position. 
 
-`Notice that, changing the elements of the array returned by `df[!, :col]` will affect the original `df`, while `df[:, :col]` returns a copy of the array, and changing it doesn't change `df` values.
+Notice that, changing the elements of the column returned by `df[!, :col]` will affect the values stored in the original `df`, while `df[:, :col]` returns a copy of the column, and changing it does not change `df`.
 
 ```jldoctest dataframe
 julia> df.A

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -47,7 +47,7 @@ julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
 
 Columns can be directly (i.e. without copying) accessed via `df.col` or `df[!, :col]`. The latter syntax is more flexible as it allows passing a variable holding the name of the column, and not only a literal name. Note that column names are symbols (`:col` or `Symbol("col")`) rather than strings (`"col"`). Columns can also be accessed using an integer index specifying their position. 
 
-Notice that, changing the elements of the column returned by `df[!, :col]` will affect the values stored in the original `df`, while `df[:, :col]` returns a copy of the column, and changing it does not change `df`.
+Notice that, changing the elements of the column returned by `df[!, :col]` will affect the values stored in the original `df`. To get a copy of the column use `df[:, :col]`. Changing the column returned by `df[:, :col]` does not change `df`.
 
 ```jldoctest dataframe
 julia> df.A

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -47,9 +47,8 @@ julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
 
 Columns can be directly (i.e. without copying) accessed via `df.col` or `df[!, :col]`. The latter syntax is more flexible as it allows passing a variable holding the name of the column, and not only a literal name. Note that column names are symbols (`:col` or `Symbol("col")`) rather than strings (`"col"`). Columns can also be accessed using an integer index specifying their position. 
 
-Since `df[!, :col]` does not make a copy, changing the elements of the column returned by this syntax will affect the values stored in the original `df`. 
+Since `df[!, :col]` does not make a copy, changing the elements of the column vector returned by this syntax will affect the values stored in the original `df`. To get a copy of the column use `df[:, :col]`: changing the vector returned by this syntax does not change `df`.
 
-To get a copy of the column use `df[:, :col]`. Changing the column returned by this syntax does not change `df`.
 
 ```jldoctest dataframe
 julia> df.A


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/1999