### PR TITLE
Avoid computing group indices when possible

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -244,6 +244,7 @@ end
 
 function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Symbol},
                   colkey::Int, value::Int, keycol, valuecol, g, renamecols)
+    g.idx === nothing && compute_indices!(g)
     groupidxs = [g.idx[g.starts[i]:g.ends[i]] for i in 1:length(g.starts)]
     rowkey = zeros(Int, size(df, 1))
     for i in 1:length(groupidxs)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -244,13 +244,13 @@ end
 
 function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Symbol},
                   colkey::Int, value::Int, keycol, valuecol, g, renamecols)
-    g.idx === nothing && compute_indices!(g)
-    groupidxs = [g.idx[g.starts[i]:g.ends[i]] for i in 1:length(g.starts)]
+    idx, starts, ends = g.idx, g.starts, g.ends
+    groupidxs = [idx[starts[i]:ends[i]] for i in 1:length(starts)]
     rowkey = zeros(Int, size(df, 1))
     for i in 1:length(groupidxs)
         rowkey[groupidxs[i]] .= i
     end
-    df1 = df[g.idx[g.starts], g.cols]
+    df1 = df[idx[starts], g.cols]
     Nrow = length(g)
     Ncol = length(levels(keycol))
     unstacked_val = [similar_missing(valuecol, Nrow) for i in 1:Ncol]

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -263,7 +263,7 @@ function compute_indices(groups::AbstractVector{<:Integer}, ngroups::Integer)
     end
     stops .-= 1
 
-    # drop group 1 which contains rows with missings in grouping columns (if any)
+    # group 1 corresponds to missings to drop (if any)
     popfirst!(starts)
     popfirst!(stops)
 

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -121,7 +121,6 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
         # Use -1 for non-missing values to catch bugs if group is not found
         gix = skipmissing && missings[i] ? 0 : -1
         probe = 0
-        # If skipmissing=true, assign rows containing at least one missing to group 0
         if !skipmissing || !missings[i]
             while true
                 g_row = gslots[slotix]

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -918,11 +918,11 @@ function fillfirst!(condf, outcol::AbstractVector, incol::AbstractVector,
         filled = fill(false, gd.ngroups)
         nfilled = 0
         @inbounds for i in r
-            g_ix = groups[i]
+            gix = groups[i]
             x = incol[i]
-            if g_ix > 0 && (condf === nothing || condf(x)) && !filled[g_ix]
-                filled[g_ix] = true
-                outcol[g_ix] = x
+            if gix > 0 && (condf === nothing || condf(x)) && !filled[gix]
+                filled[gix] = true
+                outcol[gix] = x
                 nfilled += 1
                 nfilled == ngroups && break
             end
@@ -1051,8 +1051,8 @@ end
 function (agg::Aggregate{typeof(length)})(incol::AbstractVector, gd::GroupedDataFrame)
     if gd.idx === nothing
         lens = zeros(Int, length(gd))
-        @inbounds for g_ix in gd.groups
-            g_ix > 0 && (lens[g_ix] += 1)
+        @inbounds for gix in gd.groups
+            gix > 0 && (lens[gix] += 1)
         end
         return lens
     else

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1147,11 +1147,7 @@ function _combine(f::Any, gd::GroupedDataFrame)
     agg = check_aggregate(fun)
     if agg isa AbstractAggregate && f isa Pair{<:ColumnIndex}
         idx = Vector{Int}(undef, length(gd))
-        # Find a representative row for each group
-        # TODO: see whether short-circuiting would be possible without slowing down the loop
-        @inbounds for (i, g_ix) in enumerate(gd.groups)
-            g_ix > 0 && (idx[g_ix] = i)
-        end
+        fillfirst!(nothing, idx, 1:length(incol), gd)
         outcols = (agg(incols, gd),)
         # nms is set below
     else

--- a/src/groupeddataframe/grouping.jl
+++ b/src/groupeddataframe/grouping.jl
@@ -1100,11 +1100,7 @@ function _combine(f::AbstractVector{<:Pair}, gd::GroupedDataFrame)
         if agg isa AbstractAggregate && p isa Pair{<:ColumnIndex}
             incol = gd.parent[!, first(p)]
             idx = Vector{Int}(undef, length(gd))
-            # Find a representative row for each group
-            # TODO: see whether short-circuiting would be possible without slowing down the loop
-            @inbounds for (i, g_ix) in enumerate(gd.groups)
-                g_ix > 0 && (idx[g_ix] = i)
-            end
+            fillfirst!(nothing, idx, 1:length(incol), gd)
             outcol = agg(incol, gd)
             return idx, outcol
         else


### PR DESCRIPTION
This can make simple aggregation functions more than twice faster.

Some benchmarking shows no regression from current state even when a custom function (which doesn't benefit from optimization) is used:
```julia
using DataFrames, PooledArrays, BenchmarkTools
n = 100_000;
for k in (10, 10_000)
    global df = DataFrame(x=PooledArray(rand(1:k, n)), y=rand(n));
    println("groupby with $k groups")
    @btime groupby(df, :x);
    global gd = groupby(df, :x);

    println("sum with $k groups")
    @btime by(df, :x, :y => sum);
    @btime combine(gd2, :y => sum) setup=(gd2=deepcopy(gd));

    println("sum+length with $k groups")
    @btime by(df, :x, :y => sum, :y => length);
    @btime combine(gd2, :y => sum, :y => length) setup=(gd2=deepcopy(gd));

    println("x -> x[1] with $k groups")
    @btime by(df, :x, :y => (x -> x[1]));
    @btime combine(gd2, :y => (x -> x[1])) setup=(gd2=deepcopy(gd));
end

# Before
groupby with 10 groups
  463.561 μs (49 allocations: 1.53 MiB)
sum with 10 groups
  612.750 μs (188 allocations: 1.54 MiB)
  97.593 μs (139 allocations: 10.28 KiB)
sum+length with 10 groups
  599.455 μs (220 allocations: 1.54 MiB)
  106.351 μs (171 allocations: 12.14 KiB)
x -> x[1] with 10 groups
  702.722 μs (269 allocations: 2.30 MiB)
  153.622 μs (220 allocations: 793.52 KiB) # Indices have already been computed by first run
groupby with 10000 groups
  1.505 ms (52 allocations: 1.77 MiB)
sum with 10000 groups
  1.881 ms (210 allocations: 2.35 MiB)
  382.246 μs (158 allocations: 596.09 KiB)
sum+length with 10000 groups
  2.099 ms (253 allocations: 2.66 MiB)
  475.889 μs (201 allocations: 910.25 KiB)
x -> x[1] with 10000 groups
  4.099 ms (89172 allocations: 5.12 MiB)
  2.436 ms (89120 allocations: 3.35 MiB) # Indices have already been computed by first run

# After
groupby with 10 groups
  152.112 μs (44 allocations: 784.13 KiB)
sum with 10 groups
  271.348 μs (173 allocations: 794.02 KiB)
  92.858 μs (129 allocations: 9.89 KiB)
sum+length with 10 groups
  362.215 μs (205 allocations: 795.77 KiB)
  180.631 μs (161 allocations: 11.64 KiB) # Counts groups again every time
x -> x[1] with 10 groups
  689.666 μs (264 allocations: 2.30 MiB)
  152.599 μs (215 allocations: 793.34 KiB) # Indices have already been computed by first run
groupby with 10000 groups
  235.042 μs (45 allocations: 872.06 KiB)
sum with 10000 groups
  780.547 μs (193 allocations: 1.44 MiB)
  524.955 μs (148 allocations: 605.55 KiB)
sum+length with 10000 groups
  997.213 μs (235 allocations: 1.67 MiB)
  710.533 μs (190 allocations: 841.55 KiB) # Counts groups again every time
x -> x[1] with 10000 groups
  4.060 ms (89186 allocations: 5.12 MiB)
  2.540 ms (89133 allocations: 3.35 MiB) # Indices have already been computed by first run
```