### PR TITLE
[BREAKING] add groupcols and valuecols functions

### DIFF
--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -23,8 +23,8 @@ by
 combine
 groupby
 groupindices
-groupvars
-valuevars
+groupcols
+valuecols
 keys
 get
 map

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -24,6 +24,7 @@ combine
 groupby
 groupindices
 groupvars
+valuevars
 keys
 get
 map

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -41,7 +41,7 @@ export AbstractDataFrame,
        flatten,
        groupby,
        groupindices,
-       groupvars,
+       groupcols,
        innerjoin,
        insertcols!,
        leftjoin,
@@ -62,7 +62,7 @@ export AbstractDataFrame,
        transform!,
        unique!,
        unstack,
-       valuevars
+       valuecols
 
 if VERSION >= v"1.1.0-DEV.792"
     import Base.eachcol, Base.eachrow

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -59,7 +59,8 @@ export AbstractDataFrame,
        semijoin,
        stack,
        unique!,
-       unstack
+       unstack,
+       valuevars
 
 if VERSION >= v"1.1.0-DEV.792"
     import Base.eachcol, Base.eachrow

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -355,3 +355,5 @@ function by(d::AbstractDataFrame, cols::Any; sort::Bool=false, skipmissing::Bool
                  " use `by(gd, cols, source_cols => fun => :target_col, ...)` instead", :by)
     return combine(groupby(d, cols, sort=sort, skipmissing=skipmissing); f...)
 end
+
+@deprecate groupvars(gd::GroupedDataFrame) groupcols(gd)

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -119,6 +119,14 @@ Return a vector of column names in `parent(gd)` used for grouping.
 """
 groupvars(gd::GroupedDataFrame) = _names(gd)[gd.cols]
 
+"""
+    valuevars(gd::GroupedDataFrame)
+
+Return a vector of column names in `parent(gd)` not used for grouping.
+"""
+groupvars(gd::GroupedDataFrame) = _names(gd)[Not(gd.cols)]
+
+
 # Get grouping variable index by its name
 function _groupvar_idx(gd::GroupedDataFrame, name::Symbol, strict::Bool)
     i = findfirst(==(name), groupvars(gd))

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -124,7 +124,7 @@ groupvars(gd::GroupedDataFrame) = _names(gd)[gd.cols]
 
 Return a vector of column names in `parent(gd)` not used for grouping.
 """
-groupvars(gd::GroupedDataFrame) = _names(gd)[Not(gd.cols)]
+valuevars(gd::GroupedDataFrame) = _names(gd)[Not(gd.cols)]
 
 
 # Get grouping variable index by its name

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -113,23 +113,23 @@ passed when creating `gd`, or if `gd` is a subset from a larger [`GroupedDataFra
 groupindices(gd::GroupedDataFrame) = replace(gd.groups, 0=>missing)
 
 """
-    groupvars(gd::GroupedDataFrame)
+    groupcols(gd::GroupedDataFrame)
 
 Return a vector of column names in `parent(gd)` used for grouping.
 """
-groupvars(gd::GroupedDataFrame) = _names(gd)[gd.cols]
+groupcols(gd::GroupedDataFrame) = _names(gd)[gd.cols]
 
 """
-    valuevars(gd::GroupedDataFrame)
+    valuecols(gd::GroupedDataFrame)
 
 Return a vector of column names in `parent(gd)` not used for grouping.
 """
-valuevars(gd::GroupedDataFrame) = _names(gd)[Not(gd.cols)]
+valuecols(gd::GroupedDataFrame) = _names(gd)[Not(gd.cols)]
 
 
 # Get grouping variable index by its name
 function _groupvar_idx(gd::GroupedDataFrame, name::Symbol, strict::Bool)
-    i = findfirst(==(name), groupvars(gd))
+    i = findfirst(==(name), groupcols(gd))
     i === nothing && strict && throw(ArgumentError("$name is not a grouping column"))
     return i
 end
@@ -226,10 +226,10 @@ end
 
 Base.parent(key::GroupKey) = getfield(key, :parent)
 Base.length(key::GroupKey) = length(parent(key).cols)
-Base.keys(key::GroupKey) = Tuple(groupvars(parent(key)))
-Base.haskey(key::GroupKey, idx::Symbol) = idx in groupvars(parent(key))
+Base.keys(key::GroupKey) = Tuple(groupcols(parent(key)))
+Base.haskey(key::GroupKey, idx::Symbol) = idx in groupcols(parent(key))
 Base.haskey(key::GroupKey, idx::Union{Signed,Unsigned}) = 1 <= idx <= length(key)
-Base.names(key::GroupKey) = groupvars(parent(key))
+Base.names(key::GroupKey) = groupcols(parent(key))
 # Private fields are never exposed since they can conflict with column names
 Base.propertynames(key::GroupKey, private::Bool=false) = keys(key)
 Base.values(key::GroupKey) = Tuple(_groupvalues(parent(key), getfield(key, :idx)))
@@ -255,7 +255,7 @@ function Base.getproperty(key::GroupKey, p::Symbol)
 end
 
 function Base.NamedTuple(key::GroupKey)
-    N = NamedTuple{Tuple(groupvars(parent(key)))}
+    N = NamedTuple{Tuple(groupcols(parent(key)))}
     N(_groupvalues(parent(key), getfield(key, :idx)))
 end
 Base.Tuple(key::GroupKey) = values(key)

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -3,7 +3,7 @@ function Base.summary(io::IO, gd::GroupedDataFrame)
     keystr = length(gd.cols) > 1 ? "keys" : "key"
     groupstr = N == 1 ? "group" : "groups"
     print(io, "$(typeof(gd).name) with $N $groupstr based on $keystr: ")
-    join(io, groupvars(gd), ", ")
+    join(io, groupcols(gd), ", ")
 end
 
 function Base.show(io::IO, gd::GroupedDataFrame;

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -563,7 +563,7 @@ function combine_helper(f, gd::GroupedDataFrame,
     if length(gd) > 0
         idx, valscat = _combine(f, gd, nms)
         keepkeys || return valscat
-        keys = groupvars(gd)
+        keys = groupcols(gd)
         for key in keys
             if hasproperty(valscat, key) &&
                !isequal(valscat[!, key], view(parent(gd)[!, key], idx))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1281,53 +1281,53 @@ end
     @test eltype.(eachcol(DataFrame(gd))) == [Union{Missing, Symbol}, Int]
 end
 
-@testset "groupindices, groupvars, and valuevars" begin
+@testset "groupindices, groupcols, and valuecols" begin
     df = DataFrame(A = [missing, :A, :B, :A, :B, missing], B = 1:6)
     gd = groupby_checked(df, :A)
     @inferred groupindices(gd)
     @test groupindices(gd) == [1, 2, 3, 2, 3, 1]
-    @test groupvars(gd) == [:A]
-    @test valuevars(gd) == [:B]
+    @test groupcols(gd) == [:A]
+    @test valuecols(gd) == [:B]
     gd2 = gd[[3,2]]
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 2, 1, 2, 1, missing]
-    @test groupvars(gd2) == [:A]
-    @test valuevars(gd2) == [:B]
+    @test groupcols(gd2) == [:A]
+    @test valuecols(gd2) == [:B]
 
     gd = groupby_checked(df, :A, skipmissing=true)
     @inferred groupindices(gd)
     @test groupindices(gd) ≅ [missing, 1, 2, 1, 2, missing]
-    @test groupvars(gd) == [:A]
-    @test valuevars(gd) == [:B]
+    @test groupcols(gd) == [:A]
+    @test valuecols(gd) == [:B]
     gd2 = gd[[2,1]]
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 2, 1, 2, 1, missing]
-    @test groupvars(gd2) == [:A]
-    @test valuevars(gd2) == [:B]
+    @test groupcols(gd2) == [:A]
+    @test valuecols(gd2) == [:B]
 
     df2 = DataFrame(A = vcat(df.A, df.A), B = repeat([:X, :Y], inner=6), C = 1:12)
 
     gd = groupby_checked(df2, [:A, :B])
     @inferred groupindices(gd)
     @test groupindices(gd) == [1, 2, 3, 2, 3, 1, 4, 5, 6, 5, 6, 4]
-    @test groupvars(gd) == [:A, :B]
-    @test valuevars(gd) == [:C]
+    @test groupcols(gd) == [:A, :B]
+    @test valuecols(gd) == [:C]
     gd2 = gd[[3,2,5]]
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 2, 1, 2, 1, missing, missing, 3, missing, 3, missing, missing]
-    @test groupvars(gd2) == [:A, :B]
-    @test valuevars(gd) == [:C]
+    @test groupcols(gd2) == [:A, :B]
+    @test valuecols(gd) == [:C]
 
     gd = groupby_checked(df2, [:A, :B], skipmissing=true)
     @inferred groupindices(gd)
     @test groupindices(gd) ≅ [missing, 1, 2, 1, 2, missing, missing, 3, 4, 3, 4, missing]
-    @test groupvars(gd) == [:A, :B]
-    @test valuevars(gd) == [:C]
+    @test groupcols(gd) == [:A, :B]
+    @test valuecols(gd) == [:C]
     gd2 = gd[[4,2,1]]
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 3, 2, 3, 2, missing, missing, missing, 1, missing, 1, missing]
-    @test groupvars(gd2) == [:A, :B]
-    @test valuevars(gd) == [:C]
+    @test groupcols(gd2) == [:A, :B]
+    @test valuecols(gd) == [:C]
 end
 
 @testset "by skipmissing and sort" begin
@@ -1341,23 +1341,23 @@ end
 @testset "non standard cols arguments" begin
     df = DataFrame(x1=Int64[1,2,2], x2=Int64[1,1,2], y=Int64[1,2,3])
     gdf = groupby_checked(df, r"x")
-    @test groupvars(gdf) == [:x1, :x2]
-    @test valuevars(gdf) == [:y]
+    @test groupcols(gdf) == [:x1, :x2]
+    @test valuecols(gdf) == [:y]
     @test groupindices(gdf) == [1,2,3]
 
     gdf = groupby_checked(df, Not(r"x"))
-    @test groupvars(gdf) == [:y]
-    @test valuevars(gdf) == [:x1, :x2]
+    @test groupcols(gdf) == [:y]
+    @test valuecols(gdf) == [:x1, :x2]
     @test groupindices(gdf) == [1,2,3]
 
     gdf = groupby_checked(df, [])
-    @test groupvars(gdf) == []
-    @test valuevars(gdf) == [:x1, :x2, :y]
+    @test groupcols(gdf) == []
+    @test valuecols(gdf) == [:x1, :x2, :y]
     @test groupindices(gdf) == [1,1,1]
 
     gdf = groupby_checked(df, r"z")
-    @test groupvars(gdf) == []
-    @test valuevars(gdf) == [:x1, :x2, :y]
+    @test groupcols(gdf) == []
+    @test valuecols(gdf) == [:x1, :x2, :y]
     @test groupindices(gdf) == [1,1,1]
 
     @test by(df, [], :x1 => sum => :a, :x2=>length => :b) == DataFrame(a=5, b=3)
@@ -1631,8 +1631,8 @@ end
     gd = groupby_checked(df, [:a, :b])
 
     @test names(gd) == names(df)
-    @test groupvars(gd) == [:a, :b]
-    @test valuevars(gd) == [:c]
+    @test groupcols(gd) == [:a, :b]
+    @test valuecols(gd) == [:c]
     @test map(NamedTuple, keys(gd)) ≅
         [(a=:A, b=:X), (a=:B, b=:X), (a=missing, b=:X), (a=:A, b=:Y), (a=:B, b=:Y), (a=missing, b=:Y)]
     @test gd[(a=:A, b=:X)] ≅ gd[1]
@@ -1643,8 +1643,8 @@ end
     rename!(df, [:d, :e, :f])
 
     @test names(gd) == names(df)
-    @test groupvars(gd) == [:d, :e]
-    @test valuevars(gd) == [:f]
+    @test groupcols(gd) == [:d, :e]
+    @test valuecols(gd) == [:f]
     @test map(NamedTuple, keys(gd)) ≅
         [(d=:A, e=:X), (d=:B, e=:X), (d=missing, e=:X), (d=:A, e=:Y), (d=:B, e=:Y), (d=missing, e=:Y)]
     @test gd[(d=:A, e=:X)] ≅ gd[1]

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1256,25 +1256,29 @@ end
     @test eltype.(eachcol(DataFrame(gd))) == [Union{Missing, Symbol}, Int]
 end
 
-@testset "groupindices and groupvars" begin
+@testset "groupindices, groupvars, and valuevars" begin
     df = DataFrame(A = [missing, :A, :B, :A, :B, missing], B = 1:6)
     gd = groupby_checked(df, :A)
     @inferred groupindices(gd)
     @test groupindices(gd) == [1, 2, 3, 2, 3, 1]
     @test groupvars(gd) == [:A]
+    @test valuevars(gd) == [:B]
     gd2 = gd[[3,2]]
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 2, 1, 2, 1, missing]
     @test groupvars(gd2) == [:A]
+    @test valuevars(gd2) == [:B]
 
     gd = groupby_checked(df, :A, skipmissing=true)
     @inferred groupindices(gd)
     @test groupindices(gd) ≅ [missing, 1, 2, 1, 2, missing]
     @test groupvars(gd) == [:A]
+    @test valuevars(gd) == [:B]
     gd2 = gd[[2,1]]
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 2, 1, 2, 1, missing]
     @test groupvars(gd2) == [:A]
+    @test valuevars(gd2) == [:B]
 
     df2 = DataFrame(A = vcat(df.A, df.A), B = repeat([:X, :Y], inner=6), C = 1:12)
 
@@ -1282,19 +1286,23 @@ end
     @inferred groupindices(gd)
     @test groupindices(gd) == [1, 2, 3, 2, 3, 1, 4, 5, 6, 5, 6, 4]
     @test groupvars(gd) == [:A, :B]
+    @test valuevars(gd) == [:C]
     gd2 = gd[[3,2,5]]
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 2, 1, 2, 1, missing, missing, 3, missing, 3, missing, missing]
     @test groupvars(gd2) == [:A, :B]
+    @test valuevars(gd) == [:C]
 
     gd = groupby_checked(df2, [:A, :B], skipmissing=true)
     @inferred groupindices(gd)
     @test groupindices(gd) ≅ [missing, 1, 2, 1, 2, missing, missing, 3, 4, 3, 4, missing]
     @test groupvars(gd) == [:A, :B]
+    @test valuevars(gd) == [:C]
     gd2 = gd[[4,2,1]]
     @inferred groupindices(gd2)
     @test groupindices(gd2) ≅ [missing, 3, 2, 3, 2, missing, missing, missing, 1, missing, 1, missing]
     @test groupvars(gd2) == [:A, :B]
+    @test valuevars(gd) == [:C]
 end
 
 @testset "by skipmissing and sort" begin
@@ -1309,18 +1317,22 @@ end
     df = DataFrame(x1=Int64[1,2,2], x2=Int64[1,1,2], y=Int64[1,2,3])
     gdf = groupby_checked(df, r"x")
     @test groupvars(gdf) == [:x1, :x2]
+    @test valuevars(gdf) == [:y]
     @test groupindices(gdf) == [1,2,3]
 
     gdf = groupby_checked(df, Not(r"x"))
     @test groupvars(gdf) == [:y]
+    @test valuevars(gdf) == [:x1, :x2]
     @test groupindices(gdf) == [1,2,3]
 
     gdf = groupby_checked(df, [])
     @test groupvars(gdf) == []
+    @test valuevars(gdf) == [:x1, :x2, :y]
     @test groupindices(gdf) == [1,1,1]
 
     gdf = groupby_checked(df, r"z")
     @test groupvars(gdf) == []
+    @test valuevars(gdf) == [:x1, :x2, :y]
     @test groupindices(gdf) == [1,1,1]
 
     @test by(df, [], a=:x1=>sum, b=:x2=>length) == DataFrame(a=5, b=3)
@@ -1590,6 +1602,7 @@ end
 
     @test names(gd) == names(df)
     @test groupvars(gd) == [:a, :b]
+    @test valuevars(gd) == [:c]
     @test map(NamedTuple, keys(gd)) ≅
         [(a=:A, b=:X), (a=:B, b=:X), (a=missing, b=:X), (a=:A, b=:Y), (a=:B, b=:Y), (a=missing, b=:Y)]
     @test gd[(a=:A, b=:X)] ≅ gd[1]
@@ -1601,6 +1614,7 @@ end
 
     @test names(gd) == names(df)
     @test groupvars(gd) == [:d, :e]
+    @test valuevars(gd) == [:f]
     @test map(NamedTuple, keys(gd)) ≅
         [(d=:A, e=:X), (d=:B, e=:X), (d=missing, e=:X), (d=:A, e=:Y), (d=:B, e=:Y), (d=missing, e=:Y)]
     @test gd[(d=:A, e=:X)] ≅ gd[1]


### PR DESCRIPTION
`valuevars` function will be a useful complement to `groupvars` function.

If we have it we can actually deprecate `aggregate` already now, as then:
```
aggregate(df, :a, sum)
```
becomes
```
combine(gdf, valuevars(gdf) .=> sum)
```

@nalimilan In particular that adding broadcasting of `All` will not allow to deprecate `aggregate` as `All()` would include grouping columns which are skipped by `aggregate`.

If you think that some other name would be better please comment.