### PR TITLE
[BREAKING] add to combine and by: column selection, pseudo broadcasting, fix bug with unequal column lengths

### DIFF
--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -47,9 +47,9 @@ The kind of return value and the number and names of columns must be the same fo
 
 It is allowed to mix single values and vectors if multiple transformations
 are requested. In this case single value will be broadcasted to match the length
-of columns specified by returned vectors. In this case as a convinience values stored
-in `Ref` and 0-dimensional arrays are extracted from them.
-
+of columns specified by returned vectors. 
+As a particular rule, values wrapped in a `Ref` or a `0`-dimensional `AbstractArray`
+are unwrapped and then broadcasted.
 
 If a single value or a vector is returned by the `function` and `target_col` is not
 provided, it is generated automatically, by concatenating source column name and

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -11,22 +11,22 @@ function, which is a shorthand for `groupby` followed by `map` and/or `combine`.
 `by` takes in three arguments: (1) a `DataFrame`, (2) one or more columns to split
 the `DataFrame` on, and (3) a specification of one or more functions to apply to
 each subset of the `DataFrame`. This specification can be of the following forms:
-1. a `cols => function` pair indicating that `function` should be called with
-   positional arguments holding columns `cols`, which can be a any valid column selector
-2. a `cols => function => target_col` form additionally
-   specifying the name of the target column (this assumes that `function` returns a single value or a vector)
-3. a `col => target_col` pair, which renames the column `col` to `target_col`
-4. a `nrow` or `nrow => target_col` form which efficiently computes the number of rows in a group
-   (without `target_col` the new column is called `:nrow`)
-5. standard column selectors (integers, symbols, vectors of integers, vectors of symbols,
+1. standard column selectors (integers, symbols, vectors of integers, vectors of symbols,
    `All`, `:`, `Between`, `Not` and regular expressions)
-5. several arguments of the forms given above, or vectors thereof
-6. a function which will be called with a `SubDataFrame` corresponding to each group;
+2. a `cols => function` pair indicating that `function` should be called with
+   positional arguments holding columns `cols`, which can be a any valid column selector
+3. a `cols => function => target_col` form additionally
+   specifying the name of the target column (this assumes that `function` returns a single value or a vector)
+4. a `col => target_col` pair, which renames the column `col` to `target_col`
+5. a `nrow` or `nrow => target_col` form which efficiently computes the number of rows in a group
+   (without `target_col` the new column is called `:nrow`)
+6. several arguments of the forms given above, or vectors thereof
+7. a function which will be called with a `SubDataFrame` corresponding to each group;
    this form should be avoided due to its poor performance unless a very large
    number of columns are processed (in which case `SubDataFrame` avoids excessive
    compilation)
 
-All forms except 6 can be also passed as the first argument to `map`.
+All forms except 1 and 6 can be also passed as the first argument to `map`.
 
 In all of these cases, `function` can return either a single row or multiple rows.
 `function` can always generate a single column by returning a single value or a vector.
@@ -47,7 +47,7 @@ The kind of return value and the number and names of columns must be the same fo
 
 It is allowed to mix single values and vectors if multiple transformations
 are requested. In this case single value will be broadcasted to match the length
-of columns specified by returned vectors. 
+of columns specified by returned vectors.
 As a particular rule, values wrapped in a `Ref` or a `0`-dimensional `AbstractArray`
 are unwrapped and then broadcasted.
 

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -1186,11 +1186,11 @@ function _combine_with_first(first::Union{NamedTuple, DataFrameRow, AbstractData
     elseif first isa DataFrameRow
         n = length(gd)
         eltys = [eltype(parent(first)[!, i]) for i in parentcols(index(first))]
-    elseif firstmulticol == Val(false) && first.x1 isa Union{AbstractArray{<:Any, 0}, Ref}
+    elseif firstmulticol == Val(false) && first[1] isa Union{AbstractArray{<:Any, 0}, Ref}
         extrude_case = true
-        first = wrap_row(first.x1, firstmulticol)
+        first = wrap_row(first[1], firstmulticol)
         n = length(gd)
-        eltys = (typeof(first.x1),)
+        eltys = (typeof(first[1]),)
     else # other NamedTuple giving a single row
         n = length(gd)
         eltys = map(typeof, first)

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -1169,7 +1169,7 @@ function _combine_multicol(firstres, fun::Any, gd::GroupedDataFrame,
     else
         idx_agg = nothing
     end
-    return _combine_with_first(wrap(firstres), fun, gd, nothing,
+    return _combine_with_first(wrap(firstres), fun, gd, incols,
                                Val(firstmulticol), idx_agg)
 end
 

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -1160,7 +1160,7 @@ function _combine(p::Pair, gd::GroupedDataFrame, ::Nothing)
 end
 
 function _combine_multicol(firstres, fun::Any, gd::GroupedDataFrame,
-                        incols::Union{Nothing, AbstractVector, Tuple})
+                           incols::Union{Nothing, AbstractVector, Tuple})
     firstmulticol = firstres isa MULTI_COLS_TYPE
     if !(firstres isa Union{AbstractVecOrMat, AbstractDataFrame,
                             NamedTuple{<:Any, <:Tuple{Vararg{AbstractVector}}}})

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1909,4 +1909,15 @@ end
     @test_throws ArgumentError by(df, :g, 1, :x1 => ByRow(sin) => :x1)
 end
 
+@testset "correct dropping of groups" begin
+    df = DataFrame(g = 10:-1:1)
+
+    for keep in [[3,2,1], [5,3,1], [9], Int[]]
+        @test by(df, :g, :g => first => :keep, :g => x -> x[1] in keep ? x : Int[]) ==
+              DataFrame(g=keep, keep=keep, g_function=keep)
+        @test by(df, :g, :g => first => :keep, :g => x -> x[1] in keep ? x : Int[],
+                 sort=true) == sort(DataFrame(g=keep, keep=keep, g_function=keep))
+    end
+end
+
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1822,4 +1822,25 @@ end
     end
 end
 
+@testset "mixing of different return lengths and pseudo-broadcasting" begin
+    df = DataFrame(g=[1,1,1,2,2]);
+    f1(i) = i[1] == 1 ? ["a", "b"] : ["c"];
+    f2(i) = i[1] == 1 ? ["d"] : ["e", "f"];
+    @test_throws ArgumentError by(df, :g, :g => f1, :g => f2)
+
+    f1(i) = i[1] == 1 ? ["a"] : ["c"];
+    f2(i) = i[1] == 1 ? "d" : "e";
+    @test by(df, :g, :g => f1, :g => f2) ==
+          DataFrame(g=[1,2], g_f1=["a", "c"], g_f2 = ["d", "e"])
+
+    f1(i) = i[1] == 1 ? ["a","c"] : [];
+    f2(i) = i[1] == 1 ? "d" : "e";
+    @test by(df, :g, :g => f1, :g => f2) ==
+          DataFrame(g = [1,1], g_f1 = ["a", "c"], g_f2 = ["d", "d"])
+
+    # TODO: test unwrapping of `Ref` and 0-dimensional Array
+    # TODO: test pseudo-broadcasting
+    # TODO: test passing columns
+end
+
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -806,9 +806,12 @@ end
                         f(d -> (xyz=sum(d.b), xzz=sum(d.c)), gd)
                     @test f(gd, cols2[1] => sum => :xyz, cols2[1] => sum => :xzz) ==
                         f(d -> (xyz=sum(d.b), xzz=sum(d.b)), gd)
-                    @test f(gd, cols2[1] => sum => :xyz, cols2[2] => (x -> first(x)) => :xzz) ==
+                    @test f(gd, cols2[1] => sum => :xyz,
+                            cols2[2] => (x -> first(x)) => :xzz) ==
                         f(d -> (xyz=sum(d.b), xzz=first(d.c)), gd)
-                    @test_throws ArgumentError f(gd, cols2[1] => vexp => :xyz, cols2[2] => sum => :xzz)
+                    @test f(gd, cols2[1] => vexp => :xyz,
+                            cols2[2] => sum => :xzz) ==
+                        f(d -> (xyz=vexp(d.b), xzz=fill(sum(d.c), length(vexp(d.b)))), gd)
                 end
             end
 
@@ -1837,6 +1840,9 @@ end
     f2(i) = i[1] == 1 ? "d" : "e";
     @test by(df, :g, :g => f1, :g => f2) ==
           DataFrame(g = [1,1], g_f1 = ["a", "c"], g_f2 = ["d", "d"])
+
+    @test by(df, :g, :g => Ref) == DataFrame(g=[1,2], g_Ref=[[1,1,1], [2,2]])
+    @test by(df, :g, :g => x -> view([x],1)) == DataFrame(g=[1,2], g_function=[[1,1,1], [2,2]])
 
     # TODO: test unwrapping of `Ref` and 0-dimensional Array
     # TODO: test pseudo-broadcasting

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1855,6 +1855,7 @@ end
     df_ref.g = shuffle!([1,2,2,3,3,3,4,4,4,4])
 
     for i in 0:nrow(df_ref), dosort in [true, false], dokeepkeys in [true, false]
+        df = df_ref[1:i, :]
         @test by(df, :g, :x1 => sum => :x1, :x2 => identity => :x2,
                  :x3 => (x -> Ref(sum(x))) => :x3, nrow, :x4 => ByRow(sin) => :x4,
                  sort=dosort, keepkeys=dokeepkeys) ==


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2166

I still need to update the documentation and tests, but all from #2166 is implemented here.

One comment is that we treat `NamedTuple` as-is (i.e. we do not unpack `NamedTuples` when pseudo-broadcasting)