### PR TITLE
Add Tables.jl interface for DataFrame(Rows|Columns)

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -48,17 +48,14 @@ DataFrame!(x::Vector{<:NamedTuple}) =
                         "`$(typeof(x))` without allocating new columns: use " *
                         "`DataFrame(x)` instead"))
 
-for T in [DataFrameRows, DataFrameColumns]
-    @eval begin
-        Tables.istable(::Type{<:$T}) = true
-        Tables.columnaccess(::Type{<:$T}) = true
-        Tables.rowaccess(::Type{<:$T}) = true
-        Tables.columns(itr::$T) = Tables.columns(parent(itr))
-        Tables.rows(itr::$T) = Tables.rows(parent(itr))
-        Tables.schema(itr::$T) = Tables.schema(parent(itr))
-        Tables.materializer(itr::$T) = Tables.materializer(parent(itr))
-    end
-end
+Tables.istable(::Type{<:Union{DataFrameRows,DataFrameColumns}}) = true
+Tables.columnaccess(::Type{<:Union{DataFrameRows,DataFrameColumns}}) = true
+Tables.rowaccess(::Type{<:Union{DataFrameRows,DataFrameColumns}}) = true
+Tables.columns(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.columns(parent(itr))
+Tables.rows(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.rows(parent(itr))
+Tables.schema(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.schema(parent(itr))
+Tables.materializer(itr::Union{DataFrameRows,DataFrameColumns}) =
+    Tables.materializer(parent(itr))
 
 IteratorInterfaceExtensions.getiterator(df::AbstractDataFrame) = Tables.datavaluerows(df)
 IteratorInterfaceExtensions.isiterable(x::AbstractDataFrame) = true

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -48,6 +48,15 @@ DataFrame!(x::Vector{<:NamedTuple}) =
                         "`$(typeof(x))` without allocating new columns: use " *
                         "`DataFrame(x)` instead"))
 
+const _DataFrameIter = Union{DataFrameRows, DataFrameColumns}
+Tables.istable(::Type{<:_DataFrameIter}) = true
+Tables.columnaccess(::Type{<:_DataFrameIter}) = true
+Tables.rowaccess(::Type{<:_DataFrameIter}) = true
+Tables.columns(itr::_DataFrameIter) = Tables.columns(getfield(itr, :df))
+Tables.rows(itr::_DataFrameIter) = Tables.rows(getfield(itr, :df))
+Tables.schema(itr::_DataFrameIter) = Tables.schema(getfield(itr, :df))
+Tables.materializer(itr::_DataFrameIter) = Tables.materializer(getfield(itr, :df))
+
 IteratorInterfaceExtensions.getiterator(df::AbstractDataFrame) = Tables.datavaluerows(df)
 IteratorInterfaceExtensions.isiterable(x::AbstractDataFrame) = true
 TableTraits.isiterabletable(x::AbstractDataFrame) = true

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -53,10 +53,10 @@ for T in [DataFrameRows, DataFrameColumns]
         Tables.istable(::Type{<:$T}) = true
         Tables.columnaccess(::Type{<:$T}) = true
         Tables.rowaccess(::Type{<:$T}) = true
-        Tables.columns(itr::$T) = Tables.columns(getfield(itr, :df))
-        Tables.rows(itr::$T) = Tables.rows(getfield(itr, :df))
-        Tables.schema(itr::$T) = Tables.schema(getfield(itr, :df))
-        Tables.materializer(itr::$T) = Tables.materializer(getfield(itr, :df))
+        Tables.columns(itr::$T) = Tables.columns(parent(itr))
+        Tables.rows(itr::$T) = Tables.rows(parent(itr))
+        Tables.schema(itr::$T) = Tables.schema(parent(itr))
+        Tables.materializer(itr::$T) = Tables.materializer(parent(itr))
     end
 end
 

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -56,8 +56,14 @@ Tables.rows(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.rows(parent(itr
 Tables.schema(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.schema(parent(itr))
 Tables.materializer(itr::DataFrameRows) =
     eachrow ∘ prefer_singleton_callable(Tables.materializer(parent(itr)))
-Tables.materializer(itr::DataFrameColumns) =
-    eachcol ∘ prefer_singleton_callable(Tables.materializer(parent(itr)))
+function Tables.materializer(itr::DataFrameColumns)
+    f = prefer_singleton_callable(Tables.materializer(parent(itr)))
+    if eltype(itr) <: Pair
+        return x -> eachcol(f(x), true)
+    else
+        return x -> eachcol(f(x), false)
+    end
+end
 
 # A hack to workaround the type-instability of `∘`:
 prefer_singleton_callable(::Type{T}) where T = SingletonCallable{T}()

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -48,14 +48,17 @@ DataFrame!(x::Vector{<:NamedTuple}) =
                         "`$(typeof(x))` without allocating new columns: use " *
                         "`DataFrame(x)` instead"))
 
-const _DataFrameIter = Union{DataFrameRows, DataFrameColumns}
-Tables.istable(::Type{<:_DataFrameIter}) = true
-Tables.columnaccess(::Type{<:_DataFrameIter}) = true
-Tables.rowaccess(::Type{<:_DataFrameIter}) = true
-Tables.columns(itr::_DataFrameIter) = Tables.columns(getfield(itr, :df))
-Tables.rows(itr::_DataFrameIter) = Tables.rows(getfield(itr, :df))
-Tables.schema(itr::_DataFrameIter) = Tables.schema(getfield(itr, :df))
-Tables.materializer(itr::_DataFrameIter) = Tables.materializer(getfield(itr, :df))
+for T in [DataFrameRows, DataFrameColumns]
+    @eval begin
+        Tables.istable(::Type{<:$T}) = true
+        Tables.columnaccess(::Type{<:$T}) = true
+        Tables.rowaccess(::Type{<:$T}) = true
+        Tables.columns(itr::$T) = Tables.columns(getfield(itr, :df))
+        Tables.rows(itr::$T) = Tables.rows(getfield(itr, :df))
+        Tables.schema(itr::$T) = Tables.schema(getfield(itr, :df))
+        Tables.materializer(itr::$T) = Tables.materializer(getfield(itr, :df))
+    end
+end
 
 IteratorInterfaceExtensions.getiterator(df::AbstractDataFrame) = Tables.datavaluerows(df)
 IteratorInterfaceExtensions.isiterable(x::AbstractDataFrame) = true

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -62,7 +62,7 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test Tables.columnaccess(table)
         @test Tables.schema(table) === Tables.Schema((:a, :b), Tuple{Int64, Symbol})
         @test Tables.schema(table) == Tables.schema(Tables.rows(table)) == Tables.schema(Tables.columns(table))
-        @test @inferred(Tables.materializer(table)(Tables.columns(table))) isa typeof(df)
+        @test @inferred(Tables.materializer(table)(Tables.columns(table))) isa typeof(table)
 
         row = first(Tables.rows(table))
         @test propertynames(row) == (:a, :b)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -56,15 +56,15 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
 @testset "Tables" begin
     df = DataFrame(a=Int64[1, 2, 3], b=[:a, :b, :c])
 
-    @testset "basics" begin
-        @test Tables.istable(df)
-        @test Tables.rowaccess(df)
-        @test Tables.columnaccess(df)
-        @test Tables.schema(df) === Tables.Schema((:a, :b), Tuple{Int64, Symbol})
-        @test Tables.schema(df) == Tables.schema(Tables.rows(df)) == Tables.schema(Tables.columns(df))
-        @test @inferred(Tables.materializer(df)(Tables.columns(df))) isa typeof(df)
+    @testset "basics $(nameof(typeof(table)))" for table in [df, eachrow(df), eachcol(df)]
+        @test Tables.istable(table)
+        @test Tables.rowaccess(table)
+        @test Tables.columnaccess(table)
+        @test Tables.schema(table) === Tables.Schema((:a, :b), Tuple{Int64, Symbol})
+        @test Tables.schema(table) == Tables.schema(Tables.rows(table)) == Tables.schema(Tables.columns(table))
+        @test @inferred(Tables.materializer(table)(Tables.columns(table))) isa typeof(df)
 
-        row = first(Tables.rows(df))
+        row = first(Tables.rows(table))
         @test propertynames(row) == (:a, :b)
         @test getproperty(row, :a) == 1
         @test getproperty(row, :b) == :a

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -56,7 +56,12 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
 @testset "Tables" begin
     df = DataFrame(a=Int64[1, 2, 3], b=[:a, :b, :c])
 
-    @testset "basics $(nameof(typeof(table)))" for table in [df, eachrow(df), eachcol(df)]
+    @testset "basics $(nameof(typeof(table)))" for table in [
+        df,
+        eachrow(df),
+        eachcol(df),
+        eachcol(df, true),
+    ]
         @test Tables.istable(table)
         @test Tables.rowaccess(table)
         @test Tables.columnaccess(table)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -182,7 +182,7 @@ end
 
      df2 = DataFrame!(eachrow(df))
      @test df == df2
-     @test !any(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+     @test all(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
 
      df2 = DataFrame(eachcol(df, true))
      @test df == df2


### PR DESCRIPTION
This PR adds Tables.jl interface for `DataFrameRows` and `DataFrameColumns`.  It is useful for defining data manipulation functions expecting iterators.  Example:

```julia
julia> tablemap(f, xs) = Tables.materializer(xs)(map(f, xs))
tablemap (generic function with 1 method)

julia> tablemap(x -> (A=x.a, B=x.b), eachrow(DataFrame(a=[3], b=[4])))
1×2 DataFrame
│ Row │ A     │ B     │
│     │ Int64 │ Int64 │
├─────┼───────┼───────┤
│ 1   │ 3     │ 4     │
```
