### PR TITLE
Show friendly error when trying to iterate DataFrames

### DIFF
--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -21,7 +21,8 @@ Base.summary(dfrs::DataFrameRows) = "$(length(dfrs))-element DataFrameRows"
 Base.summary(io::IO, dfrs::DataFrameRows) = print(io, summary(dfrs))
 
 Base.iterate(::AbstractDataFrame) =
-    error("AbstractDataFrame is not iterable. Use eachrow(adf) to iterate rows.")
+    error("AbstractDataFrame is not iterable. Use eachrow(df) to get a row iterator" *
+          " or eachcol(df) to get a column iterator")
 
 """
     eachrow(df::AbstractDataFrame)

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -20,6 +20,9 @@ end
 Base.summary(dfrs::DataFrameRows) = "$(length(dfrs))-element DataFrameRows"
 Base.summary(io::IO, dfrs::DataFrameRows) = print(io, summary(dfrs))
 
+Base.iterate(::AbstractDataFrame) =
+    error("AbstractDataFrame is not iterable. Use eachrow(adf) to iterate rows.")
+
 """
     eachrow(df::AbstractDataFrame)
 

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -43,7 +43,7 @@ using Test, DataFrames
     @test eltype.(eachcol(mapcols(Vector{Float64}, df))) == [Float64, Float64]
     @test eltype(map(Vector{Float64}, eachcol(df))) == Vector{Float64}
 
-    @test_throws MethodError for x in df; end
+    @test_throws ErrorException for x in df; end
 end
 
 @testset "mapcols" begin


### PR DESCRIPTION
Apologies if this has already been proposed before and rejected. I couldn't find it with cursory searching. I semi-frequently see people confused by the `MethodError` stacktrace thrown when trying to iterate over a DataFrame (e.g. https://discourse.julialang.org/t/i-do-not-understand-this-error-methoderror-no-method-matching-iterate-dataframe/34530 although that person has more confusion than just the exception). This PR adds a method for `iterate(::AbstractDataFrame)` which simply throws an error with more explanation of what went wrong.