### PR TITLE
remove lastindex without a dimension

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -285,7 +285,6 @@ end
 
 Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0 || size(df, 2) == 0
 
-Base.lastindex(df::AbstractDataFrame) = ncol(df)
 Base.lastindex(df::AbstractDataFrame, i::Integer) = last(axes(df, i))
 Base.axes(df::AbstractDataFrame, i::Integer) = Base.OneTo(size(df, i))
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1565,4 +1565,4 @@ import DataAPI: describe
                                         view=view)
 
 import Base: lastindex
-@deprecate lastindex(df:AbstractDataFrame) ncol(df)
+@deprecate lastindex(df::AbstractDataFrame) ncol(df)

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1563,3 +1563,6 @@ import DataAPI: describe
 @deprecate melt(df::AbstractDataFrame; variable_name::Symbol=:variable, value_name::Symbol=:value,
                 view::Bool=false) stack(df; variable_name=variable_name, value_name=value_name,
                                         view=view)
+
+import Base: lastindex
+@deprecate lastindex(df:AbstractDataFrame) ncol(df)


### PR DESCRIPTION
The removed method should not be used. It was needed when we supported single-index indexing.