### PR TITLE
Fix BoundsError messages

### DIFF
--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -103,6 +103,10 @@ struct DataFrameColumns{T<:AbstractDataFrame, V} <: AbstractVector{V}
     df::T
 end
 
+Base.summary(dfcs::DataFrameColumns{T, V}) where {T,V} =
+    "$(length(dfcs))-element DataFrameColumns (with names=$(V <: Pair))"
+Base.summary(io::IO, dfcs::DataFrameColumns) = print(io, summary(dfcs))
+
 """
     eachcol(df::AbstractDataFrame, names::Bool=false)
 

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -1,5 +1,6 @@
 Base.summary(df::AbstractDataFrame) = # -> String
     @sprintf("%d×%d %s", size(df)..., typeof(df).name)
+Base.summary(io::IO, df::AbstractDataFrame) = print(io, summary(df))
 
 let
     local buffer = IOBuffer(Vector{UInt8}(undef, 80), read=true, write=true)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -307,7 +307,7 @@ _check_consistency(df::AbstractDataFrame) = _check_consistency(parent(df))
     cols = _columns(df)
     @boundscheck begin
         if !checkindex(Bool, axes(cols, 1), col_ind)
-            throw(BoundsError(df, (row_ind, col_ind))
+            throw(BoundsError(df, (row_ind, col_ind)))
         end
         if !checkindex(Bool, axes(df, 1), row_ind)
             throw(BoundsError(df, (row_ind, col_ind)))

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -639,7 +639,7 @@ function insertcols!(df::DataFrame, col_ind::Int, name_col::Pair{Symbol, <:Abstr
                      makeunique::Bool=false)
     name, item = name_col
     if !(0 < col_ind <= ncol(df) + 1)
-        throw(DimensionMismatch("attempt to insert a column to a data frame with $(ncol(df)) columns at index $col_ind"))
+        throw(ArgumentError("attempt to insert a column to a data frame with $(ncol(df)) columns at index $col_ind"))
     end
     if !(size(df, 1) == length(item) || size(df, 2) == 0)
         throw(DimensionMismatch("length of new column ($(length(item))) must match the number of rows in data frame ($(nrow(df)))"))

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -50,8 +50,7 @@ end
 
 Base.@propagate_inbounds function DataFrameRow(df::DataFrame, row::Integer, cols)
     @boundscheck if !checkindex(Bool, axes(df, 1), row)
-        throw(BoundsError("attempt to access a data frame with $(nrow(df)) " *
-                          "rows at index $row"))
+        throw(BoundsError(df, (row, cols)))
     end
     DataFrameRow(df, SubIndex(index(df), cols), row)
 end
@@ -61,8 +60,7 @@ Base.@propagate_inbounds DataFrameRow(df::DataFrame, row::Bool, cols) =
 
 Base.@propagate_inbounds function DataFrameRow(sdf::SubDataFrame, row::Integer, cols)
     @boundscheck if !checkindex(Bool, axes(sdf, 1), row)
-        throw(BoundsError("attempt to access a data frame with $(nrow(sdf)) " *
-                          "rows at index $row"))
+        throw(BoundsError(sdf, (row, cols)))
     end
     if index(sdf) isa Index # sdf was created using : as row selector
         colindex = SubIndex(index(sdf), cols)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -80,6 +80,10 @@ row(r::DataFrameRow) = getfield(r, :row)
 Base.parent(r::DataFrameRow) = getfield(r, :df)
 Base.parentindices(r::DataFrameRow) = (row(r), parentcols(index(r)))
 
+Base.summary(dfr::DataFrameRow) = # -> String
+    @sprintf("%d-element %s", length(dfr), typeof(dfr).name)
+Base.summary(io::IO, dfr::DataFrameRow) = print(io, summary(dfr))
+
 Base.@propagate_inbounds Base.view(adf::AbstractDataFrame, rowind::Integer,
                                    colinds::Union{Colon, AbstractVector, Regex, Not, Between, All}) =
     DataFrameRow(adf, rowind, colinds)

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -3,8 +3,10 @@
 # through cleanly.
 abstract type AbstractIndex end
 
-Base.summary(idx::AbstractIndex) = # -> String
-    @sprintf("%d-element %s", length(idx), typeof(idx).name)
+function Base.summary(idx::AbstractIndex)
+    l = length(idx)
+    "data frame with $l column$(l == 1 ? "" : "s")"
+end
 Base.summary(io::IO, idx::AbstractIndex) = print(io, summary(idx))
 
 const ColumnIndex = Union{Signed, Unsigned, Symbol}

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -3,6 +3,10 @@
 # through cleanly.
 abstract type AbstractIndex end
 
+Base.summary(idx::AbstractIndex) = # -> String
+    @sprintf("%d-element %s", length(idx), typeof(idx).name)
+Base.summary(io::IO, idx::AbstractIndex) = print(io, summary(idx))
+
 const ColumnIndex = Union{Signed, Unsigned, Symbol}
 
 struct Index <: AbstractIndex   # an OrderedDict would be nice here...

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -141,7 +141,7 @@ end
 
 function Base.insert!(x::Index, idx::Integer, nm::Symbol)
     if !(1 <= idx <= length(x.names)+1)
-        throw(BoundsError("attempt to insert a column to a data frame with $(length(x)) columns at index $idx"))
+        throw(BoundsError(x, idx))
      end
     for i = idx:length(x.names)
         x.lookup[x.names[i]] = i + 1
@@ -155,7 +155,7 @@ end
 
 @inline function Base.getindex(x::AbstractIndex, idx::Integer)
     if !(1 <= idx <= length(x))
-        throw(BoundsError("attempt to access a data frame with $(length(x)) columns at index $idx"))
+        throw(BoundsError(x, idx))
     end
     Int(idx)
 end
@@ -164,10 +164,10 @@ end
     isempty(idx) && return idx
     minidx, maxidx = extrema(idx)
     if minidx < 1
-        throw(BoundsError("attempt to access a data frame with $(length(x)) columns at index $minidx"))
+        throw(BoundsError(x, idx))
     end
     if maxidx > length(x)
-        throw(BoundsError("attempt to access a data frame with $(length(x)) columns at index $maxidx"))
+        throw(BoundsError(x, idx))
     end
     allunique(idx) || throw(ArgumentError("Elements of $idx must be unique"))
     idx
@@ -177,10 +177,10 @@ end
     isempty(idx) && return idx
     minidx, maxidx = extrema(idx)
     if minidx < 1
-        throw(BoundsError("attempt to access a data frame with $(length(x)) columns at index $minidx"))
+        throw(BoundsError(x, idx))
     end
     if maxidx > length(x)
-        throw(BoundsError("attempt to access a data frame with $(length(x)) columns at index $maxidx"))
+        throw(BoundsError(x, idx))
     end
     allunique(idx) || throw(ArgumentError("Elements of $idx must be unique"))
     idx
@@ -344,7 +344,7 @@ function SubIndex(parent::AbstractIndex, cols::AbstractUnitRange{Int})
     l = last(cols)
     f = first(cols)
     if !checkindex(Bool, Base.OneTo(length(parent)), cols)
-        throw(BoundsError("invalid columns $cols selected"))
+        throw(BoundsError(parent, cols))
     end
     remap = (1:l) .- f .+ 1
     SubIndex(parent, cols, remap)
@@ -355,8 +355,7 @@ function SubIndex(parent::AbstractIndex, cols::AbstractVector{Int})
     remap = zeros(Int, ncols)
     for (i, col) in enumerate(cols)
         if !(1 <= col <= ncols)
-            throw(BoundsError("column index must be greater than zero " *
-                              "and not larger than number columns in the parent"))
+            throw(BoundsError(parent, cols))
         end
         if remap[col] != 0
             throw(ArgumentError("duplicate selected column detected"))

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -34,8 +34,7 @@ end
 
 Base.@propagate_inbounds function SubDataFrame(parent::DataFrame, rows::AbstractVector{Int}, cols)
     @boundscheck if !checkindex(Bool, axes(parent, 1), rows)
-        throw(BoundsError("attempt to access a data frame with $(nrow(parent)) " *
-                          "rows at indices $rows"))
+        throw(BoundsError(parent, (rows, cols)))
     end
     SubDataFrame(parent, SubIndex(index(parent), cols), rows)
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -165,7 +165,7 @@ end
 
 @testset "insertcols!" begin
     df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
-    @test_throws BoundsError insertcols!(df, 5, :newcol => ["a", "b"], )
+    @test_throws DimensionMismatch insertcols!(df, 5, :newcol => ["a", "b"], )
     @test_throws DimensionMismatch insertcols!(df, 1, :newcol => ["a"])
     @test insertcols!(df, 1, :newcol => ["a", "b"]) == df
     @test names(df) == [:newcol, :a, :b]
@@ -187,13 +187,13 @@ end
     @test names(df) == [:a_2, :a, :a_1]
     insertcols!(df, 4, :a => [11,12], makeunique=true)
     @test names(df) == [:a_2, :a, :a_1, :a_3]
-    @test_throws BoundsError insertcols!(df, 10, :a => [11,12], makeunique=true)
+    @test_throws DimensionMismatch insertcols!(df, 10, :a => [11,12], makeunique=true)
     df = DataFrame(a=[1,2], a_1=[3,4])
     insertcols!(df, 1, :a => 11, makeunique=true)
     @test names(df) == [:a_2, :a, :a_1]
     insertcols!(df, 4, :a => 11, makeunique=true)
     @test names(df) == [:a_2, :a, :a_1, :a_3]
-    @test_throws BoundsError insertcols!(df, 10, :a => 11, makeunique=true)
+    @test_throws DimensionMismatch insertcols!(df, 10, :a => 11, makeunique=true)
 
     df = DataFrame(x = 1:2)
     @test insertcols!(df, 2, y=2:3) == DataFrame(x=1:2, y=2:3)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -165,7 +165,7 @@ end
 
 @testset "insertcols!" begin
     df = DataFrame(a=Union{Int, Missing}[1, 2], b=Union{Float64, Missing}[3.0, 4.0])
-    @test_throws DimensionMismatch insertcols!(df, 5, :newcol => ["a", "b"], )
+    @test_throws ArgumentError insertcols!(df, 5, :newcol => ["a", "b"], )
     @test_throws DimensionMismatch insertcols!(df, 1, :newcol => ["a"])
     @test insertcols!(df, 1, :newcol => ["a", "b"]) == df
     @test names(df) == [:newcol, :a, :b]
@@ -187,13 +187,13 @@ end
     @test names(df) == [:a_2, :a, :a_1]
     insertcols!(df, 4, :a => [11,12], makeunique=true)
     @test names(df) == [:a_2, :a, :a_1, :a_3]
-    @test_throws DimensionMismatch insertcols!(df, 10, :a => [11,12], makeunique=true)
+    @test_throws ArgumentError insertcols!(df, 10, :a => [11,12], makeunique=true)
     df = DataFrame(a=[1,2], a_1=[3,4])
     insertcols!(df, 1, :a => 11, makeunique=true)
     @test names(df) == [:a_2, :a, :a_1]
     insertcols!(df, 4, :a => 11, makeunique=true)
     @test names(df) == [:a_2, :a, :a_1, :a_3]
-    @test_throws DimensionMismatch insertcols!(df, 10, :a => 11, makeunique=true)
+    @test_throws ArgumentError insertcols!(df, 10, :a => 11, makeunique=true)
 
     df = DataFrame(x = 1:2)
     @test insertcols!(df, 2, y=2:3) == DataFrame(x=1:2, y=2:3)

--- a/test/io.jl
+++ b/test/io.jl
@@ -234,4 +234,23 @@ end
     @test_throws AssertionError sprint(show, "text/tab-separated-values", df)
 end
 
+@testset "summary tests" begin
+    df = DataFrame(ones(2,3))
+
+    for (v, s) in [(df, "2×3 DataFrame"),
+                   (view(df, :, :), "2×3 SubDataFrame"),
+                   (df[1, :], "3-element DataFrameRow"),
+                   (DataFrames.index(df), "data frame with 3 columns"),
+                   (DataFrames.index(df[1:1, 1:1]), "data frame with 1 column"),
+                   (DataFrames.index(view(df, 1:1, 1:1)), "data frame with 1 column"),
+                   (eachrow(df), "2-element DataFrameRows"),
+                   (eachcol(df), "3-element DataFrameColumns (with names=false)"),
+                   (eachcol(df, true), "3-element DataFrameColumns (with names=true)")]
+        @test summary(v) == s
+        io = IOBuffer()
+        summary(io, v)
+        @test String(take!(io)) == s
+    end
+end
+
 end # module


### PR DESCRIPTION
We were using wrong syntax for `BoundsError` in the whole package (it does not allow a custom message). This PR fixes this.