### PR TITLE
remove median and nunique from describe by default

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -457,8 +457,8 @@ where each row represents a variable and each column a summary statistic.
   Arguments can be:
     - A symbol from the list `:mean`, `:std`, `:min`, `:q25`,
       `:median`, `:q75`, `:max`, `:eltype`, `:nunique`, `:first`, `:last`, and
-      `:nmissing`. The default statistics used are `:mean`, `:min`, `:median`,
-      `:max`, `:nunique`, `:nmissing`, and `:eltype`.
+      `:nmissing`. The default statistics used are `:mean`, `:min`,
+      `:max`, `:nmissing`, and `:eltype`.
     - `:all` as the only `Symbol` argument to return all statistics.
     - A `name => function` pair where `name` is a `Symbol` or string. This will
       create a column of summary statistics with the provided name.
@@ -489,30 +489,16 @@ access missing values.
 
 # Examples
 ```julia
-julia> df = DataFrame(i=1:10, x=0.1:0.1:1.0, y='a':'j')
-10×3 DataFrame
-│ Row │ i     │ x       │ y    │
-│     │ Int64 │ Float64 │ Char │
-├─────┼───────┼─────────┼──────┤
-│ 1   │ 1     │ 0.1     │ 'a'  │
-│ 2   │ 2     │ 0.2     │ 'b'  │
-│ 3   │ 3     │ 0.3     │ 'c'  │
-│ 4   │ 4     │ 0.4     │ 'd'  │
-│ 5   │ 5     │ 0.5     │ 'e'  │
-│ 6   │ 6     │ 0.6     │ 'f'  │
-│ 7   │ 7     │ 0.7     │ 'g'  │
-│ 8   │ 8     │ 0.8     │ 'h'  │
-│ 9   │ 9     │ 0.9     │ 'i'  │
-│ 10  │ 10    │ 1.0     │ 'j'  │
+julia> df = DataFrame(i=1:10, x=0.1:0.1:1.0, y='a':'j');
 
 julia> describe(df)
-3×8 DataFrame
-│ Row │ variable │ mean   │ min │ median │ max │ nunique │ nmissing │ eltype   │
-│     │ Symbol   │ Union… │ Any │ Union… │ Any │ Union…  │ Nothing  │ DataType │
-├─────┼──────────┼────────┼─────┼────────┼─────┼─────────┼──────────┼──────────┤
-│ 1   │ i        │ 5.5    │ 1   │ 5.5    │ 10  │         │          │ Int64    │
-│ 2   │ x        │ 0.55   │ 0.1 │ 0.55   │ 1.0 │         │          │ Float64  │
-│ 3   │ y        │        │ 'a' │        │ 'j' │ 10      │          │ Char     │
+3×6 DataFrame
+│ Row │ variable │ mean   │ min │ max │ nmissing │ eltype   │
+│     │ Symbol   │ Union… │ Any │ Any │ Nothing  │ DataType │
+├─────┼──────────┼────────┼─────┼─────┼──────────┼──────────┤
+│ 1   │ i        │ 5.5    │ 1   │ 10  │          │ Int64    │
+│ 2   │ x        │ 0.55   │ 0.1 │ 1.0 │          │ Float64  │
+│ 3   │ y        │        │ 'a' │ 'j' │          │ Char     │
 
 julia> describe(df, :min, :max)
 3×3 DataFrame
@@ -547,7 +533,7 @@ DataAPI.describe(df::AbstractDataFrame,
 
 DataAPI.describe(df::AbstractDataFrame; cols=:) =
     _describe(select(df, cols, copycols=false),
-              [:mean, :min, :median, :max, :nunique, :nmissing, :eltype])
+              [:mean, :min, :max, :nmissing, :eltype])
 
 function _describe(df::AbstractDataFrame, stats::AbstractVector)
     predefined_funs = Symbol[s for s in stats if s isa Symbol]

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -457,7 +457,7 @@ where each row represents a variable and each column a summary statistic.
   Arguments can be:
     - A symbol from the list `:mean`, `:std`, `:min`, `:q25`,
       `:median`, `:q75`, `:max`, `:eltype`, `:nunique`, `:first`, `:last`, and
-      `:nmissing`. The default statistics used are `:mean`, `:min`,
+      `:nmissing`. The default statistics used are `:mean`, `:min`, `:median`
       `:max`, `:nmissing`, and `:eltype`.
     - `:all` as the only `Symbol` argument to return all statistics.
     - A `name => function` pair where `name` is a `Symbol` or string. This will
@@ -492,13 +492,13 @@ access missing values.
 julia> df = DataFrame(i=1:10, x=0.1:0.1:1.0, y='a':'j');
 
 julia> describe(df)
-3×6 DataFrame
-│ Row │ variable │ mean   │ min │ max │ nmissing │ eltype   │
-│     │ Symbol   │ Union… │ Any │ Any │ Nothing  │ DataType │
-├─────┼──────────┼────────┼─────┼─────┼──────────┼──────────┤
-│ 1   │ i        │ 5.5    │ 1   │ 10  │          │ Int64    │
-│ 2   │ x        │ 0.55   │ 0.1 │ 1.0 │          │ Float64  │
-│ 3   │ y        │        │ 'a' │ 'j' │          │ Char     │
+3×7 DataFrame
+│ Row │ variable │ mean   │ min │ median │ max │ nmissing │ eltype   │
+│     │ Symbol   │ Union… │ Any │ Union… │ Any │ Nothing  │ DataType │
+├─────┼──────────┼────────┼─────┼────────┼─────┼──────────┼──────────┤
+│ 1   │ i        │ 5.5    │ 1   │ 5.5    │ 10  │          │ Int64    │
+│ 2   │ x        │ 0.55   │ 0.1 │ 0.55   │ 1.0 │          │ Float64  │
+│ 3   │ y        │        │ 'a' │        │ 'j' │          │ Char     │
 
 julia> describe(df, :min, :max)
 3×3 DataFrame
@@ -533,7 +533,7 @@ DataAPI.describe(df::AbstractDataFrame,
 
 DataAPI.describe(df::AbstractDataFrame; cols=:) =
     _describe(select(df, cols, copycols=false),
-              [:mean, :min, :max, :nmissing, :eltype])
+              [:mean, :min, :median, :max, :nmissing, :eltype])
 
 function _describe(df::AbstractDataFrame, stats::AbstractVector)
     predefined_funs = Symbol[s for s in stats if s isa Symbol]

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -457,7 +457,7 @@ where each row represents a variable and each column a summary statistic.
   Arguments can be:
     - A symbol from the list `:mean`, `:std`, `:min`, `:q25`,
       `:median`, `:q75`, `:max`, `:eltype`, `:nunique`, `:first`, `:last`, and
-      `:nmissing`. The default statistics used are `:mean`, `:min`, `:median`
+      `:nmissing`. The default statistics used are `:mean`, `:min`, `:median`,
       `:max`, `:nmissing`, and `:eltype`.
     - `:all` as the only `Symbol` argument to return all statistics.
     - A `name => function` pair where `name` is a `Symbol` or string. This will

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -641,7 +641,7 @@ function get_stats(col::AbstractVector, stats::AbstractVector{Symbol})
         if eltype(col) <: Real
             d[:nunique] = nothing
         else
-            d[:nunique] = try length(unique(col)) catch end
+            d[:nunique] = try length(Set(col)) catch end
         end
     end
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -641,7 +641,7 @@ end
                                 eltype = [Int, Union{Missing, Int}, String,
                                           Union{Missing, String}, Date, CategoricalValue{Int, UInt32}])
 
-    default_fields = [:mean, :min, :median, :max, :nunique, :nmissing, :eltype]
+    default_fields = [:mean, :min, :max, :nmissing, :eltype]
 
     # Test that it works as a whole, without keyword arguments
     @test describe_output[:, [:variable; default_fields]] == describe(df)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -641,7 +641,7 @@ end
                                 eltype = [Int, Union{Missing, Int}, String,
                                           Union{Missing, String}, Date, CategoricalValue{Int, UInt32}])
 
-    default_fields = [:mean, :min, :max, :nmissing, :eltype]
+    default_fields = [:mean, :min, :median, :max, :nmissing, :eltype]
 
     # Test that it works as a whole, without keyword arguments
     @test describe_output[:, [:variable; default_fields]] == describe(df)


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2269

As decided there we just drop computing `:median` and `:nunique` by default.
This is simplest to change, and if someone wants them it is easy to opt-in.

Just to get a relative impact on performance of dropping this consider:
```
julia> x = rand(10^8);

julia> @time mean(x)
  0.055976 seconds (1 allocation: 16 bytes)
0.5000065333980973

julia> @time median(x)
  2.046998 seconds (3 allocations: 762.940 MiB, 8.01% gc time)
0.5000076592923275

julia> @time length(unique(x))
 24.142629 seconds (112 allocations: 4.903 GiB, 0.49% gc time)
100000000
```
which when you have even several dozens of variables only starts to be prohibitive.