### PR TITLE
Don't specialize groupreduce! on result array element type

### DIFF
--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -962,8 +962,8 @@ function copyto_widen!(res::AbstractVector{T}, x::AbstractVector) where T
     return res
 end
 
-function groupreduce!(res::AbstractVector{U}, f, op, condf, adjust, checkempty::Bool,
-                      incol::AbstractVector{T}, gd::GroupedDataFrame) where {U,T}
+function groupreduce!(res, f, op, condf, adjust, checkempty::Bool,
+                      incol::AbstractVector{T}, gd::GroupedDataFrame) where {T}
     n = length(gd)
     if adjust !== nothing || checkempty
         counts = zeros(Int, n)
@@ -974,7 +974,7 @@ function groupreduce!(res::AbstractVector{U}, f, op, condf, adjust, checkempty::
         x = incol[i]
         if gix > 0 && (condf === nothing || condf(x))
             # this check should be optimized out if U is not Any
-            if U === Any && !isassigned(res, gix)
+            if eltype(res) === Any && !isassigned(res, gix)
                 res[gix] = f(x, gix)
             else
                 res[gix] = op(res[gix], f(x, gix))
@@ -985,7 +985,7 @@ function groupreduce!(res::AbstractVector{U}, f, op, condf, adjust, checkempty::
         end
     end
     # handle the case of an unitialized reduction
-    if U === Any
+    if eltype(res) === Any
         if op === Base.add_sum
             initf = zero
         elseif op === Base.mul_prod

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -962,7 +962,7 @@ function copyto_widen!(res::AbstractVector{T}, x::AbstractVector) where T
     return res
 end
 
-function groupreduce!(res, f, op, condf, adjust, checkempty::Bool,
+function groupreduce!(res::AbstractVector, f, op, condf, adjust, checkempty::Bool,
                       incol::AbstractVector{T}, gd::GroupedDataFrame) where {T}
     n = length(gd)
     if adjust !== nothing || checkempty


### PR DESCRIPTION
Works around crash seen in #2326. The inferred return type of
`groupreduce_init` is `Union{Vector{Any}, SentinelVector{Float64}}` and
it seems the compiler then crashes when trying to correctly identify `U`
from that union of types. Part of my conclusion here is based on the
fact that if you remove all other argument type constraints and just
make `groupreduce!` return `res` directly, it still crashes; thus, by
deduction, the crash has something to do with the compiler having
trouble with the `::AbstractVector{U}` argument type
constraint/specialization.

The work-around is pretty uncontroversial; we were already calling
`eltype(res)` in several other places, and I've checked that it infers
the same. I didn't add a test since this seems like such an obscure
compiler bug that it doesn't really seem necessary for DataFrames to be
testing core compiler behavior.

Also note that this bug exists in Julia <= 1.5, so current Julia master
(pending 1.6), which includes a number of compiler refactorings/changes,
seems to have resolved whatever the issue was.

cc: @Keno, @vtjnash, @JeffBezanson