### PR TITLE
Add names to data frame iterators

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -294,7 +294,7 @@ Base.ndims(::Type{<:AbstractDataFrame}) = 2
 
 Base.getproperty(df::AbstractDataFrame, col_ind::Symbol) = df[!, col_ind]
 # Private fields are never exposed since they can conflict with column names
-Base.propertynames(df::AbstractDataFrame, private::Bool=false) = names(df)
+Base.propertynames(df::AbstractDataFrame, private::Bool=false) = Tuple(_names(df))
 
 ##############################################################################
 ##

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -228,8 +228,8 @@ function mapcols(f::Union{Function,Type}, df::AbstractDataFrame)
     DataFrame(vs, _names(df), copycols=false)
 end
 
-Base.parent(dfrs::DataFrameRows) = getfield(dfrs, :df)
-Base.parent(dfcs::DataFrameColumns) = getfield(dfcs, :df)
+Base.parent(itr::Union{DataFrameRows, DataFrameColumns}) = getfield(itr, :df)
+Base.names(itr::Union{DataFrameRows, DataFrameColumns}) = names(parent(itr))
 
 function Base.show(io::IO, dfrs::DataFrameRows;
                    allrows::Bool = !get(io, :limit, false),

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -87,7 +87,7 @@ end
 
 Base.getproperty(itr::DataFrameRows, col_ind::Symbol) = getproperty(parent(itr), col_ind)
 # Private fields are never exposed since they can conflict with column names
-Base.propertynames(itr::DataFrameRows, private::Bool=false) = names(parent(itr))
+Base.propertynames(itr::DataFrameRows, private::Bool=false) = propertynames(parent(itr))
 
 # Iteration by columns
 """
@@ -170,7 +170,7 @@ end
 
 Base.getproperty(itr::DataFrameColumns, col_ind::Symbol) = getproperty(parent(itr), col_ind)
 # Private fields are never exposed since they can conflict with column names
-Base.propertynames(itr::DataFrameColumns, private::Bool=false) = names(parent(itr))
+Base.propertynames(itr::DataFrameColumns, private::Bool=false) = propertynames(parent(itr))
 
 """
     mapcols(f::Union{Function,Type}, df::AbstractDataFrame)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -152,7 +152,7 @@ end
 Base.getproperty(r::DataFrameRow, idx::Symbol) = getindex(r, idx)
 Base.setproperty!(r::DataFrameRow, idx::Symbol, x::Any) = setindex!(r, x, idx)
 # Private fields are never exposed since they can conflict with column names
-Base.propertynames(r::DataFrameRow, private::Bool=false) = names(r)
+Base.propertynames(r::DataFrameRow, private::Bool=false) = Tuple(_names(r))
 
 Base.view(r::DataFrameRow, col::ColumnIndex) =
     view(parent(r)[!, parentcols(index(r), col)], row(r))

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1878,7 +1878,7 @@ end
     z = collect(10:-1:1)
     df = DataFrame(x=x, y=y, copycols=false)
 
-    @test Base.propertynames(df) == names(df)
+    @test Base.propertynames(df) == Tuple(names(df))
 
     @test df.x === x
     @test df.y === y

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -206,7 +206,7 @@ end
     df = deepcopy(ref_df)
 
     r = DataFrameRow(df, 1, :)
-    @test Base.propertynames(r) == names(df)
+    @test Base.propertynames(r) == Tuple(names(df))
     @test r.a === 1
     @test r.b === 2.0
     @test copy(r[[:a,:b]]) === (a=1, b=2.0)

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -5,6 +5,8 @@ using Test, DataFrames
 df = DataFrame(A = Vector{Union{Int, Missing}}(1:2), B = Vector{Union{Int, Missing}}(2:3))
 
 @test size(eachrow(df)) == (size(df, 1),)
+@test parent(eachrow(df)) === df
+@test names(eachrow(df)) == names(df)
 @test IndexStyle(eachrow(df)) == IndexLinear()
 @test sprint(summary, eachrow(df)) == "2-element DataFrameRows"
 @test Base.IndexStyle(eachrow(df)) == IndexLinear()
@@ -19,9 +21,13 @@ for row in eachrow(df)
 end
 
 @test size(eachcol(df)) == (size(df, 2),)
+@test parent(eachcol(df)) === df
+@test names(eachcol(df)) == names(df)
 @test IndexStyle(eachcol(df)) == IndexLinear()
 @test Base.IndexStyle(eachcol(df)) == IndexLinear()
 @test size(eachcol(df, true)) == (size(df, 2),)
+@test parent(eachcol(df, true)) === df
+@test names(eachcol(df, true)) == names(df)
 @test IndexStyle(eachcol(df, true)) == IndexLinear()
 @test size(eachcol(df, false)) == (size(df, 2),)
 @test IndexStyle(eachcol(df, false)) == IndexLinear()

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -187,7 +187,7 @@ end
     y = collect(1.0:10.0)
     df = view(DataFrame(:x=>x, :y=>y, copycols=false), 2:6, :)
 
-    @test Base.propertynames(df) == names(df)
+    @test Base.propertynames(df) == Tuple(names(df))
 
     @test df.x == 2:6
     @test df.y == 2:6


### PR DESCRIPTION
Following https://github.com/JuliaData/DataFrames.jl/pull/2055#issuecomment-566225609. Actually it seems that only `names` was missing for `eachcol` and `eachrow` return values.