### PR TITLE
add support for extended help

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -4,10 +4,12 @@
 An abstract type for which all concrete types expose an interface
 for working with tabular data.
 
-# Common methods
-
 An `AbstractDataFrame` is a two-dimensional table with `Symbol`s or strings
 for column names.
+
+# Extended help
+
+# Common methods
 
 The following are normally implemented for AbstractDataFrames:
 
@@ -102,6 +104,8 @@ Compat.hasproperty(df::AbstractDataFrame, s::AbstractString) = haskey(index(df),
 
 Rename columns of `df` in-place.
 Each name is changed at most once. Permutation of names is allowed.
+
+# Extended help
 
 # Arguments
 - `df` : the `AbstractDataFrame`
@@ -224,6 +228,8 @@ end
 Create a new data frame that is a copy of `df` with changed column names.
 Each name is changed at most once. Permutation of names is allowed.
 
+# Extended help
+
 # Arguments
 - `df` : the `AbstractDataFrame`
 - `d` : an `AbstractDict` or an `AbstractVector` of `Pair`s that maps
@@ -305,6 +311,8 @@ Optionally a dimension `dim` can be specified, where `1` corresponds to rows
 and `2` corresponds to columns.
 
 See also: [`nrow`](@ref), [`ncol`](@ref)
+
+# Extended help
 
 # Examples
 ```julia
@@ -442,6 +450,8 @@ Base.last(df::AbstractDataFrame, n::Integer) = df[max(1,nrow(df)-n+1):nrow(df), 
 
 Return descriptive statistics for a data frame as a new `DataFrame`
 where each row represents a variable and each column a summary statistic.
+
+# Extended help
 
 # Arguments
 - `df` : the `AbstractDataFrame`
@@ -676,6 +686,8 @@ Return a Boolean vector with `true` entries indicating rows without missing valu
 If `cols` is provided, only missing values in the corresponding columns areconsidered.
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 
+# Extended help
+
 See also: [`dropmissing`](@ref) and [`dropmissing!`](@ref).
 Use `findall(completecases(df))` to get the indices of the rows.
 
@@ -751,6 +763,8 @@ be converted so as not to allow for missing values using [`disallowmissing!`](@r
 
 See also: [`completecases`](@ref) and [`dropmissing!`](@ref).
 
+# Extended help
+
 # Examples
 
 ```julia
@@ -821,6 +835,8 @@ If `disallowmissing` is `true` (the default) then the `cols` columns will
 get converted using [`disallowmissing!`](@ref).
 
 See also: [`dropmissing`](@ref) and [`completecases`](@ref).
+
+# Extended help
 
 ```jldoctest
 julia> df = DataFrame(i = 1:5,
@@ -897,6 +913,8 @@ is passed.
 Passing `cols` leads to a more efficient execution of the operation for large data frames.
 
 See also: [`filter!`](@ref)
+
+# Extended help
 
 # Examples
 ```
@@ -996,6 +1014,8 @@ is passed.
 Passing `cols` leads to a more efficient execution of the operation for large data frames.
 
 See also: [`filter`](@ref)
+
+# Extended help
 
 # Examples
 ```
@@ -1130,6 +1150,8 @@ equal values (according to `isequal`).
 
 See also [`unique`](@ref) and [`unique!`](@ref).
 
+# Extended help
+
 # Arguments
 - `df` : `AbstractDataFrame`
 - `cols` : a selector specifying the column(s) to compare. Can be any column
@@ -1185,6 +1207,8 @@ retaining in each case the first instance for which `df[cols]` is unique.
 When `unique` is called a new data frame is returned; `unique!` updates `df` in-place.
 
 See also [`nonunique`](@ref).
+
+# Extended help
 
 # Arguments
 - `df` : the AbstractDataFrame
@@ -1299,6 +1323,8 @@ The `cols` keyword argument determines the columns of the returned data frame:
   Columns not present in some data frames are filled with `missing` where necessary.
 * A vector of `Symbol`s or strings: only listed columns are kept.
   Columns not present in some data frames are filled with `missing` where necessary.
+
+# Extended help
 
 The order of columns is determined by the order they appear in the included data
 frames, searching through the header of the first data frame, then the second,
@@ -1465,6 +1491,8 @@ Construct a data frame by repeating rows in `df`. `inner` specifies how many
 times each row is repeated, and `outer` specifies how many times the full set
 of rows is repeated.
 
+# Extended help
+
 # Example
 ```jldoctest
 julia> df = DataFrame(a = 1:2, b = 3:4)
@@ -1565,6 +1593,8 @@ Return the number of rows or columns in an `AbstractDataFrame` `df`.
 
 See also [`size`](@ref).
 
+# Extended help
+
 **Examples**
 
 ```jldoctest
@@ -1595,6 +1625,8 @@ If `cols` is omitted all columns in the data frame are converted.
 
 If `error=false` then columns containing a `missing` value will be skipped instead
 of throwing an error.
+
+# Extended help
 
 **Examples**
 
@@ -1663,6 +1695,8 @@ to element type `Union{T, Missing}` from `T` to allow support for missing values
 
 If `cols` is omitted all columns in the data frame are converted.
 
+# Extended help
+
 **Examples**
 
 ```jldoctest
@@ -1704,6 +1738,8 @@ end
                 compress::Bool=false)
 
 Return a copy of data frame `df` with columns `cols` converted to `CategoricalVector`.
+
+# Extended help
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR)
 or a `Type`.
@@ -1790,6 +1826,8 @@ according to the length of `df[i, col]`. These lengths must therefore be the
 same for each `col` in `cols`, or else an error is raised. Note that these
 elements are not copied, and thus if they are mutable changing them in the
 returned `DataFrame` will affect `df`.
+
+# Extended help
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -3,6 +3,8 @@
 
 Render a data frame to an I/O stream in MIME type `mime`.
 
+# Extended help
+
 # Arguments
 - `io::IO`: The I/O stream to which `df` will be printed.
 - `mime::MIME`: supported MIME types are: `"text/plain"`, `"text/html"`, `"text/latex"`,

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -30,9 +30,11 @@ Base.iterate(::AbstractDataFrame) =
 Return a `DataFrameRows` that iterates a data frame row by row,
 with each row represented as a `DataFrameRow`.
 
-Because `DataFrameRow`s have an `eltype` of `Any`, use `copy(dfr::DataFrameRow)` to obtain 
-a named tuple, which supports iteration and property access like a `DataFrameRow`, 
-but also passes information on the `eltypes` of the columns of `df`. 
+Because `DataFrameRow`s have an `eltype` of `Any`, use `copy(dfr::DataFrameRow)` to obtain
+a named tuple, which supports iteration and property access like a `DataFrameRow`,
+but also passes information on the `eltypes` of the columns of `df`.
+
+# Extended help
 
 # Examples
 ```jldoctest
@@ -126,6 +128,8 @@ Base.summary(io::IO, dfcs::DataFrameColumns) = print(io, summary(dfcs))
 Return a `DataFrameColumns` that is an `AbstractVector`
 that allows iterating an `AbstractDataFrame` column by column.
 Additionally it is allowed to index `DataFrameColumns` using column names.
+
+# Extended help
 
 # Examples
 ```jldoctest
@@ -332,6 +336,8 @@ end
 Update a `DataFrame` in-place where each column of `df` is transformed using function `f`.
 `f` must return `AbstractVector` objects all with the same length or scalars
 (all values other than `AbstractVector` are considered to be a scalar).
+
+# Extended help
 
 Note that `mapcols!` reuses the columns from `df` if they are returned by `f`.
 

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -368,6 +368,8 @@ Perform an inner join of two or more data frame objects and return a `DataFrame`
 containing the result. An inner join includes rows with keys that match in all
 passed data frames.
 
+# Extended help
+
 # Arguments
 - `df1`, `df2`, `dfs...`: the `AbstractDataFrames` to be joined
 
@@ -475,6 +477,8 @@ innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame
 Perform a left join of twodata frame objects and return a `DataFrame` containing
 the result. A left join includes all rows from `df1`.
 
+# Extended help
+
 # Arguments
 - `df1`, `df2`: the `AbstractDataFrames` to be joined
 
@@ -577,6 +581,8 @@ leftjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
 
 Perform a right join on two data frame objects and return a `DataFrame` containing
 the result. A right join includes all rows from `df2`.
+
+# Extended help
 
 # Arguments
 - `df1`, `df2`: the `AbstractDataFrames` to be joined
@@ -683,6 +689,8 @@ rightjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
 Perform an outer join of two or more data frame objects and return a `DataFrame`
 containing the result. An outer join includes rows with keys that appear in any
 of the passed data frames.
+
+# Extended help
 
 # Arguments
 - `df1`, `df2`, `dfs...` : the `AbstractDataFrames` to be joined
@@ -804,6 +812,8 @@ Perform a semi join of two data frame objects and return a `DataFrame`
 containing the result. A semi join returns the subset of rows of `df1` that
 match with the keys in `df2`.
 
+# Extended help
+
 # Arguments
 - `df1`, `df2`: the `AbstractDataFrames` to be joined
 
@@ -901,6 +911,8 @@ Perform an anti join of two data frame objects and return a `DataFrame`
 containing the result. An anti join returns the subset of rows of `df1` that do
 not match with the keys in `df2`.
 
+# Extended help
+
 # Arguments
 - `df1`, `df2`: the `AbstractDataFrames` to be joined
 
@@ -990,6 +1002,8 @@ antijoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
 Perform a cross join of two or more data frame objects and return a `DataFrame`
 containing the result. A cross join returns the cartesian product of rows from
 all passed data frames.
+
+# Extended help
 
 # Arguments
 - `df1`, `df2`, `dfs...` : the `AbstractDataFrames` to be joined

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -15,6 +15,7 @@ If `view=true` then return a stacked view of a data frame (long format).
 The result is a view because the columns are special `AbstractVectors`
 that return views into the original data frame.
 
+# Extended help
 
 # Arguments
 - `df` : the AbstractDataFrame to be stacked
@@ -124,6 +125,8 @@ end
     unstack(df::AbstractDataFrame; renamecols::Function=identity)
 
 Unstack data frame `df`, i.e. convert it from long to wide format.
+
+# Extended help
 
 If `colkey` contains `missing` values then they will be skipped and a warning
 will be printed.

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -280,6 +280,8 @@ SELECT_ARG_RULES =
 Mutate `df` in place to retain only columns specified by `args...` and return it.
 The result is guaranteed to have the same number of rows as `df`.
 
+# Extended help
+
 $SELECT_ARG_RULES
 
 Note that including the same column several times in the data frame via renaming
@@ -374,6 +376,8 @@ transform!(df::DataFrame, args...) = select!(df, :, args...)
 
 Create a new data frame that contains columns from `df` specified by `args` and
 return it. The result is guaranteed to have the same number of rows as `df`.
+
+# Extended help
 
 If `df` is a `DataFrame` or `copycols=true` then column renaming and transformations
 are supported.

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -386,6 +386,8 @@ I/O stream.
 NOTE: The value of `maxwidths[end]` must be the string width of
 `rowlabel`.
 
+# Extended help
+
 # Arguments
 - `io::IO`: The I/O stream to which `df` will be printed.
 - `df::AbstractDataFrame`: An AbstractDataFrame.
@@ -619,6 +621,8 @@ representation chosen depends on the width of the display.
 If `io` is omitted, the result is printed to `stdout`,
 and `allrows`, `allcols` and `allgroups` default to `false`
 while `splitcols` defaults to `true`.
+
+# Extended help
 
 # Arguments
 - `io::IO`: The I/O stream to which `df` will be printed.

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -364,6 +364,8 @@ end
 
 Return a copy of data frame `df` sorted by column(s) `cols`.
 
+# Extended help
+
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
@@ -438,6 +440,8 @@ Return a permutation vector of row indices of data frame `df` that puts them in
 sorted order according to column(s) `cols`.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
+
+# Extended help
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -6,6 +6,16 @@ An AbstractDataFrame that stores a set of named columns
 The columns are normally AbstractVectors stored in memory,
 particularly a Vector or CategoricalVector.
 
+# Examples
+```julia
+df = DataFrame()
+v = ["x","y","z"][rand(1:3, 10)]
+df1 = DataFrame(Any[collect(1:10), v, rand(10)], [:A, :B, :C])
+df2 = DataFrame(A = 1:10, B = v, C = rand(10))
+```
+
+# Extended help
+
 # Constructors
 ```julia
 DataFrame(columns::AbstractVector, names::AbstractVector{Symbol};
@@ -671,6 +681,8 @@ Insert a column into a data frame in place. Return the updated `DataFrame`.
 If `ind` is omitted it is set to `ncol(df)+1`
 (the column is inserted as the last column).
 
+# Extended help
+
 # Arguments
 - `df` : the DataFrame to which we want to add columns
 - `ind` : a position at which we want to insert a column
@@ -1039,6 +1051,8 @@ Change columns selected by `cols` in data frame `df` to `CategoricalVector`.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR) or a `Type`.
 
+# Extended help
+
 If `categorical!` is called with the `cols` argument being a `Type`, then
 all columns whose element type is a subtype of this type
 (by default `Union{AbstractString, Missing}`) will be converted to categorical.
@@ -1134,6 +1148,8 @@ end
 Add the rows of `df2` to the end of `df`. If the second argument `table` is not an
 `AbstractDataFrame` then it is converted using `DataFrame(table, copycols=false)`
 before being appended.
+
+# Extended help
 
 The exact behavior of `append!` depends on the `cols` argument:
 * If `cols == :setequal` (this is the default)
@@ -1448,6 +1464,8 @@ end
 
 Add in-place one row at the end of `df` taking the values from `row`.
 
+# Extended help
+
 Column types of `df` are preserved, and new values are converted if necessary.
 An error is thrown if conversion fails.
 
@@ -1603,6 +1621,8 @@ end
 Update a data frame `df` in-place by repeating its rows. `inner` specifies how many
 times each row is repeated, and `outer` specifies how many times the full set
 of rows is repeated. Columns of `df` are freshly allocated.
+
+# Extended help
 
 # Example
 ```jldoctest

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -8,6 +8,8 @@ Sort data frame `df` by column(s) `cols`.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 
+# Extended help
+
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending
 on the type of the sorting columns and on the number of rows in `df`.

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -7,6 +7,8 @@ A `DataFrameRow` is returned by `getindex` or `view` functions when one row and 
 selection of columns are requested, or when iterating the result
 of the call to the [`eachrow`](@ref) function.
 
+# Extended help
+
 The `DataFrameRow` constructor can also be called directly:
 
 ```

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -403,6 +403,8 @@ Unlike the equivalent `Tuple` and `NamedTuple`, these keys can be used to index
 into `gd` efficiently. The ordering of the keys is identical to the ordering of
 the groups of `gd` under iteration and integer indexing.
 
+# Extended help
+
 # Examples
 
 ```jldoctest groupkeys
@@ -518,6 +520,8 @@ Get a group based on the values of the grouping columns.
 
 `key` may be a `NamedTuple` or `Tuple` of grouping column values (in the same
 order as the `cols` argument to `groupby`).
+
+# Extended help
 
 # Examples
 

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -14,6 +14,8 @@ into row groups.
 - `skipmissing` : whether to skip groups with `missing` values in one of the
   grouping columns `cols`
 
+# Extended help
+
 # Details
 An iterator over a `GroupedDataFrame` returns a `SubDataFrame` view
 for each grouping into `df`.
@@ -262,7 +264,9 @@ Apply operations to each group in a [`GroupedDataFrame`](@ref) and return the co
 result as a `DataFrame` if `ungroup=true` or `GroupedDataFrame` if `ungroup=false`.
 
 If an `AbstractDataFrame` is passed, apply operations to the data frame as a whole
-and a `DataFrame` is always returend.
+and a `DataFrame` is always returned.
+
+# Extended help
 
 $F_ARGUMENT_RULES
 
@@ -1432,6 +1436,8 @@ The `parent` of the returned value has as many rows as `parent(gd)`. If an opera
 in `args` returns a single value it is always broadcasted to have this number of rows.
 
 If `copycols=false` then do not perform copying of columns that are not transformed.
+
+# Extended help
 
 $KWARG_PROCESSING_RULES
 


### PR DESCRIPTION
A first pass at adding support for Extended help. It looks like this:

<img width="929" alt="Screenshot 2020-05-13 at 09 31 07" src="https://user-images.githubusercontent.com/52289/81789869-7e4f0a00-94fc-11ea-9561-c17909ddb054.png">

It's not always easy to judge the right amount of help before inserting `Extended help`, but a rough guide was to make sure you can still see the function definition when the `julia>` prompt reappears... 