### PR TITLE
Support `append!`ing row-oriented tables

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -32,7 +32,13 @@ function DataFrame(x::T; copycols::Bool=true) where {T}
     return fromcolumns(Tables.columns(x), copycols=copycols)
 end
 
-Base.append!(df::DataFrame, x) = append!(df, DataFrame(x, copycols=false))
+function Base.append!(df::DataFrame, x)
+    if Tables.columnaccess(x)
+        return append!(df, DataFrame(x, copycols=false))
+    else
+        return foldl(push!, Tables.rows(x); init=df)
+    end
+end
 
 # This supports the Tables.RowTable type; needed to avoid ambiguities w/ another constructor
 function DataFrame(x::Vector{<:NamedTuple}; copycols::Bool=true)

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -32,13 +32,7 @@ function DataFrame(x::T; copycols::Bool=true) where {T}
     return fromcolumns(Tables.columns(x), copycols=copycols)
 end
 
-function Base.append!(df::DataFrame, x)
-    if Tables.columnaccess(x)
-        return append!(df, DataFrame(x, copycols=false))
-    else
-        return foldl(push!, Tables.rows(x); init=df)
-    end
-end
+Base.append!(df::DataFrame, x) = append!(df, DataFrame(Tables.columns(x), copycols=false))
 
 # This supports the Tables.RowTable type; needed to avoid ambiguities w/ another constructor
 function DataFrame(x::Vector{<:NamedTuple}; copycols::Bool=true)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -129,6 +129,9 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         append!(df, etu)
         @test size(df) == (6, 3)
 
+        append!(df, [nt])
+        @test size(df) == (7, 3)
+
         # categorical values
         cat = CategoricalVector(["hey", "there", "sailor"])
         cat2 = [c for c in cat] # Vector of CategoricalString


### PR DESCRIPTION
This PR makes code such as `append!(DataFrame(), [(a=1,)])` work.