### PR TITLE
add handling to cases when all is not optimized out

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.21.2"
+version = "0.21.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1344,12 +1344,9 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple};
     end
 
     old_row_type = typeof(row)
-    if row isa AbstractDict
-        if !(keytype(row) <: Symbol)
-            if keytype(row) <: AbstractString || all(x -> x isa AbstractString, keys(row))
-                row = (;(Symbol.(keys(row)) .=> values(row))...)
-            end
-        end
+    if row isa AbstractDict && keytype(row) !== Symbol &&
+        (keytype(row) <: AbstractString || all(x -> x isa AbstractString, keys(row)))
+        row = (;(Symbol.(keys(row)) .=> values(row))...)
     end
 
     # in the code below we use a direct access to _columns because
@@ -1357,7 +1354,7 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple};
     # inconsistent and normal data frame indexing would error.
     if cols == :union
         if row isa AbstractDict
-            if !(keytype(row) <: Symbol) && !all(x -> x isa Symbol, keys(row))
+            if keytype(row) !== Symbol && !all(x -> x isa Symbol, keys(row))
                 throw(ArgumentError("when `cols == :union` all keys of row must be Symbol"))
             end
         end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1353,10 +1353,8 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple};
     # we resize the columns so temporarily the `DataFrame` is internally
     # inconsistent and normal data frame indexing would error.
     if cols == :union
-        if row isa AbstractDict
-            if keytype(row) !== Symbol && !all(x -> x isa Symbol, keys(row))
+        if row isa AbstractDict && keytype(row) !== Symbol && !all(x -> x isa Symbol, keys(row))
                 throw(ArgumentError("when `cols == :union` all keys of row must be Symbol"))
-            end
         end
         for (i, colname) in enumerate(_names(df))
             col = _columns(df)[i]

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -225,7 +225,7 @@ end
 
 function DataFrame(columns::AbstractVector, cnames::AbstractVector{Symbol};
                    makeunique::Bool=false, copycols::Bool=true)::DataFrame
-    if !all(col -> isa(col, AbstractVector), columns)
+    if !(eltype(columns) <: AbstractVector) && !all(col -> isa(col, AbstractVector), columns)
         throw(ArgumentError("columns argument must be a vector of AbstractVector objects"))
     end
     return DataFrame(collect(AbstractVector, columns),
@@ -1344,16 +1344,22 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple};
     end
 
     old_row_type = typeof(row)
-    if row isa AbstractDict && all(x -> x isa AbstractString, keys(row))
-        row = (;(Symbol.(keys(row)) .=> values(row))...)
+    if row isa AbstractDict
+        if !(keytype(row) <: Symbol)
+            if keytype(row) <: AbstractString || all(x -> x isa AbstractString, keys(row))
+                row = (;(Symbol.(keys(row)) .=> values(row))...)
+            end
+        end
     end
 
     # in the code below we use a direct access to _columns because
     # we resize the columns so temporarily the `DataFrame` is internally
     # inconsistent and normal data frame indexing would error.
     if cols == :union
-        if row isa AbstractDict && !all(x -> x isa Symbol, keys(row))
-            throw(ArgumentError("when `cols == :union` all keys of row must be Symbol"))
+        if row isa AbstractDict
+            if !(keytype(row) <: Symbol) && !all(x -> x isa Symbol, keys(row))
+                throw(ArgumentError("when `cols == :union` all keys of row must be Symbol"))
+            end
         end
         for (i, colname) in enumerate(_names(df))
             col = _columns(df)[i]

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -111,8 +111,10 @@ for T in (:AbstractVector, :Regex, :Not, :Between, :All, :Colon)
         end
 
         if v isa AbstractDict
-            if all(x -> x isa AbstractString, keys(v))
-                v = (;(Symbol.(keys(v)) .=> values(v))...)
+            if !(keytype(v) <: Symbol)
+                if keytype(row) <: AbstractString || all(x -> x isa AbstractString, keys(v))
+                    v = (;(Symbol.(keys(v)) .=> values(v))...)
+                end
             end
             for n in view(_names(df), idxs)
                 if !haskey(v, n)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -112,7 +112,7 @@ for T in (:AbstractVector, :Regex, :Not, :Between, :All, :Colon)
 
         if v isa AbstractDict
             if !(keytype(v) <: Symbol)
-                if keytype(row) <: AbstractString || all(x -> x isa AbstractString, keys(v))
+                if keytype(v) <: AbstractString || all(x -> x isa AbstractString, keys(v))
                     v = (;(Symbol.(keys(v)) .=> values(v))...)
                 end
             end

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -111,10 +111,9 @@ for T in (:AbstractVector, :Regex, :Not, :Between, :All, :Colon)
         end
 
         if v isa AbstractDict
-            if !(keytype(v) <: Symbol)
-                if keytype(v) <: AbstractString || all(x -> x isa AbstractString, keys(v))
-                    v = (;(Symbol.(keys(v)) .=> values(v))...)
-                end
+            if keytype(v) !== Symbol &&
+                (keytype(v) <: AbstractString || all(x -> x isa AbstractString, keys(v)))
+                v = (;(Symbol.(keys(v)) .=> values(v))...)
             end
             for n in view(_names(df), idxs)
                 if !haskey(v, n)


### PR DESCRIPTION
This should not change any functionality, but just speed up common cases, as it seems that `all` tests are not optimized out by the compiler.

Also it is a workaround for https://github.com/JuliaData/DataFrames.jl/issues/2289, although probably the bug there is unrelated to DataFrames.jl