### PR TITLE
Flatten multiple columns at once

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1682,7 +1682,8 @@ function flatten(df::AbstractDataFrame,
     for col in idxcols
         v = df[!, col]
         if any(x -> length(x[1]) != x[2], zip(v, lengths))
-            throw(ArgumentError("Vector lengths across columns in col, within the same row, must be the same"))
+            r = findfirst(!=(0), length.(v) .- lengths)
+            throw(ArgumentError("Lengths of iterables stored in columns $col1 and $col are not the the same in row $r"))
         end
     end
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1677,10 +1677,11 @@ ERROR: ArgumentError: Vector lengths across columns in col, within the same row,
 function flatten(df::AbstractDataFrame,
                  cols::Union{ColumnIndex, AbstractVector, Regex, Not, Between, All, Colon})
     idxcols = index(df)[cols]
-    col1 = idxcols isa AbstractVector ? idxcols[1] : idxcols
+    col1 = first(idxcols)
     lengths = length.(df[!, col1])
     for col in idxcols
-        if length.(df[!, col]) != length.(df[!, col1])
+        v = df[!, col]
+        if any(x -> length(x[1]) != x[2], zip(v, lengths))
             throw(ArgumentError("Vector lengths across columns in col, within the same row, must be the same"))
         end
     end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1602,7 +1602,8 @@ function CategoricalArrays.categorical(df::AbstractDataFrame,
 end
 
 """
-    flatten(df::AbstractDataFrame, cols::Union{ColumnIndex, AbstractVector, Regex, Not, Between, All, Colon})
+    flatten(df::AbstractDataFrame, cols::Union{ColumnIndex, AbstractVector, Regex, Not,
+            Between, All, Colon})
 
 When columns `cols` of data frame `df` have iterable elements that define `length` (for
 example a `Vector` of `Vector`s), return a `DataFrame` where each element of each `col` in
@@ -1671,7 +1672,8 @@ julia> df3 = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7]])
 │ 2   │ 2     │ [3, 4] │ [7]    │
 
 julia> flatten(df3, [:b, :c])
-ERROR: ArgumentError: Vector lengths across columns in col, within the same row, must be the same
+ERROR: ArgumentError: Lengths of iterables stored in columns 2 and 3 are not the the same in
+row 2
 ```
 """
 function flatten(df::AbstractDataFrame,
@@ -1685,7 +1687,8 @@ function flatten(df::AbstractDataFrame,
         v = df[!, col]
         if any(x -> length(x[1]) != x[2], zip(v, lengths))
             r = findfirst(!=(0), length.(v) .- lengths)
-            throw(ArgumentError("Lengths of iterables stored in columns $col1 and $col are not the the same in row $r"))
+            throw(ArgumentError("Lengths of iterables stored in columns $col1 and $col are"
+                                * " not the the same in row $r"))
         end
     end
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1676,6 +1676,8 @@ ERROR: ArgumentError: Vector lengths across columns in col, within the same row,
 """
 function flatten(df::AbstractDataFrame,
                  cols::Union{ColumnIndex, AbstractVector, Regex, Not, Between, All, Colon})
+    _check_consistency(df)
+
     idxcols = index(df)[cols]
     col1 = first(idxcols)
     lengths = length.(df[!, col1])

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1691,6 +1691,7 @@ function flatten(df::AbstractDataFrame,
     for name in _names(new_df)
         repeat_lengths!(new_df[!, name], df[!, name], lengths)
     end
+    length(idxcols) > 1 && sort!(idxcols)
     for col in idxcols
         col_to_flatten = df[!, col]
         flattened_col = col_to_flatten isa AbstractVector{<:AbstractVector} ?

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1689,8 +1689,8 @@ function flatten(df::AbstractDataFrame,
         if any(x -> length(x[1]) != x[2], zip(v, lengths))
             r = findfirst(x -> x != 0, length.(v) .- lengths)
             colnames = names(df)
-            throw(ArgumentError("Lengths of iterables stored in columns $(colnames[col1])"
-                                 * " and $(colnames[col]) are not the the same in row $r"))
+            throw(ArgumentError("Lengths of iterables stored in columns $(colnames[col1])" *
+                                " and $(colnames[col]) are not the the same in row $r"))
         end
     end
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1602,8 +1602,8 @@ function CategoricalArrays.categorical(df::AbstractDataFrame,
 end
 
 """
-    flatten(df::AbstractDataFrame, cols::Union{ColumnIndex, AbstractVector, Regex, Not,
-            Between, All, Colon})
+    flatten(df::AbstractDataFrame,
+            cols::Union{ColumnIndex, AbstractVector, Regex, Not, Between, All, Colon})
 
 When columns `cols` of data frame `df` have iterable elements that define `length` (for
 example a `Vector` of `Vector`s), return a `DataFrame` where each element of each `col` in

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1688,8 +1688,9 @@ function flatten(df::AbstractDataFrame,
         v = df[!, col]
         if any(x -> length(x[1]) != x[2], zip(v, lengths))
             r = findfirst(x -> x != 0, length.(v) .- lengths)
-            throw(ArgumentError("Lengths of iterables stored in columns $col1 and $col are"
-                                * " not the the same in row $r"))
+            colnames = names(df)
+            throw(ArgumentError("Lengths of iterables stored in columns $(colnames[col1])"
+                                 * " and $(colnames[col]) are not the the same in row $r"))
         end
     end
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1607,7 +1607,7 @@ end
 
 When columns `cols` of data frame `df` have iterable elements that define `length` (for
 example a `Vector` of `Vector`s), return a `DataFrame` where each element of each `col` in
-`cols` is flattened, meaning the column corresponding to `col` becomes a longer `Vector`
+`cols` is flattened, meaning the column corresponding to `col` becomes a longer vector
 where the original entries are concatenated. Elements of row `i` of `df` in columns other
 than `cols` will be repeated according to the length of `df[i, col]`. These lengths must
 therefore be the same for each `col` in `cols`, or else an error is raised. Note that these

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1672,8 +1672,8 @@ julia> df3 = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7]])
 │ 2   │ 2     │ [3, 4] │ [7]    │
 
 julia> flatten(df3, [:b, :c])
-ERROR: ArgumentError: Lengths of iterables stored in columns :b and :c are not the the same in
-row 2
+ERROR: ArgumentError: Lengths of iterables stored in columns :b and :c
+are not the the same in row 2
 ```
 """
 function flatten(df::AbstractDataFrame,

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1602,35 +1602,47 @@ function CategoricalArrays.categorical(df::AbstractDataFrame,
 end
 
 """
-    flatten(df::AbstractDataFrame, col::Union{Integer, Symbol})
+    flatten(df::AbstractDataFrame, cols::Union{ColumnIndex, AbstractVector, Regex, Not, Between, All, Colon})
 
-When column `col` of data frame `df` has iterable elements that define `length` (for example
-a `Vector` of `Vector`s), return a `DataFrame` where each element of `col` is flattened, meaning
-the column corresponding to `col` becomes a longer `Vector` where the original entries
-are concatenated. Elements of row `i` of `df` in columns other than `col` will be repeated
-according to the length of `df[i, col]`. Note that these elements are not copied,
-and thus if they are mutable changing them in the returned `DataFrame` will affect `df`.
+When columns `cols` of data frame `df` have iterable elements that define `length` (for
+example a `Vector` of `Vector`s), return a `DataFrame` where each element of each `col` in
+ `cols` is flattened, meaning the column corresponding to `col` becomes a longer `Vector`
+where the original entries are concatenated. Elements of row `i` of `df` in columns other
+than `cols` will be repeated according to the length of `df[i, col]`. These lengths must
+therefore be the same for each `col` in `cols`, or else an error is raised. Note that these
+ elements are not copied, and thus if they are mutable changing them in the returned
+ `DataFrame` will affect `df`.
 
 # Examples
 
 ```
-julia> df1 = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]])
-2×2 DataFrame
-│ Row │ a     │ b      │
-│     │ Int64 │ Array… │
-├─────┼───────┼────────┤
-│ 1   │ 1     │ [1, 2] │
-│ 2   │ 2     │ [3, 4] │
+julia> df1 = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7, 8]])
+2×3 DataFrame
+│ Row │ a     │ b      │ c      │
+│     │ Int64 │ Array… │ Array… │
+├─────┼───────┼────────┼────────┤
+│ 1   │ 1     │ [1, 2] │ [5, 6] │
+│ 2   │ 2     │ [3, 4] │ [7, 8] │
 
 julia> flatten(df1, :b)
-4×2 DataFrame
-│ Row │ a     │ b     │
-│     │ Int64 │ Int64 │
-├─────┼───────┼───────┤
-│ 1   │ 1     │ 1     │
-│ 2   │ 1     │ 2     │
-│ 3   │ 2     │ 3     │
-│ 4   │ 2     │ 4     │
+4×3 DataFrame
+│ Row │ a     │ b     │ c      │
+│     │ Int64 │ Int64 │ Array… │
+├─────┼───────┼───────┼────────┤
+│ 1   │ 1     │ 1     │ [5, 6] │
+│ 2   │ 1     │ 2     │ [5, 6] │
+│ 3   │ 2     │ 3     │ [7, 8] │
+│ 4   │ 2     │ 4     │ [7, 8] │
+
+julia> flatten(df1, [:b, :c])
+4×3 DataFrame
+│ Row │ a     │ b     │ c     │
+│     │ Int64 │ Int64 │ Int64 │
+├─────┼───────┼───────┼───────┤
+│ 1   │ 1     │ 1     │ 5     │
+│ 2   │ 1     │ 2     │ 6     │
+│ 3   │ 2     │ 3     │ 7     │
+│ 4   │ 2     │ 4     │ 8     │
 
 julia> df2 = DataFrame(a = [1, 2], b = [("p", "q"), ("r", "s")])
 2×2 DataFrame
@@ -1650,22 +1662,41 @@ julia> flatten(df2, :b)
 │ 3   │ 2     │ r      │
 │ 4   │ 2     │ s      │
 
+julia> df3 = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7]])
+2×3 DataFrame
+│ Row │ a     │ b      │ c      │
+│     │ Int64 │ Array… │ Array… │
+├─────┼───────┼────────┼────────┤
+│ 1   │ 1     │ [1, 2] │ [5, 6] │
+│ 2   │ 2     │ [3, 4] │ [7]    │
+
+julia> flatten(df3, [:b, :c])
+ERROR: ArgumentError: Vector lengths across columns in col, within the same row, must be the same
 ```
 """
-function flatten(df::AbstractDataFrame, col::ColumnIndex)
-    col_to_flatten = df[!, col]
-    lengths = length.(col_to_flatten)
-    new_df = similar(df[!, Not(col)], sum(lengths))
+function flatten(df::AbstractDataFrame,
+                 cols::Union{ColumnIndex, AbstractVector, Regex, Not, Between, All, Colon})
+    idxcols = index(df)[cols]
+    col1 = idxcols isa AbstractVector ? idxcols[1] : idxcols
+    lengths = length.(df[!, col1])
+    for col in idxcols
+        if length.(df[!, col]) != length.(df[!, col1])
+            throw(ArgumentError("Vector lengths across columns in col, within the same row, must be the same"))
+        end
+    end
 
+    new_df = similar(df[!, Not(cols)], sum(lengths))
     for name in _names(new_df)
         repeat_lengths!(new_df[!, name], df[!, name], lengths)
     end
+    for col in idxcols
+        col_to_flatten = df[!, col]
+        flattened_col = col_to_flatten isa AbstractVector{<:AbstractVector} ?
+            reduce(vcat, col_to_flatten) :
+            collect(Iterators.flatten(col_to_flatten))
 
-    flattened_col = col_to_flatten isa AbstractVector{<:AbstractVector} ?
-        reduce(vcat, col_to_flatten) :
-        collect(Iterators.flatten(col_to_flatten))
-
-    insertcols!(new_df, columnindex(df, col), col => flattened_col)
+        insertcols!(new_df, col, names(df)[col] => flattened_col)
+    end
 
     return new_df
 end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1606,12 +1606,12 @@ end
 
 When columns `cols` of data frame `df` have iterable elements that define `length` (for
 example a `Vector` of `Vector`s), return a `DataFrame` where each element of each `col` in
- `cols` is flattened, meaning the column corresponding to `col` becomes a longer `Vector`
+`cols` is flattened, meaning the column corresponding to `col` becomes a longer `Vector`
 where the original entries are concatenated. Elements of row `i` of `df` in columns other
 than `cols` will be repeated according to the length of `df[i, col]`. These lengths must
 therefore be the same for each `col` in `cols`, or else an error is raised. Note that these
- elements are not copied, and thus if they are mutable changing them in the returned
- `DataFrame` will affect `df`.
+elements are not copied, and thus if they are mutable changing them in the returned
+`DataFrame` will affect `df`.
 
 # Examples
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1672,7 +1672,7 @@ julia> df3 = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7]])
 │ 2   │ 2     │ [3, 4] │ [7]    │
 
 julia> flatten(df3, [:b, :c])
-ERROR: ArgumentError: Lengths of iterables stored in columns 2 and 3 are not the the same in
+ERROR: ArgumentError: Lengths of iterables stored in columns :b and :c are not the the same in
 row 2
 ```
 """
@@ -1689,8 +1689,8 @@ function flatten(df::AbstractDataFrame,
         if any(x -> length(x[1]) != x[2], zip(v, lengths))
             r = findfirst(x -> x != 0, length.(v) .- lengths)
             colnames = names(df)
-            throw(ArgumentError("Lengths of iterables stored in columns $(colnames[col1])" *
-                                " and $(colnames[col]) are not the the same in row $r"))
+            throw(ArgumentError("Lengths of iterables stored in columns :$(colnames[col1])" *
+                                " and :$(colnames[col]) are not the the same in row $r"))
         end
     end
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1681,6 +1681,7 @@ function flatten(df::AbstractDataFrame,
     _check_consistency(df)
 
     idxcols = index(df)[cols]
+    isempty(idxcols) && return copy(df)
     col1 = first(idxcols)
     lengths = length.(df[!, col1])
     for col in idxcols

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1687,7 +1687,7 @@ function flatten(df::AbstractDataFrame,
     for col in idxcols
         v = df[!, col]
         if any(x -> length(x[1]) != x[2], zip(v, lengths))
-            r = findfirst(!=(0), length.(v) .- lengths)
+            r = findfirst(x -> x != 0, length.(v) .- lengths)
             throw(ArgumentError("Lengths of iterables stored in columns $col1 and $col are"
                                 * " not the the same in row $r"))
         end

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -399,17 +399,17 @@ end
 @testset "flatten multiple columns" begin
     df = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7, 8]])
     ref = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4], c = [5, 6, 7, 8])
-    @test flatten(df, [:b, :c])        == ref
-    @test flatten(df, 2:3)             == ref
-    @test flatten(df, r"[bc]")         == ref
-    @test flatten(df, Not(:a))         == ref
+    @test flatten(df, [:b, :c]) == ref
+    @test flatten(df, 2:3) == ref
+    @test flatten(df, r"[bc]") == ref
+    @test flatten(df, Not(:a)) == ref
     @test flatten(df, Between(:b, :c)) == ref
     df_allcols = DataFrame(b = [[1, 2], [3, 4]], c = [[5, 6], [7, 8]])
     ref_allcols = DataFrame(b = [1, 2, 3, 4], c = [5, 6, 7, 8])
     @test flatten(df_allcols, All()) == ref_allcols
-    @test flatten(df_allcols, :)     == ref_allcols
-    df_vec_bad = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7]])
-    @test_throws ArgumentError flatten(df_vec_bad, [:b, :c])
+    @test flatten(df_allcols, :) == ref_allcols
+    df_bad = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7]])
+    @test_throws ArgumentError flatten(df_bad, [:b, :c])
 end
 
 @testset "test RepeatedVector for categorical" begin

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -400,6 +400,7 @@ end
     df = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7, 8]])
     ref = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4], c = [5, 6, 7, 8])
     @test flatten(df, [:b, :c]) == ref
+    @test flatten(df, [:c, :b]) == ref
     @test flatten(df, 2:3) == ref
     @test flatten(df, r"[bc]") == ref
     @test flatten(df, Not(:a)) == ref

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -366,7 +366,7 @@ end
     @test wide3 == w2[!, Not(2)]
 end
 
-@testset "flatten" begin
+@testset "flatten single column" begin
     df_vec = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]])
     df_tup = DataFrame(a = [1, 2], b = [(1, 2), (3, 4)])
     ref = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4])
@@ -394,6 +394,22 @@ end
     ref_cat = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 1, 2])
     @test df_flat_cat == ref_cat
     @test df_flat_cat.b isa CategoricalArray
+end
+
+@testset "flatten multiple columns" begin
+    df = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7, 8]])
+    ref = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4], c = [5, 6, 7, 8])
+    @test flatten(df, [:b, :c])        == ref
+    @test flatten(df, 2:3)             == ref
+    @test flatten(df, r"[bc]")         == ref
+    @test flatten(df, Not(:a))         == ref
+    @test flatten(df, Between(:b, :c)) == ref
+    df_allcols = DataFrame(b = [[1, 2], [3, 4]], c = [[5, 6], [7, 8]])
+    ref_allcols = DataFrame(b = [1, 2, 3, 4], c = [5, 6, 7, 8])
+    @test flatten(df_allcols, All()) == ref_allcols
+    @test flatten(df_allcols, :)     == ref_allcols
+    df_vec_bad = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7]])
+    @test_throws ArgumentError flatten(df_vec_bad, [:b, :c])
 end
 
 @testset "test RepeatedVector for categorical" begin

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -398,6 +398,7 @@ end
 
 @testset "flatten multiple columns" begin
     df = DataFrame(a = [1, 2], b = [[1, 2], [3, 4]], c = [[5, 6], [7, 8]])
+    @test flatten(df, []) == df
     ref = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4], c = [5, 6, 7, 8])
     @test flatten(df, [:b, :c]) == ref
     @test flatten(df, [:c, :b]) == ref


### PR DESCRIPTION
This is a feature I wanted for `flatten`, to be able to use it on multiple vector-valued columns at a time. I couldn't quite figure out how to word the error message for when the lengths don't match up between the columns (see the `df3` example I've added to the docstring). I definitely welcome your suggestions on that and anything else!