### PR TITLE
Release 0.20.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.19.3"
+version = "0.20.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -16,7 +16,6 @@ by
 combine
 groupby
 groupindices
-groupvalues
 groupvars
 keys
 get


### PR DESCRIPTION
PRs required to be merged before 0.20 release:
- [x] https://github.com/JuliaData/DataFrames.jl/pull/1958

PRs that I would like merge before 0.20 release (but they are pending consensus or final changes, hopefully this can be resolved soon - if there are problems with them they will not get included):
- [x] https://github.com/JuliaData/DataFrames.jl/pull/1961
- [x] https://github.com/JuliaData/DataFrames.jl/pull/1908

Nice to have PRs (should be easy so possibly they can be included in the release, but they are non blocking):
- [x] https://github.com/JuliaData/DataFrames.jl/pull/2027
- ~https://github.com/JuliaData/DataFrames.jl/pull/1864~ (excluded from the release)