### PR TITLE
Key in warning doesn't reflect the the right entry

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -287,7 +287,7 @@ function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Symbol},
         i = rowkey[k]
         if !warned_dup && mask_filled[i, j]
             @warn("Duplicate entries in unstack at row $k for key "*
-                 "$(tuple((df[1,s] for s in rowkeys)...)) and variable $(keycol[k]).")
+                 "$(tuple((df[k,s] for s in rowkeys)...)) and variable $(keycol[k]).")
             warned_dup = true
         end
         unstacked_val[j][i] = valuecol[k]


### PR DESCRIPTION
```julia
using DataFrames
a = DataFrame( i=["a","a","b","b"], j=["a1","a1","b1","b1"],
    var1=[1,2,3,3], val=[11,22,33,44])

unstack(a,:i,:var1,:val)
#┌ Warning: Duplicate entries in unstack at row 4 for key b and variable 3.
# > correct key

unstack(a,[:i,:j],:var1,:val)
#┌ Warning: Duplicate entries in unstack at row 4 for key ("a", "a1") and variable 3.
# > key ("a", "a1") isn't the duplicate

# this PR:
unstack(a,[:i,:j],:var1,:val)
#┌ Warning: Duplicate entries in unstack at row 4 for key ("b", "b1") and variable 3.
# > corrected key
```