### PR TITLE
[BREAKING] stricter isless for DataFrameRow

### DIFF
--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -334,7 +334,7 @@ end
 
 # lexicographic ordering on DataFrame rows, missing > !missing
 function Base.isless(r1::DataFrameRow, r2::DataFrameRow)
-    length(r1) == length(r2) ||
+    (length(r1) == length(r2) && _names(r1) == _names(r2)) ||
         throw(ArgumentError("compared DataFrameRows must have the same number " *
                             "of columns (got $(length(r1)) and $(length(r2)))"))
     for (a,b) in zip(r1, r2)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -334,9 +334,16 @@ end
 
 # lexicographic ordering on DataFrame rows, missing > !missing
 function Base.isless(r1::DataFrameRow, r2::DataFrameRow)
-    (length(r1) == length(r2) && _names(r1) == _names(r2)) ||
+    length(r1) == length(r2) ||
         throw(ArgumentError("compared DataFrameRows must have the same number " *
                             "of columns (got $(length(r1)) and $(length(r2)))"))
+    if _names(r1) != _names(r2)
+        mismatch = findfirst(i -> _names(r1)[i] != _names(r2)[i], 1:length(r1))
+        throw(ArgumentError("compared DataFrameRows must have the same colum " *
+                            "names and they differ in column number $mismatch" *
+                            " where the names are :$(names(r1)[mismatch]) and " *
+                            ":$(_names(r2)[mismatch]) respecitvely"))
+    end
     for (a,b) in zip(r1, r2)
         isequal(a, b) || return isless(a, b)
     end

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -340,9 +340,9 @@ function Base.isless(r1::DataFrameRow, r2::DataFrameRow)
     if _names(r1) != _names(r2)
         mismatch = findfirst(i -> _names(r1)[i] != _names(r2)[i], 1:length(r1))
         throw(ArgumentError("compared DataFrameRows must have the same colum " *
-                            "names and they differ in column number $mismatch" *
+                            "names but they differ in column number $mismatch" *
                             " where the names are :$(names(r1)[mismatch]) and " *
-                            ":$(_names(r2)[mismatch]) respecitvely"))
+                            ":$(_names(r2)[mismatch]) respectively"))
     end
     for (a,b) in zip(r1, r2)
         isequal(a, b) || return isless(a, b)

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -162,6 +162,9 @@ end
     @test !isless(DataFrameRow(df, 5, :), DataFrameRow(df, 6, :))
     @test isless(DataFrameRow(df, 7, :), DataFrameRow(df, 8, :))
     @test !isless(DataFrameRow(df, 8, :), DataFrameRow(df, 7, :))
+
+    @test_throws ArgumentError df[1, 1:2] < df[1, 1:3]
+    @test_throws ArgumentError df[1, 1:2] < df[1, 2:3]
 end
 
 @testset "hashing" begin


### PR DESCRIPTION
Fixes #2287.

I do not do deprecation as it is a corner case and could be considered a bug in the old implementation.