### PR TITLE
[BREAKING] deprecate names=true in eachcol

### DIFF
--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -40,14 +40,6 @@ serves as an iterator over rows of an `AbstractDataFrame`, returning `DataFrameR
 
 Similarly, the `eachcol` function returns a value of the `DataFrameColumns` type, which
 serves as an iterator over columns of an `AbstractDataFrame`.
-The return value can have two concrete types:
-
-* If the `eachcol` function is called with the `names` argument set to `true` then it returns a value of the
-  `DataFrameColumns{<:AbstractDataFrame, Pair{Symbol, AbstractVector}}` type, which is an
-  iterator returning a pair containing the column name and the column vector.
-* If the `eachcol` function is called with `names` argument set to `false` (the default) then it returns a value of the
-  `DataFrameColumns{<:AbstractDataFrame, AbstractVector}` type, which is an
-  iterator returning the column vector only.
 
 The `DataFrameRows` and `DataFrameColumns` types are subtypes of `AbstractVector` and support its interface
 with the exception that they are read only. Note that they are not exported and should not be constructed directly,

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -775,7 +775,7 @@ true
 julia> df[1] !== x
 true
 
-julia> eachcol(df, false)[1] === df.x
+julia> eachcol(df)[1] === df.x
 true
 ```
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -934,7 +934,7 @@ function Base.convert(::Type{Matrix{T}}, df::AbstractDataFrame) where T
     n, p = size(df)
     res = Matrix{T}(undef, n, p)
     idx = 1
-    for (name, col) in eachcol(df, true)
+    for (name, col) in pairs(eachcol(df))
         try
             copyto!(res, idx, col)
         catch err

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -162,11 +162,11 @@ function Base.show(io::IO, mime::MIME"text/html", dfrs::DataFrameRows; summary::
     _show(io, mime, df, summary=false)
 end
 
-function Base.show(io::IO, mime::MIME"text/html", dfcs::DataFrameColumns{T,V};
-                   summary::Bool=true) where {T,V}
+function Base.show(io::IO, mime::MIME"text/html", dfcs::DataFrameColumns;
+                   summary::Bool=true)
     df = parent(dfcs)
     if summary
-        write(io, "<p>$(nrow(df))×$(ncol(df)) DataFrameColumns (with names=$(V <: Pair))</p>")
+        write(io, "<p>$(nrow(df))×$(ncol(df)) DataFrameColumns</p>")
     end
     _show(io, mime, df, summary=false)
 end

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -94,8 +94,9 @@ Base.propertynames(itr::DataFrameRows, private::Bool=false) = propertynames(pare
 """
     DataFrameColumns{<:AbstractDataFrame, V} <: AbstractVector{V}
 
-An `AbstractVector` that allows for an iteration over columns of an `AbstractDataFrame`.
-Additionally it is allowed to index `DataFrameColumns` using column names.
+An `AbstractVector` that allows iteration over columns of an `AbstractDataFrame`.
+Indexing into `DataFrameColumns` objects using integer or symbol indices
+returns the corresponding column (without copying).
 """
 struct DataFrameColumns{T<:AbstractDataFrame} <: AbstractVector{AbstractVector}
     df::T
@@ -108,7 +109,7 @@ Base.summary(io::IO, dfcs::DataFrameColumns) = print(io, summary(dfcs))
     eachcol(df::AbstractDataFrame)
 
 Return a `DataFrameColumns` that is an `AbstractVector`
-that alows to iterate an `AbstractDataFrame` column by column.
+that allows iterating an `AbstractDataFrame` column by column.
 Additionally it is allowed to index `DataFrameColumns` using column names.
 
 # Examples
@@ -158,16 +159,17 @@ Base.getproperty(itr::DataFrameColumns, col_ind::Symbol) = getproperty(parent(it
 Base.propertynames(itr::DataFrameColumns, private::Bool=false) = propertynames(parent(itr))
 
 """
-    keys(::DataFrameColumns)
+    keys(dfc::DataFrameColumns)
 
-Get a vector of column names of a parent data frame.
+Get a vector of column names of `dfc`.
 """
 Base.keys(itr::DataFrameColumns) = names(parent(itr))
 
 """
     pairs(dfc::DataFrameColumns)
 
-An iterator that accesses each column of a parent data frame, returning `name => col`,
+Return an iterator of pairs associating the name of each column of `dfc`
+with the corresponding column vector, i.e. `name => col`
 where `name` is the column name of the column `col`.
 """
 Base.pairs(itr::DataFrameColumns) = Base.Iterators.Pairs(itr, keys(itr))

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -92,7 +92,7 @@ Base.propertynames(itr::DataFrameRows, private::Bool=false) = propertynames(pare
 # Iteration by columns
 
 """
-    DataFrameColumns{<:AbstractDataFrame, V} <: AbstractVector{V}
+    DataFrameColumns{<:AbstractDataFrame} <: AbstractVector{AbstractVector}
 
 An `AbstractVector` that allows iteration over columns of an `AbstractDataFrame`.
 Indexing into `DataFrameColumns` objects using integer or symbol indices

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -105,7 +105,7 @@ function getmaxwidths(df::AbstractDataFrame,
     undefstrwidth = ourstrwidth(io, Base.undef_ref_str)
 
     j = 1
-    for (name, col) in eachcol(df, true)
+    for (name, col) in pairs(eachcol(df))
         # (1) Consider length of column name
         maxwidth = ourstrwidth(io, name)
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -61,7 +61,6 @@ import Base: delete!, insert!, merge!
 
 import Base: map
 @deprecate map(f::Function, sdf::SubDataFrame) f(sdf)
-@deprecate map(f::Union{Function,Type}, dfc::DataFrameColumns{<:AbstractDataFrame, Pair{Symbol, AbstractVector}}) mapcols(f, dfc.df)
 
 @deprecate head(df::AbstractDataFrame) first(df, 6)
 @deprecate tail(df::AbstractDataFrame) last(df, 6)
@@ -347,3 +346,5 @@ function Base.join(df1::AbstractDataFrame, df2::AbstractDataFrame,
                             "joining more than two data frames"))
     end
 end
+
+@deprecate eachcol(df::AbstractDataFrame, names::Bool) names ? collect(pairs(eachcol(df))) : eachcol(df)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -475,4 +475,15 @@ end
     @test eltype(Vector(dfr)) == Int
 end
 
+@testset "DataFrameRow" begin
+    df = DataFrame(A = Vector{Union{Int, Missing}}(1:2), B = Vector{Union{Int, Missing}}(2:3))
+    row = DataFrameRow(df, 1, :)
+
+    row[:A] = 100
+    @test df[1, :A] == 100
+
+    row[1] = 101
+    @test df[1, :A] == 101
+end
+
 end # module

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -544,45 +544,9 @@ end
     @test eachcol(df)[1] === last(eachcol(df, true)[1])
     @test eachcol(df)[1] === last(eachcol(df, true)[1])
 
-
-    # show for eachcol(df, true) is breaking but this is a minor thing
-
-    # df = DataFrame(Fish = Vector{String}(undef, 2), Mass = [1.5, missing])
-    # io = IOBuffer()
-    # show(io, "text/html", eachcol(df, true))
-    # str = String(take!(io))
-    # @test str == "<p>2×2 DataFrameColumns</p>" *
-    #              "<table class=\"data-frame\"><thead><tr><th>" *
-    #              "</th><th>Fish</th><th>Mass</th></tr>" *
-    #              "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
-    #              "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
-    #              "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
-
-    # df = DataFrame(ones(2,3))
-    # (v, s) = (eachcol(df, true), "3-element DataFrameColumns")
-    # @test summary(v) == s
-    # io = IOBuffer()
-    # summary(io, v)
-    # @test String(take!(io)) == s
-
-    # df = DataFrame(x = [float(pi)])
-    # @test sprint(show, eachcol(df, true)) == """
-    #     1×1 DataFrameColumns
-    #     │ Row │ x       │
-    #     │     │ Float64 │
-    #     ├─────┼─────────┤
-    #     │ 1   │ 3.14159 │"""
-    # @test sprint((io, x) -> show(io, x, summary=false), eachcol(df, true)) == """
-
-    #     │ Row │ x       │
-    #     │     │ Float64 │
-    #     ├─────┼─────────┤
-    #     │ 1   │ 3.14159 │"""
-
     df = DataFrame(rand(3,4), [:a, :b, :c, :d])
     df2 = DataFrame(eachcol(df, true))
     @test df == df2
-    @test !any(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
     df2 = DataFrame!(eachcol(df, true))
     @test df == df2
     @test all(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -222,13 +222,13 @@ end
         @test df[r"[ab]"] == DataFrame(a=1:3, b=4:6)
         @test df[Not(Not(r"[ab]"))] == DataFrame(a=1:3, b=4:6)
         @test df[Not(3)] == DataFrame(a=1:3, b=4:6)
-        @test eachcol(df, false)[1] === df[1]
-        @test eachcol(view(df,1:2), false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[1:2], false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[r"[ab]"], false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[Not(Not(r"[ab]"))], false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[Not(r"[c]")], false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[1:2], false)[1] !== eachcol(df, false)[1]
+        @test eachcol(df)[1] === df[1]
+        @test eachcol(view(df,1:2))[1] == eachcol(df)[1]
+        @test eachcol(df[1:2])[1] == eachcol(df)[1]
+        @test eachcol(df[r"[ab]"])[1] == eachcol(df)[1]
+        @test eachcol(df[Not(Not(r"[ab]"))])[1] == eachcol(df)[1]
+        @test eachcol(df[Not(r"[c]")])[1] == eachcol(df)[1]
+        @test eachcol(df[1:2])[1] !== eachcol(df)[1]
         @test df[:] == df
         @test df[r""] == df
         @test df[Not(Not(r""))] == df
@@ -237,13 +237,13 @@ end
         @test df[r""] !== df
         @test df[Not(Not(r""))] !== df
         @test df[Not(1:0)] !== df
-        @test eachcol(view(df, :), false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[:], false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[r""], false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[Not(1:0)], false)[1] == eachcol(df, false)[1]
-        @test eachcol(df[:], false)[1] !== eachcol(df, false)[1]
-        @test eachcol(df[r""], false)[1] !== eachcol(df, false)[1]
-        @test eachcol(df[Not(1:0)], false)[1] !== eachcol(df, false)[1]
+        @test eachcol(view(df, :))[1] == eachcol(df)[1]
+        @test eachcol(df[:])[1] == eachcol(df)[1]
+        @test eachcol(df[r""])[1] == eachcol(df)[1]
+        @test eachcol(df[Not(1:0)])[1] == eachcol(df)[1]
+        @test eachcol(df[:])[1] !== eachcol(df)[1]
+        @test eachcol(df[r""])[1] !== eachcol(df)[1]
+        @test eachcol(df[Not(1:0)])[1] !== eachcol(df)[1]
     end
     @testset "getindex df[col] and df[cols]" begin
         x = [1, 2, 3]
@@ -537,6 +537,108 @@ end
     df2 = DataFrame(id=[1,2,4], y=[1,2,4])
     df3 = DataFrame(id=[1,3,4], z=[1,3,4])
     @test_throws ArgumentError join(df1, df2, df3, on=:id, kind=:xxx)
+end
+
+@testset "eachcol(df, true)" begin
+    df = DataFrame(a=1:3, b=4:6, c=7:9)
+    @test eachcol(df)[1] === last(eachcol(df, true)[1])
+    @test eachcol(df)[1] === last(eachcol(df, true)[1])
+
+
+    # show for eachcol(df, true) is breaking but this is a minor thing
+
+    # df = DataFrame(Fish = Vector{String}(undef, 2), Mass = [1.5, missing])
+    # io = IOBuffer()
+    # show(io, "text/html", eachcol(df, true))
+    # str = String(take!(io))
+    # @test str == "<p>2×2 DataFrameColumns</p>" *
+    #              "<table class=\"data-frame\"><thead><tr><th>" *
+    #              "</th><th>Fish</th><th>Mass</th></tr>" *
+    #              "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
+    #              "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
+    #              "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
+
+    # df = DataFrame(ones(2,3))
+    # (v, s) = (eachcol(df, true), "3-element DataFrameColumns")
+    # @test summary(v) == s
+    # io = IOBuffer()
+    # summary(io, v)
+    # @test String(take!(io)) == s
+
+    # df = DataFrame(x = [float(pi)])
+    # @test sprint(show, eachcol(df, true)) == """
+    #     1×1 DataFrameColumns
+    #     │ Row │ x       │
+    #     │     │ Float64 │
+    #     ├─────┼─────────┤
+    #     │ 1   │ 3.14159 │"""
+    # @test sprint((io, x) -> show(io, x, summary=false), eachcol(df, true)) == """
+
+    #     │ Row │ x       │
+    #     │     │ Float64 │
+    #     ├─────┼─────────┤
+    #     │ 1   │ 3.14159 │"""
+
+    df = DataFrame(rand(3,4), [:a, :b, :c, :d])
+    df2 = DataFrame(eachcol(df, true))
+    @test df == df2
+    @test !any(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+    df2 = DataFrame!(eachcol(df, true))
+    @test df == df2
+    @test all(((a,b),) -> a === b, zip(eachcol(df), eachcol(df2)))
+
+    @test Tables.rowtable(df) == Tables.rowtable((;eachcol(df, true)...))
+    @test Tables.columntable(df) == Tables.columntable((;eachcol(df, true)...))
+
+    for (a, b, c, d) in zip(Tables.rowtable(df),
+                            Tables.namedtupleiterator(eachrow(df)),
+                            Tables.namedtupleiterator(eachcol(df)),
+                            Tables.namedtupleiterator((;eachcol(df, true)...)))
+        @test a isa NamedTuple
+        @test a === b === c === d
+    end
+
+    @test Tables.getcolumn((;eachcol(df, true)...), 1) == Tables.getcolumn(df, 1)
+    @test Tables.getcolumn((;eachcol(df, true)...), :a) == Tables.getcolumn(df, :a)
+    @test Tables.columnnames((;eachcol(df, true)...)) == Tuple(Tables.columnnames(df))
+
+    df = DataFrame(A = Vector{Union{Int, Missing}}(1:2), B = Vector{Union{Int, Missing}}(2:3))
+    @test size(eachcol(df, true)) == (size(df, 2),)
+    @test parent(DataFrame(eachcol(df, true))) == df
+    @test names(DataFrame(eachcol(df, true))) == names(df)
+    @test IndexStyle(eachcol(df, true)) == IndexLinear()
+    @test size(eachcol(df, false)) == (size(df, 2),)
+    @test IndexStyle(eachcol(df, false)) == IndexLinear()
+    @test length(eachcol(df, true)) == size(df, 2)
+    @test length(eachcol(df, false)) == size(df, 2)
+    @test eachcol(df, true)[1] == (:A => df[:, 1])
+    @test eachcol(df, false)[1] == df[:, 1]
+    @test collect(eachcol(df, true)) isa Vector{Pair{Symbol, AbstractVector}}
+    @test collect(eachcol(df, true)) == [:A => [1, 2], :B => [2, 3]]
+    @test collect(eachcol(df, false)) isa Vector{AbstractVector}
+    @test collect(eachcol(df, false)) == [[1, 2], [2, 3]]
+    @test eltype(eachcol(df, true)) == Pair{Symbol, AbstractVector}
+    @test eltype(eachcol(df, false)) == AbstractVector
+    for col in eachcol(df, true)
+        @test typeof(col) <: Pair{Symbol, <:AbstractVector}
+    end
+    for col in eachcol(df, false)
+        @test isa(col, AbstractVector)
+    end
+    @test map(minimum, eachcol(df, false)) == [1, 2]
+    @test eltype(map(Vector{Float64}, eachcol(df, false))) == Vector{Float64}
+
+    df = DataFrame([11:16 21:26 31:36 41:46])
+    sdf = view(df, [3,1,4], [3,1,4])
+    @test eachcol(sdf, true) == eachcol(df[[3,1,4], [3,1,4]], true)
+    @test eachcol(sdf, false) == eachcol(df[[3,1,4], [3,1,4]], false)
+    @test size(eachcol(sdf, true)) == (3,)
+    @test size(eachcol(sdf, false)) == (3,)
+
+    df_base = DataFrame([11:16 21:26 31:36 41:46])
+    for df in (df_base, view(df_base, 1:3, 1:3))
+        @test df == DataFrame(eachcol(df, true))
+    end
 end
 
 global_logger(old_logger)

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -19,9 +19,6 @@ using Test, DataFrames
         @test dfx[!, 1] === df[!, names(dfx)[1]]
     end
 
-    @test eachcol(df)[1] === last(eachcol(df, true)[1])
-    @test eachcol(df)[1] === last(eachcol(df, true)[1])
-
     @test df[1, 1] == 1
     @test df[1, 1:2] isa DataFrameRow
     @test df[1, r"[ab]"] isa DataFrameRow

--- a/test/io.jl
+++ b/test/io.jl
@@ -79,17 +79,7 @@ end
     io = IOBuffer()
     show(io, "text/html", eachcol(df))
     str = String(take!(io))
-    @test str == "<p>2×2 DataFrameColumns (with names=false)</p>" *
-                 "<table class=\"data-frame\"><thead><tr><th>" *
-                 "</th><th>Fish</th><th>Mass</th></tr>" *
-                 "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
-                 "<tr><th>1</th><td>#undef</td><td>1.5</td></tr>" *
-                 "<tr><th>2</th><td>#undef</td><td>missing</td></tr></tbody></table>"
-
-    io = IOBuffer()
-    show(io, "text/html", eachcol(df, true))
-    str = String(take!(io))
-    @test str == "<p>2×2 DataFrameColumns (with names=true)</p>" *
+    @test str == "<p>2×2 DataFrameColumns</p>" *
                  "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr>" *
                  "<tr><th></th><th>String</th><th>Float64⍰</th></tr></thead><tbody>" *
@@ -244,8 +234,7 @@ end
                    (DataFrames.index(df[1:1, 1:1]), "data frame with 1 column"),
                    (DataFrames.index(view(df, 1:1, 1:1)), "data frame with 1 column"),
                    (eachrow(df), "2-element DataFrameRows"),
-                   (eachcol(df), "3-element DataFrameColumns (with names=false)"),
-                   (eachcol(df, true), "3-element DataFrameColumns (with names=true)")]
+                   (eachcol(df), "3-element DataFrameColumns")]
         @test summary(v) == s
         io = IOBuffer()
         summary(io, v)

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -65,6 +65,8 @@ end
     @test sdf == df[[3,1,4], [3,1,4]]
     @test eachrow(sdf) == eachrow(df[[3,1,4], [3,1,4]])
     @test size(eachrow(sdf)) == (3,)
+    @test eachcol(sdf) == eachcol(df[[3,1,4], [3,1,4]])
+    @test size(eachcol(sdf)) == (3,)
 end
 
 @testset "parent mutation" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -347,27 +347,13 @@ end
         │ 1   │ 3.14159 │"""
 
     @test sprint(show, eachcol(df)) == """
-        1×1 DataFrameColumns (with names=false)
+        1×1 DataFrameColumns
         │ Row │ x       │
         │     │ Float64 │
         ├─────┼─────────┤
         │ 1   │ 3.14159 │"""
 
     @test sprint((io, x) -> show(io, x, summary=false), eachcol(df)) == """
-
-        │ Row │ x       │
-        │     │ Float64 │
-        ├─────┼─────────┤
-        │ 1   │ 3.14159 │"""
-
-    @test sprint(show, eachcol(df, true)) == """
-        1×1 DataFrameColumns (with names=true)
-        │ Row │ x       │
-        │     │ Float64 │
-        ├─────┼─────────┤
-        │ 1   │ 3.14159 │"""
-
-    @test sprint((io, x) -> show(io, x, summary=false), eachcol(df, true)) == """
 
         │ Row │ x       │
         │     │ Float64 │

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -268,4 +268,18 @@ end
     @test df2.y == [12, 13]
 end
 
+@testset "setindex! in view" begin
+    df = DataFrame(A = Vector{Union{Int, Missing}}(1:4), B = Union{String, Missing}["M", "F", "F", "M"])
+
+    s1 = view(df, 1:3, :)
+    s1[2,:A] = 4
+    @test df[2, :A] == 4
+    @test view(s1, 1:2, :) == view(df, 1:2, :)
+
+    s2 = view(df, 1:2:3, :)
+    s2[2, :B] = "M"
+    @test df[3, :B] == "M"
+    @test view(s2, 1:1:2, :) == view(df, [1,3], :)
+end
+
 end # module

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -219,25 +219,19 @@ end
 
     @test Tables.rowtable(df) == Tables.rowtable(eachrow(df))
     @test Tables.rowtable(df) == Tables.rowtable(eachcol(df))
-    @test Tables.rowtable(df) == Tables.rowtable(eachcol(df, true))
     @test Tables.columntable(df) == Tables.columntable(eachrow(df))
     @test Tables.columntable(df) == Tables.columntable(eachcol(df))
-    @test Tables.columntable(df) == Tables.columntable(eachcol(df, true))
 
-    for (a, b, c, d) in zip(Tables.rowtable(df),
-                            Tables.namedtupleiterator(eachrow(df)),
-                            Tables.namedtupleiterator(eachcol(df)),
-                            Tables.namedtupleiterator(eachcol(df, true)))
+    for (a, b, c) in zip(Tables.rowtable(df),
+                         Tables.namedtupleiterator(eachrow(df)),
+                         Tables.namedtupleiterator(eachcol(df)))
         @test a isa NamedTuple
-        @test a === b === c === d
+        @test a === b === c
     end
 
     @test Tables.getcolumn(eachcol(df), 1) == Tables.getcolumn(df, 1)
     @test Tables.getcolumn(eachcol(df), :a) == Tables.getcolumn(df, :a)
     @test Tables.columnnames(eachcol(df)) == Tables.columnnames(df)
-    @test Tables.getcolumn(eachcol(df, true), 1) == Tables.getcolumn(df, 1)
-    @test Tables.getcolumn(eachcol(df, true), :a) == Tables.getcolumn(df, :a)
-    @test Tables.columnnames(eachcol(df, true)) == Tables.columnnames(df)
     @test Tables.getcolumn(eachrow(df), 1) == Tables.getcolumn(df, 1)
     @test Tables.getcolumn(eachrow(df), :a) == Tables.getcolumn(df, :a)
     @test Tables.columnnames(eachrow(df)) == Tables.columnnames(df)


### PR DESCRIPTION
Fixes #2090.

In the next move we will drop V parameter of `DataFrameColumns`.

Making this PR revealed that `names=true` is in practice almost never used (at least internally), so this change - while big - should not be that problematic.