### PR TITLE
cleanup after string PR

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -45,7 +45,7 @@ julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
 
 ```
 
-Columns can be directly (i.e. without copying) accessed via `df.col`, `df."col"`, `df[!, :col]` or `df[!, "col"]`. The two latter syntaxes are more flexible as they allow passing a variable holding the name of the column, and not only a literal name. Note that column names can be either symbols (written as `:col`, `:var"col"` or `Symbol("col")`) or strings (written as `"col"`; in particular variable interpolation using `$` is not allowed).
+Columns can be directly (i.e. without copying) accessed via `df.col`, `df."col"`, `df[!, :col]` or `df[!, "col"]`. The two latter syntaxes are more flexible as they allow passing a variable holding the name of the column, and not only a literal name. Note that column names can be either symbols (written as `:col`, `:var"col"` or `Symbol("col")`) or strings (written as `"col"`). Note that in the forms `df."col"` and `:var"col"` variable interpolation into a string using `$` does not work.
 Columns can also be accessed using an integer index specifying their position.
 
 Since `df[!, :col]` does not make a copy, changing the elements of the column vector returned by this syntax will affect the values stored in the original `df`. To get a copy of the column use `df[:, :col]`: changing the vector returned by this syntax does not change `df`.

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -45,7 +45,7 @@ julia> df = DataFrame(A = 1:4, B = ["M", "F", "F", "M"])
 
 ```
 
-Columns can be directly (i.e. without copying) accessed via `df.col`, `df."col"`, `df[!, :col]` or `df[!, "col"]`. The two latter syntaxes are more flexible as they allow passing a variable holding the name of the column, and not only a literal name. Note that column names can be either symbols (written as `:col`, `:var"col"` or `Symbol("col")`) or strings (written as `"col"`).
+Columns can be directly (i.e. without copying) accessed via `df.col`, `df."col"`, `df[!, :col]` or `df[!, "col"]`. The two latter syntaxes are more flexible as they allow passing a variable holding the name of the column, and not only a literal name. Note that column names can be either symbols (written as `:col`, `:var"col"` or `Symbol("col")`) or strings (written as `"col"`; in particular variable interpolation using `$` is not allowed).
 Columns can also be accessed using an integer index specifying their position.
 
 Since `df[!, :col]` does not make a copy, changing the elements of the column vector returned by this syntax will affect the values stored in the original `df`. To get a copy of the column use `df[:, :col]`: changing the vector returned by this syntax does not change `df`.
@@ -127,7 +127,7 @@ julia> propertynames(df)
 
     DataFrames.jl allows to use `Symbol`s (like `:A`) and strings (like `"A"`)
     for all column indexing operations for convenience.
-    However, using `Symbol`s is slightly faster and should generally be preferred.
+    However, using `Symbol`s is slightly faster and should generally be preferred, if not generating them via string manipulation.
 
 
 ### Constructing Column by Column

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -572,7 +572,7 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
 
     # Put the summary stats into the return data frame
     data = DataFrame()
-    data.variable = copy(_names(df))
+    data.variable = propertynames(df)
 
     # An array of Dicts for summary statistics
     col_stats_dicts = map(eachcol(df)) do col

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -1207,7 +1207,7 @@ function _combine(p::Pair, gd::GroupedDataFrame, ::Nothing)
     idx, outcols, nms = _combine_multicol(firstres, fun, gd, incols)
     # disallow passing target column name to genuine tables
     if firstres isa MULTI_COLS_TYPE
-        if p isa Pair{<:Any, <:Pair{<:Any, Symbol}}
+        if p isa Pair{<:Any, <:Pair{<:Any, <:SymbolOrString}}
             throw(ArgumentError("setting column name for tabular return value is disallowed"))
         end
     else

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -694,6 +694,7 @@ end
           by(df, :a, 1 => length => :res, 1 => length => :nrow, 1 => length => :res2)
 
     @test_throws ArgumentError by([:b,:c] => ((b,c) -> [1 2; 3 4]) => :xxx, df, :a)
+    @test_throws ArgumentError by([:b,:c] => ((b,c) -> [1 2; 3 4]) => "xxx", df, :a)
     @test_throws ArgumentError by(df, :a, [:b,:c] => ((b,c) -> [1 2; 3 4]) => :xxx)
     @test_throws ArgumentError by(df, :a, nrow, nrow)
     @test_throws ArgumentError by(df, :a, [nrow])


### PR DESCRIPTION
This is a PR implementing the suggestions of @oxinabox to #2199.

@nalimilan - the major comment was if we want to allow `AbstractVector{<:SymbolOrString}`
in place of `Union{AbstractVector{Symbol}, AbstractVector{<:AbstractString}}` (in technical terms, as in some places in the code this has a different manifestation, but essentially - I was defensive in #2199 and disallowed mixing `Symbol`s and strings, and @oxinabox suggests to allow this).

(as a note - my preference is to disallow mixing - as I do not see a use case where it is really useful)

@oxinabox - note that currently we also disallow mixing integers and `Symbol`s or strings (of course this is not the same, but ...).