### PR TITLE
up version to 0.21.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.20.0"
+version = "0.21.0"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"


### PR DESCRIPTION
A final check before 0.21 release.

The plan is that ideally the next release is 1.0 and we do not include any breaking changes (the reality might turn out to be different).

What are key objectives to do after 0.21 release till 1.0 release:
1. documentation improvements
2. decouple DataFramesBase.jl to make the core much more lightweight
3. adding requested non-breaking functionality
4. find as many bugs as possible before 1.0 release

I would plan that we shall make 1.0 release in 3 to 6 months from now (depending how the things progress and the user feedback).

What I also will do after the release:
1. Write release notes on Discourse + Slack x-ref
2. Update DataFramesTutorial.jl

Thank you for working on the package!