### PR TITLE
add conversions and merge for DataFrameRow

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -205,7 +205,7 @@ Base.get(f::Base.Callable, dfr::DataFrameRow, key::ColumnIndex) =
 Base.broadcastable(::DataFrameRow) =
     throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 
-Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(dfr))
+Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(dfr))}(values(dfr))
 
 """
     copy(dfr::DataFrameRow)
@@ -215,7 +215,7 @@ This method returns a `NamedTuple` so that the returned object
 is not affected by changes to the parent data frame of which `dfr` is a view.
 
 """
-Base.copy(r::DataFrameRow) = NamedTuple(r)
+Base.copy(dfr::DataFrameRow) = NamedTuple(dfr)
 
 Base.convert(::Type{NamedTuple}, dfr::DataFrameRow) = NamedTuple(dfr)
 Base.convert(::Type{Tuple}, dfr::DataFrameRow) = Tuple(dfr)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -205,24 +205,24 @@ Base.get(f::Base.Callable, dfr::DataFrameRow, key::ColumnIndex) =
 Base.broadcastable(::DataFrameRow) =
     throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 
+Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
+
 """
     copy(dfr::DataFrameRow)
 
 Convert a [`DataFrameRow`](@ref) to a `NamedTuple`.
 """
-Base.copy(r::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
+Base.copy(r::DataFrameRow) = NamedTuple(r)
 
-Base.NamedTuple(dfr::DataFrameRow) = copy(dfr)
-
-Base.convert(::Type{NamedTuple}, dfr::DataFrameRow) = copy(dfr)
+Base.convert(::Type{NamedTuple}, dfr::DataFrameRow) = NamedTuple(dfr)
 Base.convert(::Type{Tuple}, dfr::DataFrameRow) = Tuple(dfr)
 
-Base.merge(a::DataFrameRow) = copy(a)
-Base.merge(a::DataFrameRow, b::NamedTuple) = merge(copy(a), b)
-Base.merge(a::NamedTuple, b::DataFrameRow) = merge(a, copy(b))
-Base.merge(a::DataFrameRow, b::DataFrameRow) = merge(copy(a), copy(b))
-Base.merge(a::DataFrameRow, b::Base.Iterators.Pairs) = merge(copy(a), b)
-Base.merge(a::DataFrameRow, itr) = merge(copy(a), itr)
+Base.merge(a::DataFrameRow) = NamedTuple(a)
+Base.merge(a::DataFrameRow, b::NamedTuple) = merge(NamedTuple(a), b)
+Base.merge(a::NamedTuple, b::DataFrameRow) = merge(a, NamedTuple(b))
+Base.merge(a::DataFrameRow, b::DataFrameRow) = merge(NamedTuple(a), NamedTuple(b))
+Base.merge(a::DataFrameRow, b::Base.Iterators.Pairs) = merge(NamedTuple(a), b)
+Base.merge(a::DataFrameRow, itr) = merge(NamedTuple(a), itr)
 
 # hash column element
 Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) =

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -212,6 +212,18 @@ Convert a [`DataFrameRow`](@ref) to a `NamedTuple`.
 """
 Base.copy(r::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
 
+Base.NamedTuple(dfr::DataFrameRow) = copy(dfr)
+
+Base.convert(::Type{NamedTuple}, dfr::DataFrameRow) = copy(dfr)
+Base.convert(::Type{Tuple}, dfr::DataFrameRow) = Tuple(dfr)
+
+Base.merge(a::DataFrameRow) = copy(a)
+Base.merge(a::DataFrameRow, b::NamedTuple) = merge(copy(a), b)
+Base.merge(a::NamedTuple, b::DataFrameRow) = merge(a, copy(b))
+Base.merge(a::DataFrameRow, b::DataFrameRow) = merge(copy(a), copy(b))
+Base.merge(a::DataFrameRow, b::Base.Iterators.Pairs) = merge(copy(a), b)
+Base.merge(a::DataFrameRow, itr) = merge(copy(a), itr)
+
 # hash column element
 Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) =
     hash(v[i], h)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -211,9 +211,8 @@ Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
     copy(dfr::DataFrameRow)
 
 Construct a `NamedTuple` with the same contents as the [`DataFrameRow`](@ref).
-A  [`DataFrameRow`](@ref) is a view into a row of a  [`DataFrame`](@ref), following
-the convention that `copy` materializes the view into an independent concrete object,
-this thus creates a `NamedTuple`.
+This method returns a `NamedTuple` so that the returned object
+is not affected by changes to the parent data frame of which `dfr` is a view.
 
 """
 Base.copy(r::DataFrameRow) = NamedTuple(r)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -205,7 +205,7 @@ Base.get(f::Base.Callable, dfr::DataFrameRow, key::ColumnIndex) =
 Base.broadcastable(::DataFrameRow) =
     throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 
-Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
+Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(dfr))
 
 """
     copy(dfr::DataFrameRow)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -210,7 +210,9 @@ Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
 """
     copy(dfr::DataFrameRow)
 
-Convert a [`DataFrameRow`](@ref) to a `NamedTuple`.
+Constucts a `NamedTuple` with the same content as the [`DataFrameRow`](@ref).
+A  [`DataFrameRow`](@ref) is a view into a row of a  [`DataFrame`](@ref), following the convention that `copy` materializes the view into a independent concrete object, this thus creates a `NamedTuple`.
+
 """
 Base.copy(r::DataFrameRow) = NamedTuple(r)
 

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -210,7 +210,7 @@ Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
 """
     copy(dfr::DataFrameRow)
 
-Constucts a `NamedTuple` with the same content as the [`DataFrameRow`](@ref).
+Construct a `NamedTuple` with the same contents as the [`DataFrameRow`](@ref).
 A  [`DataFrameRow`](@ref) is a view into a row of a  [`DataFrame`](@ref), following
 the convention that `copy` materializes the view into an independent concrete object,
 this thus creates a `NamedTuple`.

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -211,7 +211,9 @@ Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(r))}(values(r))
     copy(dfr::DataFrameRow)
 
 Constucts a `NamedTuple` with the same content as the [`DataFrameRow`](@ref).
-A  [`DataFrameRow`](@ref) is a view into a row of a  [`DataFrame`](@ref), following the convention that `copy` materializes the view into a independent concrete object, this thus creates a `NamedTuple`.
+A  [`DataFrameRow`](@ref) is a view into a row of a  [`DataFrame`](@ref), following
+the convention that `copy` materializes the view into an independent concrete object,
+this thus creates a `NamedTuple`.
 
 """
 Base.copy(r::DataFrameRow) = NamedTuple(r)


### PR DESCRIPTION
Fixes #2059.

Notes:
1) I did not add docstrings for these functionalities following the logic that we treat `DataFrameRow` as if it is a `NamedTuple`
2) I skipped defining `merge` for more than 2 passed arguments as this is not supported in 1.0 (it is new in 1.1) and additionally it is problematic (there is no clean way to define `merge` with `Union` approach as it overwrites the original `merge(a::NamedTuple, b::NamedTuple, cs::NamedTuple...)` definition which I think we should avoid); I think thought that in practice this is not needed
3) in tests I check to make sure splatting as kwargs works as expected for `DataFrameRow`