### PR TITLE
dataframerow related docstrings

### DIFF
--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -32,7 +32,7 @@ with each row represented as a `DataFrameRow`.
 
 Because `DataFrameRow`s have an `eltype` of `Any`, use `copy(dfr::DataFrameRow)` to obtain 
 a named tuple, which supports iteration and property access like a `DataFrameRow`, 
-but also passes information of the `eltypes` of the columns of `df`. 
+but also passes information on the `eltypes` of the columns of `df`. 
 
 # Examples
 ```jldoctest

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -30,6 +30,10 @@ Base.iterate(::AbstractDataFrame) =
 Return a `DataFrameRows` that iterates a data frame row by row,
 with each row represented as a `DataFrameRow`.
 
+Because `DataFrameRow`s have an `eltype` of `Any`, use `copy(dfr::DataFrameRow)` to obtain 
+a named tuple, which supports iteration and property access like a `DataFrameRow`, 
+but also passes information of the `eltypes` of the columns of `df`. 
+
 # Examples
 ```jldoctest
 julia> df = DataFrame(x=1:4, y=11:14)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -276,7 +276,7 @@ function Base.NamedTuple(dfr::DataFrameRow)
     pc = parentcols(index(dfr))
     cols = _columns(parent(dfr))
     s = ntuple(i -> eltype(cols[pc[i]]), length(dfr))
-    NamedTuple{k, s...}(v)
+    NamedTuple{k, Tuple{s...}}(v)
 end
 
 """

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -14,8 +14,7 @@ DataFrameRow(parent::AbstractDataFrame, row::Integer, cols=:)
 ```
 
 A `DataFrameRow` supports the iteration interface and can therefore be passed to
-functions that expect a collection as an argument. In such situations `eltype`
-of `DataFrameRow` is always `Any`.
+functions that expect a collection as an argument. Its element type is always `Any`.
 
 Indexing is one-dimensional like specifying a column of a `DataFrame`.
 You can also access the data in a `DataFrameRow` using the `getproperty` and
@@ -272,11 +271,12 @@ Base.broadcastable(::DataFrameRow) =
     throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 
 function Base.NamedTuple(dfr::DataFrameRow)
-    k = keys(dfr)
-    v = values(dfr)
-    n = names(dfr)
-    s = eltype.(parent(dfr)[!, ni] for ni in n)
-    NamedTuple{Tuple(k), Tuple{s...}}(Tuple(v))
+    k = Tuple(_names(dfr))
+    v = ntuple(i -> dfr[i], length(dfr))
+    pc = parentcols(index(dfr))
+    cols = _columns(parent(dfr))
+    s = ntuple(i -> eltype(cols[pc[i]]), length(dfr))
+    NamedTuple{k, s...}(v)
 end
 
 """

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -14,7 +14,8 @@ DataFrameRow(parent::AbstractDataFrame, row::Integer, cols=:)
 ```
 
 A `DataFrameRow` supports the iteration interface and can therefore be passed to
-functions that expect a collection as an argument.
+functions that expect a collection as an argument. In such situations `eltype`
+of `DataFrameRow` is always `Any`.
 
 Indexing is one-dimensional like specifying a column of a `DataFrame`.
 You can also access the data in a `DataFrameRow` using the `getproperty` and

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -271,7 +271,13 @@ Base.get(f::Base.Callable, dfr::DataFrameRow, key::ColumnIndex) =
 Base.broadcastable(::DataFrameRow) =
     throw(ArgumentError("broadcasting over `DataFrameRow`s is reserved"))
 
-Base.NamedTuple(dfr::DataFrameRow) = NamedTuple{Tuple(keys(dfr))}(values(dfr))
+function Base.NamedTuple(dfr::DataFrameRow)
+    k = keys(dfr)
+    v = values(dfr)
+    n = names(dfr)
+    s = eltype.(parent(dfr)[!, ni] for ni in n)
+    NamedTuple{Tuple(k), Tuple{s...}}(Tuple(v))
+end
 
 """
     copy(dfr::DataFrameRow)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -270,7 +270,7 @@ end
     df = DataFrame(a=[1, missing, missing], b=[2.0, 3.0, 0.0])
     dfr = DataFrameRow(df, 1, :)
     nt = first(Tables.namedtupleiterator(df))
-    @test copy(dfr) === nt === NamedTuple{(:a, :b),Tuple{Union{Missing, Int64},Float64}}((1, 2.0))
+    @test copy(dfr) === nt === NamedTuple{(:a, :b),Tuple{Union{Missing, Int},Float64}}((1, 2.0))
     @test sum(skipmissing(copy(df[3, :]))) == 0
     @test convert(Vector, dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
     @test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -209,7 +209,7 @@ end
     @test propertynames(r) == keys(r) == Symbol.(names(df))
     @test r.a === 1
     @test r.b === 2.0
-    @test copy(r[[:a,:b]]) === (a=1, b=2.0)
+    @test copy(r[[:a,:b]]) == (a=1, b=2.0)
 
     r.a = 2
     @test r.a === 2
@@ -267,9 +267,11 @@ end
 end
 
 @testset "convert, copy and merge" begin
-    df = DataFrame(a=[1, missing], b=[2.0, 3.0])
+    df = DataFrame(a=[1, missing, missing], b=[2.0, 3.0, 0.0])
     dfr = DataFrameRow(df, 1, :)
-
+    nt = first(Tables.namedtupleiterator(df))
+    @test copy(dfr) === nt === NamedTuple{(:a, :b),Tuple{Union{Missing, Int64},Float64}}((1, 2.0))
+    @test sum(skipmissing(copy(df[3, :]))) == 0
     @test convert(Vector, dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]
     @test convert(Vector{Int}, dfr)::Vector{Int} == [1, 2]
     @test Vector(dfr)::Vector{Union{Float64, Missing}} == [1.0, 2.0]


### PR DESCRIPTION
In reference to #2164 . Just some short text to make it a bit clearer (hopefully) how to work with `eachrow` a bit better. 

Long term solutions might include a `eachrow(df, namedtuples = true)`. But this seems unnecessary given `select` with `ByRow`. 

