### PR TITLE
[BREAKING] make GroupKey API more consistent

### DIFF
--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -247,7 +247,7 @@ meant to be constructed directly.
 
 Indexing fields of `GroupKey` is allowed using an integer, a `Symbol`, or a string.
 It is also possible to access the data in a `GroupKey` using the `getproperty`
-function and convert it to a `Tuple`, `NamedTuple`, or `Vector`.
+function. A `GroupKey` can be converted to a `Tuple`, `NamedTuple`, or `Vector`.
 
 See [`keys(::GroupedDataFrame)`](@ref) for more information.
 """

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -245,8 +245,8 @@ equivalent `Tuple` or `NamedTuple`.
 Instances of this type are returned by `keys(::GroupedDataFrame)` and are not
 meant to be constructed directly.
 
-Indexing is one-dimensional like specifying a column of a `DataFrame`.
-You can also access the data in a `GroupKey` using the `getproperty`
+Indexing fields of `GroupKey` is allowed using an integer, a `Symbol`, or a string.
+It is also possible to access the data in a `GroupKey` using the `getproperty`
 function and convert it to a `Tuple`, `NamedTuple`, or `Vector`.
 
 See [`keys(::GroupedDataFrame)`](@ref) for more information.

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1395,6 +1395,8 @@ end
         # Check iteration vs indexing of GroupKeys
         @test key == gdkeys[i]
 
+        @test Base.IteratorEltype(key) == Base.EltypeUnknown()
+
         # Basic methods
         @test parent(key) === gd
         @test length(key) == length(cols)
@@ -1406,10 +1408,30 @@ end
 
         # (Named)Tuple conversion
         @test Tuple(key) ≅ values(nt)
+        @test convert(Tuple, key) ≅ values(nt)
         @test NamedTuple(key) ≅ nt
+        @test convert(NamedTuple, key) ≅ nt
+        @test copy(key) ≅ nt
+
+        # other conversions
+        @test Vector(key) ≅ collect(nt)
+        @test eltype(Vector(key)) === eltype([v for v in key])
+        @test convert(Vector, key) ≅ collect(nt)
+        @test Array(key) ≅ collect(nt)
+        @test eltype(Array(key)) === eltype([v for v in key])
+        @test convert(Array, key) ≅ collect(nt)
+        @test Vector{Any}(key) ≅ collect(nt)
+        @test eltype(Vector{Any}(key)) === Any
+        @test convert(Vector{Any}, key) ≅ collect(nt)
+        @test Array{Any}(key) ≅ collect(nt)
+        @test eltype(Array{Any}(key)) === Any
+        @test convert(Array{Any}, key) ≅ collect(nt)
 
         # Iteration
         @test collect(key) ≅ collect(nt)
+        @test eltype(collect(key)) == eltype([v for v in key])
+
+        @test_throws ArgumentError identity.(kk)
 
         # Integer/symbol indexing, getproperty of key
         for (j, n) in enumerate(cols)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1431,7 +1431,7 @@ end
         @test collect(key) ≅ collect(nt)
         @test eltype(collect(key)) == eltype([v for v in key])
 
-        @test_throws ArgumentError identity.(kk)
+        @test_throws ArgumentError identity.(key)
 
         # Integer/symbol indexing, getproperty of key
         for (j, n) in enumerate(cols)


### PR DESCRIPTION
Add missing methods for `GroupKey` to make it consistent with `DataFrameRow` which is similar.

See https://github.com/JuliaData/DataFrames.jl/issues/2305 for discussion. CC @goretkin.

Also this should be made consistent with https://github.com/JuliaData/DataFrames.jl/pull/2281 whichever gets merged first. CC @pdeffebach 

After this PR and #2281 another one with `==`, `isequal`, `in` etc. definitions should be done.

I hope I have not missed any definitions - could you please check? Thank you!