### PR TITLE
Materialize DataFrame(Rows|Columns) as DataFrame

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -56,14 +56,8 @@ Tables.rows(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.rows(parent(itr
 Tables.schema(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.schema(parent(itr))
 Tables.materializer(itr::DataFrameRows) =
     eachrow ∘ prefer_singleton_callable(Tables.materializer(parent(itr)))
-function Tables.materializer(itr::DataFrameColumns)
-    f = prefer_singleton_callable(Tables.materializer(parent(itr)))
-    if eltype(itr) <: Pair
-        return x -> eachcol(f(x), true)
-    else
-        return x -> eachcol(f(x), false)
-    end
-end
+Tables.materializer(itr::DataFrameColumns) =
+    eachcol ∘ prefer_singleton_callable(Tables.materializer(parent(itr)))
 
 # A hack to workaround the type-instability of `∘`:
 prefer_singleton_callable(::Type{T}) where T = SingletonCallable{T}()

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -54,16 +54,8 @@ Tables.rowaccess(::Type{<:Union{DataFrameRows,DataFrameColumns}}) = true
 Tables.columns(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.columns(parent(itr))
 Tables.rows(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.rows(parent(itr))
 Tables.schema(itr::Union{DataFrameRows,DataFrameColumns}) = Tables.schema(parent(itr))
-Tables.materializer(itr::DataFrameRows) =
-    eachrow ∘ prefer_singleton_callable(Tables.materializer(parent(itr)))
-Tables.materializer(itr::DataFrameColumns) =
-    eachcol ∘ prefer_singleton_callable(Tables.materializer(parent(itr)))
-
-# A hack to workaround the type-instability of `∘`:
-prefer_singleton_callable(::Type{T}) where T = SingletonCallable{T}()
-prefer_singleton_callable(f) = f
-struct SingletonCallable{T} end
-(::SingletonCallable{T})(x) where T = T(x)
+Tables.materializer(itr::Union{DataFrameRows,DataFrameColumns}) =
+    Tables.materializer(parent(itr))
 
 IteratorInterfaceExtensions.getiterator(df::AbstractDataFrame) = Tables.datavaluerows(df)
 IteratorInterfaceExtensions.isiterable(x::AbstractDataFrame) = true

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -62,7 +62,7 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test Tables.columnaccess(table)
         @test Tables.schema(table) === Tables.Schema((:a, :b), Tuple{Int64, Symbol})
         @test Tables.schema(table) == Tables.schema(Tables.rows(table)) == Tables.schema(Tables.columns(table))
-        @test @inferred(Tables.materializer(table)(Tables.columns(table))) isa typeof(df)
+        @test @inferred(Tables.materializer(table)(Tables.columns(table))) isa DataFrame
 
         row = first(Tables.rows(table))
         @test propertynames(row) == (:a, :b)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -56,12 +56,7 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
 @testset "Tables" begin
     df = DataFrame(a=Int64[1, 2, 3], b=[:a, :b, :c])
 
-    @testset "basics $(nameof(typeof(table)))" for table in [
-        df,
-        eachrow(df),
-        eachcol(df),
-        eachcol(df, true),
-    ]
+    @testset "basics $(nameof(typeof(table)))" for table in [df, eachrow(df), eachcol(df)]
         @test Tables.istable(table)
         @test Tables.rowaccess(table)
         @test Tables.columnaccess(table)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -56,7 +56,12 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
 @testset "Tables" begin
     df = DataFrame(a=Int64[1, 2, 3], b=[:a, :b, :c])
 
-    @testset "basics $(nameof(typeof(table)))" for table in [df, eachrow(df), eachcol(df)]
+    @testset "basics $(nameof(typeof(table)))" for table in [
+        df,
+        view(df, :, :),
+        eachrow(df),
+        eachcol(df),
+    ]
         @test Tables.istable(table)
         @test Tables.rowaccess(table)
         @test Tables.columnaccess(table)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -62,7 +62,7 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test Tables.columnaccess(table)
         @test Tables.schema(table) === Tables.Schema((:a, :b), Tuple{Int64, Symbol})
         @test Tables.schema(table) == Tables.schema(Tables.rows(table)) == Tables.schema(Tables.columns(table))
-        @test @inferred(Tables.materializer(table)(Tables.columns(table))) isa typeof(table)
+        @test @inferred(Tables.materializer(table)(Tables.columns(table))) isa typeof(df)
 
         row = first(Tables.rows(table))
         @test propertynames(row) == (:a, :b)


### PR DESCRIPTION
This PR reverts last two commits in #2055 so that

```julia
materializer(::Union{DataFrameRows,DataFrameColumns}) = DataFrame
```

Ref: https://github.com/JuliaData/DataFrames.jl/pull/2055#issuecomment-566421559