### PR TITLE
Fix building documentation on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,6 @@ arch:
   - x64
   - x86
 
-matrix:
-  exclude:
-    - os: osx
-      arch: x86
-  allow_failures:
-    - julia: nightly
-
 notifications:
   email: false
 
@@ -29,6 +22,11 @@ after_success:
               Coveralls.submit(Coveralls.process_folder())'
 
 jobs:
+  exclude:
+    - os: osx
+      arch: x86
+  allow_failures:
+    - julia: nightly
   include:
     - stage: "Documentation"
       julia: 1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ os:
   - windows
 
 arch:
-  - x64
-  - x86
+  - amd64
+  - i386
 
 notifications:
   email: false
@@ -24,7 +24,7 @@ after_success:
 jobs:
   exclude:
     - os: osx
-      arch: x86
+      arch: i386
   allow_failures:
     - julia: nightly
   include:


### PR DESCRIPTION
Having both `matrix` and `jobs` disables the latter.