### PR TITLE
[BREAKING] Keep naming ComposedFunction :function

### DIFF
--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -76,6 +76,6 @@ function funname(f)
     String(n)[1] == '#' ? :function : n
 end
 
-if isdefined(Base, :ComposedFunction)
+if VERSION >= v"1.6.0-DEV.85"
     funname(c::Base.ComposedFunction) = Symbol(funname(c.f), :_, funname(c.g))
 end

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -75,3 +75,7 @@ function funname(f)
     n = nameof(f)
     String(n)[1] == '#' ? :function : n
 end
+
+if isdefined(Base, :ComposedFunction)
+    funname(::Base.ComposedFunction) = :function
+end

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -77,5 +77,5 @@ function funname(f)
 end
 
 if isdefined(Base, :ComposedFunction)
-    funname(::Base.ComposedFunction) = :function
+    funname(c::Base.ComposedFunction) = Symbol(funname(c.f), :_, funname(c.g))
 end

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -76,7 +76,7 @@ function funname(f)
     String(n)[1] == '#' ? :function : n
 end
 
-if isdefined(Base, :ComposedFunction)
+if isdefined(Base, :ComposedFunction) # Julia >= 1.6.0-DEV.85
     using Base: ComposedFunction
 else
     const ComposedFunction = let h = identity ∘ convert

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -76,6 +76,15 @@ function funname(f)
     String(n)[1] == '#' ? :function : n
 end
 
-if VERSION >= v"1.6.0-DEV.85"
-    funname(c::Base.ComposedFunction) = Symbol(funname(c.f), :_, funname(c.g))
+if isdefined(Base, :ComposedFunction)
+    using Base: ComposedFunction
+else
+    const ComposedFunction = let h = identity ∘ convert
+        @assert h.f === identity
+        @assert h.g === convert
+        getfield(parentmodule(typeof(h)), nameof(typeof(h)))
+    end
+    @assert identity ∘ convert isa ComposedFunction
 end
+
+funname(c::ComposedFunction) = Symbol(funname(c.f), :_, funname(c.g))

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2223,44 +2223,26 @@ end
     gdf = groupby_checked(df, :g)
     @test combine(gdf, :x => sum) == DataFrame(g=1:2, x_sum=[3.0, 4.5])
 
-    if VERSION >= v"1.6.0-DEV.85"
-        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3.0, 4.5])
-        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.5])
-        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
-    else
-        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3.0, 4.5])
-        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.5])
-        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
-    end
+    @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3.0, 4.5])
+    @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.5])
+    @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
     @test combine(gdf, :x => mean) == DataFrame(g=1:2, x_mean=[1.0, 1.5])
     @test combine(gdf, :x => var) == DataFrame(g=1:2, x_var=[0.0, 0.0])
 
     df = DataFrame(g=[1,1,1,2,2,2], x=Any[1,1,1,1,1,missing])
     gdf = groupby_checked(df, :g)
-    if VERSION >= v"1.6.0-DEV.85"
-        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3, 2])
-        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.0])
-        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
-    else
-        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3, 2])
-        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.0])
-        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
-    end
+    @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3, 2])
+    @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.0])
+    @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
     @test combine(gdf, :x => sum) ≅ DataFrame(g=1:2, x_sum=[3, missing])
     @test combine(gdf, :x => mean) ≅ DataFrame(g=1:2, x_mean=[1.0, missing])
     @test combine(gdf, :x => var) ≅ DataFrame(g=1:2, x_var=[0.0, missing])
 
     df = DataFrame(g=[1,1,1,2,2,2], x=Union{Real, Missing}[1,1,1,1,1,missing])
     gdf = groupby_checked(df, :g)
-    if VERSION >= v"1.6.0-DEV.85"
-        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3, 2])
-        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.0])
-        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
-    else
-        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3, 2])
-        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.0])
-        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
-    end
+    @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3, 2])
+    @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.0])
+    @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
     @test combine(gdf, :x => sum) ≅ DataFrame(g=1:2, x_sum=[3, missing])
     @test combine(gdf, :x => mean) ≅ DataFrame(g=1:2, x_mean=[1.0, missing])
     @test combine(gdf, :x => var) ≅ DataFrame(g=1:2, x_var=[0.0, missing])
@@ -2302,11 +2284,7 @@ end
     gdf = groupby_checked(df, :g)
     @test combine(gdf, :x => sum)[1, 2] isa Missing
     @test eltype(combine(gdf, :x => sum)[!, 2]) === Missing
-    if VERSION >= v"1.6.0-DEV.85"
-        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1, x_sum_skipmissing=0)
-    else
-        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1, x_function=0)
-    end
+    @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1, x_sum_skipmissing=0)
     @test eltype(combine(gdf, :x => sum∘skipmissing)[!, 2]) === Int
     df = DataFrame(g=[1,1,1,1,1,1], x=convert(Vector{Union{Int, Missing}}, fill(missing, 6)))
     gdf = groupby_checked(df, :g)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2309,12 +2309,12 @@ end
           combine(gdf, :x => (x -> sum(x)) => :a, :x => (x -> prod(x)) => :b)
     df = DataFrame(g=[1, 1], x=[missing, "a"])
     gdf = groupby_checked(df, :g)
-    @test Matrix(combine(gdf, :x => sum∘skipmissing => :a, :x => prod∘skipmissing => :b)) ==
-          Matrix(combine(gdf, :x => (x -> sum(skipmissing(x))) => :a, :x => (x -> prod(skipmissing(x))) => :b))
+    @test combine(gdf, :x => sum∘skipmissing => :a, :x => prod∘skipmissing => :b) ==
+          combine(gdf, :x => (x -> sum(skipmissing(x))) => :a, :x => (x -> prod(skipmissing(x))) => :b)
     df = DataFrame(g=[1, 1], x=Any[missing, "a"])
     gdf = groupby_checked(df, :g)
-    @test Matrix(combine(gdf, :x => sum∘skipmissing => :a, :x => prod∘skipmissing => :b)) ==
-          Matrix(combine(gdf, :x => (x -> sum(skipmissing(x))) => :a, :x => (x -> prod(skipmissing(x))) => :b))
+    @test combine(gdf, :x => sum∘skipmissing => :a, :x => prod∘skipmissing => :b) ==
+          combine(gdf, :x => (x -> sum(skipmissing(x))) => :a, :x => (x -> prod(skipmissing(x))) => :b)
 
     df = DataFrame(g=[1, 2], x=Any[nothing, "a"])
     gdf = groupby_checked(df, :g)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2222,29 +2222,48 @@ end
     df = DataFrame(g=[1,1,1,2,2,2], x=Any[1,1,1,1.5,1.5,1.5])
     gdf = groupby_checked(df, :g)
     @test combine(gdf, :x => sum) == DataFrame(g=1:2, x_sum=[3.0, 4.5])
-    @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3.0, 4.5])
+
+    if VERSION >= v"1.6.0-DEV.85"
+        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3.0, 4.5])
+        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.5])
+        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
+    else
+        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3.0, 4.5])
+        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.5])
+        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
+    end
     @test combine(gdf, :x => mean) == DataFrame(g=1:2, x_mean=[1.0, 1.5])
-    @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.5])
     @test combine(gdf, :x => var) == DataFrame(g=1:2, x_var=[0.0, 0.0])
-    @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
 
     df = DataFrame(g=[1,1,1,2,2,2], x=Any[1,1,1,1,1,missing])
     gdf = groupby_checked(df, :g)
+    if VERSION >= v"1.6.0-DEV.85"
+        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3, 2])
+        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.0])
+        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
+    else
+        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3, 2])
+        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.0])
+        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
+    end
     @test combine(gdf, :x => sum) ≅ DataFrame(g=1:2, x_sum=[3, missing])
-    @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3, 2])
     @test combine(gdf, :x => mean) ≅ DataFrame(g=1:2, x_mean=[1.0, missing])
-    @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.0])
     @test combine(gdf, :x => var) ≅ DataFrame(g=1:2, x_var=[0.0, missing])
-    @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
 
     df = DataFrame(g=[1,1,1,2,2,2], x=Union{Real, Missing}[1,1,1,1,1,missing])
     gdf = groupby_checked(df, :g)
+    if VERSION >= v"1.6.0-DEV.85"
+        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_sum_skipmissing=[3, 2])
+        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_mean_skipmissing=[1.0, 1.0])
+        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_var_skipmissing=[0.0, 0.0])
+    else
+        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3, 2])
+        @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.0])
+        @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
+    end
     @test combine(gdf, :x => sum) ≅ DataFrame(g=1:2, x_sum=[3, missing])
-    @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1:2, x_function=[3, 2])
     @test combine(gdf, :x => mean) ≅ DataFrame(g=1:2, x_mean=[1.0, missing])
-    @test combine(gdf, :x => mean∘skipmissing) == DataFrame(g=1:2, x_function=[1.0, 1.0])
     @test combine(gdf, :x => var) ≅ DataFrame(g=1:2, x_var=[0.0, missing])
-    @test combine(gdf, :x => var∘skipmissing) == DataFrame(g=1:2, x_function=[0.0, 0.0])
 
     Random.seed!(1)
     df = DataFrame(g = rand(1:2, 1000), x1 = rand(Int, 1000))
@@ -2283,7 +2302,11 @@ end
     gdf = groupby_checked(df, :g)
     @test combine(gdf, :x => sum)[1, 2] isa Missing
     @test eltype(combine(gdf, :x => sum)[!, 2]) === Missing
-    @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1, x_function=0)
+    if VERSION >= v"1.6.0-DEV.85"
+        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1, x_sum_skipmissing=0)
+    else
+        @test combine(gdf, :x => sum∘skipmissing) == DataFrame(g=1, x_function=0)
+    end
     @test eltype(combine(gdf, :x => sum∘skipmissing)[!, 2]) === Int
     df = DataFrame(g=[1,1,1,1,1,1], x=convert(Vector{Union{Int, Missing}}, fill(missing, 6)))
     gdf = groupby_checked(df, :g)
@@ -2308,12 +2331,12 @@ end
           combine(gdf, :x => (x -> sum(x)) => :a, :x => (x -> prod(x)) => :b)
     df = DataFrame(g=[1, 1], x=[missing, "a"])
     gdf = groupby_checked(df, :g)
-    @test combine(gdf, :x => sum∘skipmissing => :a, :x => prod∘skipmissing => :b) ==
-          combine(gdf, :x => (x -> sum(skipmissing(x))) => :a, :x => (x -> prod(skipmissing(x))) => :b)
+    @test Matrix(combine(gdf, :x => sum∘skipmissing => :a, :x => prod∘skipmissing => :b)) ==
+          Matrix(combine(gdf, :x => (x -> sum(skipmissing(x))) => :a, :x => (x -> prod(skipmissing(x))) => :b))
     df = DataFrame(g=[1, 1], x=Any[missing, "a"])
     gdf = groupby_checked(df, :g)
-    @test combine(gdf, :x => sum∘skipmissing => :a, :x => prod∘skipmissing => :b) ==
-          combine(gdf, :x => (x -> sum(skipmissing(x))) => :a, :x => (x -> prod(skipmissing(x))) => :b)
+    @test Matrix(combine(gdf, :x => sum∘skipmissing => :a, :x => prod∘skipmissing => :b)) ==
+          Matrix(combine(gdf, :x => (x -> sum(skipmissing(x))) => :a, :x => (x -> prod(skipmissing(x))) => :b))
 
     df = DataFrame(g=[1, 2], x=Any[nothing, "a"])
     gdf = groupby_checked(df, :g)

--- a/test/select.jl
+++ b/test/select.jl
@@ -1106,12 +1106,22 @@ end
           DataFrame(a_b_c_sum=map(sum, eachrow(df)))
     @test transform(df, AsTable(:) => sum) ==
           DataFrame(a=1:3, b=4:6, c=7:9, a_b_c_sum=map(sum, eachrow(df)))
-    @test select(df, AsTable(:) => sum ∘ sum) ==
-          repeat(DataFrame(a_b_c_function=45), nrow(df))
-    @test combine(df, AsTable(:) => sum ∘ sum) ==
-          DataFrame(a_b_c_function=45)
-    @test transform(df, AsTable(:) => sum ∘ sum) ==
-          DataFrame(a=1:3, b=4:6, c=7:9, a_b_c_function=45)
+
+    if VERSION >= v"1.6.0-DEV.85"
+        @test select(df, AsTable(:) => sum ∘ sum) ==
+              repeat(DataFrame(a_b_c_sum_sum=45), nrow(df))
+        @test combine(df, AsTable(:) => sum ∘ sum) ==
+              DataFrame(a_b_c_sum_sum=45)
+        @test transform(df, AsTable(:) => sum ∘ sum) ==
+              DataFrame(a=1:3, b=4:6, c=7:9, a_b_c_sum_sum=45)
+    else
+        @test select(df, AsTable(:) => sum ∘ sum) ==
+              repeat(DataFrame(a_b_c_function=45), nrow(df))
+        @test combine(df, AsTable(:) => sum ∘ sum) ==
+              DataFrame(a_b_c_function=45)
+        @test transform(df, AsTable(:) => sum ∘ sum) ==
+              DataFrame(a=1:3, b=4:6, c=7:9, a_b_c_function=45)
+    end
 
     @test select(df, AsTable(:) => ByRow(x -> [x])) ==
           DataFrame(a_b_c_function=[[(a = 1, b = 4, c = 7)],
@@ -1174,10 +1184,17 @@ end
     @test df2[:, 1] == df.x
     @test df2[:, 1] !== df.x
 
-    @test combine(df, :x => sum, :y => collect ∘ extrema) ==
-          DataFrame(x_sum=[6, 6], y_function = [4, 6])
-    @test combine(df, :y => collect ∘ extrema, :x => sum) ==
-          DataFrame(y_function = [4, 6], x_sum=[6, 6])
+    if VERSION >= v"1.6.0-DEV.85"
+        @test combine(df, :x => sum, :y => collect ∘ extrema) ==
+              DataFrame(x_sum=[6, 6], y_collect_extrema = [4, 6])
+        @test combine(df, :y => collect ∘ extrema, :x => sum) ==
+              DataFrame(y_collect_extrema = [4, 6], x_sum=[6, 6])
+    else
+        @test combine(df, :x => sum, :y => collect ∘ extrema) ==
+              DataFrame(x_sum=[6, 6], y_function = [4, 6])
+        @test combine(df, :y => collect ∘ extrema, :x => sum) ==
+              DataFrame(y_function = [4, 6], x_sum=[6, 6])
+    end
     @test combine(df, :x => sum, :y => x -> []) ==
           DataFrame(x_sum=[], y_function = [])
     @test combine(df, :y => x -> [], :x => sum) ==
@@ -1194,10 +1211,17 @@ end
     @test df2[:, 1] == dfv.x
     @test df2[:, 1] !== dfv.x
 
-    @test combine(dfv, :x => sum, :y => collect ∘ extrema) ==
-          DataFrame(x_sum=[3, 3], y_function = [4, 5])
-    @test combine(dfv, :y => collect ∘ extrema, :x => sum) ==
-          DataFrame(y_function = [4, 5], x_sum=[3, 3])
+    if VERSION >= v"1.6.0-DEV.85"
+        @test combine(dfv, :x => sum, :y => collect ∘ extrema) ==
+              DataFrame(x_sum=[3, 3], y_collect_extrema = [4, 5])
+        @test combine(dfv, :y => collect ∘ extrema, :x => sum) ==
+              DataFrame(y_collect_extrema = [4, 5], x_sum=[3, 3])
+    else
+        @test combine(dfv, :x => sum, :y => collect ∘ extrema) ==
+              DataFrame(x_sum=[3, 3], y_function = [4, 5])
+        @test combine(dfv, :y => collect ∘ extrema, :x => sum) ==
+              DataFrame(y_function = [4, 5], x_sum=[3, 3])
+    end
 end
 
 @testset "select and transform AbstractDataFrame" begin

--- a/test/select.jl
+++ b/test/select.jl
@@ -1107,21 +1107,12 @@ end
     @test transform(df, AsTable(:) => sum) ==
           DataFrame(a=1:3, b=4:6, c=7:9, a_b_c_sum=map(sum, eachrow(df)))
 
-    if VERSION >= v"1.6.0-DEV.85"
-        @test select(df, AsTable(:) => sum ∘ sum) ==
-              repeat(DataFrame(a_b_c_sum_sum=45), nrow(df))
-        @test combine(df, AsTable(:) => sum ∘ sum) ==
-              DataFrame(a_b_c_sum_sum=45)
-        @test transform(df, AsTable(:) => sum ∘ sum) ==
-              DataFrame(a=1:3, b=4:6, c=7:9, a_b_c_sum_sum=45)
-    else
-        @test select(df, AsTable(:) => sum ∘ sum) ==
-              repeat(DataFrame(a_b_c_function=45), nrow(df))
-        @test combine(df, AsTable(:) => sum ∘ sum) ==
-              DataFrame(a_b_c_function=45)
-        @test transform(df, AsTable(:) => sum ∘ sum) ==
-              DataFrame(a=1:3, b=4:6, c=7:9, a_b_c_function=45)
-    end
+    @test select(df, AsTable(:) => sum ∘ sum) ==
+          repeat(DataFrame(a_b_c_sum_sum=45), nrow(df))
+    @test combine(df, AsTable(:) => sum ∘ sum) ==
+          DataFrame(a_b_c_sum_sum=45)
+    @test transform(df, AsTable(:) => sum ∘ sum) ==
+          DataFrame(a=1:3, b=4:6, c=7:9, a_b_c_sum_sum=45)
 
     @test select(df, AsTable(:) => ByRow(x -> [x])) ==
           DataFrame(a_b_c_function=[[(a = 1, b = 4, c = 7)],
@@ -1184,17 +1175,10 @@ end
     @test df2[:, 1] == df.x
     @test df2[:, 1] !== df.x
 
-    if VERSION >= v"1.6.0-DEV.85"
-        @test combine(df, :x => sum, :y => collect ∘ extrema) ==
-              DataFrame(x_sum=[6, 6], y_collect_extrema = [4, 6])
-        @test combine(df, :y => collect ∘ extrema, :x => sum) ==
-              DataFrame(y_collect_extrema = [4, 6], x_sum=[6, 6])
-    else
-        @test combine(df, :x => sum, :y => collect ∘ extrema) ==
-              DataFrame(x_sum=[6, 6], y_function = [4, 6])
-        @test combine(df, :y => collect ∘ extrema, :x => sum) ==
-              DataFrame(y_function = [4, 6], x_sum=[6, 6])
-    end
+    @test combine(df, :x => sum, :y => collect ∘ extrema) ==
+          DataFrame(x_sum=[6, 6], y_collect_extrema = [4, 6])
+    @test combine(df, :y => collect ∘ extrema, :x => sum) ==
+          DataFrame(y_collect_extrema = [4, 6], x_sum=[6, 6])
     @test combine(df, :x => sum, :y => x -> []) ==
           DataFrame(x_sum=[], y_function = [])
     @test combine(df, :y => x -> [], :x => sum) ==
@@ -1211,17 +1195,10 @@ end
     @test df2[:, 1] == dfv.x
     @test df2[:, 1] !== dfv.x
 
-    if VERSION >= v"1.6.0-DEV.85"
-        @test combine(dfv, :x => sum, :y => collect ∘ extrema) ==
-              DataFrame(x_sum=[3, 3], y_collect_extrema = [4, 5])
-        @test combine(dfv, :y => collect ∘ extrema, :x => sum) ==
-              DataFrame(y_collect_extrema = [4, 5], x_sum=[3, 3])
-    else
-        @test combine(dfv, :x => sum, :y => collect ∘ extrema) ==
-              DataFrame(x_sum=[3, 3], y_function = [4, 5])
-        @test combine(dfv, :y => collect ∘ extrema, :x => sum) ==
-              DataFrame(y_function = [4, 5], x_sum=[3, 3])
-    end
+    @test combine(dfv, :x => sum, :y => collect ∘ extrema) ==
+          DataFrame(x_sum=[3, 3], y_collect_extrema = [4, 5])
+    @test combine(dfv, :y => collect ∘ extrema, :x => sum) ==
+          DataFrame(y_collect_extrema = [4, 5], x_sum=[3, 3])
 end
 
 @testset "select and transform AbstractDataFrame" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -95,6 +95,4 @@ end
 
 end
 
-end
-
 end # module

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -91,7 +91,7 @@ end
 
 @testset "funname" begin
     @test DataFrames.funname(sum ∘ skipmissing ∘ Base.div12) ==
-          :sum_skipmissing_div12 : :function
+          :sum_skipmissing_div12
 
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -91,7 +91,7 @@ end
 
 @testset "funname" begin
     @test DataFrames.funname(sum ∘ skipmissing ∘ Base.div12) ==
-          (VERSION >= v"1.6.0-DEV.85" ? :sum_skipmissing_div12 : :function)
+          :sum_skipmissing_div12 : :function
 
 end
 

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -92,7 +92,6 @@ end
 @testset "funname" begin
     @test DataFrames.funname(sum ∘ skipmissing ∘ Base.div12) ==
           :sum_skipmissing_div12
-
 end
 
 end # module

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -89,4 +89,12 @@ end
     @test_throws MethodError repeat!(view(df, 1:2, :), inner = 2, outer = 3)
 end
 
+@testset "funname" begin
+    @test DataFrames.funname(sum ∘ skipmissing ∘ Base.div12) ==
+          (VERSION >= v"1.6.0-DEV.85" ? :sum_skipmissing_div12 : :function)
+
+end
+
+end
+
 end # module


### PR DESCRIPTION
Fixes change introduced by https://github.com/JuliaLang/julia/pull/35980.

I assume we prefer `function` rather than `ComposedFunction` to be used in auto-generated column names. Also this is non-breaking this way.

@nalimilan - I have checked and I think that https://github.com/JuliaLang/julia/pull/35980 does not break aggregation code for composed functions (we still should use a fast branch then), but maybe you will want to take a second look.