### PR TITLE
Port to CategoricalArrays 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ test = ["DataStructures", "DataValues", "Dates", "Logging", "Random", "Test"]
 
 [compat]
 julia = "1"
-CategoricalArrays = "0.7"
+CategoricalArrays = "0.8"
 Compat = "2.2, 3"
 DataAPI = "1.0.1"
 InvertedIndices = "1"

--- a/docs/src/man/categorical.md
+++ b/docs/src/man/categorical.md
@@ -32,7 +32,7 @@ julia> cv = CategoricalArray(v)
 
 ```
 
-`CategoricalArrays` support missing values.
+`CategoricalArray`s support missing values.
 
 ```jldoctest categorical
 julia> cv = CategoricalArray(["Group A", missing, "Group A",
@@ -96,10 +96,10 @@ julia> cv = compress(cv)
 ```
 
 Instead of using the `CategoricalArray` constructor directly you can use `categorical`
-function. It additionally accepts one positional argument `compress` which when set to `true`
+function. It additionally accepts a keyword argument `compress` which when set to `true`
 is equivalent to calling `compress` on the new vector:
 ```jldoctest categorical
-julia> cv1 = categorical(["A", "B"], true)
+julia> cv1 = categorical(["A", "B"], compress=true)
 2-element CategoricalArray{String,1,UInt8}:
  "A"
  "B"
@@ -108,7 +108,7 @@ julia> cv1 = categorical(["A", "B"], true)
 If the `ordered` keyword argument is set to `true`, the resulting `CategoricalArray` will be
 ordered, which means that its levels can be tested for order (rather than throwing an error):
 ```jldoctest categorical
-julia> cv2 = categorical(["A", "B"], true, ordered=true)
+julia> cv2 = categorical(["A", "B"], ordered=true)
 2-element CategoricalArray{String,1,UInt8}:
  "A"
  "B"
@@ -191,8 +191,8 @@ julia> categorical!(df, compress=true)
 
 julia> eltype.(eachcol(df))
 2-element Array{DataType,1}:
- CategoricalString{UInt8}
- CategoricalString{UInt8}
+ CategoricalValue{String,UInt8}
+ CategoricalValue{String,UInt8}
 
 ```
 

--- a/docs/src/man/categorical.md
+++ b/docs/src/man/categorical.md
@@ -109,7 +109,7 @@ If the `ordered` keyword argument is set to `true`, the resulting `CategoricalAr
 ordered, which means that its levels can be tested for order (rather than throwing an error):
 ```jldoctest categorical
 julia> cv2 = categorical(["A", "B"], ordered=true)
-2-element CategoricalArray{String,1,UInt8}:
+2-element CategoricalArray{String,1,UInt32}:
  "A"
  "B"
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -719,16 +719,13 @@ function completecases(df::AbstractDataFrame, col::Colon=:)
     end
     res = trues(size(df, 1))
     for i in 1:size(df, 2)
-        _nonmissing!(res, df[!, i])
+        res .&= .!ismissing.(df[!, i])
     end
     res
 end
 
-function completecases(df::AbstractDataFrame, col::ColumnIndex)
-    res = trues(size(df, 1))
-    _nonmissing!(res, df[!, col])
-    res
-end
+completecases(df::AbstractDataFrame, col::ColumnIndex) =
+    .!ismissing.(df[!, col])
 
 completecases(df::AbstractDataFrame, cols::Union{AbstractVector, Regex, Not, Between, All}) =
     completecases(df[!, cols])
@@ -1719,7 +1716,7 @@ function CategoricalArrays.categorical(df::AbstractDataFrame,
         x = df[!, i]
         if i in idxcols
             # categorical always copies
-            push!(newcols, categorical(x, compress))
+            push!(newcols, categorical(x, compress=compress))
         else
             push!(newcols, copy(x))
         end
@@ -1735,7 +1732,7 @@ function CategoricalArrays.categorical(df::AbstractDataFrame,
         x = df[!, i]
         if eltype(x) <: cols
             # categorical always copies
-            push!(newcols, categorical(x, compress))
+            push!(newcols, categorical(x, compress=compress))
         else
             push!(newcols, copy(x))
         end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -645,21 +645,6 @@ end
 ##
 ##############################################################################
 
-function _nonmissing!(res, col)
-    @inbounds for (i, el) in enumerate(col)
-        res[i] &= !ismissing(el)
-    end
-    return nothing
-end
-
-function _nonmissing!(res, col::CategoricalArray{>: Missing})
-    for (i, el) in enumerate(col.refs)
-        res[i] &= el > 0
-    end
-    return nothing
-end
-
-
 """
     completecases(df::AbstractDataFrame, cols::Colon=:)
     completecases(df::AbstractDataFrame, cols::Union{AbstractVector, Regex, Not, Between, All})

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -1,7 +1,7 @@
 """
     stack(df::AbstractDataFrame, [measure_vars], [id_vars];
           variable_name::Symbol=:variable, value_name::Symbol=:value,
-          view::Bool=false, variable_eltype::Type=CategoricalString)
+          view::Bool=false, variable_eltype::Type=CategoricalValue{String})
 
 Stack a data frame `df`, i.e. convert it from wide to long format.
 
@@ -57,7 +57,7 @@ function stack(df::AbstractDataFrame,
                id_vars = Not(measure_vars);
                variable_name::Symbol=:variable,
                value_name::Symbol=:value, view::Bool=false,
-               variable_eltype::Type=CategoricalString)
+               variable_eltype::Type=CategoricalValue{String})
     # getindex from index returns either Int or AbstractVector{Int}
     mv_tmp = index(df)[measure_vars]
     ints_measure_vars = mv_tmp isa Int ? [mv_tmp] : mv_tmp
@@ -71,7 +71,7 @@ function stack(df::AbstractDataFrame,
     cnames = _names(df)[ints_id_vars]
     push!(cnames, variable_name)
     push!(cnames, value_name)
-    if variable_eltype <: CategoricalString
+    if variable_eltype <: CategoricalValue{String}
         nms = String.(_names(df)[ints_measure_vars])
         catnms = categorical(nms)
         levels!(catnms, nms)
@@ -80,7 +80,7 @@ function stack(df::AbstractDataFrame,
     elseif variable_eltype === String
         catnms = PooledArray(String.(_names(df)[ints_measure_vars]))
     else
-        throw(ArgumentError("`variable_eltype` keyword argument accepts only `CategoricalString`, " *
+        throw(ArgumentError("`variable_eltype` keyword argument accepts only `CategoricalValue{String}`, " *
                             "`String` or `Symbol` as a value."))
     end
     return DataFrame(AbstractVector[[repeat(df[!, c], outer=N) for c in ints_id_vars]..., # id_var columns
@@ -96,7 +96,7 @@ function _stackview(df::AbstractDataFrame, measure_vars::AbstractVector{Int},
     cnames = _names(df)[id_vars]
     push!(cnames, variable_name)
     push!(cnames, value_name)
-    if variable_eltype <: CategoricalString
+    if variable_eltype <: CategoricalValue{String}
         nms = String.(_names(df)[measure_vars])
         catnms = categorical(nms)
         levels!(catnms, nms)
@@ -105,7 +105,7 @@ function _stackview(df::AbstractDataFrame, measure_vars::AbstractVector{Int},
     elseif variable_eltype <: String
         catnms = String.(_names(df)[measure_vars])
     else
-        throw(ArgumentError("`variable_eltype` keyword argument accepts only `CategoricalString`, " *
+        throw(ArgumentError("`variable_eltype` keyword argument accepts only `CategoricalValue{String}`, " *
                             "`String` or `Symbol` as a value."))
     end
     return DataFrame(AbstractVector[[RepeatedVector(df[!, c], 1, N) for c in id_vars]..., # id_var columns
@@ -180,8 +180,6 @@ function _unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int,
     mask_filled = falses(Nrow+1, Ncol) # has a given [row,col] entry been filled?
     warned_dup = false # have we already printed duplicate entries warning?
     warned_missing = false # have we already printed missing in keycol warning?
-    keycol_order = Vector{Int}(CategoricalArrays.order(keycol.pool))
-    refkeycol_order = Vector{Int}(CategoricalArrays.order(refkeycol.pool))
     for k in 1:nrow(df)
         kref = keycol.refs[k]
         if kref <= 0 # we have found missing in colkey
@@ -191,7 +189,6 @@ function _unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int,
             end
             continue # skip processing it
         end
-        j = keycol_order[kref]
         refkref = refkeycol.refs[k]
         if refkref <= 0 # we have found missing in rowkey
             if !hadmissing # if it is the first time we have to add a new row
@@ -203,15 +200,15 @@ function _unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int,
             end
             i = length(unstacked_val[1])
         else
-            i = refkeycol_order[refkref]
+            i = refkref
         end
-        if !warned_dup && mask_filled[i, j]
+        if !warned_dup && mask_filled[i, kref]
             @warn("Duplicate entries in unstack at row $k for key "*
                   "$(refkeycol[k]) and variable $(keycol[k]).")
             warned_dup = true
         end
-        unstacked_val[j][i] = valuecol[k]
-        mask_filled[i, j] = true
+        unstacked_val[kref][i] = valuecol[k]
+        mask_filled[i, kref] = true
     end
     levs = levels(refkeycol)
     # we have to handle a case with missings in refkeycol as levs will skip missing
@@ -262,7 +259,6 @@ function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Int},
     mask_filled = falses(Nrow, Ncol)
     warned_dup = false
     warned_missing = false
-    keycol_order = Vector{Int}(CategoricalArrays.order(keycol.pool))
     for k in 1:nrow(df)
         kref = keycol.refs[k]
         if kref <= 0
@@ -272,15 +268,14 @@ function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Int},
             end
             continue
         end
-        j = keycol_order[kref]
         i = rowkey[k]
-        if !warned_dup && mask_filled[i, j]
+        if !warned_dup && mask_filled[i, kref]
             @warn("Duplicate entries in unstack at row $k for key "*
                  "$(tuple((df[k,s] for s in rowkeys)...)) and variable $(keycol[k]).")
             warned_dup = true
         end
-        unstacked_val[j][i] = valuecol[k]
-        mask_filled[i, j] = true
+        unstacked_val[kref][i] = valuecol[k]
+        mask_filled[i, kref] = true
     end
     df2 = DataFrame(unstacked_val, Symbol.(renamecols.(levels(keycol))), copycols=false)
     hcat(df1, df2, copycols=false)
@@ -375,8 +370,7 @@ end
 
 Base.parent(v::RepeatedVector) = v.parent
 DataAPI.levels(v::RepeatedVector) = levels(parent(v))
-CategoricalArrays.isordered(v::RepeatedVector{<:Union{CategoricalValue, CategoricalString,
-                                                      Missing}}) =
+CategoricalArrays.isordered(v::RepeatedVector{<:Union{CategoricalValue, Missing}}) =
     isordered(parent(v))
 
 function Base.getindex(v::RepeatedVector, i::Int)
@@ -394,7 +388,7 @@ Base.similar(v::RepeatedVector, T::Type, dims::Dims) = similar(parent(v), T, dim
 Base.unique(v::RepeatedVector) = unique(parent(v))
 
 function CategoricalArrays.CategoricalArray(v::RepeatedVector)
-    res = CategoricalArray(parent(v))
+    res = CategoricalArray(parent(v), levels=levels(parent(v)))
     res.refs = repeat(res.refs, inner = [v.inner], outer = [v.outer])
     res
 end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -172,7 +172,8 @@ function unstack(df::AbstractDataFrame, rowkey::ColumnIndex, colkey::ColumnIndex
 end
 
 function _unstack(df::AbstractDataFrame, rowkey::Int, colkey::Int,
-                  keycol, valuecol, refkeycol, renamecols::Function)
+                  keycol::CategoricalVector, valuecol::AbstractVector,
+                  refkeycol::CategoricalVector, renamecols::Function)
     Nrow = length(refkeycol.pool)
     Ncol = length(keycol.pool)
     unstacked_val = [similar_missing(valuecol, Nrow) for i in 1:Ncol]
@@ -245,7 +246,9 @@ unstack(df::AbstractDataFrame; renamecols::Function=identity) =
     unstack(df, :variable, :value, renamecols=renamecols)
 
 function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Int},
-                  colkey::Int, keycol, valuecol, g, renamecols)
+                  colkey::Int, keycol::CategoricalVector,
+                  valuecol::AbstractVector, g::GroupedDataFrame,
+                  renamecols::Function)
     idx, starts, ends = g.idx, g.starts, g.ends
     groupidxs = [idx[starts[i]:ends[i]] for i in 1:length(starts)]
     rowkey = zeros(Int, size(df, 1))

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -41,6 +41,7 @@ function ourshow(io::IO, x::Any)
 end
 
 ourshow(io::IO, x::AbstractString) = escape_string(io, x, "")
+ourshow(io::IO, x::CategoricalValue{<:AbstractString}) = escape_string(io, get(x), "")
 ourshow(io::IO, x::Symbol) = ourshow(io, string(x))
 ourshow(io::IO, x::Nothing) = nothing
 
@@ -76,7 +77,7 @@ function compacttype(T::Type, maxwidth::Int=8, initial::Bool=true)
 
     maxwidth -= 1 # we will add "…" at the end
 
-    if T <: CategoricalString || T <: CategoricalValue
+    if T <: CategoricalValue
         sT = string(T.name)
         if textwidth(sT) ≤ maxwidth
             return sT * "…" * suffix

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -993,9 +993,9 @@ julia> categorical!(df)
 
 julia> eltype.(eachcol(df))
 3-element Array{DataType,1}:
- CategoricalString{UInt32}
+ CategoricalValue{String,UInt32}
  Int64
- CategoricalString{UInt32}
+ CategoricalValue{String,UInt32}
 
 julia> df = DataFrame(X=["a", "b"], Y=[1, 2], Z=["p", "q"])
 2×3 DataFrame
@@ -1024,14 +1024,14 @@ function categorical! end
 
 function categorical!(df::DataFrame, cname::ColumnIndex;
                       compress::Bool=false)
-    df[!, cname] = categorical(df[!, cname], compress)
+    df[!, cname] = categorical(df[!, cname], compress=compress)
     df
 end
 
 function categorical!(df::DataFrame, cnames::AbstractVector{<:ColumnIndex};
                       compress::Bool=false)
     for cname in cnames
-        df[!, cname] = categorical(df[!, cname], compress)
+        df[!, cname] = categorical(df[!, cname], compress=compress)
     end
     df
 end
@@ -1044,7 +1044,7 @@ function categorical!(df::DataFrame,
                       compress::Bool=false)
     for i in 1:size(df, 2)
         if eltype(df[!, i]) <: cols
-            df[!, i] = categorical(df[!, i], compress)
+            df[!, i] = categorical(df[!, i], compress=compress)
         end
     end
     df

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -278,26 +278,13 @@ Base.merge(a::DataFrameRow, b::DataFrameRow) = merge(NamedTuple(a), NamedTuple(b
 Base.merge(a::DataFrameRow, b::Base.Iterators.Pairs) = merge(NamedTuple(a), b)
 Base.merge(a::DataFrameRow, itr) = merge(NamedTuple(a), itr)
 
-# hash column element
-Base.@propagate_inbounds hash_colel(v::AbstractArray, i, h::UInt = zero(UInt)) =
-    hash(v[i], h)
-Base.@propagate_inbounds function hash_colel(v::AbstractCategoricalArray, i,
-                                             h::UInt = zero(UInt))
-    ref = v.refs[i]
-    if eltype(v) >: Missing && ref == 0
-        hash(missing, h)
-    else
-        hash(CategoricalArrays.index(v.pool)[ref], h)
-    end
-end
-
 # hash of DataFrame rows based on its values
 # so that duplicate rows would have the same hash
 # table columns are passed as a tuple of vectors to ensure type specialization
 rowhash(cols::Tuple{AbstractVector}, r::Int, h::UInt = zero(UInt))::UInt =
-    hash_colel(cols[1], r, h)
+    hash(cols[1][r], h)
 function rowhash(cols::Tuple{Vararg{AbstractVector}}, r::Int, h::UInt = zero(UInt))::UInt
-    h = hash_colel(cols[1], r, h)
+    h = hash(cols[1][r], h)
     rowhash(Base.tail(cols), r, h)
 end
 

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -18,8 +18,8 @@ function DataFrame(column_eltypes::AbstractVector{T}, cnames::AbstractVector{Sym
     end
     for i in eachindex(categorical)
         categorical[i] || continue
-        elty = CategoricalArrays.catvaluetype(nonmissingtype(updated_types[i]),
-                                              CategoricalArrays.DefaultRefType)
+        elty = CategoricalValue{nonmissingtype(updated_types[i]),
+                                CategoricalArrays.DefaultRefType}
         if updated_types[i] >: Missing
             updated_types[i] = Union{elty, Missing}
         else

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -699,9 +699,9 @@ end
         @test levels(df.c1) == levels(v)
         @test levels(df.c1) !== levels(v)
         df[!, :c2] .= v[2]
-        @test df.c2 == get.([v[2], v[2], v[2]])
+        @test df.c2 == fill(v[2], 3)
         @test df.c2 isa CategoricalVector
-        @test levels(df.c2) != levels(v)
+        @test levels(df.c2) == levels(v)
         df[!, :c3] .= (x->x).(v)
         @test df.c3 ≅ v
         @test df.c3 !== v

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -757,43 +757,43 @@ end
 @testset "categorical!" begin
     df = DataFrame([["a", "b"], ['a', 'b'], [true, false], 1:2, ["x", "y"]])
     @test all(map(<:, eltype.(eachcol(categorical!(deepcopy(df)))),
-                  [CategoricalArrays.CategoricalString{UInt32},
+                  [CategoricalArrays.CategoricalValue{String,UInt32},
                    Char, Bool, Int,
-                   CategoricalArrays.CategoricalString{UInt32}]))
+                   CategoricalArrays.CategoricalValue{String,UInt32}]))
     @test all(map(<:, eltype.(eachcol(categorical!(deepcopy(df), :))),
-                  [CategoricalArrays.CategoricalString{UInt32},
+                  [CategoricalArrays.CategoricalValue{String,UInt32},
                    CategoricalArrays.CategoricalValue{Char,UInt32},
                    CategoricalArrays.CategoricalValue{Bool,UInt32},
                    CategoricalArrays.CategoricalValue{Int,UInt32},
-                   CategoricalArrays.CategoricalString{UInt32}]))
+                   CategoricalArrays.CategoricalValue{String,UInt32}]))
     @test all(map(<:, eltype.(eachcol(categorical!(deepcopy(df), compress=true))),
-                  [CategoricalArrays.CategoricalString{UInt8},
+                  [CategoricalArrays.CategoricalValue{String,UInt8},
                    Char, Bool, Int,
-                   CategoricalArrays.CategoricalString{UInt8}]))
+                   CategoricalArrays.CategoricalValue{String,UInt8}]))
     @test all(map(<:, eltype.(eachcol(categorical!(deepcopy(df), names(df)))),
-                  [CategoricalArrays.CategoricalString{UInt32},
+                  [CategoricalArrays.CategoricalValue{String,UInt32},
                    CategoricalArrays.CategoricalValue{Char,UInt32},
                    CategoricalArrays.CategoricalValue{Bool,UInt32},
                    CategoricalArrays.CategoricalValue{Int,UInt32},
-                   CategoricalArrays.CategoricalString{UInt32}]))
+                   CategoricalArrays.CategoricalValue{String,UInt32}]))
     @test all(map(<:, eltype.(eachcol(categorical!(deepcopy(df), names(df), compress=true))),
-                  [CategoricalArrays.CategoricalString{UInt8},
+                  [CategoricalArrays.CategoricalValue{String,UInt8},
                    CategoricalArrays.CategoricalValue{Char,UInt8},
                    CategoricalArrays.CategoricalValue{Bool,UInt8},
                    CategoricalArrays.CategoricalValue{Int,UInt8},
-                   CategoricalArrays.CategoricalString{UInt8}]))
+                   CategoricalArrays.CategoricalValue{String,UInt8}]))
     @test all(map(<:, eltype.(eachcol(categorical!(deepcopy(df), Not(1:0)))),
-                  [CategoricalArrays.CategoricalString{UInt32},
+                  [CategoricalArrays.CategoricalValue{String,UInt32},
                    CategoricalArrays.CategoricalValue{Char,UInt32},
                    CategoricalArrays.CategoricalValue{Bool,UInt32},
                    CategoricalArrays.CategoricalValue{Int,UInt32},
-                   CategoricalArrays.CategoricalString{UInt32}]))
+                   CategoricalArrays.CategoricalValue{String,UInt32}]))
     @test all(map(<:, eltype.(eachcol(categorical!(deepcopy(df), Not(1:0), compress=true))),
-                  [CategoricalArrays.CategoricalString{UInt8},
+                  [CategoricalArrays.CategoricalValue{String,UInt8},
                    CategoricalArrays.CategoricalValue{Char,UInt8},
                    CategoricalArrays.CategoricalValue{Bool,UInt8},
                    CategoricalArrays.CategoricalValue{Int,UInt8},
-                   CategoricalArrays.CategoricalString{UInt8}]))
+                   CategoricalArrays.CategoricalValue{String,UInt8}]))
 
     @test all(map(<:, eltype.(eachcol(categorical!(deepcopy(df), Integer))),
                   [String, Char,
@@ -1002,7 +1002,7 @@ end
     @test allowmissing!(df) === df
     @test all(x->x <: CategoricalVector, typeof.(eachcol(df)))
     @test eltype(df[!, 1]) <: Union{CategoricalValue{Int}, Missing}
-    @test eltype(df[!, 2]) <: Union{CategoricalString, Missing}
+    @test eltype(df[!, 2]) <: Union{CategoricalValue{String}, Missing}
     df[1,2] = missing
     @test_throws MissingException disallowmissing!(df)
     tmpcol =df[!, 2]
@@ -1012,7 +1012,7 @@ end
     @test disallowmissing!(df) === df
     @test all(x->x <: CategoricalVector, typeof.(eachcol(df)))
     @test eltype(df[!, 1]) <: CategoricalValue{Int}
-    @test eltype(df[!, 2]) <: CategoricalString
+    @test eltype(df[!, 2]) <: CategoricalValue{String}
 
     for em in [true, false]
         df = DataFrame(b=[1,2], c=[1,2], d=[1,2])

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -344,7 +344,7 @@ end
     res = combine(d -> d.Key1 == ["A", "A"] ? (x=d[1, :Key1],) : (x="C",),
                   groupby_checked(df, :Key1))
     @test res.x isa Vector{String}
-    # ...even when CategoricalString comes second
+    # ...even when CategoricalValue comes second
     res = combine(d -> d.Key1 == ["B", "B"] ? DataFrame(x=d[1, :Key1]) : DataFrame(x="C"),
                   groupby_checked(df, :Key1))
     @test res.x isa Vector{String}

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -443,7 +443,7 @@ end
     @test d1s.variable isa CategoricalVector{String}
     @test levels(d1s.variable) == ["d", "c"]
     d1s = stack(d1, [:d, :c], view=true)
-    @test d1s.variable isa DataFrames.RepeatedVector{<:CategoricalString}
+    @test d1s.variable isa DataFrames.RepeatedVector{<:CategoricalValue{String}}
     @test levels(d1s.variable) == ["d", "c"]
     @test d1s[:, 4] isa CategoricalVector{String}
     @test levels(d1s[:, 4]) == ["d", "c"]
@@ -491,13 +491,13 @@ end
 @testset "test stack eltype" begin
     df = DataFrame(rand(4,5))
     sdf = stack(df)
-    @test eltype(sdf.variable) <: CategoricalString
-    @test eltype(typeof(sdf.variable)) <: CategoricalString
+    @test eltype(sdf.variable) <: CategoricalValue{String}
+    @test eltype(typeof(sdf.variable)) <: CategoricalValue{String}
     @test eltype(sdf.value) <: Float64
     @test eltype(typeof(sdf.value)) <: Float64
     sdf2 = first(sdf, 3)
-    @test eltype(sdf2.variable) <: CategoricalString
-    @test eltype(typeof(sdf2.variable)) <: CategoricalString
+    @test eltype(sdf2.variable) <: CategoricalValue{String}
+    @test eltype(typeof(sdf2.variable)) <: CategoricalValue{String}
     @test eltype(sdf2.value) <: Float64
     @test eltype(typeof(sdf2.value)) <: Float64
 end

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -147,13 +147,13 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
 
         # categorical values
         cat = CategoricalVector(["hey", "there", "sailor"])
-        cat2 = [c for c in cat] # Vector of CategoricalString
+        cat2 = [c for c in cat] # Vector of CategoricalValue
         nt = (a=cat, b=cat2)
         df = DataFrame(nt, copycols=false)
         @test df.a === cat
         @test df.b === cat2
         # test in the unknown schema case that a
-        # Vector of CategoricalString is built into CategoricalVector
+        # Vector of CategoricalValue is built into CategoricalVector
         ct = Tables.buildcolumns(nothing, Tables.rows(nt))
         @test ct.a !== cat
         @test ct.b !== cat2


### PR DESCRIPTION
Replace `CategoricalString` with `CategoricalValue{String}` and stop using `CategoricalArrays.index`. This simplifies the code a bit. Also drop some specializations which are equivalent to optimized methods defined in CategoricalArrays.