### PR TITLE
add nrow to select

### DIFF
--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -47,6 +47,13 @@ normalize_selection(idx::AbstractIndex, sel) =
         end
     end
 
+
+normalize_selection(idx::AbstractIndex, sel::Pair{typeof(nrow), Symbol}) =
+    length(idx) == 0 ? (Int[] => (() -> 0) => last(sel)) : (1 => length => last(sel))
+
+normalize_selection(idx::AbstractIndex, sel::typeof(nrow)) =
+    normalize_selection(idx, nrow => :nrow)
+
 function normalize_selection(idx::AbstractIndex, sel::ColumnIndex)
     c = idx[sel]
     return c => ColRename() => _names(idx)[c]
@@ -198,6 +205,10 @@ using `_`; if more than three columns are passed then the name consists of the
 first two names and `etc` suffix then, e.g. `[:a,:b,:c,:d] => fun` produces
 the new column name `:a_b_etc_fun`.
 
+As a special rule passing `nrow` as an argument creates a column named `:nrow`
+containing a number of rows in a source data frame, and passing `nrow => new_column_name`
+stores a number of rows in a source data frame in `new_column_name` column.
+
 If a collection of column names is passed to `select!` then requesting duplicate column
 names in target data frame are accepted (e.g. `select!(df, [:a], :, r"a")` is allowed)
 and only the first occurrence is used. In particular a syntax to move column `:col`
@@ -337,6 +348,10 @@ Up to three column names are used for multiple input columns and they are joined
 using `_`; if more than three columns are passed then the name consists of the
 first two names and `etc` suffix then, e.g. `[:a,:b,:c,:d] => fun` produces
 the new column name `:a_b_etc_fun`.
+
+As a special rule passing `nrow` as an argument creates a column named `:nrow`
+containing a number of rows in a source data frame, and passing `nrow => new_column_name`
+stores a number of rows in a source data frame in `new_column_name` column.
 
 If a collection of column names is passed to `select!` then requesting duplicate column
 names in target data frame are accepted (e.g. `select!(df, [:a], :, r"a")` is allowed)

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -205,9 +205,9 @@ using `_`; if more than three columns are passed then the name consists of the
 first two names and `etc` suffix then, e.g. `[:a,:b,:c,:d] => fun` produces
 the new column name `:a_b_etc_fun`.
 
-As a special rule passing `nrow` as an argument creates a column named `:nrow`
+As a special rule passing `nrow` without specifying `old_column` creates a column named `:nrow`
 containing a number of rows in a source data frame, and passing `nrow => new_column_name`
-stores a number of rows in a source data frame in `new_column_name` column.
+stores the number of rows in source data frame in `new_column_name` column.
 
 If a collection of column names is passed to `select!` then requesting duplicate column
 names in target data frame are accepted (e.g. `select!(df, [:a], :, r"a")` is allowed)
@@ -351,7 +351,7 @@ the new column name `:a_b_etc_fun`.
 
 As a special rule passing `nrow` as an argument creates a column named `:nrow`
 containing a number of rows in a source data frame, and passing `nrow => new_column_name`
-stores a number of rows in a source data frame in `new_column_name` column.
+stores the number of rows in source data frame in `new_column_name` column.
 
 If a collection of column names is passed to `select!` then requesting duplicate column
 names in target data frame are accepted (e.g. `select!(df, [:a], :, r"a")` is allowed)

--- a/test/select.jl
+++ b/test/select.jl
@@ -697,6 +697,15 @@ end
     @test df.x3 == x1 ./ x2
 end
 
+@testset "nrow in select" begin
+    df_ref = DataFrame(ones(3,4))
+    for df in [df_ref, view(df, 1:2, 1:2),
+               df_ref[1:2, []], view(df, 1:2, []),
+               df_ref[[], 1:2], view(df, [], 1:2)]
+        @test select(df, nrow => :z, nrow) == DataFrame(z=nrow(df), nrow=nrow(df))
+    end
+end
+
 @testset "select and select! reserved return values" begin
     df = DataFrame(x=1)
     df2 = copy(df)

--- a/test/select.jl
+++ b/test/select.jl
@@ -699,9 +699,9 @@ end
 
 @testset "nrow in select" begin
     df_ref = DataFrame(ones(3,4))
-    for df in [df_ref, view(df, 1:2, 1:2),
-               df_ref[1:2, []], view(df, 1:2, []),
-               df_ref[[], 1:2], view(df, [], 1:2)]
+    for df in [df_ref, view(df_ref, 1:2, 1:2),
+               df_ref[1:2, []], view(df_ref, 1:2, []),
+               df_ref[[], 1:2], view(df_ref, [], 1:2)]
         @test select(df, nrow => :z, nrow) == DataFrame(z=nrow(df), nrow=nrow(df))
     end
 end


### PR DESCRIPTION
Allow an easy way to get a number of rows in `select`. It was such a clean idea that I could not resist it (but maybe other people will think otherwise).

I think having this as a special case is justified.

When this is merged the full benefit will be in https://github.com/JuliaData/DataFrames.jl/pull/2158, as `nrow` is routinely required in split-apply-combine operations and now we did not have a clean and quick way to do it.