### PR TITLE
Allow containers with no columns in combine

### DIFF
--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -201,7 +201,8 @@ which is determined using the following rules:
   for each group as the length of the returned vector for that group.
 - A data frame, a named tuple of vectors or a matrix gives the same additional columns
   and as many rows for each group as the rows returned for that group.
-  (a table with zero columns drops the group)
+  As a special case, returning an empty table with zero columns is allowed,
+  whatever the number of columns returned for other groups.
 
 `f` must always return the same kind of object (as defined in the above list) for
 all groups, and if a named tuple or data frame, with the same fields or columns.
@@ -341,7 +342,8 @@ which is determined using the following rules:
   for each group as the length of the returned vector for that group.
 - A data frame, a named tuple of vectors or a matrix gives a `DataFrame` with the same
   additional columns and as many rows for each group as the rows returned for that group.
-  (a table with zero columns drops the group)
+  As a special case, returning an empty table with zero columns is allowed,
+  whatever the number of columns returned for other groups.
 
 `f` must always return the same kind of object (as defined in the above list) for
 all groups, and if a named tuple or data frame, with the same fields or columns.
@@ -1055,7 +1057,8 @@ which is determined using the following rules:
   for each group as the length of the returned vector for that group.
 - A data frame, a named tuple of vectors or a matrix gives a `DataFrame` with the same
   additional columns and as many rows for each group as the rows returned for that group.
-  (a table with zero columns drops the group)
+  As a special case, returning an empty table with zero columns is allowed,
+  whatever the number of columns returned for other groups.
 
 `f` must always return the same kind of object (as defined in the above list) for
 all groups, and if a named tuple or data frame, with the same fields or columns.

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1485,9 +1485,10 @@ end
                NamedTuple(), rand(0,0), rand(5,0))
         df = DataFrame(a = 1:8, x1 = Bool.(collect(bitstring(UInt8(i))) .- '0'))
         res = by(sdf -> sdf.x1[1] ? DataFrame(x1=[true]) : er, df, :a)
-        @test res == DataFrame(map(sdf -> sdf.x1[1] ? DataFrame(x1=[true]) : er, groupby(df, :a)))
+        @test res == DataFrame(map(sdf -> sdf.x1[1] ? DataFrame(x1=[true]) : er, groupby_checked(df, :a)))
         if nrow(res) == 0
-            @test res == DataFrame(a=Int[])
+            @test res == DataFrame(a=[])
+            @test typeof(res.a) == Vector{Int}
         else
             @test res == df[df.x1, :]
         end
@@ -1496,9 +1497,10 @@ end
         if typemin(UInt8) < i < typemax(UInt8)
             @test_throws ArgumentError by(sdf -> sdf.x1[1] ? (x1=true,) : er, df, :a)
         end
-        @test res == DataFrame(map(sdf -> sdf.x1[1] ? (x1=[true],) : er, groupby(df, :a)))
+        @test res == DataFrame(map(sdf -> sdf.x1[1] ? (x1=[true],) : er, groupby_checked(df, :a)))
         if nrow(res) == 0
-            @test res == DataFrame(a=Int[])
+            @test res == DataFrame(a=[])
+            @test typeof(res.a) == Vector{Int}
         else
             @test res == df[df.x1, :]
         end
@@ -1507,9 +1509,10 @@ end
         if typemin(UInt8) < i < typemax(UInt8)
             @test_throws ArgumentError by(sdf -> sdf.x1[1] ? true : er, df, :a)
         end
-        @test res == DataFrame(map(sdf -> sdf.x1[1] ? hcat(true) : er, groupby(df, :a)))
+        @test res == DataFrame(map(sdf -> sdf.x1[1] ? hcat(true) : er, groupby_checked(df, :a)))
         if nrow(res) == 0
-            @test res == DataFrame(a=Int[])
+            @test res == DataFrame(a=[])
+            @test typeof(res.a) == Vector{Int}
         else
             @test res == df[df.x1, :]
         end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1457,7 +1457,10 @@ end
 end
 
 @testset "Allow returning DataFrame() or NamedTuple() to drop group" begin
-    for i in typemin(UInt8):typemax(UInt8), er in (DataFrame(), NamedTuple(), rand(0,0), rand(5,0))
+    for i in typemin(UInt8):typemax(UInt8),
+        er in (DataFrame(), view(DataFrame(ones(2,2)), 2:1, 2:1),
+               view(DataFrame(ones(2,2)), 1:2, 2:1),
+               NamedTuple(), rand(0,0), rand(5,0))
         df = DataFrame(a = 1:8, x1 = Bool.(collect(bitstring(UInt8(i))) .- '0'))
         res = by(sdf -> sdf.x1[1] ? DataFrame(x1=[true]) : er, df, :a)
         @test res == DataFrame(map(sdf -> sdf.x1[1] ? DataFrame(x1=[true]) : er, groupby(df, :a)))


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/1981

Allow `NamedTuple()`, `DataFrame` and zero columns matrix as return value in `combine` and `map`. They are ignored and drop columns.

Additionally fixes some small issues in tests.

@nalimilan - one potential performance consideration is that now I use `colnames` as `Vector{Symbol}` - do you think it will be problematic?

Also I had to separate `_combine_with_first_row!` and `_combine_with_first!` as separate functions as for some strange reason alternatively in some cases Julia had problems with type inference.

Importantly  - we allow these 0-column containers only for vector-oriented containers. They are disallowed in scalar-oriented containers.

Finally - this PR touches parts of code that I do not know very well, so feel free to comment/fix/add test proposals, as some strange interactions might kick in.