### PR TITLE
[BREAKING] allow pseudo-broadcasting in select

### DIFF
--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -145,8 +145,8 @@ function select_transform!(nc::Pair{<:Union{Int, AbstractVector{Int}},
                             "of type $(typeof(res)) is currently not allowed."))
     end
     if res isa AbstractVector
-        # disallow shortening to 0 rows
-        if allow_resizing_newdf[] && nrow(newdf) == 1 && length(res) > 1
+        # allow shortening to 0 rows
+        if allow_resizing_newdf[] && nrow(newdf) == 1
             newdfcols = _columns(newdf)
             for (i, col) in enumerate(newdfcols)
                 newdfcols[i] = fill!(similar(col, length(res)), first(col))
@@ -162,8 +162,10 @@ function select_transform!(nc::Pair{<:Union{Int, AbstractVector{Int}},
         end
     else
         res_unwrap = res isa Union{AbstractArray{<:Any, 0}, Ref} ? res[] : res
-        # disallow squashing a scalar to 0 rows
-        newdf[!, newname] = fill!(Tables.allocatecolumn(typeof(res_unwrap), max(1, nrow(newdf))), res_unwrap)
+        # allow squashing a scalar to 0 rows
+        newdf[!, newname] = fill!(Tables.allocatecolumn(typeof(res_unwrap),
+                                                        ncol(newdf) == 0 ? 1 : nrow(newdf)),
+                                  res_unwrap)
     end
     # mark that column transformation was applied
     # nothing is not possible otherwise as a value in this dict
@@ -534,8 +536,8 @@ function _select(df::AbstractDataFrame, normalized_cs, copycols::Bool)
                         select_transform!(nct, df, newdf, transformed_cols, copycols,
                                           allow_resizing_newdf)
                     else
-                        # disallow shortening to 0 rows
-                        if allow_resizing_newdf[] && nrow(newdf) == 1 && nrow(df) > 1
+                        # allow shortening to 0 rows
+                        if allow_resizing_newdf[] && nrow(newdf) == 1
                             newdfcols = _columns(newdf)
                             for (i, col) in enumerate(newdfcols)
                                 newdfcols[i] = fill!(similar(col, nrow(df)), first(col))

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -199,7 +199,7 @@ and transformed using the `old_column => fun => new_column_name` syntax.
 is a `Symbol` or an integer then `fun` is applied to the corresponding column vector.
 Otherwise `old_column` can be any column indexing syntax, in which case `fun`
 will be passed the column vectors specified by `old_column` as separate arguments.
-If `fun` returns a value of type other than `AbstractVector` then: it will be wrapped
+If `fun` returns a value of type other than `AbstractVector` then: it will be spread
 into a vector matching the target number of rows in the data frame
 (as a particular rule a values stored in a `Ref` or a `0`-dimensional `AbstractArray`
  are unwrapped and treated in the same way),
@@ -342,7 +342,7 @@ and transformed using the `old_column => fun => new_column_name` syntax.
 is a `Symbol` or an integer then `fun` is applied to the corresponding column vector.
 Otherwise `old_column` can be any column indexing syntax, in which case `fun`
 will be passed the column vectors specified by `old_column` as separate arguments.
-If `fun` returns a value of type other than `AbstractVector` then: it will be wrapped
+If `fun` returns a value of type other than `AbstractVector` then: it will be spread
 into a vector matching the target number of rows in the data frame
 (as a particular rule a values stored in a `Ref` or a `0`-dimensional `AbstractArray`
  are unwrapped and treated in the same way),

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -123,7 +123,7 @@ struct DataFrame <: AbstractDataFrame
         end
         len == -1 && (len = 1) # we got no vectors so make one row of scalars
 
-        # we write into columns as we know that it is guarantted
+        # we write into columns as we know that it is guaranteed
         # that it was freshly allocated in the outer constructor
         for (i, col) in enumerate(columns)
             # check for vectors first as they are most common

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -96,6 +96,7 @@ struct DataFrame <: AbstractDataFrame
     columns::Vector{AbstractVector}
     colindex::Index
 
+    # the inner constructor should not be used directly
     function DataFrame(columns::Union{Vector{Any}, Vector{AbstractVector}},
                        colindex::Index; copycols::Bool=true)
         if length(columns) == length(colindex) == 0
@@ -104,37 +105,44 @@ struct DataFrame <: AbstractDataFrame
             throw(DimensionMismatch("Number of columns ($(length(columns))) and number of" *
                                     " column names ($(length(colindex))) are not equal"))
         end
-        lengths = [isa(col, AbstractArray) ? length(col) : 1 for col in columns]
-        minlen, maxlen = extrema(lengths)
-        if minlen != maxlen || minlen == maxlen == 1
-            # recycle scalars
-            for (i, col) in enumerate(columns)
-                if col isa Union{AbstractArray{<:Any, 0}, Ref}
-                    x = col[]
-                    columns[i] = fill!(Tables.allocatecolumn(typeof(x), maxlen), x)
-                    lengths[i] = maxlen
-                elseif !(col isa AbstractArray)
-                    columns[i] = fill!(Tables.allocatecolumn(typeof(col), maxlen), col)
-                    lengths[i] = maxlen
+
+        len = -1
+        firstvec = -1
+        for (i, col) in enumerate(columns)
+            if col isa AbstractVector
+                if len == -1
+                    len = length(col)
+                    firstvec = i
+                elseif len != length(col)
+                    n1 = _names(colindex)[firstvec]
+                    n2 = _names(colindex)[i]
+                    throw(DimensionMismatch("column :$n1 has length $len and column " *
+                                            ":$n2 has length $(length(col))"))
                 end
             end
-            uls = unique(lengths)
-            if length(uls) != 1
-                strnames = string.(names(colindex))
-                estrings = ["column length $u for column(s) " *
-                            join(strnames[lengths .== u], ", ", " and ") for (i, u) in enumerate(uls)]
-                throw(DimensionMismatch(join(estrings, " is incompatible with ", ", and is incompatible with ")))
+        end
+        len == -1 && (len = 1) # we got no vectors so make one row of scalars
+
+        # we write into columns as we know that it is guarantted
+        # that it was freshly allocated in the outer constructor
+        for (i, col) in enumerate(columns)
+            # check for vectors first as they are most common
+            if col isa AbstractRange
+                columns[i] = collect(col)
+            elseif col isa AbstractVector
+                columns[i] = copycols ? copy(col) : col
+            elseif col isa Union{AbstractArray{<:Any, 0}, Ref}
+                x = col[]
+                columns[i] = fill!(Tables.allocatecolumn(typeof(x), len), x)
+            else
+                if col isa AbstractArray
+                    throw(ArgumentError("adding AbstractArray other than AbstractVector" *
+                                        " as a column of a data frame is not allowed"))
+                end
+                columns[i] = fill!(Tables.allocatecolumn(typeof(col), len), col)
             end
         end
-        for (i, c) in enumerate(columns)
-            if isa(c, AbstractRange)
-                columns[i] = collect(c)
-            elseif !isa(c, AbstractVector)
-                throw(DimensionMismatch("columns must be 1-dimensional"))
-            elseif copycols
-                columns[i] = copy(c)
-            end
-        end
+
         new(convert(Vector{AbstractVector}, columns), colindex)
     end
 end
@@ -187,18 +195,17 @@ function DataFrame(columns::AbstractVector, cnames::AbstractVector{Symbol};
     if !all(col -> isa(col, AbstractVector), columns)
         throw(ArgumentError("columns argument must be a vector of AbstractVector objects"))
     end
-    return DataFrame(convert(Vector{AbstractVector}, columns),
+    return DataFrame(collect(AbstractVector, columns),
                      Index(convert(Vector{Symbol}, cnames), makeunique=makeunique),
                      copycols=copycols)
 end
 
-function DataFrame(columns::AbstractVector{<:AbstractVector},
-                   cnames::AbstractVector{Symbol}=gennames(length(columns));
-                   makeunique::Bool=false, copycols::Bool=true)::DataFrame
-    return DataFrame(convert(Vector{AbstractVector}, columns),
-                     Index(convert(Vector{Symbol}, cnames), makeunique=makeunique),
-                     copycols=copycols)
-end
+DataFrame(columns::AbstractVector{<:AbstractVector},
+          cnames::AbstractVector{Symbol}=gennames(length(columns));
+          makeunique::Bool=false, copycols::Bool=true)::DataFrame =
+    DataFrame(collect(AbstractVector, columns),
+              Index(convert(Vector{Symbol}, cnames), makeunique=makeunique),
+              copycols=copycols)
 
 DataFrame(columns::NTuple{N, AbstractVector}, cnames::NTuple{N, Symbol};
           makeunique::Bool=false, copycols::Bool=true) where {N} =
@@ -681,9 +688,9 @@ function insertcols!(df::DataFrame, col_ind::Int, name_cols::Pair{Symbol,<:Any}.
                                             "a data frame must have the same length"))
                 end
             end
-        elseif v isa AbstractArray && ndims(v) > 0
-            throw(ArgumentError("adding AbstractArray other than AbstractVector as a column " *
-                                "of a data frame is not allowed"))
+        elseif v isa AbstractArray && ndims(v) > 1
+            throw(ArgumentError("adding AbstractArray other than AbstractVector as " *
+                                "a column of a data frame is not allowed"))
         end
     end
     if target_row_count == -1

--- a/test/select.jl
+++ b/test/select.jl
@@ -825,35 +825,35 @@ end
     df2 = DataFrame([1 2 3])
     df3 = DataFrame(x1=Int[], x2=Int[], x3=Int[])
     for v in [9, Ref(9), view([9], 1)]
-        @test select(df, [] => (() -> 9) => :a, :, (:) => (+) => :d) ==
+        @test select(df, [] => (() -> v) => :a, :, (:) => (+) => :d) ==
               DataFrame([9 1 2 3 6
                          9 4 5 6 15], [:a, :x1, :x2, :x3, :d])
-        @test select(df, (:) => (+) => :d, :, r"z" => (() -> 9)  => :a) ==
+        @test select(df, (:) => (+) => :d, :, r"z" => (() -> v)  => :a) ==
               DataFrame([6  1 2 3 9
                          15 4 5 6 9], [:d, :x1, :x2, :x3, :a])
-        @test select(df, [] => (() -> 9) => :a, :x1 => :b, (:) => (+) => :d) ==
+        @test select(df, [] => (() -> v) => :a, :x1 => :b, (:) => (+) => :d) ==
               DataFrame([9 1 6
                          9 4 15], [:a, :b, :d])
-        @test select(df, (:) => (+) => :d, :x1 => :b, [] => (() -> 9) => :a) ==
+        @test select(df, (:) => (+) => :d, :x1 => :b, [] => (() -> v) => :a) ==
               DataFrame([6  1 9
                          15 4 9], [:d, :b, :a])
-        @test select(df, [] => (() -> 9) => :a, :x1 => (x -> x) => :b, (:) => (+) => :d) ==
+        @test select(df, [] => (() -> v) => :a, :x1 => (x -> x) => :b, (:) => (+) => :d) ==
               DataFrame([9 1 6
                          9 4 15], [:a, :b, :d])
-        @test select(df, (:) => (+) => :d, :x1 => (x -> x) => :b, [] => (() -> 9) => :a) ==
+        @test select(df, (:) => (+) => :d, :x1 => (x -> x) => :b, [] => (() -> v) => :a) ==
               DataFrame([6  1 9
                          15 4 9], [:d, :b, :a])
-        @test select(df2, [] => (() -> 9) => :a, :, (:) => (+) => :d) ==
+        @test select(df2, [] => (() -> v) => :a, :, (:) => (+) => :d) ==
               DataFrame([9 1 2 3 6], [:a, :x1, :x2, :x3, :d])
-        @test select(df2, (:) => (+) => :d, :, r"z" => (() -> 9)  => :a) ==
+        @test select(df2, (:) => (+) => :d, :, r"z" => (() -> v)  => :a) ==
               DataFrame([6  1 2 3 9], [:d, :x1, :x2, :x3, :a])
-        @test select(df2, [] => (() -> 9) => :a, :x1 => :b, (:) => (+) => :d) ==
+        @test select(df2, [] => (() -> v) => :a, :x1 => :b, (:) => (+) => :d) ==
               DataFrame([9 1 6], [:a, :b, :d])
-        @test select(df2, (:) => (+) => :d, :x1 => :b, [] => (() -> 9) => :a) ==
+        @test select(df2, (:) => (+) => :d, :x1 => :b, [] => (() -> v) => :a) ==
               DataFrame([6  1 9], [:d, :b, :a])
-        @test select(df2, [] => (() -> 9) => :a, :x1 => (x -> x) => :b, (:) => (+) => :d) ==
+        @test select(df2, [] => (() -> v) => :a, :x1 => (x -> x) => :b, (:) => (+) => :d) ==
               DataFrame([9 1 6], [:a, :b, :d])
-        @test select(df2, (:) => (+) => :d, :x1 => (x -> x) => :b, [] => (() -> 9) => :a) ==
+        @test select(df2, (:) => (+) => :d, :x1 => (x -> x) => :b, [] => (() -> v) => :a) ==
               DataFrame([6  1 9], [:d, :b, :a])
         @test_throws ArgumentError select(df3, [] => (() -> v) => :a, :x1 => x -> [])
         @test_throws ArgumentError select(df3, :x1 => x -> [], [] => (() -> v) => :a)

--- a/test/select.jl
+++ b/test/select.jl
@@ -813,6 +813,49 @@ end
     @test_throws ArgumentError select(sdf, :x1 => identity => :r1, copycols=false)
 end
 
+@testset "pseudo-broadcasting" begin
+    df = DataFrame([1 2 3
+                    4 5 6])
+    df2 = DataFrame([1 2 3])
+    df3 = DataFrame(x1=Int[], x2=Int[], x3=Int[])
+    for v in [9, Ref(9), view([9], 1)]
+        @test select(df, [] => (() -> 9) => :a, :, (:) => (+) => :d) ==
+              DataFrame([9 1 2 3 6
+                         9 4 5 6 15], [:a, :x1, :x2, :x3, :d])
+        @test select(df, (:) => (+) => :d, :, r"z" => (() -> 9)  => :a) ==
+              DataFrame([6  1 2 3 9
+                         15 4 5 6 9], [:d, :x1, :x2, :x3, :a])
+        @test select(df, [] => (() -> 9) => :a, :x1 => :b, (:) => (+) => :d) ==
+              DataFrame([9 1 6
+                         9 4 15], [:a, :b, :d])
+        @test select(df, (:) => (+) => :d, :x1 => :b, [] => (() -> 9) => :a) ==
+              DataFrame([6  1 9
+                         15 4 9], [:d, :b, :a])
+        @test select(df, [] => (() -> 9) => :a, :x1 => (x -> x) => :b, (:) => (+) => :d) ==
+              DataFrame([9 1 6
+                         9 4 15], [:a, :b, :d])
+        @test select(df, (:) => (+) => :d, :x1 => (x -> x) => :b, [] => (() -> 9) => :a) ==
+              DataFrame([6  1 9
+                         15 4 9], [:d, :b, :a])
+        @test select(df2, [] => (() -> 9) => :a, :, (:) => (+) => :d) ==
+              DataFrame([9 1 2 3 6], [:a, :x1, :x2, :x3, :d])
+        @test select(df2, (:) => (+) => :d, :, r"z" => (() -> 9)  => :a) ==
+              DataFrame([6  1 2 3 9], [:d, :x1, :x2, :x3, :a])
+        @test select(df2, [] => (() -> 9) => :a, :x1 => :b, (:) => (+) => :d) ==
+              DataFrame([9 1 6], [:a, :b, :d])
+        @test select(df2, (:) => (+) => :d, :x1 => :b, [] => (() -> 9) => :a) ==
+              DataFrame([6  1 9], [:d, :b, :a])
+        @test select(df2, [] => (() -> 9) => :a, :x1 => (x -> x) => :b, (:) => (+) => :d) ==
+              DataFrame([9 1 6], [:a, :b, :d])
+        @test select(df2, (:) => (+) => :d, :x1 => (x -> x) => :b, [] => (() -> 9) => :a) ==
+              DataFrame([6  1 9], [:d, :b, :a])
+        @test_throws ArgumentError select(df3, [] => (() -> v) => :a, :x1 => x -> [])
+        @test_throws ArgumentError select(df3, :x1 => x -> [], [] => (() -> v) => :a)
+    end
+    @test_throws ArgumentError select(df, [] => (() -> [9]) => :a, :)
+    @test_throws ArgumentError select(df, :, [] => (() -> [9]) => :a)
+end
+
 @testset "copycols special cases" begin
     df = DataFrame(a=1:3, b=4:6)
     c = [7, 8]

--- a/test/select.jl
+++ b/test/select.jl
@@ -2,6 +2,8 @@ module TestSelect
 
 using DataFrames, Test, Random
 
+const ≅ = isequal
+
 Random.seed!(1234)
 
 @testset "select! Not" begin
@@ -889,6 +891,93 @@ end
     @test transform(df3, names(df3) .=> (x -> 9) .=> names(df3)) == DataFrame([9 9 9])
     @test transform(df3, names(df3) .=> (x -> 9) .=> names(df3), :x1 => :x4) ==
           DataFrame(ones(0, 4))
+
+    df = DataFrame(x1=1:2, x2=categorical(1:2),
+                   x3=[missing,2], x4=categorical([missing, 2]))
+
+    df2 = select(df, names(df) .=> first)
+    @test df2 ≅ DataFrame(x1_first=1, x2_first=1, x3_first=missing,
+                          x4_first=missing)
+    @test df2.x1_first isa Vector{Int}
+    @test df2.x2_first isa CategoricalVector
+    @test df2.x3_first isa Vector{Missing}
+    @test df2.x4_first isa Vector{Missing}
+
+    df2 = select(df, names(df) .=> last)
+    @test df2 ≅ DataFrame(x1_last=2, x2_last=2, x3_last=2,
+                          x4_last=2)
+    @test df2.x1_last isa Vector{Int}
+    @test df2.x2_last isa CategoricalVector
+    @test df2.x3_last isa Vector{Int}
+    @test df2.x4_last isa CategoricalVector
+
+    for v in [:x1, :x1 => (x -> x) => :x1]
+        df2 = select(df, names(df) .=> first, v)
+        @test df2 ≅ DataFrame(x1_first=1, x2_first=1, x3_first=missing,
+                              x4_first=missing, x1=[1,2])
+        @test df2.x1_first isa Vector{Int}
+        @test df2.x2_first isa CategoricalVector
+        @test df2.x3_first isa Vector{Missing}
+        @test df2.x4_first isa Vector{Missing}
+
+
+        df2 = select(df, names(df) .=> last, v)
+        @test df2 ≅ DataFrame(x1_last=2, x2_last=2, x3_last=2,
+                              x4_last=2, x1=[1,2])
+        @test df2.x1_last isa Vector{Int}
+        @test df2.x2_last isa CategoricalVector
+        @test df2.x3_last isa Vector{Int}
+        @test df2.x4_last isa CategoricalVector
+
+
+        df2 = select(df, v, names(df) .=> first)
+        @test df2 ≅ DataFrame(x1=[1,2], x1_first=1, x2_first=1, x3_first=missing,
+                              x4_first=missing)
+        @test df2.x1_first isa Vector{Int}
+        @test df2.x2_first isa CategoricalVector
+        @test df2.x3_first isa Vector{Missing}
+        @test df2.x4_first isa Vector{Missing}
+
+
+        df2 = select(df, v, names(df) .=> last)
+        @test df2 ≅ DataFrame(x1=[1,2], x1_last=2, x2_last=2, x3_last=2,
+                              x4_last=2)
+        @test df2.x1_last isa Vector{Int}
+        @test df2.x2_last isa CategoricalVector
+        @test df2.x3_last isa Vector{Int}
+        @test df2.x4_last isa CategoricalVector
+    end
+
+    df2 = select(df, names(df) .=> first, [] => (() -> Int[]) => :x1)
+    @test size(df2) == (0, 5)
+    @test df2.x1_first isa Vector{Int}
+    @test df2.x2_first isa CategoricalVector
+    @test df2.x3_first isa Vector{Missing}
+    @test df2.x4_first isa Vector{Missing}
+
+
+    df2 = select(df, names(df) .=> last, [] => (() -> Int[]) => :x1)
+    @test size(df2) == (0, 5)
+    @test df2.x1_last isa Vector{Int}
+    @test df2.x2_last isa CategoricalVector
+    @test df2.x3_last isa Vector{Int}
+    @test df2.x4_last isa CategoricalVector
+
+
+    df2 = select(df, [] => (() -> Int[]) => :x1, names(df) .=> first)
+    @test size(df2) == (0, 5)
+    @test df2.x1_first isa Vector{Int}
+    @test df2.x2_first isa CategoricalVector
+    @test df2.x3_first isa Vector{Missing}
+    @test df2.x4_first isa Vector{Missing}
+
+
+    df2 = select(df, [] => (() -> Int[]) => :x1, names(df) .=> last)
+    @test size(df2) == (0, 5)
+    @test df2.x1_last isa Vector{Int}
+    @test df2.x2_last isa CategoricalVector
+    @test df2.x3_last isa Vector{Int}
+    @test df2.x4_last isa CategoricalVector
 end
 
 @testset "copycols special cases" begin

--- a/test/select.jl
+++ b/test/select.jl
@@ -899,7 +899,7 @@ end
     @test df2 ≅ DataFrame(x1_first=1, x2_first=1, x3_first=missing,
                           x4_first=missing)
     @test df2.x1_first isa Vector{Int}
-    @test df2.x2_first isa CategoricalVector
+    @test df2.x2_first isa CategoricalVector{Int}
     @test df2.x3_first isa Vector{Missing}
     @test df2.x4_first isa Vector{Missing}
 
@@ -907,16 +907,16 @@ end
     @test df2 ≅ DataFrame(x1_last=2, x2_last=2, x3_last=2,
                           x4_last=2)
     @test df2.x1_last isa Vector{Int}
-    @test df2.x2_last isa CategoricalVector
+    @test df2.x2_last isa CategoricalVector{Int}
     @test df2.x3_last isa Vector{Int}
-    @test df2.x4_last isa CategoricalVector
+    @test df2.x4_last isa CategoricalVector{Int}
 
     for v in [:x1, :x1 => (x -> x) => :x1]
         df2 = select(df, names(df) .=> first, v)
         @test df2 ≅ DataFrame(x1_first=1, x2_first=1, x3_first=missing,
                               x4_first=missing, x1=[1,2])
         @test df2.x1_first isa Vector{Int}
-        @test df2.x2_first isa CategoricalVector
+        @test df2.x2_first isa CategoricalVector{Int}
         @test df2.x3_first isa Vector{Missing}
         @test df2.x4_first isa Vector{Missing}
 
@@ -925,16 +925,16 @@ end
         @test df2 ≅ DataFrame(x1_last=2, x2_last=2, x3_last=2,
                               x4_last=2, x1=[1,2])
         @test df2.x1_last isa Vector{Int}
-        @test df2.x2_last isa CategoricalVector
+        @test df2.x2_last isa CategoricalVector{Int}
         @test df2.x3_last isa Vector{Int}
-        @test df2.x4_last isa CategoricalVector
+        @test df2.x4_last isa CategoricalVector{Int}
 
 
         df2 = select(df, v, names(df) .=> first)
         @test df2 ≅ DataFrame(x1=[1,2], x1_first=1, x2_first=1, x3_first=missing,
                               x4_first=missing)
         @test df2.x1_first isa Vector{Int}
-        @test df2.x2_first isa CategoricalVector
+        @test df2.x2_first isa CategoricalVector{Int}
         @test df2.x3_first isa Vector{Missing}
         @test df2.x4_first isa Vector{Missing}
 
@@ -943,15 +943,15 @@ end
         @test df2 ≅ DataFrame(x1=[1,2], x1_last=2, x2_last=2, x3_last=2,
                               x4_last=2)
         @test df2.x1_last isa Vector{Int}
-        @test df2.x2_last isa CategoricalVector
+        @test df2.x2_last isa CategoricalVector{Int}
         @test df2.x3_last isa Vector{Int}
-        @test df2.x4_last isa CategoricalVector
+        @test df2.x4_last isa CategoricalVector{Int}
     end
 
     df2 = select(df, names(df) .=> first, [] => (() -> Int[]) => :x1)
     @test size(df2) == (0, 5)
     @test df2.x1_first isa Vector{Int}
-    @test df2.x2_first isa CategoricalVector
+    @test df2.x2_first isa CategoricalVector{Int}
     @test df2.x3_first isa Vector{Missing}
     @test df2.x4_first isa Vector{Missing}
 
@@ -959,15 +959,15 @@ end
     df2 = select(df, names(df) .=> last, [] => (() -> Int[]) => :x1)
     @test size(df2) == (0, 5)
     @test df2.x1_last isa Vector{Int}
-    @test df2.x2_last isa CategoricalVector
+    @test df2.x2_last isa CategoricalVector{Int}
     @test df2.x3_last isa Vector{Int}
-    @test df2.x4_last isa CategoricalVector
+    @test df2.x4_last isa CategoricalVector{Int}
 
 
     df2 = select(df, [] => (() -> Int[]) => :x1, names(df) .=> first)
     @test size(df2) == (0, 5)
     @test df2.x1_first isa Vector{Int}
-    @test df2.x2_first isa CategoricalVector
+    @test df2.x2_first isa CategoricalVector{Int}
     @test df2.x3_first isa Vector{Missing}
     @test df2.x4_first isa Vector{Missing}
 
@@ -975,9 +975,9 @@ end
     df2 = select(df, [] => (() -> Int[]) => :x1, names(df) .=> last)
     @test size(df2) == (0, 5)
     @test df2.x1_last isa Vector{Int}
-    @test df2.x2_last isa CategoricalVector
+    @test df2.x2_last isa CategoricalVector{Int}
     @test df2.x3_last isa Vector{Int}
-    @test df2.x4_last isa CategoricalVector
+    @test df2.x4_last isa CategoricalVector{Int}
 end
 
 @testset "copycols special cases" begin


### PR DESCRIPTION
Resolves the `select` part of https://github.com/JuliaData/DataFrames.jl/issues/2162.

I have disallowed "squashing" scalars to 0-rows if vectors have 0-rows. So this is a decision to make what we should do (I disallowed it as later allowing it would be non-breaking).

BTW `DataFrame` and `insertcols!` are currently inconsistent here (`DataFrame` does not allow squashing and `insertcols!` allows it). We should decide what should be the target functionality and make it consistent across these three use cases (and `combine` in the future)