### PR TITLE
Make omitting columns more obvious with ellipses

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -250,6 +250,8 @@ function getchunkbounds(maxwidths::Vector{Int},
                         availablewidth::Int)
     ncols = length(maxwidths) - 1
     rowmaxwidth = maxwidths[ncols + 1]
+    # Artificially make the display one column smaller because some terminals are bad
+    availablewidth -= 1
     if splitcols
         chunkbounds = [0]
         # Include 2 spaces + 2 | characters for row/col label

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -540,7 +540,7 @@ function showrows(io::IO,
 
         if !isempty(rowindices2)
             print(io, "\n⋮", repeat(' ', rowmaxwidth + 2 + sum(x->x+3, maxwidths[leftcol:rightcol])), "⋮")
-            omitted_cols && print(io, " ⋯")
+            omittedcols && print(io, " ⋯")
             println(io)
             showrowindices(io,
                            df,

--- a/test/show.jl
+++ b/test/show.jl
@@ -61,18 +61,31 @@ end
 @testset "displaysize test" begin
     df_big = DataFrame(reshape(Int64(10000001):Int64(10000000+25*5), 25, 5))
 
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,42), :limit=>true)
     show(io, df_big)
     str = String(take!(io.io))
     @test str == """
     25×5 DataFrame. Omitted printing of 2 columns
-    │ Row │ x1       │ x2       │ x3       │
+    │ Row │ x1       │ x2       │ x3       │ ⋯
     │     │ Int64    │ Int64    │ Int64    │
-    ├─────┼──────────┼──────────┼──────────┤
+    ├─────┼──────────┼──────────┼──────────┼ ⋯
     │ 1   │ 10000001 │ 10000026 │ 10000051 │
-    ⋮
+    ⋮                                      ⋮ ⋯
     │ 24  │ 10000024 │ 10000049 │ 10000074 │
     │ 25  │ 10000025 │ 10000050 │ 10000075 │"""
+
+    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+    show(io, df_big)
+    str = String(take!(io.io))
+    @test str == """
+    25×5 DataFrame. Omitted printing of 3 columns
+    │ Row │ x1       │ x2       │ ⋯
+    │     │ Int64    │ Int64    │
+    ├─────┼──────────┼──────────┼ ⋯
+    │ 1   │ 10000001 │ 10000026 │
+    ⋮                           ⋮ ⋯
+    │ 24  │ 10000024 │ 10000049 │
+    │ 25  │ 10000025 │ 10000050 │"""
 
     io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
     show(io, df_big, allcols=true)
@@ -83,7 +96,7 @@ end
     │     │ Int64    │ Int64    │ Int64    │
     ├─────┼──────────┼──────────┼──────────┤
     │ 1   │ 10000001 │ 10000026 │ 10000051 │
-    ⋮
+    ⋮                                      ⋮
     │ 24  │ 10000024 │ 10000049 │ 10000074 │
     │ 25  │ 10000025 │ 10000050 │ 10000075 │
 
@@ -91,7 +104,7 @@ end
     │     │ Int64    │ Int64    │
     ├─────┼──────────┼──────────┤
     │ 1   │ 10000076 │ 10000101 │
-    ⋮
+    ⋮                           ⋮
     │ 24  │ 10000099 │ 10000124 │
     │ 25  │ 10000100 │ 10000125 │"""
 
@@ -163,9 +176,9 @@ end
     str = String(take!(io.io))
     @test str == """
     25×5 DataFrame. Omitted printing of 2 columns
-    │ Row │ x1       │ x2       │ x3       │
+    │ Row │ x1       │ x2       │ x3       │ ⋯
     │     │ Int64    │ Int64    │ Int64    │
-    ├─────┼──────────┼──────────┼──────────┤
+    ├─────┼──────────┼──────────┼──────────┼ ⋯
     │ 1   │ 10000001 │ 10000026 │ 10000051 │
     │ 2   │ 10000002 │ 10000027 │ 10000052 │
     │ 3   │ 10000003 │ 10000028 │ 10000053 │

--- a/test/show.jl
+++ b/test/show.jl
@@ -61,7 +61,7 @@ end
 @testset "displaysize test" begin
     df_big = DataFrame(reshape(Int64(10000001):Int64(10000000+25*5), 25, 5))
 
-    io = IOContext(IOBuffer(), :displaysize=>(11,42), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,43), :limit=>true)
     show(io, df_big)
     str = String(take!(io.io))
     @test str == """
@@ -74,7 +74,7 @@ end
     │ 24  │ 10000024 │ 10000049 │ 10000074 │
     │ 25  │ 10000025 │ 10000050 │ 10000075 │"""
 
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,41), :limit=>true)
     show(io, df_big)
     str = String(take!(io.io))
     @test str == """
@@ -87,7 +87,7 @@ end
     │ 24  │ 10000024 │ 10000049 │
     │ 25  │ 10000025 │ 10000050 │"""
 
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,41), :limit=>true)
     show(io, df_big, allcols=true)
     str = String(take!(io.io))
     @test str == """
@@ -108,7 +108,7 @@ end
     │ 24  │ 10000099 │ 10000124 │
     │ 25  │ 10000100 │ 10000125 │"""
 
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,43), :limit=>true)
     show(io, df_big, allrows=true, allcols=true)
     str = String(take!(io.io))
     @test str == """
@@ -171,7 +171,7 @@ end
     │ 24  │ 10000099 │ 10000124 │
     │ 25  │ 10000100 │ 10000125 │"""
 
-    io = IOContext(IOBuffer(), :displaysize=>(11,40), :limit=>true)
+    io = IOContext(IOBuffer(), :displaysize=>(11,41), :limit=>true)
     show(io, df_big, allrows=true, allcols=false)
     str = String(take!(io.io))
     @test str == """


### PR DESCRIPTION
The current printing has frequently fooled me that my dataset is missing columns.  This simple change adds a few more visual indicators that it's an incomplete printing in the place where you'd first look, and avoids the "complete"-looking `┤` character.  Before:

```
julia> DataFrame([i .+ rand(100) for i in 1:20])
100×20 DataFrame. Omitted printing of 14 columns
│ Row │ x1      │ x2      │ x3      │ x4      │ x5      │ x6      │
│     │ Float64 │ Float64 │ Float64 │ Float64 │ Float64 │ Float64 │
├─────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│ 1   │ 1.25535 │ 2.23703 │ 3.81429 │ 4.68575 │ 5.67015 │ 6.87798 │
│ 2   │ 1.77179 │ 2.36252 │ 3.24647 │ 4.38293 │ 5.93563 │ 6.21075 │
│ 3   │ 1.33585 │ 2.40766 │ 3.7644  │ 4.1805  │ 5.81954 │ 6.65656 │
│ 4   │ 1.35647 │ 2.52656 │ 3.24724 │ 4.41236 │ 5.32153 │ 6.99919 │
⋮
│ 96  │ 1.607   │ 2.82297 │ 3.295   │ 4.25163 │ 5.17801 │ 6.1482  │
│ 97  │ 1.7333  │ 2.71543 │ 3.41232 │ 4.36542 │ 5.80653 │ 6.7187  │
│ 98  │ 1.72051 │ 2.01457 │ 3.95139 │ 4.89867 │ 5.08942 │ 6.79844 │
│ 99  │ 1.59108 │ 2.09934 │ 3.24291 │ 4.727   │ 5.83118 │ 6.80525 │
│ 100 │ 1.79802 │ 2.86081 │ 3.53143 │ 4.61471 │ 5.90259 │ 6.05322 │
```

After:

```
julia> DataFrame([i .+ rand(100) for i in 1:20])
100×20 DataFrame. Omitted printing of 14 columns
│ Row │ x1      │ x2      │ x3      │ x4      │ x5      │ x6      │ ⋯
│     │ Float64 │ Float64 │ Float64 │ Float64 │ Float64 │ Float64 │
├─────┼─────────┼─────────┼─────────┼─────────┼─────────┼─────────┼ ⋯
│ 1   │ 1.02564 │ 2.27613 │ 3.30434 │ 4.26961 │ 5.96806 │ 6.42394 │
│ 2   │ 1.8685  │ 2.56581 │ 3.54104 │ 4.2908  │ 5.72022 │ 6.42958 │
│ 3   │ 1.56869 │ 2.03671 │ 3.03344 │ 4.14143 │ 5.60765 │ 6.72854 │
│ 4   │ 1.8403  │ 2.06023 │ 3.76093 │ 4.59431 │ 5.71541 │ 6.80651 │
⋮                                                                 ⋮ ⋯
│ 96  │ 1.30477 │ 2.59928 │ 3.64041 │ 4.968   │ 5.46243 │ 6.16648 │
│ 97  │ 1.00585 │ 2.5669  │ 3.65184 │ 4.55873 │ 5.07416 │ 6.53845 │
│ 98  │ 1.98973 │ 2.17375 │ 3.62001 │ 4.72003 │ 5.33069 │ 6.44367 │
│ 99  │ 1.35354 │ 2.50724 │ 3.8579  │ 4.0234  │ 5.6262  │ 6.81527 │
│ 100 │ 1.31846 │ 2.78889 │ 3.34216 │ 4.43111 │ 5.18149 │ 6.27506 │
```