### PR TITLE
Change Tables.rows implementation to use eachrow

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -49,6 +49,6 @@ DataFrame!(x::Vector{<:NamedTuple}) =
                         "`$(typeof(x))` without allocating new columns: use " *
                         "`DataFrame(x)` instead"))
 
-IteratorInterfaceExtensions.getiterator(df::AbstractDataFrame) = Tables.datavaluerows(df)
+IteratorInterfaceExtensions.getiterator(df::AbstractDataFrame) = Tables.datavaluerows(columntable(df))
 IteratorInterfaceExtensions.isiterable(x::AbstractDataFrame) = true
 TableTraits.isiterabletable(x::AbstractDataFrame) = true

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -2,9 +2,10 @@ Tables.istable(::Type{<:AbstractDataFrame}) = true
 Tables.columnaccess(::Type{<:AbstractDataFrame}) = true
 Tables.columns(df::AbstractDataFrame) = df
 Tables.rowaccess(::Type{<:AbstractDataFrame}) = true
-Tables.rows(df::AbstractDataFrame) = Tables.rows(columntable(df))
+Tables.rows(df::AbstractDataFrame) = eachrow(df)
 
 Tables.schema(df::AbstractDataFrame) = Tables.Schema(names(df), eltype.(eachcol(df)))
+Tables.schema(df::DataFrameRows) = Tables.schema(getfield(df, :df))
 Tables.materializer(df::AbstractDataFrame) = DataFrame
 
 getvector(x::AbstractVector) = x

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -70,7 +70,7 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test @inferred(Tables.materializer(table)(Tables.columns(table))) isa typeof(table)
 
         row = first(Tables.rows(table))
-        @test propertynames(row) == (:a, :b)
+        @test collect(propertynames(row)) == [:a, :b]
         @test getproperty(row, :a) == 1
         @test getproperty(row, :b) == :a
     end

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -65,7 +65,7 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test @inferred(Tables.materializer(df)(Tables.columns(df))) isa typeof(df)
 
         row = first(Tables.rows(df))
-        @test propertynames(row) == (:a, :b)
+        @test propertynames(row) == [:a, :b]
         @test getproperty(row, :a) == 1
         @test getproperty(row, :b) == :a
     end


### PR DESCRIPTION
Instead of converting to a NamedTuple of Vectors (via `columntable`). The conversion to
NamedTuple is problematic in the case of extremely wide DataFrames, and
as such is the root cause of
https://github.com/JuliaData/CSV.jl/issues/538.

The reason NamedTuple was used in the first place, however, was due to a
desire in certain querying contexts to be able to get a type-stable
row-iterator (cc: @davidanthoff ).

While this change generally follows the DataFrames.jl approach to
avoiding extreme compiler pressure, it does incur just over 2x
performance penalty on a simple manipulation like:

```julia
df |> @map({x=_.id + 1, y=_.salary * 2.0}) |> DataFrame
```

Perhaps it's easy enough for users who need that extra speed to just do
`columntable(df)` first before manipulating and when they know their
DataFrame has a reasonable amount of columns, but it might be possible
to automatically switch between typed/untyped representations
automatically, depending on the # of columns and pre-selected
thresholds.