### PR TITLE
change how copycols in Vector{<:NamedTuple} constructor

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -45,8 +45,9 @@ DataFrame(::GroupedDataFrame)
 * `table` : any type that implements the
   [Tables.jl](https://github.com/JuliaData/Tables.jl) interface; in particular
   a tuple or vector of `Pair{Symbol, <:AbstractVector}}` objects is a table.
-* `copycols` : whether vectors passed as columns should be copied; note that
-  `DataFrame(kwargs...)` does not support this keyword argument and always copies columns.
+* `copycols` : whether vectors passed as columns should be copied; if set
+  to `false` then the constructor will still copy the passed columns
+  if it is not possible to construct a `DataFrame` without materializing new columns.
 
 All columns in `columns` should have the same length.
 

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -35,13 +35,8 @@ end
 Base.append!(df::DataFrame, x) = append!(df, DataFrame(x, copycols=false))
 
 # This supports the Tables.RowTable type; needed to avoid ambiguities w/ another constructor
-function DataFrame(x::Vector{<:NamedTuple}; copycols::Bool=true)
-    if !copycols
-        throw(ArgumentError("It is not possible to construct a `DataFrame`" *
-                            "from a `Vector{<:NamedTuple}` with `copycols=false`"))
-    end
+DataFrame(x::Vector{<:NamedTuple}; copycols::Bool=true) =
     fromcolumns(Tables.columns(Tables.IteratorWrapper(x)), copycols=false)
-end
 DataFrame!(x::Vector{<:NamedTuple}) =
     throw(ArgumentError("It is not possible to construct a `DataFrame` from " *
                         "`$(typeof(x))` without allocating new columns: use " *

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -161,8 +161,8 @@ end
     @test size(df) == (2, 2)
     @test df.a == [1, 3]
     @test df.b == [2, 4]
+    @test DataFrame(v, copycols=false) == DataFrame(v, copycols=true) == df
     @test_throws ArgumentError DataFrame!(v)
-    @test_throws ArgumentError DataFrame(v, copycols=false)
 end
 
 @testset "columnindex" begin


### PR DESCRIPTION
Additionally I have cleaned a minor bug in the documentation of `DataFrame` constructor.

See https://github.com/JuliaData/DataFrames.jl/pull/2003#issuecomment-550217542 for a rationale of this change.