### PR TITLE
fix combine with DataFrameRow

### DIFF
--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -805,7 +805,7 @@ function _combine_with_first(first::Union{NamedTuple, DataFrameRow, AbstractData
         eltys = map(eltype, first)
     elseif first isa DataFrameRow
         n = length(gd)
-        eltys = eltype.(eachcol(parent(first)))
+        eltys = [eltype(parent(first)[!, i]) for i in parentcols(index(first))]
     else # NamedTuple giving a single row
         n = length(gd)
         eltys = map(typeof, first)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1462,6 +1462,9 @@ end
     df = DataFrame(a=1)
     dfr = DataFrame(x=1, y="1")[1, 2:2]
     @test by(sdf -> dfr, df, :a) == DataFrame(a=1, y="1")
+
+    df = DataFrame(a=[1,1,2,2,3,3], b='a':'f', c=string.(1:6))
+    @test by(sdf -> sdf[1, [3,2,1]], df, :a) == df[1:2:5, [1,3,2]]
 end
 
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1458,4 +1458,10 @@ end
     @test_throws KeyError gd[(a=:A, b=:X)]
 end
 
+@testset "Check aggregation of DataFrameRow" begin
+    df = DataFrame(a=1)
+    dfr = DataFrame(x=1, y="1")[1, 2:2]
+    @test by(sdf -> dfr, df, :a) == DataFrame(a=1, y="1")
+end
+
 end # module


### PR DESCRIPTION
Fixes the following problem:
```
julia> df = DataFrame(a=1)
1×1 DataFrame
│ Row │ a     │
│     │ Int64 │
├─────┼───────┤
│ 1   │ 1     │

julia> dfr = DataFrame(x=1, y="1")[1, 2:2]
DataFrameRow
│ Row │ y      │
│     │ String │
├─────┼────────┤
│ 1   │ 1      │

julia> by(sdf -> dfr, df, :a)
ERROR: AssertionError: j === nothing
```