### PR TITLE
make SubIndex strict about duplicates

### DIFF
--- a/test/cat.jl
+++ b/test/cat.jl
@@ -267,10 +267,8 @@ end
 
     df = DataFrame(A=1:5, B=11:15, C=21:25)
     @test vcat(view(df, 1:2, :), view(df, 3:5, [3,2,1])) == df
-    @test_throws ArgumentError vcat(view(df, 1:2, [1,2,3,1,2,3]),
-                                    view(df, 3:5, [3,2,1,1,2,3])) == df
-    @test_throws ArgumentError all(==(df[1, :]), eachrow(vcat(view(df, [1,1,1], [1,2,3,1,2,3]),
-                                                              view(df, [1,1,1], [3,2,1,1,2,3]))))
+    @test_throws ArgumentError view(df, 1:2, [1,2,3,1,2,3])
+    @test_throws ArgumentError view(df, 3:5, [3,2,1,1,2,3])
 end
 
 @testset "vcat copy" begin

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -267,9 +267,10 @@ end
 
     df = DataFrame(A=1:5, B=11:15, C=21:25)
     @test vcat(view(df, 1:2, :), view(df, 3:5, [3,2,1])) == df
-    @test vcat(view(df, 1:2, [1,2,3,1,2,3]), view(df, 3:5, [3,2,1,1,2,3])) == df
-    @test all(==(df[1, :]), eachrow(vcat(view(df, [1,1,1], [1,2,3,1,2,3]),
-                                         view(df, [1,1,1], [3,2,1,1,2,3]))))
+    @test_throws ArgumentError vcat(view(df, 1:2, [1,2,3,1,2,3]),
+                                    view(df, 3:5, [3,2,1,1,2,3])) == df
+    @test_throws ArgumentError all(==(df[1, :]), eachrow(vcat(view(df, [1,1,1], [1,2,3,1,2,3]),
+                                                              view(df, [1,1,1], [3,2,1,1,2,3]))))
 end
 
 @testset "vcat copy" begin

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -298,7 +298,7 @@ end
     @test parentindices(sdf[2, r"a"]) == (3, [1])
     @test parentindices(sdf[2, r"x"]) == (3, Int[])
     @test parent(sdf[1, 1:2]) === df
-    @test_throws ArgumentError parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
+    @test_throws ArgumentError parentindices(sdf[1, [2, 2]])
     @test parent(df[2, r""]) === df
     @test parent(df[2, r"a"]) === df
     @test parent(df[2, r"x"]) === df
@@ -318,7 +318,7 @@ end
     @test parentindices(sdf[2, r"a"]) == (3, [1])
     @test parentindices(sdf[2, r"x"]) == (3, Int[])
     @test parent(sdf[1, 1:2]) === df
-    @test_throws ArgumentError parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
+    @test_throws ArgumentError parentindices(sdf[1, [2, 2]])
 end
 
 @testset "iteration and collect" begin
@@ -341,8 +341,8 @@ end
 @testset "duplicate column" begin
     df = DataFrame([11:16 21:26 31:36 41:46])
     sdf = view(df, [3,1,4], [3,1,4])
-    @test_throws ArgumentError dfr1 = df[2, [2,2,2]]
-    @test_throws ArgumentError dfr2 = sdf[2, [2,2,2]]
+    @test_throws ArgumentError df[2, [2,2,2]]
+    @test_throws ArgumentError sdf[2, [2,2,2]]
 end
 
 @testset "conversion and push!" begin

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -365,7 +365,7 @@ end
     @test push!(df, df[1, :]) == DataFrame(x=[1, 1], y=[2, 2])
     @test push!(df, df[1, [2,1]]) == DataFrame(x=[1, 1, 1], y=[2, 2, 2])
 
-    push!(df, df[1, [2,1,2]], columns=:intersect)
+    push!(df, df[1, [2,1]], columns=:intersect)
     @test df == DataFrame(x=[1, 1, 1, 1], y=[2, 2, 2, 2])
 
     df2 = DataFrame()

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -298,7 +298,7 @@ end
     @test parentindices(sdf[2, r"a"]) == (3, [1])
     @test parentindices(sdf[2, r"x"]) == (3, Int[])
     @test parent(sdf[1, 1:2]) === df
-    @test parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
+    @test_throws ArgumentError parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
     @test parent(df[2, r""]) === df
     @test parent(df[2, r"a"]) === df
     @test parent(df[2, r"x"]) === df
@@ -318,7 +318,7 @@ end
     @test parentindices(sdf[2, r"a"]) == (3, [1])
     @test parentindices(sdf[2, r"x"]) == (3, Int[])
     @test parent(sdf[1, 1:2]) === df
-    @test parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
+    @test_throws ArgumentError parentindices(sdf[1, [2, 2]]) == (4, [1, 1])
 end
 
 @testset "iteration and collect" begin

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -341,22 +341,8 @@ end
 @testset "duplicate column" begin
     df = DataFrame([11:16 21:26 31:36 41:46])
     sdf = view(df, [3,1,4], [3,1,4])
-    dfr1 = df[2, [2,2,2]]
-    dfr2 = sdf[2, [2,2,2]]
-    @test names(dfr1) == fill(:x2, 3)
-    @test names(dfr2) == fill(:x1, 3)
-    @test values(dfr1) == (22, 22, 22)
-    @test values(dfr2) == (11, 11, 11)
-    @test dfr1.x2 == 22
-    dfr1.x2 = 100
-    @test values(dfr1) == (100, 100, 100)
-    @test df[2, 2] == 100
-    @test_throws ArgumentError dfr1.x1
-    @test dfr2.x1 == 11
-    dfr2.x1 = 200
-    @test values(dfr2) == (200, 200, 200)
-    @test df[1, 1] == 200
-    @test_throws ArgumentError dfr2.x2
+    @test_throws ArgumentError dfr1 = df[2, [2,2,2]]
+    @test_throws ArgumentError dfr2 = sdf[2, [2,2,2]]
 end
 
 @testset "conversion and push!" begin

--- a/test/index.jl
+++ b/test/index.jl
@@ -125,23 +125,23 @@ si7 = SubIndex(i, Not(1:2))
 @test si2.cols == 3:5
 @test si2.remap == -1:3
 @test si3.cols == 3:5
-@test si3.remap == Int[]
+@test si3.remap == [0, 0, 1, 2, 3]
 @test !haskey(si3, :A)
 @test si3.remap == [0, 0, 1, 2, 3]
 @test si4.cols == 3:5
-@test si4.remap == Int[]
+@test si4.remap == [0, 0, 1, 2, 3]
 @test !haskey(si4, :A)
 @test si4.remap == [0, 0, 1, 2, 3]
 @test si5.cols == 3:5
-@test si5.remap == Int[]
+@test si5.remap == [0, 0, 1, 2, 3]
 @test !haskey(si5, :A)
 @test si5.remap == [0, 0, 1, 2, 3]
 @test si6.cols == 3:5
-@test si6.remap == Int[]
+@test si6.remap == [0, 0, 1, 2, 3]
 @test !haskey(si6, :A)
 @test si6.remap == [0, 0, 1, 2, 3]
 @test si7.cols == 3:5
-@test si7.remap == Int[]
+@test si7.remap == [0, 0, 1, 2, 3]
 @test !haskey(si7, :A)
 @test si7.remap == [0, 0, 1, 2, 3]
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1394,4 +1394,16 @@ end
     @test_throws InexactError df[:, 2] = fill(1.5, 4)
 end
 
+@testset "invalid view tests" begin
+    df = DataFrame(ones(2,3))
+    for r in (1, 1:1)
+        @test_throws BoundsError view(df, r, 0:1)
+        @test_throws BoundsError view(df, r, 1:4)
+        @test_throws BoundsError view(df, r, [0,1])
+        @test_throws BoundsError view(df, r, [1,4])
+        @test_throws ArgumentError view(df, r, [1,2,1])
+        @test_throws ArgumentError view(df, r, [:x1,:x2,:x1])
+    end
+end
+
 end # module

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1395,14 +1395,16 @@ end
 end
 
 @testset "invalid view tests" begin
-    df = DataFrame(ones(2,3))
-    for r in (1, 1:1)
-        @test_throws BoundsError view(df, r, 0:1)
-        @test_throws BoundsError view(df, r, 1:4)
-        @test_throws BoundsError view(df, r, [0,1])
-        @test_throws BoundsError view(df, r, [1,4])
-        @test_throws ArgumentError view(df, r, [1,2,1])
-        @test_throws ArgumentError view(df, r, [:x1,:x2,:x1])
+    dfr = DataFrame(ones(2,3))
+    for df in (dfr, view(dfr, 1:2, 1:3))
+        for r in (1, 1:1)
+            @test_throws BoundsError view(df, r, 0:1)
+            @test_throws BoundsError view(df, r, 1:4)
+            @test_throws BoundsError view(df, r, [0,1])
+            @test_throws BoundsError view(df, r, [1,4])
+            @test_throws ArgumentError view(df, r, [1,2,1])
+            @test_throws ArgumentError view(df, r, [:x1,:x2,:x1])
+        end
     end
 end
 

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -241,7 +241,7 @@ end
 
 @testset "duplicate column" begin
     df = DataFrame([11:16 21:26 31:36 41:46])
-    @test_throws ArgumentError sdf = view(df, [3,1,4], [3,3,3])
+    @test_throws ArgumentError view(df, [3,1,4], [3,3,3])
 end
 
 @testset "conversion to DataFrame" begin

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -241,14 +241,7 @@ end
 
 @testset "duplicate column" begin
     df = DataFrame([11:16 21:26 31:36 41:46])
-    sdf = view(df, [3,1,4], [3,3,3])
-    @test names(sdf) == fill(:x3, 3)
-    @test sdf[!, 1] == [33, 31, 34]
-    @test sdf[!, 1] === sdf[!, 2] === sdf[!, 3]
-    @test sdf.x3[1] == 33
-    sdf.x3[1] = 333
-    @test df.x3[3] == 333
-    @test_throws ArgumentError sdf.x1
+    @test_throws ArgumentError sdf = view(df, [3,1,4], [3,3,3])
 end
 
 @testset "conversion to DataFrame" begin


### PR DESCRIPTION
see the discussion in https://github.com/JuliaData/DataFrames.jl/pull/1958.

Rationale for this change:
* the case when the cost of creation of `DataFrameRow` or `SubDataFrame` will be affected is only when indexing by `AbstractVector{Int}` is performed (abut not ranges - as they will be fast) - so I guess the case when it is needed is pretty rare
* if someone really wants to avoid checking for duplicates it is possible to call `SubIndex` default constructor with appropriate values
* the additional benefit is that functions that previously called `lazyremap!` have a bit less work to do later