### PR TITLE
[BREAKING] fix eltype in stack with view=true

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -335,7 +335,7 @@ end
 StackedVector(d::AbstractVector) =
     StackedVector{promote_type(map(eltype, d)...)}(d)
 
-function Base.getindex(v::StackedVector, i::Int)
+function Base.getindex(v::StackedVector{T}, i::Int)::T where T
     lengths = [length(x)::Int for x in v.components]
     cumlengths = [0; cumsum(lengths)]
     j = searchsortedlast(cumlengths .+ 1, i)
@@ -346,7 +346,7 @@ function Base.getindex(v::StackedVector, i::Int)
     if k < 1 || k > length(v.components[j])
         error("indexing bounds error")
     end
-    v.components[j][k]
+    return v.components[j][k]
 end
 
 Base.IndexStyle(::Type{StackedVector}) = Base.IndexLinear()

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -490,4 +490,18 @@ end
     @test isordered(d2.e) == isordered(d2s.e)
 end
 
+@testset "test stack eltype" begin
+    df = DataFrame(rand(4,5))
+    sdf = stack(df)
+    @test eltype(sdf.variable) <: CategoricalString
+    @test eltype(typeof(sdf.variable)) <: CategoricalString
+    @test eltype(sdf.value) <: Float64
+    @test eltype(typeof(sdf.value)) <: Float64
+    sdf2 = first(sdf, 3)
+    @test eltype(sdf2.variable) <: CategoricalString
+    @test eltype(typeof(sdf2.variable)) <: CategoricalString
+    @test eltype(sdf2.value) <: Float64
+    @test eltype(typeof(sdf2.value)) <: Float64
+end
+
 end # module


### PR DESCRIPTION
Fixes a wrong definition of `eltype` when `stack` with `view=true` is used. We switch from dynamic to static calculation of eltype (which is needed as Base uses static eltype information for vectors to manipulate them).

Do not merge before #2140 is merged as docs (the manual) need to be updated here which is not done yet.