### PR TITLE
bugfix: io context no longer ignored

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -272,7 +272,7 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
                 if showable(MIME("text/latex"), cell)
                     show(io, MIME("text/latex"), cell)
                 else
-                    print(io, latex_escape(sprint(ourshow, cell)))
+                    print(io, latex_escape(sprint(ourshow, cell, context=io)))
                 end
             end
         end


### PR DESCRIPTION
Without this bugfix IOContext specifications (e.g. to which precision to print Float64) will be ignored.