### PR TITLE
Fix various bugs in split/apply/combine in 0.21 release

### DIFF
--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -278,7 +278,8 @@ SELECT_ARG_RULES =
     select!(df::DataFrame, args...)
 
 Mutate `df` in place to retain only columns specified by `args...` and return it.
-The result is guaranteed to have the same number of rows as `df`.
+The result is guaranteed to have the same number of rows as `df`, except when no
+columns are selected.
 
 $SELECT_ARG_RULES
 
@@ -373,7 +374,8 @@ transform!(df::DataFrame, args...) = select!(df, :, args...)
     select(df::AbstractDataFrame, args...; copycols::Bool=true)
 
 Create a new data frame that contains columns from `df` specified by `args` and
-return it. The result is guaranteed to have the same number of rows as `df`.
+return it. The result is guaranteed to have the same number of rows as `df`,
+except when no columns are selected.
 
 If `df` is a `DataFrame` or `copycols=true` then column renaming and transformations
 are supported.

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -279,7 +279,7 @@ SELECT_ARG_RULES =
 
 Mutate `df` in place to retain only columns specified by `args...` and return it.
 The result is guaranteed to have the same number of rows as `df`, except when no
-columns are selected.
+columns are selected (in which case the result has zero rows).
 
 $SELECT_ARG_RULES
 
@@ -375,7 +375,7 @@ transform!(df::DataFrame, args...) = select!(df, :, args...)
 
 Create a new data frame that contains columns from `df` specified by `args` and
 return it. The result is guaranteed to have the same number of rows as `df`,
-except when no columns are selected.
+except when no columns are selected (in which case the result has zero rows)..
 
 If `df` is a `DataFrame` or `copycols=true` then column renaming and transformations
 are supported.

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -299,8 +299,10 @@ end
 # The full version (to_indices) is required rather than to_index even though
 # GroupedDataFrame behaves as a 1D array due to the behavior of Colon and Not.
 # Note that this behavior would be the default if it was <:AbstractArray
-Base.getindex(gd::GroupedDataFrame, idx...) =
-    getindex(gd, Base.to_indices(gd, idx)...)
+function Base.getindex(gd::GroupedDataFrame, idx...)
+    length(idx) == 1 || throw(ArgumentError("GroupedDataFrame requires a single index"))
+    return getindex(gd, Base.to_indices(gd, idx)...)
+end
 
 # The allowed key types for dictionary-like indexing
 const GroupKeyTypes = Union{GroupKey, Tuple, NamedTuple}

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -48,8 +48,8 @@ function Base.getproperty(gd::GroupedDataFrame, f::Symbol)
         if getfield(gd, f) === nothing
             gd.keymap = genkeymap(gd, ntuple(i -> parent(gd)[!, gd.cols[i]], length(gd.cols)))
         end
-        return getfield(gd, f)::Dict{Any,Int}
         Threads.unlock(gd.lazy_lock)
+        return getfield(gd, f)::Dict{Any,Int}
     else
         return getfield(gd, f)
     end

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -1,9 +1,9 @@
 # Implementation note
-# There are two important design  features of GroupedDataFrame
-# 1. idx, starts, ends and keymap are by default left uninitiated;
+# There are two important design features of GroupedDataFrame
+# 1. idx, starts, ends and keymap are by default left uninitialized;
 #    they get populated only on demand; this means that every GroupedDataFrame
 #    has lazy_lock field which is used to make sure that two threads concurrently
-#    do not try to create them. The lock should be used in every function hat
+#    do not try to create them. The lock should be used in every function that
 #    does a direct access to these fields via getfield.
 # 2. Except for point 1 above currently fields of GroupedDataFrame are never
 #    mutated after it is created. This means that internally when copying

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -203,13 +203,16 @@ end
 # Index with colon (creates copy)
 function Base.getindex(gd::GroupedDataFrame, idxs::Colon)
     maybe_copy(x) = isnothing(x) ? x : copy(x)
-    return GroupedDataFrame(gd.parent, copy(gd.cols), copy(gd.groups),
-                            maybe_copy(getfield(gd, :idx)),
-                            maybe_copy(getfield(gd, :starts)),
-                            maybe_copy(getfield(gd, :ends)),
-                            gd.ngroups,
-                            maybe_copy(getfield(gd, :keymap)),
-                            Threads.ReentrantLock())
+    Threads.lock(gd.lazy_lock)
+    new_gd = GroupedDataFrame(gd.parent, copy(gd.cols), copy(gd.groups),
+                              maybe_copy(getfield(gd, :idx)),
+                              maybe_copy(getfield(gd, :starts)),
+                              maybe_copy(getfield(gd, :ends)),
+                              gd.ngroups,
+                              maybe_copy(getfield(gd, :keymap)),
+                              Threads.ReentrantLock())
+    Threads.unlock(gd.lazy_lock)
+    return new_gd
 end
 
 

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -1524,7 +1524,7 @@ end
 Apply `args` to `gd` following the rules described in [`combine`](@ref).
 
 If `ungroup=true` the result is a `DataFrame`.
-If  `ungroup=false` thee result is a `GroupedDataFrame`
+If  `ungroup=false` the result is a `GroupedDataFrame`
 (in this case the returned value retains the order of groups of `gd`).
 
 The `parent` of the returned value has as many rows as `parent(gd)` and

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -245,6 +245,8 @@ const KWARG_PROCESSING_RULES =
     in addition to those generated. In this case if the returned
     value contains columns with the same names as the grouping columns, they are
     required to be equal.
+    If `keepkeys=false` if generated columns have the same name as grouping columns
+    they are kept and are not required to be equal to grouping columns.
 
     If `ungroup=true` (the default) a `DataFrame` is returned.
     If `ungroup=false` a `GroupedDataFrame` grouped using `keycols(gdf)` is returned.
@@ -548,10 +550,6 @@ function _combine_prepare(gd::GroupedDataFrame,
 end
 
 function combine(gd::GroupedDataFrame; f...)
-    if length(f) == 0
-        throw(ArgumentError("combine(gd) is not allowed, use DataFrame(gd) " *
-                            "to combine a GroupedDataFrame into a DataFrame"))
-    end
     Base.depwarn("`combine(gd; target_col = source_cols => fun, ...)` is deprecated" *
                  ", use `combine(gd, source_cols => fun => :target_col, ...)` instead",
                  :combine)
@@ -1483,10 +1481,13 @@ end
            copycols::Bool=true, keepkeys::Bool=true, ungroup::Bool=true)
 
 Apply `args` to `gd` following the rules described in [`combine`](@ref) and return the
-result as a `DataFrame` if `ungroup=true` or `GroupedDataFrame` if `ungroup=false`.
+result as a `DataFrame` if `ungroup=true` or `GroupedDataFrame` if `ungroup=false`
+(in this case the returned value retains the order of groups of `gd`).
 
-The `parent` of the returned value has as many rows as `parent(gd)`. If an operation
-in `args` returns a single value it is always broadcasted to have this number of rows.
+The `parent` of the returned value has as many rows as `parent(gd)`, except when
+`gd` has no grouping columns or `keepkeys=false` and no columns are selected.
+Also order of rows in the parent is preserved. If an operation in `args` returns
+a single value it is always broadcasted to have this number of rows.
 
 If `copycols=false` then do not perform copying of columns that are not transformed.
 

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -237,6 +237,8 @@ const F_ARGUMENT_RULES =
     If the first or last argument is a function `fun`, it is passed a [`SubDataFrame`](@ref)
     view for each group and can return any return value defined below.
     Note that this form is slower than `pair` or `args` due to type instability.
+
+    If grouped data frame has zero groups then no transformations are applied.
     """
 
 const KWARG_PROCESSING_RULES =
@@ -250,6 +252,8 @@ const KWARG_PROCESSING_RULES =
 
     If `ungroup=true` (the default) a `DataFrame` is returned.
     If `ungroup=false` a `GroupedDataFrame` grouped using `keycols(gdf)` is returned.
+
+    If `gd` has zero groups then no additional columns are computed.
     """
 
 """
@@ -473,7 +477,6 @@ function _combine_prepare(gd::GroupedDataFrame,
                           @nospecialize(cs::Union{Pair, typeof(nrow),
                                                   ColumnIndex, MultiColumnIndex}...);
                  keepkeys::Bool, ungroup::Bool, copycols::Bool, keeprows::Bool)
-    @assert !isempty(cs)
     cs_vec = []
     for p in cs
         if p === nrow
@@ -550,9 +553,12 @@ function _combine_prepare(gd::GroupedDataFrame,
 end
 
 function combine(gd::GroupedDataFrame; f...)
-    Base.depwarn("`combine(gd; target_col = source_cols => fun, ...)` is deprecated" *
-                 ", use `combine(gd, source_cols => fun => :target_col, ...)` instead",
-                 :combine)
+    if length(f) > 0
+        Base.depwarn("`combine(gd; target_col = source_cols => fun, ...)` is deprecated" *
+                     ", use `combine(gd, source_cols => fun => :target_col, ...)` instead",
+                     :combine)
+    end
+    # in the future handle keepkeys and ungroup
     return combine(gd, [source_cols => fun => out_col for (out_col, (source_cols, fun)) in f])
 end
 
@@ -574,6 +580,9 @@ function combine_helper(f, gd::GroupedDataFrame,
                         nms::Union{AbstractVector{Symbol},Nothing}=nothing;
                         keepkeys::Bool, ungroup::Bool,
                         copycols::Bool, keeprows::Bool)
+    # helper function for creating a new GroupedDataFrame
+    maybe_copy(x) = isnothing(x) ? x : copy(x)
+
     if !ungroup && !keepkeys
         throw(ArgumentError("keepkeys=false when ungroup=false is not allowed"))
     end
@@ -595,33 +604,52 @@ function combine_helper(f, gd::GroupedDataFrame,
         else
             newparent = parent(gd)[idx, gd.cols]
         end
-        hcat!(newparent, select(valscat, Not(intersect(keys, _names(valscat))), copycols=false),
+        hcat!(newparent,
+              select(valscat, Not(intersect(keys, _names(valscat))), copycols=false),
               copycols=false)
         ungroup && return newparent
 
-        if length(idx) == 0
+        if length(idx) == 0 && !(keeprows && length(keys) > 0)
             @assert nrow(newparent) == 0
             return GroupedDataFrame(newparent, collect(1:length(gd.cols)), Int[],
-                                    Int[], Int[], Int[], 0, Dict{Any,Int}())
+                                        Int[], Int[], Int[], 0, Dict{Any,Int}())
         end
         if keeprows
+            @assert length(keys) > 0 || idx == gd.idx
+            @assert names(newparent, 1:length(gd.cols)) == names(parent(gd), gd.cols)
             # in this case we are sure that the result GroupedDataFrame has the
-            # same structure as the source
-            # we do not copy data as it should be safe - we never mutate fields of gd
-            return GroupedDataFrame(newparent, gd.cols, gd.groups, gd.idx,
-                                    gd.starts, gd.ends, gd.ngroups, getfield(gd, :keymap))
+            # same structure as the source except that grouping columns are at the start
+            return GroupedDataFrame(newparent, collect(1:length(gd.cols)), copy(gd.groups),
+                                    maybe_copy(getfield(gd, :idx)),
+                                    maybe_copy(getfield(gd, :starts)),
+                                    maybe_copy(getfield(gd, :ends)),
+                                    gd.ngroups,
+                                    maybe_copy(getfield(gd, :keymap)))
         else
             groups = gen_groups(idx)
             @assert groups[end] <= length(gd)
+            @assert names(newparent, 1:length(gd.cols)) == names(parent(gd), gd.cols)
             return GroupedDataFrame(newparent, collect(1:length(gd.cols)), groups,
                                     nothing, nothing, nothing, groups[end], nothing)
         end
     else
-        if ungroup
-            return keepkeys ? parent(gd)[1:0, gd.cols] : DataFrame()
+        if keeprows
+            if nrow(parent(gd)) > 0
+                 throw(ArgumentError("select and transform do not support " *
+                                    "`GroupedDataFrame`s from which some groups have "*
+                                    "been dropped (including skipmissing=true)"))
+            end
+            if ungroup
+                return keepkeys ? select(parent(gd), gd.cols, copycols=copycols) : DataFrame()
+            else
+                return groupby(select(parent(gd), gd.cols, copycols=copycols), 1:length(gd.cols))
+            end
         else
-            return GroupedDataFrame(parent(gd)[1:0, gd.cols], collect(1:length(gd.cols)),
-                                    Int[], Int[], Int[], Int[], 0, Dict{Any,Int}())
+            if ungroup
+                return keepkeys ? parent(gd)[1:0, gd.cols] : DataFrame()
+            else
+                return groupby(parent(gd)[1:0, gd.cols], 1:length(gd.cols))
+            end
         end
     end
 end
@@ -1084,6 +1112,7 @@ function _combine(f::AbstractVector{<:Pair},
     @assert all(x -> first(x) isa Union{Int, AbstractVector{Int}, AsTable}, f)
     @assert all(x -> last(x) isa Base.Callable, f)
 
+    isempty(f) && return Int[], DataFrame()
     if keeprows
         if minimum(gd.groups) == 0
             throw(ArgumentError("select and transform do not support " *

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -582,9 +582,6 @@ function combine_helper(f, gd::GroupedDataFrame,
                         nms::Union{AbstractVector{Symbol},Nothing}=nothing;
                         keepkeys::Bool, ungroup::Bool,
                         copycols::Bool, keeprows::Bool)
-    # helper function for creating a new GroupedDataFrame
-    maybe_copy(x) = isnothing(x) ? x : copy(x)
-
     if !ungroup && !keepkeys
         throw(ArgumentError("keepkeys=false when ungroup=false is not allowed"))
     end
@@ -622,13 +619,10 @@ function combine_helper(f, gd::GroupedDataFrame,
             # in this case we are sure that the result GroupedDataFrame has the
             # same structure as the source except that grouping columns are at the start
             Threads.lock(gd.lazy_lock)
-            new_gd = GroupedDataFrame(newparent, collect(1:length(gd.cols)), copy(gd.groups),
-                                      maybe_copy(getfield(gd, :idx)),
-                                      maybe_copy(getfield(gd, :starts)),
-                                      maybe_copy(getfield(gd, :ends)),
-                                      gd.ngroups,
-                                      maybe_copy(getfield(gd, :keymap)),
-                                      Threads.ReentrantLock())
+            new_gd = GroupedDataFrame(newparent, collect(1:length(gd.cols)), gd.groups,
+                                      getfield(gd, :idx), getfield(gd, :starts),
+                                      getfield(gd, :ends), gd.ngroups,
+                                      getfield(gd, :keymap), Threads.ReentrantLock())
             Threads.lock(gd.lazy_lock)
             return new_gd
         else

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -953,6 +953,7 @@ end
     @test_throws ArgumentError gd[true]
     @test_throws ArgumentError gd[[1, 2, 1]]  # Duplicate
     @test_throws ArgumentError gd["a"]
+    @test_throws ArgumentError gd[1, 1]
 
     # Single integer
     @test gd[1] isa SubDataFrame
@@ -1008,6 +1009,7 @@ end
 
     # Out-of-bounds
     @test_throws BoundsError gd[1:5]
+    @test_throws BoundsError gd[0]
 end
 
 @testset "== and isequal" begin
@@ -1329,7 +1331,6 @@ end
     gd = groupby_checked(df, [:a, :b])
 
     @test gd[1] == DataFrame(a=[:A, :A], b=[1, 1], c=[1, 4])
-    @test_throws ArgumentError gd[1, 1]
 
     @test map(NamedTuple, keys(gd)) ≅
         [(a=:A, b=1), (a=:B, b=1), (a=missing, b=1), (a=:A, b=2), (a=:B, b=2), (a=missing, b=2)]
@@ -2254,7 +2255,9 @@ end
 
     @test size(combine(gdf)) == (0, 1)
     @test names(combine(gdf)) == ["g"]
-    # TODO: add tests for keepkeys and ungroup after deprecation
+    # TODO: uncomment tests for keepkeys and ungroup after deprecation
+    # @test combine(gdf, keepkeys=false) == DataFrame()
+    # @test combine(gdf, ungroup=false) == groupby(DataFrame(g=[]), :g)
     @test size(select(gdf)) == (0, 1)
     @test names(select(gdf)) == ["g"]
     @test groupcols(validate_gdf(select(gdf, ungroup=false))) == [:g]
@@ -2274,7 +2277,8 @@ end
 
     @test size(combine(x -> DataFrame(col=1), gdf)) == (0, 1)
     @test names(combine(x -> DataFrame(col=1), gdf)) == ["g"]
-    # TODO: add tests for keepkeys and ungroup after deprecation
+    @test combine(x -> DataFrame(col=1), gdf, ungroup=false) == groupby(DataFrame(g=[]), :g)
+    @test combine(x -> DataFrame(col=1), gdf, keepkeys=false) == DataFrame()
     @test size(select(gdf, :x => :y)) == (0, 1)
     @test names(select(gdf, :x => :y)) == ["g"]
     @test groupcols(validate_gdf(select(gdf, :x => :y, ungroup=false))) == [:g]

--- a/test/select.jl
+++ b/test/select.jl
@@ -1203,6 +1203,9 @@ end
 
 @testset "select and transform AbstractDataFrame" begin
     df = DataFrame(x=1:3, y=4:6)
+
+    @test select(df) == DataFrame()
+
     @test select(df, :x => first) == DataFrame(x_first=fill(1,3))
     df2 = select(df, :x, :x => first, copycols=true)
     @test df2 == DataFrame(x=df.x, x_first=fill(1,3))


### PR DESCRIPTION
In this PR I fix some corner cases that were bugs in 0.21 release. It should be merged before https://github.com/JuliaData/DataFrames.jl/pull/2279 as it should be backported.

What it covers:
* documentation improvements of what happens (and should happen in corner cases, especially when something is "empty", where something is: `GroupedDataFrame`, `DataFrame`, list of transformations, or `groupcols`)
* fix a bug with `GroupDataFrame` indexing that caused StackOverflow
* fix a bug in creation of `GroupedDataFrame` with `ungroup=false` (wrong columns could be shown as grouping columns in the past)
* fix cases of "empty" stuff passed (listed above), especially when `keepkeys=false` or `ungroup=false` (there are several corner cases here); most likely in real usage scenarios these cases do not happen, but still we should provide a correct result here.

In general correctly handling all these corner cases is tricky so probably if someone would be willing to review it it might be challenging (so thank you in advance for the efforts). I will also try to improve test coverage for this if I find other "corner cases" still not covered.