### PR TITLE
Index GroupedDataFrame with array of keys

### DIFF
--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -212,8 +212,6 @@ performance on par with integer indexing.
 The elements of a `GroupedDataFrame` are [`SubDataFrame`](@ref)s of its parent.
 
 * `gd[i::Integer]` -> Get the `i`th group.
-* `gd[a::AbstractArray{<:Integer}]` -> Get a reduced `GroupedDataFrame` containing only the groups
-  with indices in `a`.
 * `gd[key::NamedTuple]` -> Get the group corresponding to the given values of the
   grouping columns. The fields of the `NamedTuple` must match the grouping columns
   columns passed to [`groupby`](@ref) (including order).
@@ -223,3 +221,12 @@ The elements of a `GroupedDataFrame` are [`SubDataFrame`](@ref)s of its parent.
 * `gd[key::GroupKey]` -> Get the group corresponding to the [`GroupKey`](@ref)
   `key` (one of the elements of the vector returned by [`keys(::GroupedDataFrame)`](@ref)).
   This should be nearly as fast as integer indexing.
+* `gd[a::AbstractVector]` -> Select multiple groups and return them in a new
+  `GroupedDataFrame` object. Groups may be selected by integer position using an
+  array of `Integer`s or `Bool`s, similar to a standard array. Alternatively the
+  array may contain keys of any of the types supported for dictionary-like
+  indexing (`GroupKey`, `Tuple`, or `NamedTuple`). Selected groups must be
+  unique, and different types of indices cannot be mixed.
+* `gd[n::Not]` -> Any of the above types wrapped in `Not`. The result
+   will be a new `GroupedDataFrame` containing all groups in `gd` *not* selected
+   by the wrapped index.

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -115,6 +115,7 @@ DataFrame
 DataFrameRow
 GroupedDataFrame
 GroupKey
+GroupKeys
 SubDataFrame
 DataFrameRows
 DataFrameColumns

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -288,8 +288,8 @@ end
 
 # Array of (possibly non-standard) indices
 function Base.to_index(gd::GroupedDataFrame, idxs::AbstractVector{T}) where {T}
-    # A concrete eltype which is <: GroupIndexTypes, don't need to check
-    if isconcretetype(T) && T <: GroupIndexTypes
+    # A concrete eltype which is <: GroupKeyTypes, don't need to check
+    if isconcretetype(T) && T <: GroupKeyTypes
         return [Base.to_index(gd, i) for i in idxs]
     end
 

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -312,7 +312,7 @@ function Base.to_index(gd::GroupedDataFrame, idxs::AbstractVector{T}) where {T}
 
     ints = zeros(Int, length(idxs))
     for (i, idx) in enumerate(idxs)
-        idx isa GroupIndexTypes || throw(ArgumentError("Invalid index: $idx of type $(typeof(idx))"))
+        (idx isa GroupIndexTypes && !(idx isa Bool)) || throw(ArgumentError("Invalid index: $idx of type $(typeof(idx))"))
         idx isa E || throw(ArgumentError("Mixed index types in array not allowed"))
         ints[i] = Base.to_index(gd, idx)
     end
@@ -335,10 +335,14 @@ function Base.to_indices(gd::GroupedDataFrame, (idx,)::Tuple{<:Not})
 end
 
 # InvertedIndex wrapping a boolean array
-# The definition above works but we need to define a specialized method to avoid
+# The definition above works but we need to define specialized methods to avoid
 # ambiguity in dispatch
 function Base.to_indices(gd::GroupedDataFrame,
                          (idx,)::Tuple{Not{<:Union{BitArray{1}, Vector{Bool}}}})
+    (Base.LogicalIndex(.!idx.skip),)
+end
+function Base.to_indices(gd::GroupedDataFrame,
+                         (idx,)::Tuple{Not{<:AbstractVector{Bool}}})
     (Base.LogicalIndex(.!idx.skip),)
 end
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -957,9 +957,12 @@ end
 
 @testset "iteration protocol" begin
     gd = groupby_checked(DataFrame(A = [:A, :A, :B, :B], B = 1:4), :A)
+    count = 0
     for v in gd
-        @test size(v) == (2,2)
+        count += 1
+        @test v ≅ gd[count]
     end
+    @test count == length(gd)
 end
 
 @testset "type stability of index fields" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -987,6 +987,12 @@ end
     @test gd[1] == view(df, [1, 5], :)
     @test_throws BoundsError gd[5]
 
+    # first, last, lastindex
+    @test first(gd) == gd[1]
+    @test last(gd) == gd[4]
+    @test lastindex(gd) == 4
+    @test gd[end] == gd[4]
+
     # Boolean array
     idx2 = [false, true, false, false]
     gd2 = gd[idx2]

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1463,6 +1463,25 @@ end
     ]
 end
 
+@testset "GroupedDataFrame indexing with array of keys" begin
+    df = DataFrame(a = repeat([:A, :B, missing], outer=4), b = repeat(1:2, inner=6), c = 1:12)
+    gd = groupby_checked(df, [:a, :b])
+
+    ints = [4, 6, 2, 1]
+    gd2 = gd[ints]
+    gkeys = keys(gd)[ints]
+
+    # Test with GroupKeys, Tuples, and NamedTuples
+    for converter in [identity, Tuple, NamedTuple]
+        a = converter.(gkeys)
+        @test gd[a] ≅ gd2
+
+        # Duplicate keys
+        a2 = converter.(keys(gd)[[1, 2, 1]])
+        @test_throws ArgumentError gd[a2]
+    end
+end
+
 @testset "Parent DataFrame names changed" begin
     df = DataFrame(a = repeat([:A, :B, missing], outer=4), b = repeat([:X, :Y], inner=6), c = 1:12)
     gd = groupby_checked(df, [:a, :b])


### PR DESCRIPTION
Use array of keys (`GroupKey`/`Tuple`/`NamedTuple`) in `getindex(::GroupedDataFrame, ...)`.

I also fixed a couple of issues remaining in my last PR: a test for `IndexStyle(::GroupKeys)` and added some missing bindings to the documentation.