### PR TITLE
errant space confused juliadoc builder

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -113,7 +113,7 @@ julia> names(df)
 2-element Array{String,1}:
  "A"
  "B"
- ```
+```
 
 To get column names as `Symbol`s use the `propertynames` function:
 ```


### PR DESCRIPTION
Fixes Getting Started docs -- currently look [like this](http://juliadata.github.io/DataFrames.jl/dev/man/getting_started/#write-DataFrame-out-to-CSV-file-1)