### PR TITLE
use Dict{Any,Int} to speed up GroupDataFrame lookup

### DIFF
--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -172,13 +172,14 @@ function Base.getindex(gd::GroupedDataFrame, idxs::AbstractVector{<:Integer})
         end
     end
     GroupedDataFrame(gd.parent, gd.cols, new_groups, gd.idx,
-                     new_starts, new_ends, length(new_starts))
+                     new_starts, new_ends, length(new_starts), nothing)
 end
 
 # Index with colon (creates copy)
 Base.getindex(gd::GroupedDataFrame, idxs::Colon) =
-    GroupedDataFrame(gd.parent, gd.cols, gd.groups, gd.idx,
-                     gd.starts, gd.ends, gd.ngroups)
+    GroupedDataFrame(gd.parent, gd.cols, gd.groups, getfield(gd, :idx),
+                     getfield(gd, :starts), getfield(gd, :ends), gd.ngroups,
+                     getfield(gd, :keymap))
 
 
 #

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -22,10 +22,10 @@ mutable struct GroupedDataFrame{T<:AbstractDataFrame}
 end
 
 function genkeymap(gd, cols)
-# currently we use Dict{Any,Int} because then filed :keymap in GroupedDataFrame has a concrete
-# type which makes the access to it faster as we do not have a dynamic dispatch when indexing
-# into it. In the future an optimization of this approach can be investigated
-# (also taking compilation time into account).
+    # currently we use Dict{Any,Int} because then filed :keymap in GroupedDataFrame
+    # has a concrete type which makes the access to it faster as we do not have a dynamic
+    # dispatch when indexing into it. In the future an optimization of this approach
+    # can be investigated (also taking compilation time into account).
     d = Dict{Any,Int}()
     gdidx = gd.idx
     sizehint!(d, length(gd.starts))

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -22,6 +22,10 @@ mutable struct GroupedDataFrame{T<:AbstractDataFrame}
 end
 
 function genkeymap(gd, cols)
+# currently we use Dict{Any,Int} because then filed :keymap in GroupedDataFrame has a concrete
+# type which makes the access to it faster as we do not have a dynamic dispatch when indexing
+# into it. In the future an optimization of this approach can be investigated
+# (also taking compilation time into account).
     d = Dict{Any,Int}()
     gdidx = gd.idx
     sizehint!(d, length(gd.starts))

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -41,6 +41,7 @@ function Base.getproperty(gd::GroupedDataFrame, f::Symbol)
         if getfield(gd, f) === nothing
             gd.keymap = genkeymap(gd, ntuple(i -> parent(gd)[!, gd.cols[i]], length(gd.cols)))
         end
+        return getfield(gd, f)::Dict{Any,Int}
     else
         return getfield(gd, f)
     end

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -22,7 +22,7 @@ mutable struct GroupedDataFrame{T<:AbstractDataFrame}
 end
 
 function genkeymap(gd, cols)
-    # currently we use Dict{Any,Int} because then filed :keymap in GroupedDataFrame
+    # currently we use Dict{Any,Int} because then field :keymap in GroupedDataFrame
     # has a concrete type which makes the access to it faster as we do not have a dynamic
     # dispatch when indexing into it. In the future an optimization of this approach
     # can be investigated (also taking compilation time into account).

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -24,7 +24,7 @@ end
 function genkeymap(gd, cols)
     d = Dict{Any,Int}()
     sizehint!(d, length(gd.starts))
-    for (i, s) in enumerate(gd.starts)
+    @inbounds for (i, s) in enumerate(gd.starts)
         d[getindex.(cols, s)] = i
     end
     d
@@ -37,7 +37,8 @@ function Base.getproperty(gd::GroupedDataFrame, f::Symbol)
             gd.idx, gd.starts, gd.ends = compute_indices(gd.groups, gd.ngroups)
         end
         return getfield(gd, f)::Vector{Int}
-    elseif f == :keymap
+    elseif f === :keymap
+        # Keymap is computed lazily the first time it is accessed
         if getfield(gd, f) === nothing
             gd.keymap = genkeymap(gd, ntuple(i -> parent(gd)[!, gd.cols[i]], length(gd.cols)))
         end

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -23,9 +23,10 @@ end
 
 function genkeymap(gd, cols)
     d = Dict{Any,Int}()
+    gdidx = gd.idx
     sizehint!(d, length(gd.starts))
-    @inbounds for (i, s) in enumerate(gd.starts)
-        d[getindex.(cols, s)] = i
+    for (i, s) in enumerate(gd.starts)
+        d[getindex.(cols, gdidx[s])] = i
     end
     d
 end

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -142,7 +142,7 @@ function groupby(df::AbstractDataFrame, cols;
     intcols = idxcols isa Int ? [idxcols] : convert(Vector{Int}, idxcols)
     if isempty(intcols)
         return GroupedDataFrame(df, intcols, ones(Int, nrow(df)),
-                                collect(axes(df, 1)), [1], [nrow(df)], 1)
+                                collect(axes(df, 1)), [1], [nrow(df)], 1, nothing)
     end
     sdf = df[!, intcols]
 
@@ -150,7 +150,7 @@ function groupby(df::AbstractDataFrame, cols;
     ngroups, rhashes, gslots, sorted =
         row_group_slots(ntuple(i -> sdf[!, i], ncol(sdf)), Val(false), groups, skipmissing)
 
-    gd = GroupedDataFrame(df, intcols, groups, nothing, nothing, nothing, ngroups)
+    gd = GroupedDataFrame(df, intcols, groups, nothing, nothing, nothing, ngroups, nothing)
 
     # sort groups if row_group_slots hasn't already done that
     if sort && !sorted
@@ -281,7 +281,7 @@ function Base.map(f::Any, gd::GroupedDataFrame)
                        without(valscat, intersect(keys, _names(valscat))))
         if length(idx) == 0
             return GroupedDataFrame(parent, collect(1:length(gd.cols)), idx,
-                                    Int[], Int[], Int[], 0)
+                                    Int[], Int[], Int[], 0, Dict{Any,Int}())
         end
         starts = Vector{Int}(undef, length(gd))
         ends = Vector{Int}(undef, length(gd))
@@ -299,10 +299,10 @@ function Base.map(f::Any, gd::GroupedDataFrame)
         resize!(ends, j)
         ends[end] = length(idx)
         return GroupedDataFrame(parent, collect(1:length(gd.cols)), idx,
-                                collect(1:length(idx)), starts, ends, j)
+                                collect(1:length(idx)), starts, ends, j, nothing)
     else
         return GroupedDataFrame(gd.parent[1:0, gd.cols], collect(1:length(gd.cols)),
-                                Int[], Int[], Int[], Int[], 0)
+                                Int[], Int[], Int[], Int[], 0, Dict{Any,Int}())
     end
 end
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1482,7 +1482,7 @@ end
                        b = repeat(1:2, inner=6), c = 1:12)
     Random.seed!(1234)
     for df in [df_ref, df_ref[randperm(nrow(df_ref)), :]], grpcols = [[:a, :b], :a, :b],
-               dosort in [true, false], doskipmissing in [true, false]
+        dosort in [true, false], doskipmissing in [true, false]
         gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 
         ints = unique(min.(length(gd), [4, 6, 2, 1]))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1485,7 +1485,7 @@ end
               dosort in [true, false], doskipmissing in [true, false]
         gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 
-        ints = unique(max.(length(gd), [4, 6, 2, 1]))
+        ints = unique(min.(length(gd), [4, 6, 2, 1]))
         gd2 = gd[ints]
         gkeys = keys(gd)[ints]
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1483,6 +1483,7 @@ end
     Random.seed!(1234)
     for df in [df_ref, df_ref[randperm(nrow(df_ref)), :]], grpcols = [[:a, :b], :a, :b],
         dosort in [true, false], doskipmissing in [true, false]
+
         gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 
         ints = unique(min.(length(gd), [4, 6, 2, 1]))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1482,7 +1482,7 @@ end
                        b = repeat(1:2, inner=6), c = 1:12)
     Random.seed!(1234)
     for df in [df_ref, df_ref[randperm(nrow(df_ref)), :]], grpcols = [[:a, :b], :a, :b],
-              dosort in [true, false], doskipmissing in [true, false]
+               dosort in [true, false], doskipmissing in [true, false]
         gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 
         ints = unique(min.(length(gd), [4, 6, 2, 1]))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1481,7 +1481,7 @@ end
     df_ref = DataFrame(a = repeat([:A, :B, missing], outer=4),
                        b = repeat(1:2, inner=6), c = 1:12)
     Random.seed!(1234)
-    for df in [df, df[randperm(nrow(df)), :]], grpcols = [[:a, :b], :a, :b],
+    for df in [df_ref, df_ref[randperm(nrow(df)), :]], grpcols = [[:a, :b], :a, :b],
               dosort in [true, false], doskipmissing in [true, false]
         gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1485,7 +1485,7 @@ end
               dosort in [true, false], doskipmissing in [true, false]
         gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 
-        ints = [4, 6, 2, 1]
+        ints = unique(max.(length(gd), [4, 6, 2, 1]))
         gd2 = gd[ints]
         gkeys = keys(gd)[ints]
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1481,7 +1481,7 @@ end
     df_ref = DataFrame(a = repeat([:A, :B, missing], outer=4),
                        b = repeat(1:2, inner=6), c = 1:12)
     Random.seed!(1234)
-    for df in [df_ref, df_ref[randperm(nrow(df)), :]], grpcols = [[:a, :b], :a, :b],
+    for df in [df_ref, df_ref[randperm(nrow(df_ref)), :]], grpcols = [[:a, :b], :a, :b],
               dosort in [true, false], doskipmissing in [true, false]
         gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1478,29 +1478,35 @@ end
 end
 
 @testset "GroupedDataFrame indexing with array of keys" begin
-    df = DataFrame(a = repeat([:A, :B, missing], outer=4), b = repeat(1:2, inner=6), c = 1:12)
-    gd = groupby_checked(df, [:a, :b])
+    df_ref = DataFrame(a = repeat([:A, :B, missing], outer=4),
+                       b = repeat(1:2, inner=6), c = 1:12)
+    Random.seed!(1234)
+    for df in [df, df[randperm(nrow(df)), :]], grpcols = [[:a, :b], :a, :b],
+              dosort in [true, false], doskipmissing in [true, false]
+        gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 
-    ints = [4, 6, 2, 1]
-    gd2 = gd[ints]
-    gkeys = keys(gd)[ints]
+        ints = [4, 6, 2, 1]
+        gd2 = gd[ints]
+        gkeys = keys(gd)[ints]
 
-    # Test with GroupKeys, Tuples, and NamedTuples
-    for converter in [identity, Tuple, NamedTuple]
-        a = converter.(gkeys)
-        @test gd[a] ≅ gd2
+        # Test with GroupKeys, Tuples, and NamedTuples
+        for converter in [identity, Tuple, NamedTuple]
+            a = converter.(gkeys)
+            @test gd[a] ≅ gd2
 
-        # Infer eltype
-        @test gd[Array{Any}(a)] ≅ gd2
+            # Infer eltype
+            @test gd[Array{Any}(a)] ≅ gd2
 
-        # Duplicate keys
-        a2 = converter.(keys(gd)[[1, 2, 1]])
-        @test_throws ArgumentError gd[a2]
+            # Duplicate keys
+            a2 = converter.(keys(gd)[[1, 2, 1]])
+            @test_throws ArgumentError gd[a2]
+        end
     end
 end
 
 @testset "InvertedIndex with GroupedDataFrame" begin
-    df = DataFrame(a = repeat([:A, :B, missing], outer=4), b = repeat(1:2, inner=6), c = 1:12)
+    df = DataFrame(a = repeat([:A, :B, missing], outer=4),
+                   b = repeat(1:2, inner=6), c = 1:12)
     gd = groupby_checked(df, [:a, :b])
 
     # Inverted scalar index
@@ -1548,7 +1554,8 @@ end
 end
 
 @testset "GroupedDataFrame array index homogeneity" begin
-    df = DataFrame(a = repeat([:A, :B, missing], outer=4), b = repeat(1:2, inner=6), c = 1:12)
+    df = DataFrame(a = repeat([:A, :B, missing], outer=4),
+                   b = repeat(1:2, inner=6), c = 1:12)
     gd = groupby_checked(df, [:a, :b])
 
     # All scalar index types


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2095.

I used `Dict{Any, Int}` interface which is fast enough I think. In the future this can be improved as @nalimilan noted, but already we have huge performance gains here and the end-result makes `GroupedDataFrame` practically usable as an indexed `DataFrame`.