### PR TITLE
Clean up column omission when columns overflow IOContext width

### DIFF
--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -122,7 +122,7 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
         write(io, "<p>$header</p>")
         if mxcol == 0
             write(io, "</tbody></table>")
-            mxcol == 0 && return
+            return
         end
     end
     for row in 1:mxrow
@@ -249,6 +249,14 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
         mxcol = min(mxcol, ttymxcol)
     end
 
+    nomit = size(df, 2) - mxcol
+    caption = nomit > 0 ? "omitted printing of $nomit columns" : ""
+
+    if mxcol == 0 && size(df, 2) > 0
+        write(io, "\\emph{$caption}\n")
+        return
+    end
+
     cnames = _names(df)[1:mxcol]
     alignment = repeat("c", mxcol)
     write(io, "\\begin{tabular}{r|")
@@ -293,6 +301,8 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
         write(io, " \\\\\n")
     end
     write(io, "\\end{tabular}\n")
+    nomit > 0 && write(io, "\\emph{$caption}\n")
+    return
 end
 
 function Base.show(io::IO, mime::MIME"text/latex", dfr::DataFrameRow)

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -120,7 +120,10 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
             header *= " (omitted printing of $(size(df, 2)-mxcol) columns)"
         end
         write(io, "<p>$header</p>")
-        mxcol == 0 && return
+        if mxcol == 0
+            write(io, "</tbody></table>")
+            mxcol == 0 && return
+        end
     end
     for row in 1:mxrow
         write(io, "<tr>")

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -92,7 +92,8 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
         tty_rows, tty_cols = displaysize(io)
         mxrow = min(mxrow, tty_rows)
         maxwidths = getmaxwidths(df, io, 1:mxrow, 0:-1, :X) .+ 2
-        mxcol = min(mxcol, searchsortedfirst(cumsum(maxwidths), tty_cols))
+        ttymxcol = searchsortedfirst(cumsum(maxwidths), tty_cols) - 1
+        mxcol = min(mxcol, ttymxcol)
     end
 
     cnames = _names(df)[1:mxcol]
@@ -114,12 +115,12 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
     write(io, "</thead>")
     write(io, "<tbody>")
     if summary
-        omitmsg = if mxcol < size(df, 2)
-                      " (omitted printing of $(size(df, 2)-mxcol) columns)"
-                  else
-                      ""
-                  end
-        write(io, "<p>$(digitsep(size(df, 1))) rows × $(digitsep(ncol(df))) columns$omitmsg</p>")
+        header = "$(digitsep(size(df, 1))) rows × $(digitsep(ncol(df))) columns"
+        if mxcol < size(df, 2)
+            header *= " (omitted printing of $(size(df, 2)-mxcol) columns)"
+        end
+        write(io, "<p>$header</p>")
+        mxcol == 0 && return
     end
     for row in 1:mxrow
         write(io, "<tr>")

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -242,7 +242,8 @@ function _show(io::IO, ::MIME"text/latex", df::AbstractDataFrame; rowid=nothing)
         tty_rows, tty_cols = get(io, :displaysize, displaysize(io))
         mxrow = min(mxrow, tty_rows)
         maxwidths = getmaxwidths(df, io, 1:mxrow, 0:-1, :X) .+ 2
-        mxcol = min(mxcol, searchsortedfirst(cumsum(maxwidths), tty_cols))
+        ttymxcol = searchsortedfirst(cumsum(maxwidths), tty_cols) - 1
+        mxcol = min(mxcol, ttymxcol)
     end
 
     cnames = _names(df)[1:mxcol]

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -360,8 +360,10 @@ NOTE: The value of `maxwidths[end]` must be the string width of
   required to render each column.
 - `allcols::Bool = false`: Whether to print all columns, rather than
   a subset that fits the device width.
-- `splitcols::Bool`: Whether to split printing in chunks of columns fitting the screen width
-  rather than printing all columns in the same block.
+- `splitcols::Bool`: Whether to split printing in chunks of columns fitting the
+  screen width rather than printing all columns in the same block. Unless
+  `allcols==true`, all columns will be omitted if any single chunk overflows
+  the screen width. 
 - `rowlabel::Symbol`: What label should be printed when rendering the
   numeric ID's of each row? Defaults to `:Row`.
 - `displaysummary::Bool`: Should a brief string summary of the

--- a/test/io.jl
+++ b/test/io.jl
@@ -49,13 +49,13 @@ end
     @test str == "\\emph{omitted printing of 1 columns}\n"
 
     # latex omits columns if provided an io context with width limit
-    df = DataFrame(x1 = 1, x2 = "a" ^ 1000)
+    df = DataFrame(x1 = "a", x2 = "a" ^ 1000)
     ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => true)
     show(ioc, "text/latex", df)
     str = String(take!(ioc.io))
     @test str == "\\begin{tabular}{r|cc}\n" * 
-                 "\t& x1 & \\\\\n\t\\hline\n\t& Int64 & \\\\\n" * 
-                 "\t\\hline\n\t1 & 1 & \$\\dots\$ \\\\\n\\" * 
+                 "\t& x1 & \\\\\n\t\\hline\n\t& String & \\\\\n" * 
+                 "\t\\hline\n\t1 & a & \$\\dots\$ \\\\\n\\" * 
                  "end{tabular}\n" *
                  "\\emph{omitted printing of 1 columns}\n"
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -159,7 +159,8 @@ end
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th></th>" * 
                  "<th>x1</th></tr><tr><th></th><th>String</th></tr></thead><tbody>" * 
-                 "<p>1 rows × 1 columns</p><tr><th>1</th><td>aaaaaaaaaa</td></tr></tbody></table>"
+                 "<p>1 rows × 1 columns</p><tr>" * 
+                 "<th>1</th><td>aaaaaaaaaaaaaaaaaaaa</td></tr></tbody></table>"
 
     # test that columns get omitted if they overflow the io width 
     # when io buffer has a width limit that will cutoff all columns
@@ -168,7 +169,8 @@ end
     str = String(take!(io.io))
     @test str == "<table class=\"data-frame\"><thead><tr><th></th></tr>" * 
                  "<tr><th></th></tr></thead><tbody>" * 
-                 "<p>1 rows × 1 columns (omitted printing of 1 columns)</p>"
+                 "<p>1 rows × 1 columns (omitted printing of 1 columns)</p>" * 
+                 "</tbody></table>"
 
     @test_throws ArgumentError DataFrames._show(stdout, MIME("text/html"),
                                                 DataFrame(ones(2,2)), rowid=10)

--- a/test/io.jl
+++ b/test/io.jl
@@ -41,20 +41,23 @@ end
     show(ioc, "text/latex", df)
     @test length(String(take!(ioc.io))) < 10000
 
-    # latex omits columns if provided an io context with width limit
+    # latex only prints omission message when all columns omitted
     df = DataFrame(x1 = "a" ^ 1000)
     ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => true)
     show(ioc, "text/latex", df)
     str = String(take!(ioc.io))
-    @test str == """
-        \\begin{tabular}{r|c}
-        \t&  & \\\\
-        \t\\hline
-        \t&  & \\\\
-        \t\\hline
-        \t1 & \$\\dots\$ \\\\
-        \\end{tabular}
-        """
+    @test str == "\\emph{omitted printing of 1 columns}\n"
+
+    # latex omits columns if provided an io context with width limit
+    df = DataFrame(x1 = 1, x2 = "a" ^ 1000)
+    ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => true)
+    show(ioc, "text/latex", df)
+    str = String(take!(ioc.io))
+    @test str == "\\begin{tabular}{r|cc}\n" * 
+                 "\t& x1 & \\\\\n\t\\hline\n\t& Int64 & \\\\\n" * 
+                 "\t\\hline\n\t1 & 1 & \$\\dots\$ \\\\\n\\" * 
+                 "end{tabular}\n" *
+                 "\\emph{omitted printing of 1 columns}\n"
 end
 
 #Test HTML output for IJulia and similar

--- a/test/io.jl
+++ b/test/io.jl
@@ -40,6 +40,21 @@ end
     ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => true)
     show(ioc, "text/latex", df)
     @test length(String(take!(ioc.io))) < 10000
+
+    # latex omits columns if provided an io context with width limit
+    df = DataFrame(x1 = "a" ^ 1000)
+    ioc = IOContext(IOBuffer(), :displaysize => (10, 10), :limit => true)
+    show(ioc, "text/latex", df)
+    str = String(take!(ioc.io))
+    @test str == """
+        \\begin{tabular}{r|c}
+        \t&  & \\\\
+        \t\\hline
+        \t&  & \\\\
+        \t\\hline
+        \t1 & \$\\dots\$ \\\\
+        \\end{tabular}
+        """
 end
 
 #Test HTML output for IJulia and similar

--- a/test/show.jl
+++ b/test/show.jl
@@ -218,6 +218,18 @@ end
     │     │ Int64 │
     ├─────┼───────┤
     │ 1   │ 1     │"""
+
+    # ensure no columns get printed when the first column overflows display
+    # and allcols=false
+    df_wide = DataFrame(x1 = "a" ^ 1000, x2 = :a)
+    io = IOContext(IOBuffer(), :displaysize=>(10,20), :limit=>true)
+    for splitcols=[true, false]
+        show(io, df_wide, splitcols=true, allcols=false)
+        str = String(take!(io.io))
+        @test str == """
+        1×2 DataFrame. Omitted printing of 2 columns
+        """
+    end
 end
 
 @testset "IOContext parameters test" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -184,6 +184,23 @@ end
     │ 23  │ 10802633 │ 17029758 │ 12105159 │
     │ 24  │ 14660095 │ 13529407 │ 19204569 │
     │ 25  │ 16992761 │ 15379139 │ 13043102 │"""
+
+    # print omission message if allrows=true and any column overflows display
+    df_wide = DataFrame(x1 = "a" ^ 1000, x2 = 1)
+    io = IOContext(IOBuffer(), :displaysize=>(10,20), :limit=>true)
+    show(io, df_wide, allrows=true, allcols=true)
+    str = String(take!(io.io))
+    @test str == """
+    1×2 DataFrame. Display too narrow: Omitted printing of 2 columns
+    """
+
+    # print only omission message if allrows=false and no columns fit on display
+    io = IOContext(IOBuffer(), :displaysize=>(10,20), :limit=>true)
+    show(io, df_wide, allrows=true, allcols=false)
+    str = String(take!(io.io))
+    @test str == """
+    1×2 DataFrame. Omitted printing of 2 columns
+    """
 end
 
 @testset "IOContext parameters test" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -199,18 +199,25 @@ end
     io = IOContext(IOBuffer(), :displaysize=>(10,20), :limit=>true)
     show(io, df_wide, splitcols=false, allcols=false)
     str = String(take!(io.io))
-    @test str == """1×3 DataFrame. Omitted printing of 2 columns
-                 │ Row │ x1    │
-                 │     │ Int64 │
-                 ├─────┼───────┤
-                 │ 1   │ 1     │"""
+    @test str == """
+    1×3 DataFrame. Omitted printing of 2 columns
+    │ Row │ x1    │
+    │     │ Int64 │
+    ├─────┼───────┤
+    │ 1   │ 1     │"""
   
-    # any long columns case all columns to be omitted when splitcols=true
-    df_wide = DataFrame(x1 = 1, x2 = "a" ^ 1000, x3 = :a)
+    # when splitcols=true, but allcols=false, print in a single chunk,
+    # omitting any columns that would overflow display
+    df_wide = DataFrame(x1 = 1, x2 = 2, x3 = "a" ^ 1000, x4 = :a)
     io = IOContext(IOBuffer(), :displaysize=>(10,20), :limit=>true)
     show(io, df_wide, splitcols=true, allcols=false)
     str = String(take!(io.io))
-    @test str == "1×3 DataFrame. Omitted printing of 3 columns\n"
+    @test str == """
+    1×4 DataFrame. Omitted printing of 3 columns
+    │ Row │ x1    │
+    │     │ Int64 │
+    ├─────┼───────┤
+    │ 1   │ 1     │"""
 end
 
 @testset "IOContext parameters test" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -195,33 +195,33 @@ end
     end
 
     # long columns trigger omission when splitcols=false
-    df_wide = DataFrame(x1 = 1, x2 = "a" ^ 1000, x3 = :a)
+    df_wide = DataFrame(x1 = "a", x2 = "a" ^ 1000, x3 = "a")
     io = IOContext(IOBuffer(), :displaysize=>(10,20), :limit=>true)
     show(io, df_wide, splitcols=false, allcols=false)
     str = String(take!(io.io))
     @test str == """
     1×3 DataFrame. Omitted printing of 2 columns
-    │ Row │ x1    │
-    │     │ Int64 │
-    ├─────┼───────┤
-    │ 1   │ 1     │"""
+    │ Row │ x1     │
+    │     │ String │
+    ├─────┼────────┤
+    │ 1   │ a      │"""
   
     # when splitcols=true, but allcols=false, print in a single chunk,
     # omitting any columns that would overflow display
-    df_wide = DataFrame(x1 = 1, x2 = 2, x3 = "a" ^ 1000, x4 = :a)
+    df_wide = DataFrame(x1 = "a", x2 = "a", x3 = "a" ^ 1000, x4 = "a")
     io = IOContext(IOBuffer(), :displaysize=>(10,20), :limit=>true)
     show(io, df_wide, splitcols=true, allcols=false)
     str = String(take!(io.io))
     @test str == """
     1×4 DataFrame. Omitted printing of 3 columns
-    │ Row │ x1    │
-    │     │ Int64 │
-    ├─────┼───────┤
-    │ 1   │ 1     │"""
+    │ Row │ x1     │
+    │     │ String │
+    ├─────┼────────┤
+    │ 1   │ a      │"""
 
     # ensure no columns get printed when the first column overflows display
     # and allcols=false
-    df_wide = DataFrame(x1 = "a" ^ 1000, x2 = :a)
+    df_wide = DataFrame(x1 = "a" ^ 1000, x2 = "a")
     io = IOContext(IOBuffer(), :displaysize=>(10,20), :limit=>true)
     for splitcols=[true, false]
         show(io, df_wide, splitcols=true, allcols=false)


### PR DESCRIPTION
Addresses #1779

Specifically,
- For `MIME"text/plain"`
   - When `allcols=true` and any column would cause the display to overflow the IOContext, prints "mxn DataFrame. Display too narrow: Omitted printing of $ncols columns" 
   - When `allcols=false` and no columns are displayed, only print the header (avoiding situations where all the row numbers continue to print despite all columns being omitted)
- For `MIME"text/html"`
   - This was just an off-by-one error using `searchsortedfirst`
   - Also short-circuit the printing if no columns get printed as to not print a table of only row indices
- For `MIME"text/latex"`
   - Added same off-by-one error fix for `searchsortedfirst`
   - I **think** this is all that's needed. It definitely prevents the inclusion of the column, but I think that it still prints out columnless rows of a table. I didn't render any documents to fully test this. I'm not sure what the expected behavior would be.

#### Added Tests:
- Added tests for all MIME types and parameterized variants of behavior.
- Latex was tested against a generated table that lacked the column text, but I haven't tried to render it and would appreciate guidance on expected result.
