### PR TITLE
add haskey to GroupedDataFrame and GroupKey

### DIFF
--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -484,7 +484,7 @@ end
 
 function Base.haskey(gd::GroupedDataFrame, key::NamedTuple{N}) where {N}
     if any(n != _names(gd)[c] for (n, c) in zip(N, gd.cols))
-        return throw(ArgumentError("The column names of keys do not match " *
+        return throw(ArgumentError("The column names of key do not match " *
                                    "the names of grouping columns"))
     end
     return haskey(gd, Tuple(key))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1610,6 +1610,33 @@ end
     @test_throws KeyError gd[(a=:A, b=:X)]
 end
 
+@testset "haskey for GroupKey" begin
+    gdf = groupby(DataFrame(a=1, b=2, c=3), [:a, :b])
+    k = keys(gdf)[1]
+    @test !haskey(k, 0)
+    @test haskey(k, 1)
+    @test haskey(k, 2)
+    @test !haskey(k, 3)
+    @test haskey(k, :a)
+    @test haskey(k, :b)
+    @test !haskey(k, :c)
+    @test !haskey(k, :d)
+
+    @test !haskey(gdf, 0)
+    @test haskey(gdf, 1)
+    @test !haskey(gdf, 2)
+    @test_throws MethodError haskey(gdf, true)
+
+    @test haskey(gdf, k)
+    @test !haskey(gdf, keys(groupby(DataFrame(a=1,b=2,c=3), [:a, :b]))[1])
+    @test haskey(gdf, (1,2))
+    @test !haskey(gdf, (1,3))
+    @test haskey(gdf, (a=1,b=2))
+    @test !haskey(gdf, (a=1,b=3))
+    @test !haskey(gdf, (a=1,c=3))
+    @test !haskey(gdf, (a=1,c=2))
+end
+
 @testset "Check aggregation of DataFrameRow" begin
     df = DataFrame(a=1)
     dfr = DataFrame(x=1, y="1")[1, 2:2]

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1628,13 +1628,17 @@ end
     @test_throws MethodError haskey(gdf, true)
 
     @test haskey(gdf, k)
-    @test !haskey(gdf, keys(groupby(DataFrame(a=1,b=2,c=3), [:a, :b]))[1])
+    @test_throws ArgumentError haskey(gdf, keys(groupby(DataFrame(a=1,b=2,c=3), [:a, :b]))[1])
+    @test_throws BoundsError haskey(gdf, DataFrames.GroupKey(gdf, 0))
+    @test_throws BoundsError haskey(gdf, DataFrames.GroupKey(gdf, 2))
     @test haskey(gdf, (1,2))
     @test !haskey(gdf, (1,3))
+    @test_throws ArgumentError haskey(gdf, (1,2,3))
     @test haskey(gdf, (a=1,b=2))
     @test !haskey(gdf, (a=1,b=3))
-    @test !haskey(gdf, (a=1,c=3))
-    @test !haskey(gdf, (a=1,c=2))
+    @test_throws ArgumentError haskey(gdf, (a=1,c=3))
+    @test_throws ArgumentError haskey(gdf, (a=1,c=2))
+    @test_throws ArgumentError haskey(gdf, (a=1,b=2,c=3))
 end
 
 @testset "Check aggregation of DataFrameRow" begin


### PR DESCRIPTION
When we defined `keys` for `GroupedDataFrame` and `GroupKey` we have not defined `haskey` for them. I think it is natural to define both.

When we have it defined then actually `GroupedDataFrame` can be used as a dictionary.

A design decision is if we want to define all the methods I proposed, but I think it should be OK.