### PR TITLE
Allow stack to make column variable contain a categorical vector of strings

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -385,7 +385,7 @@ struct RepeatedVector{T} <: AbstractVector{T}
 end
 
 Base.parent(v::RepeatedVector) = v.parent
-Base.levels(v::RepeatedVector) = levels(parent(v))
+DataAPI.levels(v::RepeatedVector) = levels(parent(v))
 CategoricalArrays.isordered(v::RepeatedVector) = isordered(parent(v))
 
 function CategoricalArrays._isordered(v::RepeatedVector)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -384,6 +384,15 @@ struct RepeatedVector{T} <: AbstractVector{T}
     outer::Int
 end
 
+Base.parent(v::RepeatedVector) = v.parent
+Base.levels(v::RepeatedVector) = levels(parent(v))
+CategoricalArrays.isordered(v::RepeatedVector) = isordered(parent(v))
+
+function CategoricalArrays._isordered(v::RepeatedVector)
+    p = parent(v)
+    p isa AbstractCategoricalArray ? isordered(p) : false
+end
+
 function Base.getindex(v::RepeatedVector, i::Int)
     N = length(v.parent)
     idx = Base.fld1(mod1(i,v.inner*N),v.inner)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -66,9 +66,9 @@ function stack(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
         nms = String.(_names(df)[measure_vars])
         catnms = categorical(nms)
         levels!(catnms, nms)
-    elseif vareltype <: Symbol
+    elseif vareltype === Symbol
         catnms = _names(df)[measure_vars]
-    elseif vareltype <: String
+    elseif vareltype === String
         catnms = PooledArrays.PooledArray(String.(_names(df)[measure_vars]))
     else
         throw(ArgumentError("`vareltype` keyword argument accepts only `CategoricalString`, " *

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -1,7 +1,7 @@
 """
     stack(df::AbstractDataFrame, [measure_vars], [id_vars];
           variable_name::Symbol=:variable, value_name::Symbol=:value,
-          view::Bool=false, vareltype::Type=CategoricalString)
+          view::Bool=false, variable_eltype::Type=CategoricalString)
 
 Stack a data frame `df`, i.e. convert it from wide to long format.
 
@@ -32,9 +32,10 @@ that return views into the original data frame.
   each of `measure_vars`
 - `view` : whether the stacked data frame should be a view rather than contain
    freshly allocated vectors.
-- `vareltype` : determines the element type of column `variable_name`. By default
-   a categorical vector is created. If `vareltype=Symbol` it is a vector of `Symbol`,
-   and if `vareltype=String` a vector of `String` is produced.
+- `variable_eltype` : determines the element type of column `variable_name`. By default
+   a categorical vector of strings is created.
+   If `variable_eltype=Symbol` it is a vector of `Symbol`,
+   and if `variable_eltype=String` a vector of `String` is produced.
 
 # Examples
 ```julia
@@ -53,28 +54,28 @@ d1s_name = stack(d1, Not([:a, :b, :e]), variable_name=:somemeasure)
 function stack(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
                id_vars::AbstractVector{<:Integer}; variable_name::Symbol=:variable,
                value_name::Symbol=:value, view::Bool=false,
-               vareltype::Type=CategoricalString)
+               variable_eltype::Type=CategoricalString)
     if view
         return _stackview(df, measure_vars, id_vars, variable_name=variable_name,
-                          value_name=value_name, vareltype=vareltype)
+                          value_name=value_name, variable_eltype=variable_eltype)
     end
     N = length(measure_vars)
     cnames = _names(df)[id_vars]
     pushfirst!(cnames, value_name)
     pushfirst!(cnames, variable_name)
-    if vareltype <: CategoricalString
+    if variable_eltype <: CategoricalString
         nms = String.(_names(df)[measure_vars])
         catnms = categorical(nms)
         levels!(catnms, nms)
-    elseif vareltype === Symbol
+    elseif variable_eltype === Symbol
         catnms = _names(df)[measure_vars]
-    elseif vareltype === String
-        catnms = PooledArrays.PooledArray(String.(_names(df)[measure_vars]))
+    elseif variable_eltype === String
+        catnms = PooledArray(String.(_names(df)[measure_vars]))
     else
-        throw(ArgumentError("`vareltype` keyword argument accepts only `CategoricalString`, " *
+        throw(ArgumentError("`variable_eltype` keyword argument accepts only `CategoricalString`, " *
                             "`String` or `Symbol` as a value."))
     end
-    DataFrame(AbstractVector[repeat(catnms, inner=nrow(df)), # variable
+    DataFrame(AbstractVector[repeat(catnms, inner=nrow(df)),                      # variable
                              vcat([df[!, c] for c in measure_vars]...),           # value
                              [repeat(df[!, c], outer=N) for c in id_vars]...],    # id_var columns
               cnames, copycols=false)
@@ -82,30 +83,30 @@ end
 
 function stack(df::AbstractDataFrame, measure_var::Int, id_var::Int;
                variable_name::Symbol=:variable, value_name::Symbol=:value,
-               view::Bool=false, vareltype::Type=CategoricalString)
-    stack(df, [measure_var], [id_var],
-          variable_name=variable_name, value_name=value_name, view=view, vareltype=vareltype)
+               view::Bool=false, variable_eltype::Type=CategoricalString)
+    stack(df, [measure_var], [id_var], variable_name=variable_name,
+          value_name=value_name, view=view, variable_eltype=variable_eltype)
 end
 
 function stack(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer}, id_var::Int;
                variable_name::Symbol=:variable, value_name::Symbol=:value,
-               view::Bool=false, vareltype::Type=CategoricalString)
-    stack(df, measure_vars, [id_var],
-          variable_name=variable_name, value_name=value_name, view=view, vareltype=vareltype)
+               view::Bool=false, variable_eltype::Type=CategoricalString)
+    stack(df, measure_vars, [id_var], variable_name=variable_name,
+          value_name=value_name, view=view, variable_eltype=variable_eltype)
 end
 
 function stack(df::AbstractDataFrame, measure_var::Int, id_vars::AbstractVector{<:Integer};
                variable_name::Symbol=:variable, value_name::Symbol=:value,
-               view::Bool=false, vareltype::Type=CategoricalString)
-    stack(df, [measure_var], id_vars;
-          variable_name=variable_name, value_name=value_name, view=view, vareltype=vareltype)
+               view::Bool=false, variable_eltype::Type=CategoricalString)
+    stack(df, [measure_var], id_vars; variable_name=variable_name,
+          value_name=value_name, view=view, variable_eltype=variable_eltype)
 end
 
 function stack(df::AbstractDataFrame, measure_vars, id_vars;
                variable_name::Symbol=:variable, value_name::Symbol=:value,
-               view::Bool=false, vareltype::Type=CategoricalString)
-    stack(df, index(df)[measure_vars], index(df)[id_vars];
-          variable_name=variable_name, value_name=value_name, view=view, vareltype=vareltype)
+               view::Bool=false, variable_eltype::Type=CategoricalString)
+    stack(df, index(df)[measure_vars], index(df)[id_vars]; variable_name=variable_name,
+          value_name=value_name, view=view, variable_eltype=variable_eltype)
 end
 
 # no vars specified, by default select only numeric columns
@@ -114,10 +115,10 @@ numeric_vars(df::AbstractDataFrame) =
 
 function stack(df::AbstractDataFrame, measure_vars = numeric_vars(df);
                variable_name::Symbol=:variable, value_name::Symbol=:value,
-               view::Bool=false, vareltype::Type=CategoricalString)
+               view::Bool=false, variable_eltype::Type=CategoricalString)
     mv_inds = index(df)[measure_vars]
-    stack(df, mv_inds, setdiff(1:ncol(df), mv_inds);
-          variable_name=variable_name, value_name=value_name, view=view, vareltype=vareltype)
+    stack(df, mv_inds, setdiff(1:ncol(df), mv_inds); variable_name=variable_name,
+          value_name=value_name, view=view, variable_eltype=variable_eltype)
 end
 
 """
@@ -391,45 +392,46 @@ end
 
 Base.parent(v::RepeatedVector) = v.parent
 DataAPI.levels(v::RepeatedVector) = levels(parent(v))
-CategoricalArrays.isordered(v::RepeatedVector) = isordered(parent(v))
+CategoricalArrays.isordered(v::RepeatedVector{<:Union{CategoricalValue, CategoricalString, Missing}}) =
+    isordered(parent(v))
 
 function Base.getindex(v::RepeatedVector, i::Int)
-    N = length(v.parent)
+    N = length(parent(v))
     idx = Base.fld1(mod1(i,v.inner*N),v.inner)
-    v.parent[idx]
+    parent(v)[idx]
 end
 
 Base.IndexStyle(::Type{<:RepeatedVector}) = Base.IndexLinear()
 Base.size(v::RepeatedVector) = (length(v),)
-Base.length(v::RepeatedVector) = v.inner * v.outer * length(v.parent)
+Base.length(v::RepeatedVector) = v.inner * v.outer * length(parent(v))
 Base.eltype(v::RepeatedVector{T}) where {T} = T
-Base.reverse(v::RepeatedVector) = RepeatedVector(reverse(v.parent), v.inner, v.outer)
-Base.similar(v::RepeatedVector, T::Type, dims::Dims) = similar(v.parent, T, dims)
-Base.unique(v::RepeatedVector) = unique(v.parent)
+Base.reverse(v::RepeatedVector) = RepeatedVector(reverse(parent(v)), v.inner, v.outer)
+Base.similar(v::RepeatedVector, T::Type, dims::Dims) = similar(parent(v), T, dims)
+Base.unique(v::RepeatedVector) = unique(parent(v))
 
 function CategoricalArrays.CategoricalArray(v::RepeatedVector)
-    res = CategoricalArrays.CategoricalArray(v.parent)
+    res = CategoricalArray(parent(v))
     res.refs = repeat(res.refs, inner = [v.inner], outer = [v.outer])
     res
 end
 
 function _stackview(df::AbstractDataFrame, measure_vars::AbstractVector{<:Integer},
                     id_vars::AbstractVector{<:Integer}; variable_name::Symbol=:variable,
-                    value_name::Symbol=:value, vareltype::Type=CategoricalString)
+                    value_name::Symbol=:value, variable_eltype::Type=CategoricalString)
     N = length(measure_vars)
     cnames = _names(df)[id_vars]
     pushfirst!(cnames, value_name)
     pushfirst!(cnames, variable_name)
-    if vareltype <: CategoricalString
+    if variable_eltype <: CategoricalString
         nms = String.(_names(df)[measure_vars])
         catnms = categorical(nms)
         levels!(catnms, nms)
-    elseif vareltype <: Symbol
+    elseif variable_eltype <: Symbol
         catnms = _names(df)[measure_vars]
-    elseif vareltype <: String
+    elseif variable_eltype <: String
         catnms = String.(_names(df)[measure_vars])
     else
-        throw(ArgumentError("`vareltype` keyword argument accepts only `CategoricalString`, " *
+        throw(ArgumentError("`variable_eltype` keyword argument accepts only `CategoricalString`, " *
                             "`String` or `Symbol` as a value."))
     end
     DataFrame(AbstractVector[RepeatedVector(catnms, nrow(df), 1), # variable
@@ -440,36 +442,36 @@ end
 
 function _stackview(df::AbstractDataFrame, measure_var::Int, id_var::Int;
                     variable_name::Symbol=:variable, value_name::Symbol=:value,
-                    vareltype::Type=CategoricalString)
+                    variable_eltype::Type=CategoricalString)
     _stackview(df, [measure_var], [id_var]; variable_name=variable_name,
-               value_name=value_name, vareltype=vareltype)
+               value_name=value_name, variable_eltype=variable_eltype)
 end
 
 function _stackview(df::AbstractDataFrame, measure_vars, id_var::Int;
                     variable_name::Symbol=:variable, value_name::Symbol=:value,
-                    vareltype::Type=CategoricalString)
+                    variable_eltype::Type=CategoricalString)
     _stackview(df, measure_vars, [id_var]; variable_name=variable_name,
-               value_name=value_name, vareltype=vareltype)
+               value_name=value_name, variable_eltype=variable_eltype)
 end
 
 function _stackview(df::AbstractDataFrame, measure_var::Int, id_vars;
                     variable_name::Symbol=:variable, value_name::Symbol=:value,
-                    vareltype::Type=CategoricalString)
+                    variable_eltype::Type=CategoricalString)
     _stackview(df, [measure_var], id_vars; variable_name=variable_name,
-               value_name=value_name, vareltype=vareltype)
+               value_name=value_name, variable_eltype=variable_eltype)
 end
 
 function _stackview(df::AbstractDataFrame, measure_vars, id_vars;
                     variable_name::Symbol=:variable, value_name::Symbol=:value,
-                    vareltype::Type=CategoricalString)
-    _stackview(df, index(df)[measure_vars], index(df)[id_vars];
-               variable_name=variable_name, value_name=value_name, vareltype=vareltype)
+                    variable_eltype::Type=CategoricalString)
+    _stackview(df, index(df)[measure_vars], index(df)[id_vars]; variable_name=variable_name,
+               value_name=value_name, variable_eltype=variable_eltype)
 end
 
 function _stackview(df::AbstractDataFrame, measure_vars = numeric_vars(df);
                     variable_name::Symbol=:variable, value_name::Symbol=:value,
-                    vareltype::Type=CategoricalString)
+                    variable_eltype::Type=CategoricalString)
     m_inds = index(df)[measure_vars]
-    _stackview(df, m_inds, setdiff(1:ncol(df), m_inds);
-               variable_name=variable_name, value_name=value_name, vareltype=vareltype)
+    _stackview(df, m_inds, setdiff(1:ncol(df), m_inds); variable_name=variable_name,
+               value_name=value_name, variable_eltype=variable_eltype)
 end

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -450,10 +450,19 @@ end
     @test levels(d1s[:, 1]) == [:c, :d]
 
     d2 = categorical(d1, :)
+    levels!(d2.a, [2, 1, 3])
+    ordered!(d2.a, true)
     d2s = stack(d2, [:d, :c])
     for col in eachcol(d2s)
         @test col isa CategoricalVector
     end
+    @test [levels(d2.d);levels(d2.c)] == levels(d2s.value)
+    @test levels(d2.a) == levels(d2s.a)
+    @test levels(d2.b) == levels(d2s.b)
+    @test levels(d2.e) == levels(d2s.e)
+    @test isordered(d2.a) == isordered(d2s.a)
+    @test isordered(d2.b) == isordered(d2s.b)
+    @test isordered(d2.e) == isordered(d2s.e)
 end
 
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -272,7 +272,7 @@ end
     @test d1s[!, 2] isa DataFrames.StackedVector
     @test ndims(d1s[!, 2]) == 1
     @test ndims(typeof(d1s[!, 2])) == 1
-    @test d1s[!, 1][[1,24]] == [:a, :b]
+    @test d1s[!, 1][[1,24]] == ["a", "b"]
     @test d1s[!, 2][[1,24]] == [1, 4]
     @test_throws ArgumentError d1s[!, 1][true]
     @test_throws ArgumentError d1s[!, 2][true]
@@ -281,10 +281,13 @@ end
 
     d1ss = stack(d1, [:a, :b], view=true)
     @test d1ss[!, 1][[1,24]] == ["a", "b"]
-    d1ss = stack(d1, [:a, :b], view=true, vareltype=String)
+    @test d1ss[!, 1] isa DataFrames.RepeatedVector
+    d1ss = stack(d1, [:a, :b], view=true, variable_eltype=String)
     @test d1ss[!, 1][[1,24]] == ["a", "b"]
-    d1ss = stack(d1, [:a, :b], view=true, vareltype=Symbol)
+    @test d1ss[!, 1] isa DataFrames.RepeatedVector
+    d1ss = stack(d1, [:a, :b], view=true, variable_eltype=Symbol)
     @test d1ss[!, 1][[1,24]] == [:a, :b]
+    @test d1ss[!, 1] isa DataFrames.RepeatedVector
 
     # Those tests check indexing RepeatedVector/StackedVector by a vector
     @test d1s[!, 1][trues(24)] == d1s[!, 1]
@@ -428,23 +431,29 @@ end
     @test d1s[:, 1] isa CategoricalVector{String}
     @test levels(d1s[:, 1]) == ["d", "c"]
 
-    d1s = stack(d1, [:d, :c], vareltype=String)
+    d1s = stack(d1, [:d, :c], variable_eltype=String)
     @test d1s.variable isa PooledVector{String}
     @test levels(d1s.variable) == ["c", "d"]
-    d1s = stack(d1, [:d, :c], view=true, vareltype=String)
+    d1s = stack(d1, [:d, :c], view=true, variable_eltype=String)
     @test d1s.variable isa DataFrames.RepeatedVector{String}
     @test levels(d1s.variable) == ["c", "d"]
     @test d1s[:, 1] isa Vector{String}
     @test levels(d1s[:, 1]) == ["c", "d"]
 
-    d1s = stack(d1, [:d, :c], vareltype=Symbol)
+    d1s = stack(d1, [:d, :c], variable_eltype=Symbol)
     @test d1s.variable isa Vector{Symbol}
     @test levels(d1s.variable) == [:c, :d]
-    d1s = stack(d1, [:d, :c], view=true, vareltype=Symbol)
+    d1s = stack(d1, [:d, :c], view=true, variable_eltype=Symbol)
     @test d1s.variable isa DataFrames.RepeatedVector{Symbol}
     @test levels(d1s.variable) == [:c, :d]
     @test d1s[:, 1] isa Vector{Symbol}
     @test levels(d1s[:, 1]) == [:c, :d]
+
+    d2 = categorical(d1, :)
+    d2s = stack(d2, [:d, :c])
+    for col in eachcol(d2s)
+        @test col isa CategoricalVector
+    end
 end
 
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -417,6 +417,7 @@ end
 end
 
 @testset "stack categorical test" begin
+    Random.seed!(1234)
     d1 = DataFrame(a = repeat([1:3;], inner = [4]),
                    b = repeat([1:4;], inner = [3]),
                    c = randn(12),
@@ -452,11 +453,17 @@ end
     d2 = categorical(d1, :)
     levels!(d2.a, [2, 1, 3])
     ordered!(d2.a, true)
+    ref_levels = shuffle!(unique([levels(d2.c); levels(d2.d)]))
+    levels!(d2.c, ref_levels)
+    ordered!(d2.c, true)
+    levels!(d2.d, ref_levels)
+    ordered!(d2.d, true)
     d2s = stack(d2, [:d, :c])
     for col in eachcol(d2s)
         @test col isa CategoricalVector
     end
-    @test [levels(d2.d);levels(d2.c)] == levels(d2s.value)
+    @test levels(d2s.value) == ref_levels
+    @test isordered(d2s.value)
     @test levels(d2.a) == levels(d2s.a)
     @test levels(d2.b) == levels(d2s.b)
     @test levels(d2.e) == levels(d2s.e)

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -279,6 +279,9 @@ end
     @test_throws ArgumentError d1s[!, 1][1.0]
     @test_throws ArgumentError d1s[!, 2][1.0]
 
+    d1ss = stack(d1, [:a, :b], view=true, stringvar=true)
+    @test d1ss[!, 1][[1,24]] == ["a", "b"]
+
     # Those tests check indexing RepeatedVector/StackedVector by a vector
     @test d1s[!, 1][trues(24)] == d1s[!, 1]
     @test d1s[!, 2][trues(24)] == d1s[!, 2]
@@ -384,6 +387,22 @@ end
     ref_cat = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 1, 2])
     @test df_flat_cat == ref_cat
     @test df_flat_cat.b isa CategoricalArray
+end
+
+@testset "stack categorical test" begin
+    d1 = DataFrame(a = repeat([1:3;], inner = [4]),
+                   b = repeat([1:4;], inner = [3]),
+                   c = randn(12),
+                   d = randn(12),
+                   e = map(string, 'a':'l'))
+    d1s = stack(d1, [:d, :c], stringvar=true)
+    @test d1s.variable isa CategoricalVector{String}
+    @test levels(d1s.variable) == ["d", "c"]
+    d1s = stack(d1, [:d, :c], view=true, stringvar=true)
+    @test d1s.variable isa DataFrames.RepeatedVector{<:CategoricalString}
+    @test levels(d1s.variable) == ["d", "c"]
+    @test d1s[:, 1] isa CategoricalVector{String}
+    @test levels(d1s[:, 1]) == ["d", "c"]
 end
 
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -429,7 +429,7 @@ end
     @test levels(d1s[:, 1]) == ["d", "c"]
 
     d1s = stack(d1, [:d, :c], vareltype=String)
-    @test d1s.variable isa PooledArrays.PooledArray{String}
+    @test d1s.variable isa PooledVector{String}
     @test levels(d1s.variable) == ["c", "d"]
     d1s = stack(d1, [:d, :c], view=true, vareltype=String)
     @test d1s.variable isa DataFrames.RepeatedVector{String}


### PR DESCRIPTION
Fixes #1947

I have left an option for the column to contain `Symbol`s (via a keyword argument), as it simplified the deprecation period and maybe some old code uses this.

After the deprecation the only thing to change is the default value of the kwarg (if we decide to use the design I have proposed).