### PR TITLE
Remove the dependency on `Compat.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.20.0"
+version = "0.20.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.20.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Future = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 InvertedIndices = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
@@ -34,7 +33,6 @@ test = ["DataStructures", "DataValues", "Dates", "Logging", "Random", "Test"]
 [compat]
 julia = "1"
 CategoricalArrays = "0.7"
-Compat = "2, 3"
 DataAPI = "1.0.1"
 InvertedIndices = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -1,7 +1,7 @@
 module DataFrames
 
 using Statistics, Printf, REPL
-using Reexport, SortingAlgorithms, Compat, Unicode, PooledArrays, DataAPI
+using Reexport, SortingAlgorithms, Unicode, PooledArrays, DataAPI
 @reexport using CategoricalArrays, Missings, InvertedIndices
 using Base.Sort, Base.Order, Base.Iterators
 using Tables, TableTraits, IteratorInterfaceExtensions

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -65,7 +65,7 @@ abstract type AbstractDataFrame end
 Base.names(df::AbstractDataFrame) = names(index(df))
 _names(df::AbstractDataFrame) = _names(index(df))
 
-Compat.hasproperty(df::AbstractDataFrame, s::Symbol) = haskey(index(df), s)
+Base.hasproperty(df::AbstractDataFrame, s::Symbol) = haskey(index(df), s)
 
 """
     rename!(df::AbstractDataFrame, vals::AbstractVector{Symbol}; makeunique::Bool=false)

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -186,7 +186,7 @@ function Base.iterate(gd::GroupedDataFrame, i=1)
 end
 
 Base.length(gd::GroupedDataFrame) = length(gd.starts)
-Compat.lastindex(gd::GroupedDataFrame) = length(gd.starts)
+Base.lastindex(gd::GroupedDataFrame) = length(gd.starts)
 Base.first(gd::GroupedDataFrame) = gd[1]
 Base.last(gd::GroupedDataFrame) = gd[end]
 


### PR DESCRIPTION
It turns out that the dependency on `Compat.jl` is not necessary.

This pull request removes the dependency on `Compat.jl`.

cc: @nalimilan 