### PR TITLE
Consistent period printing on Julia 1.5-DEV

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -24,11 +24,23 @@ end
 Render a value to an IO object. Unlike
 `show`, render strings without surrounding quote marks.
 """
-ourshow(io::IO, x::Any) =
-    show(IOContext(io, :compact=>get(io, :compact, true), :typeinfo=>typeof(x)), x)
+function ourshow(io::IO, x::Any)
+    ctxt = IOContext(io, :compact=>get(io, :compact, true), :typeinfo=>typeof(x))
+    show(ctxt, "text/plain", x)
+end
+
 ourshow(io::IO, x::AbstractString) = escape_string(io, x, "")
 ourshow(io::IO, x::Symbol) = ourshow(io, string(x))
 ourshow(io::IO, x::Nothing) = nothing
+
+# AbstractChar: https://github.com/JuliaLang/julia/pull/34730 (1.5.0-DEV.261)
+# Irrational: https://github.com/JuliaLang/julia/pull/34741 (1.5.0-DEV.266)
+if VERSION < v"1.5.0-DEV.261" || VERSION < v"1.5.0-DEV.266"
+    function ourshow(io::IO, x::T) where T <: Union{AbstractChar, Irrational}
+        ctxt = IOContext(io, :compact=>get(io, :compact, true), :typeinfo=>typeof(x))
+        show(ctxt, x)
+    end
+end
 
 """Return compact string representation of type T"""
 function compacttype(T::Type, maxwidth::Int=8)

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -21,12 +21,14 @@ end
 """
     DataFrames.ourshow(io::IO, x::Any)
 
-Render a value to an IO object. Unlike
-`show`, render strings without surrounding quote marks.
+Render a value to an `IO` object compactly and omitting type information, by
+calling 3-argument `show`, or 2-argument `show` if the former contains line breaks.
+Unlike `show`, render strings without surrounding quote marks.
 """
 function ourshow(io::IO, x::Any)
     io = IOContext(io, :compact=>get(io, :compact, true), :typeinfo=>typeof(x))
 
+    # This mirrors the behavior of Base.print_matrix_row
     # First try 3-arg show
     sx = sprint(show, "text/plain", x, context=io)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ fatalerrors = length(ARGS) > 0 && ARGS[1] == "-f"
 quiet = length(ARGS) > 0 && ARGS[1] == "-q"
 anyerrors = false
 
-using Test, Random, DataFrames
+using DataFrames, Dates, Test, Random
 
 my_tests = ["utils.jl",
             "cat.jl",


### PR DESCRIPTION
Keeps printing behaviour the same on Julia 1.5-DEV as it currently exists. The change https://github.com/JuliaLang/julia/pull/34387 changes the 2-arg show to display the parser-friendly version.