### PR TITLE
Add .editorconfig and comment on GitHub Actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[*.jl]
+indent_style = space
+indent_size = 4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thanks for taking the plunge!
 * Aim for atomic commits, if possible, e.g. `change 'foo' behavior like so` & `'bar' handles such and such corner case`, rather than `update 'foo' and 'bar'` & `fix typo` & `fix 'bar' better`
 * Pull requests are tested against release and development branches of Julia, so using `Pkg.test("DataFrames")` as you develop can be helpful
 * The style guidelines outlined below are not the personal style of most contributors, but for consistency throughout the project, we've adopted them
+* It is recommended to disable GitHub Actions on your fork; check Settings > Actions
 
 ## Style Guidelines
 


### PR DESCRIPTION
The `.editorconfig` is very close to the one I use personally. The lines about `end_of_line` and `charset` are best guesses. What do you think about it? If you want one but not the other, I'd be happy to split this PR.