### PR TITLE
add cols to names

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -69,7 +69,7 @@ abstract type AbstractDataFrame end
 
     If `cols` column selector argument is passed then restrict returned
     column names to those matching the selector
-    (this is useful with regular expressions, `All`, `Not`, ad `Between`).
+    (this is useful with regular expressions, `All`, `Not`, and `Between`).
 """
 Base.names(df::AbstractDataFrame) = names(index(df))
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -67,9 +67,9 @@ abstract type AbstractDataFrame end
 
     Return a `Vector{Symbol}` of names of columns contained in `df`.
 
-    If `cols` column selector argument is passed then restrict returned
+    If a `cols` column selector is passed then restrict returned
     column names to those matching the selector
-    (this is useful with regular expressions, `All`, `Not`, and `Between`).
+    (this is useful in particular with regular expressions, `Not`, and `Between`).
 """
 Base.names(df::AbstractDataFrame) = names(index(df))
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -63,10 +63,21 @@ abstract type AbstractDataFrame end
 
 """
     names(df::AbstractDataFrame)
+    names(df::AbstractDataFrame, cols)
 
     Return a `Vector{Symbol}` of names of columns contained in `df`.
+
+    If `cols` column selector argument is passed then restrict returned
+    column names to those matching the selector
+    (this is useful with regular expressions, `All`, `Not`, ad `Between`).
 """
 Base.names(df::AbstractDataFrame) = names(index(df))
+
+function Base.names(df::AbstractDataFrame, cols)
+    sel = index(df)[cols]
+    return _names(index(df))[sel isa Int ? (sel:sel) : sel]
+end
+
 _names(df::AbstractDataFrame) = _names(index(df))
 
 Compat.hasproperty(df::AbstractDataFrame, s::Symbol) = haskey(index(df), s)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -134,7 +134,13 @@ Base.@propagate_inbounds Base.setindex!(r::DataFrameRow, value, idx) =
 
 index(r::DataFrameRow) = getfield(r, :colindex)
 
-Base.names(r::DataFrameRow) = _names(parent(r))[parentcols(index(r), :)]
+Base.names(r::DataFrameRow) = names(index(r))
+
+function Base.names(r::DataFrameRow, cols)
+    sel = index(r)[cols]
+    return _names(index(r))[sel isa Int ? (sel:sel) : sel]
+end
+
 _names(r::DataFrameRow) = view(_names(parent(r)), parentcols(index(r), :))
 
 Base.haskey(r::DataFrameRow, key::Bool) =

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -76,6 +76,7 @@ function Base.isequal(gd1::GroupedDataFrame, gd2::GroupedDataFrame)
 end
 
 Base.names(gd::GroupedDataFrame) = names(gd.parent)
+Base.names(gd::GroupedDataFrame, cols) = names(gd.parent, cols)
 _names(gd::GroupedDataFrame) = _names(gd.parent)
 
 function DataFrame(gd::GroupedDataFrame; copycols::Bool=true)

--- a/test/data.jl
+++ b/test/data.jl
@@ -405,4 +405,22 @@ end
     @test_throws TypeError filter!((:) => (r...) -> r[1] > 1, df)
 end
 
+@testset "names with cols" begin
+    df = DataFrame(a = 1, x1 = 2, x2 = 3, x3 = 4, x4 = 5)
+
+    for v in [df, groupby(df, :a)]
+        @test names(v, All()) == names(v, :) == names(v) == [:a, :x1, :x2, :x3, :x4]
+        @test names(v, Between(:x1, :x3)) == [:x1, :x2, :x3]
+        @test names(v, Not(:a)) == names(v, r"x") == [:x1, :x2, :x3, :x4]
+        @test names(v, :x1) == names(v, 2) == [:x1]
+    end
+
+    for v in [view(df, :, [4,3,2,1]), groupby(view(df, :, [4,3,2,1]), 1), view(df, 1, [4,3,2,1])]
+        @test names(v, All()) == names(v, :) == names(v) ==  [:x3, :x2, :x1, :a]
+        @test names(v, Between(:x2, :x1)) == [:x2, :x1]
+        @test names(v, Not(:a)) == names(v, r"x") == [:x3, :x2, :x1]
+        @test names(v, :x1) == names(v, 3) == [:x1]
+    end
+end
+
 end # module


### PR DESCRIPTION
allow `cols` argument to `names` so that it is easy to use any valid selector in `select` and `combine` when broadcasting.