### PR TITLE
improve handling of indicator in joins

### DIFF
--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -244,8 +244,8 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
     if indicator !== nothing
         indicator_cols = ["_left", "_right"]
         for i in 1:2
-            while (hasproperty(df1, indicator_cols[i]) ||
-                   hasproperty(df2, indicator_cols[i]))
+            while hasproperty(df1, indicator_cols[i]) ||
+                   hasproperty(df2, indicator_cols[i])
                  indicator_cols[i] *= 'X'
             end
         end

--- a/test/join.jl
+++ b/test/join.jl
@@ -536,7 +536,7 @@ end
     pre_join_name = copy(name)
     pre_join_job = copy(job)
     @test outerjoin(name, job, on = :ID, indicator=:_merge,
-               makeunique=true) ≅ 
+               makeunique=true) ≅
           outerjoin(name, job, on = :ID, indicator="_merge",
                makeunique=true) ≅ outer_indicator
 
@@ -671,6 +671,19 @@ end
                                                                       x=[1,2], y=[1,2])
     @test innerjoin(df1, df2, on=[:id2=>:ID2, :id=>:id]) == DataFrame(id=[1,2], id2=[11, 12],
                                                                       x=[1,2], y=[1,2])
+end
+
+@testset "check naming of indicator" begin
+    df = DataFrame(a=1)
+    @test_throws ArgumentError outerjoin(df, df, on=:a, indicator=:a)
+    @test outerjoin(df, df, on=:a, indicator=:a, makeunique=true) == DataFrame(a=1, a_1="both")
+    @test outerjoin(df, df, on=:a, indicator="_left") == DataFrame(a=1, _left="both")
+    @test outerjoin(df, df, on=:a, indicator="_right") == DataFrame(a=1, _right="both")
+
+    df = DataFrame(_left=1)
+    @test outerjoin(df, df, on=:_left, indicator="_leftX") == DataFrame(_left=1, _leftX="both")
+    df = DataFrame(_right=1)
+    @test outerjoin(df, df, on=:_right, indicator="_rightX") == DataFrame(_right=1, _rightX="both")
 end
 
 end # module


### PR DESCRIPTION
This PR makes the code cleaner and makes the implementation follow the docstring.

@pdeffebach - this is the change I was talking about in the PR allowing strings as `indicator`.