### PR TITLE
fix bugs in append! and push! corner cases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.21.1"
+version = "0.21.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1284,8 +1284,8 @@ function Base.append!(df1::DataFrame, df2::AbstractDataFrame; cols::Symbol=:sete
                     _columns(df1)[j] = newcol
                 else
                     throw(ArgumentError("promote=false and source data frame does " *
-                                        "not contain column :$n, while destination" *
-                                        " column does not allowmissing values"))
+                                        "not contain column :$n, while destination " *
+                                        "column does not allow for missing values"))
                 end
             end
         end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -858,6 +858,58 @@ end
     end
 end
 
+@testset "new append! and push! tests" begin
+    for df in [DataFrame(a=Any[1]), DataFrame(a=1)]
+        @test append!(df, DataFrame(b=1), cols=:union) ≅
+              DataFrame(a=[1, missing], b=[missing, 1])
+        @test append!(df, DataFrame(b=1), cols=:union) ≅
+              DataFrame(a=[1, missing, missing], b=[missing, 1, 1])
+        df.x = 1:3
+        with_logger(SimpleLogger(IOBuffer())) do
+            @test_throws ArgumentError append!(df, DataFrame(b=1), cols=:union,
+                                               promote=false)
+        end
+        @test df  ≅ DataFrame(a=[1, missing, missing], b=[missing, 1, 1], x=1:3)
+        allowmissing!(df, :x)
+        @test append!(df, DataFrame(b=1), cols=:union, promote=false) ≅
+              DataFrame(a=[1, missing, missing, missing], b=[missing, 1, 1, 1],
+                        x=[1:3; missing])
+    end
+
+    for df in [DataFrame(a=Any[1]), DataFrame(a=1)]
+        @test push!(df, (b=1,), cols=:union) ≅
+              DataFrame(a=[1, missing], b=[missing, 1])
+        @test push!(df, (b=1,), cols=:union) ≅
+              DataFrame(a=[1, missing, missing], b=[missing, 1, 1])
+        df.x = 1:3
+        with_logger(SimpleLogger(IOBuffer())) do
+            @test_throws MethodError push!(df, (b=1,), cols=:union, promote=false)
+        end
+        @test df  ≅ DataFrame(a=[1, missing, missing], b=[missing, 1, 1], x=1:3)
+        allowmissing!(df, :x)
+        @test push!(df, (b=1,), cols=:union, promote=false) ≅
+              DataFrame(a=[1, missing, missing, missing], b=[missing, 1, 1, 1],
+                        x=[1:3; missing])
+    end
+
+    for df in [DataFrame(a=Any[1]), DataFrame(a=1)]
+        @test push!(df, DataFrame(b=1)[1, :], cols=:union) ≅
+              DataFrame(a=[1, missing], b=[missing, 1])
+        @test push!(df, DataFrame(b=1)[1, :], cols=:union) ≅
+              DataFrame(a=[1, missing, missing], b=[missing, 1, 1])
+        df.x = 1:3
+        with_logger(SimpleLogger(IOBuffer())) do
+            @test_throws MethodError push!(df, DataFrame(b=1)[1, :], cols=:union,
+                                           promote=false)
+        end
+        @test df  ≅ DataFrame(a=[1, missing, missing], b=[missing, 1, 1], x=1:3)
+        allowmissing!(df, :x)
+        @test push!(df, DataFrame(b=1)[1, :], cols=:union, promote=false) ≅
+              DataFrame(a=[1, missing, missing, missing], b=[missing, 1, 1, 1],
+                        x=[1:3; missing])
+    end
+end
+
 @testset "test categorical!" begin
     df = DataFrame(A = Vector{Union{Int, Missing}}(1:3), B = Vector{Union{Int, Missing}}(4:6))
     DRT = CategoricalArrays.DefaultRefType


### PR DESCRIPTION
1. `append!` incorrectly tried to access a non-existent column in source in some cases.
2. `push!` incorrectly did not clean up the data frame on error in some cases

PS. and this is a lesson for me not to do copy-paste :cry:.

After this is merged it should be backported to 0.21.2.