### PR TITLE
Make ByRow subtype Function

### DIFF
--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -102,8 +102,7 @@ function normalize_selection(idx::AbstractIndex,
 end
 
 normalize_selection(idx::AbstractIndex,
-                    sel::Pair{<:Any,<:Pair{<:Union{Base.Callable, ByRow},
-                                           <:AbstractString}}) =
+                    sel::Pair{<:Any,<:Pair{<:Base.Callable,<:AbstractString}}) =
     normalize_selection(idx, first(sel) => first(last(sel)) => Symbol(last(last(sel))))
 
 function normalize_selection(idx::AbstractIndex,
@@ -123,7 +122,7 @@ function normalize_selection(idx::AbstractIndex,
         rawc = first(sel)
         wanttable = false
     end
-    if rawc isa AbstractVector{Int}
+    if rawc isa AbstractVector{Int} 
         c = rawc
     elseif rawc isa Union{AbstractVector{Symbol}, AbstractVector{<:AbstractString}}
         c = [idx[n] for n in rawc]

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -119,7 +119,7 @@ function normalize_selection(idx::AbstractIndex,
         rawc = first(sel)
         wanttable = false
     end
-    if rawc isa AbstractVector{Int} 
+    if rawc isa AbstractVector{Int}
         c = rawc
     elseif rawc isa Union{AbstractVector{Symbol}, AbstractVector{<:AbstractString}}
         c = [idx[n] for n in rawc]

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -20,7 +20,7 @@ Note that `ByRow` always collects values returned by `fun` in a vector. Therefor
 to allow for future extensions, returning `NamedTuple` or `DataFrameRow`
 from `fun` is currently disallowed.
 """
-struct ByRow{T}
+struct ByRow{T} <: Function
     fun::T
 end
 
@@ -71,7 +71,7 @@ normalize_selection(idx::AbstractIndex, sel::Pair{<:ColumnIndex, <:AbstractStrin
     normalize_selection(idx, first(sel) => Symbol(last(sel)))
 
 function normalize_selection(idx::AbstractIndex,
-                             sel::Pair{<:Any,<:Pair{<:Union{Base.Callable, ByRow}, Symbol}})
+                             sel::Pair{<:Any,<:Pair{<:Base.Callable, Symbol}})
     if first(sel) isa AsTable
         rawc = first(sel).cols
         wanttable = true
@@ -107,7 +107,7 @@ normalize_selection(idx::AbstractIndex,
     normalize_selection(idx, first(sel) => first(last(sel)) => Symbol(last(last(sel))))
 
 function normalize_selection(idx::AbstractIndex,
-                             sel::Pair{<:ColumnIndex,<:Union{Base.Callable, ByRow}})
+                             sel::Pair{<:ColumnIndex,<:Base.Callable})
     c = idx[first(sel)]
     fun = last(sel)
     newcol = Symbol(_names(idx)[c], "_", funname(fun))
@@ -115,7 +115,7 @@ function normalize_selection(idx::AbstractIndex,
 end
 
 function normalize_selection(idx::AbstractIndex,
-                             sel::Pair{<:Any, <:Union{Base.Callable,ByRow}})
+                             sel::Pair{<:Any, <:Base.Callable})
     if first(sel) isa AsTable
         rawc = first(sel).cols
         wanttable = true
@@ -154,7 +154,7 @@ function normalize_selection(idx::AbstractIndex,
 end
 
 function select_transform!(nc::Pair{<:Union{Int, AbstractVector{Int}, AsTable},
-                                    <:Pair{<:Union{Base.Callable, ByRow}, Symbol}},
+                                    <:Pair{<:Base.Callable, Symbol}},
                            df::AbstractDataFrame, newdf::DataFrame,
                            transformed_cols::Dict{Symbol, Any}, copycols::Bool,
                            allow_resizing_newdf::Ref{Bool})

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -29,9 +29,6 @@ _by_row_helper(x::Union{NamedTuple, DataFrameRow}) =
     throw(ArgumentError("return value of type $(typeof(x)) " *
                         "is currently not allowed with ByRow."))
 
-
-Base.broadcastable(x::ByRow) = Ref(x)
-
 (f::ByRow)(cols::AbstractVector...) = _by_row_helper.(f.fun.(cols...))
 (f::ByRow)(table::NamedTuple) =
     _by_row_helper.(f.fun.(Tables.namedtupleiterator(table)))

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -1093,7 +1093,7 @@ function _combine(f::AbstractVector{<:Pair},
                   gd::GroupedDataFrame, nms::AbstractVector{Symbol})
     # here f should be normalized and in a form of source_cols => fun
     @assert all(x -> first(x) isa Union{Int, AbstractVector{Int}, AsTable}, f)
-    @assert all(x -> last(x) isa Union{Base.Callable, ByRow}, f)
+    @assert all(x -> last(x) isa Base.Callable, f)
     idx_agg = nothing
     if any(isagg, f)
         # Compute indices of representative rows only once for all AbstractAggregates


### PR DESCRIPTION
`ByRow` is a function wrapper.
Its callable, so it works like a function.
As such it is not unreasonable to for it to subtype `Function`
Which means it is also covered by `Base.Callable`.
Which means we can simplify some of the more complex type constraints.
(I noticed this because these get more complex in #2199 )

In general I think if something is callable and doesn't already have a supertype, it is a fairly good idea to make it subtype `Function`.

(i would be in general a fan of dropping the [constraints here entirely](https://white.ucc.asn.au/2020/04/19/Julia-Antipatterns.html#dispatching-on--function), but that would require closer looking at the code to see if it would cause any change in dispatch)