### PR TITLE
add transform and transform! and select cleanup

### DIFF
--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -36,6 +36,7 @@ unstack
 ```@docs
 allowmissing
 allowmissing!
+append!
 categorical
 categorical!
 completecases
@@ -47,8 +48,8 @@ disallowmissing
 disallowmissing!
 dropmissing
 dropmissing!
-eachrow
 eachcol
+eachrow
 filter
 filter!
 flatten
@@ -57,13 +58,14 @@ insertcols!
 length
 mapcols
 names
+ncol
 ndims
 nonunique
 nrow
-ncol
 order
-rename!
+push!
 rename
+rename!
 repeat
 select
 select!
@@ -71,8 +73,8 @@ show
 size
 sort
 sort!
+transform
+transform!
 unique!
 vcat
-append!
-push!
 ```

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -526,7 +526,7 @@ Equivalently, the `in` function can be called with a single argument to create
 a function object that tests whether each value belongs to the subset
 (partial application of `in`): `df[in([1, 5, 601]).(df.A), :]`.
 
-#### Column selection using `select` and `select!`
+#### Column selection using `select` and `select!`, `transform` and `transform!`
 
 You can also use the [`select`](@ref) and [`select!`](@ref) functions to select,
 rename and transform columns in a data frame.
@@ -633,9 +633,33 @@ julia> df
 │ 1   │ 2     │ 3     │
 ```
 
-While the DataFrames package provides basic data manipulation capabilities, users are encouraged to use querying frameworks for more convenient and powerful operations:
-- the [Query.jl](https://github.com/davidanthoff/Query.jl) package provides a [LINQ](https://msdn.microsoft.com/en-us/library/bb397926.aspx)-like interface to a large number of data sources
-- the [DataFramesMeta.jl](https://github.com/JuliaStats/DataFramesMeta.jl) package provides interfaces similar to LINQ and [dplyr](https://dplyr.tidyverse.org)
+`transform` and `transform!` functions work identically to `select` and `select!` with the only difference that
+they retain all columns that are present in the source data frame, for example:
+
+```jldoctest dataframe
+julia> df = DataFrame(x1=[1, 2], x2=[3, 4], y=[5, 6])
+2×3 DataFrame
+│ Row │ x1    │ x2    │ y     │
+│     │ Int64 │ Int64 │ Int64 │
+├─────┼───────┼───────┼───────┤
+│ 1   │ 1     │ 3     │ 5     │
+│ 2   │ 2     │ 4     │ 6     │
+
+julia> transform(df, All() => +)
+2×4 DataFrame
+│ Row │ x1    │ x2    │ y     │ x1_x2_y_+ │
+│     │ Int64 │ Int64 │ Int64 │ Int64     │
+├─────┼───────┼───────┼───────┼───────────┤
+│ 1   │ 1     │ 3     │ 5     │ 9         │
+│ 2   │ 2     │ 4     │ 6     │ 12        │
+```
+
+While the DataFrames package provides basic data manipulation capabilities,
+users are encouraged to use querying frameworks for more convenient and powerful operations:
+- the [Query.jl](https://github.com/davidanthoff/Query.jl) package provides a
+[LINQ](https://msdn.microsoft.com/en-us/library/bb397926.aspx)-like interface to a large number of data sources
+- the [DataFramesMeta.jl](https://github.com/JuliaStats/DataFramesMeta.jl)
+package provides interfaces similar to LINQ and [dplyr](https://dplyr.tidyverse.org)
 
 See the [Data manipulation frameworks](@ref) section for more information.
 

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -58,6 +58,8 @@ export AbstractDataFrame,
        select,
        semijoin,
        stack,
+       transform,
+       transform!,
        unique!,
        unstack
 

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -136,7 +136,7 @@ function select_transform!(nc::Pair{<:Union{Int, AbstractVector{Int}},
     if col_idx isa Int
         res = fun(df[!, col_idx])
     else
-        res = fun(i -> ntuple(cdf[col_idx[i]], length(col_idx))...)
+        res = fun(ntuple(i -> cdf[col_idx[i]], length(col_idx))...)
     end
     if res isa Union{AbstractDataFrame, NamedTuple, DataFrameRow, AbstractMatrix}
         throw(ArgumentError("return value from function $fun " *

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -1,5 +1,4 @@
 # TODO:
-# * add transform and transfom! functions
 # * add NT (or better name) to column selector passing NamedTuple
 #   (also in other places: filter, combine)
 # * add select/select!/transform/transform! for GroupedDataFrame
@@ -303,6 +302,16 @@ function select!(df::DataFrame, cs...)
 end
 
 """
+    transform!(df::DataFrame, inds...)
+
+Mutate `df` in place to add columns specified by `inds...` and return it.
+Equivalent to `select!(df, :, inds...)`.
+
+See [`select!`](@ref) for a detailed rules how the transformation is applied
+"""
+transform!(df::DataFrame, inds...) = select!(df, :, inds...)
+
+"""
     select(df::AbstractDataFrame, inds...; copycols::Bool=true)
 
 Create a new data frame that contains columns from `df` specified by `inds` and return it.
@@ -555,6 +564,18 @@ function select(dfv::SubDataFrame, inds...; copycols::Bool=true)
                 push!(newinds, newind)
             end
         end
-        return view(dfv, :, All(newinds...))
+        return view(dfv, :, isempty(newinds) ? [] : All(newinds...))
     end
 end
+
+"""
+    transform(df::AbstractDataFrame, inds...; copycols::Bool=true)
+
+Create a new data frame that contains columns from `df` and adds columns
+specified by `inds` and return it.
+Equivalent to `select(df, :, inds..., copycols=copycols)`.
+
+See [`select!`](@ref) for a detailed rules how the transformation is applied
+"""
+transform(df::AbstractDataFrame, inds...; copycols::Bool=true) =
+    select(df, :, inds..., copycols=copycols)

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -158,8 +158,8 @@ Mutate `df` in place to retain only columns specified by `args...` and return it
 
 Arguments passed as `args...` can be:
 
-* Any index that is allowed for column indexing. In particular, regular expressions,
-  `All`, `Between`, and `Not` selectors are supported.
+* Any index that is allowed for column indexing. In particular, symbols, integers,
+  regular expressions, `All`, `Between`, and `Not` selectors are supported.
 * Column transformation operations using the `Pair` notation that is described below.
 
 Columns can be renamed using the `old_column => new_column_name` syntax,

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -299,7 +299,7 @@ end
 Mutate `df` in place to add columns specified by `inds...` and return it.
 Equivalent to `select!(df, :, inds...)`.
 
-See [`select!`](@ref) for a detailed rules how the transformation is applied
+See [`select!`](@ref) for detailed rules regarding accepted values for `inds`.
 """
 transform!(df::DataFrame, inds...) = select!(df, :, inds...)
 
@@ -594,7 +594,7 @@ Create a new data frame that contains columns from `df` and adds columns
 specified by `inds` and return it.
 Equivalent to `select(df, :, inds..., copycols=copycols)`.
 
-See [`select`](@ref) for a detailed rules how the transformation is applied
+See [`select`](@ref) for detailed rules regarding accepted values for `inds`.
 """
 transform(df::AbstractDataFrame, inds...; copycols::Bool=true) =
     select(df, :, inds..., copycols=copycols)

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -129,7 +129,7 @@ function select_transform!(nc::Pair{<:Union{Int, AbstractVector{Int}},
     if col_idx isa Int
         res = fun(df[!, col_idx])
     else
-        res = fun((cdf[i] for i in col_idx)...)
+        res = fun(i -> ntuple(cdf[col_idx[i]], length(col_idx))...)
     end
     if res isa Union{AbstractDataFrame, NamedTuple, DataFrameRow, AbstractMatrix}
         throw(ArgumentError("return value from function $fun " *

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -182,6 +182,9 @@ using `_`; if more than three columns are passed then the name consists of the
 first two names and `etc` suffix then, e.g. `[:a,:b,:c,:d] => fun` produces
 the new column name `:a_b_etc_fun`.
 
+Column renaming and transformation operations can be passed wrapped in vectors
+(this is useful when combined with broadcasting).
+
 If a collection of column names is passed to `select!` then requesting duplicate column
 names in target data frame are accepted (e.g. `select!(df, [:a], :, r"a")` is allowed)
 and only the first occurrence is used. In particular a syntax to move column `:col`
@@ -214,14 +217,7 @@ julia> select!(df, 2)
 │ 2   │ 5     │
 │ 3   │ 6     │
 
-julia> df = DataFrame(a=1:3, b=4:6)
-3×2 DataFrame
-│ Row │ a     │ b     │
-│     │ Int64 │ Int64 │
-├─────┼───────┼───────┤
-│ 1   │ 1     │ 4     │
-│ 2   │ 2     │ 5     │
-│ 3   │ 3     │ 6     │
+julia> df = DataFrame(a=1:3, b=4:6);
 
 julia> select!(df, :a => ByRow(sin) => :c, :b)
 3×2 DataFrame
@@ -240,6 +236,17 @@ julia> select!(df, :, [:c, :b] => (c,b) -> c .+ b .- sum(b)/length(b))
 │ 1   │ 0.841471 │ 4     │ -0.158529    │
 │ 2   │ 0.909297 │ 5     │ 0.909297     │
 │ 3   │ 0.14112  │ 6     │ 1.14112      │
+
+julia> df = DataFrame(a=1:3, b=4:6);
+
+julia> select!(df, names(df) .=> sum .=> [:A, :B]);
+
+julia> df
+1×2 DataFrame
+│ Row │ A     │ B     │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 6     │ 15    │
 ```
 
 """
@@ -332,6 +339,9 @@ using `_`; if more than three columns are passed then the name consists of the
 first two names and `etc` suffix then, e.g. `[:a,:b,:c,:d] => fun` produces
 the new column name `:a_b_etc_fun`.
 
+Column renaming and transformation operations can be passed wrapped in vectors
+(this is useful when combined with broadcasting).
+
 If a collection of column names is passed to `select!` then requesting duplicate column
 names in target data frame are accepted (e.g. `select!(df, [:a], :, r"a")` is allowed)
 and only the first occurrence is used. In particular a syntax to move column `:col`
@@ -416,6 +426,13 @@ julia> select(df, :, [:a, :b] => (a,b) -> a .+ b .- sum(b)/length(b))
 │ 1   │ 1     │ 4     │ 0.0          │
 │ 2   │ 2     │ 5     │ 2.0          │
 │ 3   │ 3     │ 6     │ 4.0          │
+
+julia> select(df, names(df) .=> sum .=> [:A, :B])
+1×2 DataFrame
+│ Row │ A     │ B     │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 6     │ 15    │
 ```
 
 """

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -136,7 +136,8 @@ function select_transform!(nc::Pair{<:Union{Int, AbstractVector{Int}},
     if col_idx isa Int
         res = fun(df[!, col_idx])
     else
-        res = fun(ntuple(i -> cdf[col_idx[i]], length(col_idx))...)
+        # it should be fast enough here as we do not expect to do it millions of times
+        res = fun(map(c -> cdf[c], col_idx)...)
     end
     if res isa Union{AbstractDataFrame, NamedTuple, DataFrameRow, AbstractMatrix}
         throw(ArgumentError("return value from function $fun " *

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -575,7 +575,7 @@ Create a new data frame that contains columns from `df` and adds columns
 specified by `inds` and return it.
 Equivalent to `select(df, :, inds..., copycols=copycols)`.
 
-See [`select!`](@ref) for a detailed rules how the transformation is applied
+See [`select`](@ref) for a detailed rules how the transformation is applied
 """
 transform(df::AbstractDataFrame, inds...; copycols::Bool=true) =
     select(df, :, inds..., copycols=copycols)

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -159,8 +159,10 @@ Mutate `df` in place to retain only columns specified by `args...` and return it
 Arguments passed as `args...` can be:
 
 * Any index that is allowed for column indexing. In particular, symbols, integers,
-  regular expressions, `All`, `Between`, and `Not` selectors are supported.
-* Column transformation operations using the `Pair` notation that is described below.
+  vectors of symbols, vectors of integers, vectors of bools, regular expressions,
+  `All`, `Between`, and `Not` selectors are supported.
+* Column transformation operations using the `Pair` notation that is described below
+  and vectors of such pairs.
 
 Columns can be renamed using the `old_column => new_column_name` syntax,
 and transformed using the `old_column => fun => new_column_name` syntax.
@@ -315,9 +317,11 @@ Create a new data frame that contains columns from `df` specified by `args` and 
 
 Arguments passed as `args...` can be:
 
-* Any index that is allowed for column indexing. In particular, regular expressions,
+* Any index that is allowed for column indexing. In particular, symbols, integers,
+  vectors of symbols, vectors of integers, vectors of bools, regular expressions,
   `All`, `Between`, and `Not` selectors are supported.
-* Column transformation operations using the `Pair` notation that is described below.
+* Column transformation operations using the `Pair` notation that is described below
+  and vectors of such pairs.
 
 Also if `df` is a `DataFrame` or `copycols=true` then column renaming and transformations
 are supported.

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -342,12 +342,10 @@ Base.@propagate_inbounds parentcols(ind::SubIndex, idx::AbstractVector{Symbol}) 
 Base.@propagate_inbounds parentcols(ind::SubIndex, idx::Regex) =
     [parentcols(ind, i) for i in _names(ind) if occursin(idx, String(i))]
 
-Base.@propagate_inbounds parentcols(ind::SubIndex, idx::Union{All, Between}) =
+Base.@propagate_inbounds parentcols(ind::SubIndex, idx) =
     parentcols(ind, ind[idx])
 
 Base.@propagate_inbounds parentcols(ind::SubIndex, ::Colon) = ind.cols
-
-Base.@propagate_inbounds parentcols(ind::SubIndex, idx::Not) = parentcols(ind, ind[idx])
 
 function SubIndex(parent::AbstractIndex, cols::AbstractUnitRange{Int})
     l = last(cols)

--- a/test/index.jl
+++ b/test/index.jl
@@ -238,6 +238,7 @@ end
     @test DataFrames.parentcols(SubIndex(i, r"")) == 1:5
     @test DataFrames.parentcols(SubIndex(i, All())) == 1:5
     @test DataFrames.parentcols(SubIndex(i, Between(:x1, :x12))) == 1:2
+    @test isempty(DataFrames.parentcols(SubIndex(i, [])))
 
     i2 = SubIndex(i, r"")
     @test i2[r"x1."] == [2, 3]
@@ -254,6 +255,7 @@ end
     @test DataFrames.parentcols(SubIndex(i2, r"")) == 1:5
     @test DataFrames.parentcols(SubIndex(i2, All())) == 1:5
     @test DataFrames.parentcols(SubIndex(i2, Between(:x1, :x12))) == 1:2
+    @test isempty(DataFrames.parentcols(SubIndex(i2, [])))
 
     i3 = SubIndex(i, r"x1.")
     @test i3[r"x1.$"] == [1]
@@ -271,6 +273,7 @@ end
     @test DataFrames.parentcols(SubIndex(i3, All())) == 1:2
     @test_throws BoundsError DataFrames.parentcols(SubIndex(i3, Between(:x1, :x12))) == 1:2
     @test DataFrames.parentcols(SubIndex(i3, Between(:x12, :x12))) == 1:1
+    @test isempty(DataFrames.parentcols(SubIndex(i3, [])))
 end
 
 @testset "Not indexing" begin

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -475,6 +475,8 @@ end
     @test view(sdf, Not(Int[]), :) == df[2:4, 2:4]
     @test view(sdf, Not(Int[]), r"") == df[2:4, 2:4]
     @test view(sdf, Not(Int[]), Not(1:0)) == df[2:4, 2:4]
+
+    @test ncol(view(sdf, 1:2, [])) == 0
 end
 
 @testset "getindex DataFrameRow" begin

--- a/test/select.jl
+++ b/test/select.jl
@@ -835,4 +835,52 @@ end
     @test df.b === df.c === a
 end
 
+@testset "empty select" begin
+    df_ref = DataFrame(rand(10, 4))
+
+    for df in (df_ref, view(df_ref, 1:9, 1:3))
+        @test ncol(select(df)) == 0
+        @test ncol(select(df, copycols=false)) == 0
+    end
+    select!(df_ref)
+    @test ncol(df_ref) == 0
+end
+
+@testset "transform and transform!" begin
+    df = DataFrame(rand(10,4))
+
+    for dfx in (df, view(df, :, :))
+        df2 = transform(dfx, [:x1, :x2] => +, :x2 => :x3)
+        @test df2 == select(dfx, :, [:x1, :x2] => +, :x2 => :x3)
+        @test df2.x2 == df2.x3
+        @test df2.x2 !== df2.x3
+        @test dfx.x2 == df2.x3
+        @test dfx.x2 !== df2.x3
+        @test dfx.x2 !== df2.x2
+    end
+
+    df2 = transform(df, [:x1, :x2] => +, :x2 => :x3, copycols=false)
+    @test df2 == select(df, :, [:x1, :x2] => +, :x2 => :x3)
+    @test df.x2 === df2.x2 === df2.x3
+    @test_throws ArgumentError transform(view(df, :, :), [:x1, :x2] => +, :x2 => :x3, copycols=false)
+
+    x2 = df.x2
+    transform!(df, [:x1, :x2] => +, :x2 => :x3)
+    @test df == df2
+    @test x2 === df.x2 === df.x3
+
+    @test transform(df) == df
+    df2 = transform(df, copycols=false)
+    @test df2 == df
+    for (a, b) in zip(eachcol(df), eachcol(df2))
+        @test a === b
+    end
+    cols = collect(eachcol(df))
+    transform!(df)
+    @test df2 == df
+    for (a, b) in zip(eachcol(df), cols)
+        @test a === b
+    end
+end
+
 end # module

--- a/test/select.jl
+++ b/test/select.jl
@@ -913,6 +913,8 @@ end
         @test select(df, :a, [] .=> sum, :b => :x, [:b, :a] .=> identity) ==
               DataFrame(a=1:3, x=4:6, b_identity=4:6, a_identity=1:3)
         @test select(df, names(df) .=> sum .=> [:A, :B]) == DataFrame(A=6, B=15)
+        @test Base.broadcastable(ByRow(+)) isa Base.RefValue{ByRow{typeof(+)}}
+        @test identity.(ByRow(+)) == ByRow(+)
     end
 end
 

--- a/test/select.jl
+++ b/test/select.jl
@@ -889,4 +889,18 @@ end
     end
 end
 
+@testset "vectors of pairs" begin
+    df_ref = DataFrame(a=1:3, b=4:6)
+    for df in [df_ref, view(df_ref, :, :)]
+        @test select(df, [] .=> sum) == DataFrame()
+        @test select(df, names(df) .=> sum) == DataFrame(a_sum=6, b_sum=15)
+        @test transform(df, names(df) .=> ByRow(-)) ==
+              DataFrame(:a => 1:3, :b => 4:6,
+                        Symbol("a_-") => -1:-1:-3,
+                        Symbol("b_-") => -4:-1:-6)
+    end
+    @test select(df, :a, [] .=> sum, :b => :x, [:b, :a] .=> identity) ==
+          DataFrame(a=1:3, x=4:6, b_identity=4:6, a_identity=1:3)
+end
+
 end # module

--- a/test/select.jl
+++ b/test/select.jl
@@ -898,9 +898,10 @@ end
               DataFrame(:a => 1:3, :b => 4:6,
                         Symbol("a_-") => -1:-1:-3,
                         Symbol("b_-") => -4:-1:-6)
+        @test select(df, :a, [] .=> sum, :b => :x, [:b, :a] .=> identity) ==
+              DataFrame(a=1:3, x=4:6, b_identity=4:6, a_identity=1:3)
+        @test select(df, names(df) .=> sum .=> [:A, :B]) == DataFrame(A=6, B=15)
     end
-    @test select(df, :a, [] .=> sum, :b => :x, [:b, :a] .=> identity) ==
-          DataFrame(a=1:3, x=4:6, b_identity=4:6, a_identity=1:3)
 end
 
 end # module

--- a/test/select.jl
+++ b/test/select.jl
@@ -702,7 +702,10 @@ end
     for df in [df_ref, view(df_ref, 1:2, 1:2),
                df_ref[1:2, []], view(df_ref, 1:2, []),
                df_ref[[], 1:2], view(df_ref, [], 1:2)]
-        @test select(df, nrow => :z, nrow) == DataFrame(z=nrow(df), nrow=nrow(df))
+        @test select(df, nrow => :z, nrow, [nrow => :z2]) ==
+              DataFrame(z=nrow(df), nrow=nrow(df), z2=nrow(df))
+        @test_throws ArgumentError select(df, nrow, nrow)
+        @test_throws ArgumentError select(df, [nrow])
     end
 end
 


### PR DESCRIPTION
Adds transform and transform! functions.

Additionally small bug fixes in `select` (`Any()` corner case when `copycols=false`) and in making a view of a `SubDataFrame` and some small rearrangements of documentation.