### PR TITLE
export Tables and imoprt DataAPI and Tables internally

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -1,14 +1,16 @@
 module DataFrames
 
 using Statistics, Printf, REPL
-using Reexport, SortingAlgorithms, Compat, Unicode, PooledArrays, DataAPI
+using Reexport, SortingAlgorithms, Compat, Unicode, PooledArrays
 @reexport using CategoricalArrays, Missings, InvertedIndices
 using Base.Sort, Base.Order, Base.Iterators
-using Tables, TableTraits, IteratorInterfaceExtensions
+using TableTraits, IteratorInterfaceExtensions
 
-import DataAPI.All,
+import DataAPI,
+       DataAPI.All,
        DataAPI.Between,
        DataAPI.describe,
+       Tables,
        Tables.columnindex,
        Future.copy!
 
@@ -20,6 +22,7 @@ export AbstractDataFrame,
        DataFrameRow,
        GroupedDataFrame,
        SubDataFrame,
+       Tables,
        aggregate,
        allowmissing!,
        antijoin,

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -1,6 +1,6 @@
 module TestTables
 
-using Test, Tables, DataFrames
+using Test, DataFrames
 
 struct NamedTupleIterator{T <: NamedTuple}
     elements::Vector{T}


### PR DESCRIPTION
Fixes #2114.

Given @nalimilan comment I just export Tables.jl.
Also internally I switched to import Tables.jl and DataAPI.jl (not using).

I think it is cleaner if all functionality from these packages is explicitly qualified by package name when used (except we decide to export some names explicitly, as we currently do for: `columnindex`, `All`, `Between` and `describe`)