### PR TITLE
Add check if input is a table before trying alternative constructors

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -31,11 +31,11 @@ fromcolumns(x, names; copycols::Bool=true) =
               copycols=copycols)
 
 function DataFrame(x::T; copycols::Bool=true) where {T}
-    if x isa AbstractVector && all(col -> isa(col, AbstractVector), x)
-        return DataFrame(Vector{AbstractVector}(x), copycols=copycols)
-    end
-    if x isa AbstractVector || x isa Tuple
-        if all(v -> v isa Pair{Symbol, <:AbstractVector}, x)
+    if !Tables.istable(x)
+        if x isa AbstractVector && all(col -> isa(col, AbstractVector), x)
+            return DataFrame(Vector{AbstractVector}(x), copycols=copycols)
+        elseif (x isa AbstractVector || x isa Tuple) &&
+            all(v -> v isa Pair{Symbol, <:AbstractVector}, x)
             return DataFrame(AbstractVector[last(v) for v in x], [first(v) for v in x],
                              copycols=copycols)
         end

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -171,7 +171,7 @@ Base.iterate(x::EmptyTableWithNames, st=1) = nothing
 
         # https://github.com/JuliaData/CSV.jl/issues/702
         df = DataFrame(EmptyTableWithNames())
-        @test size(df) = (0, 3)
+        @test size(df) == (0, 3)
         @test names(df) == ["a", "b", "c"]
         @test eltype.(eachcol(df)) == [Float64, String, Float64]
     end

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -53,6 +53,15 @@ Tables.schema(x::DuplicateNamesColumnTable) = Tables.Schema((:a, :a, :b), Tuple{
 Base.getproperty(d::DuplicateNamesColumnTable, nm::Symbol) = [1.0, 2.0, 3.0]
 Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
 
+struct EmptyTableWithNames <: AbstractVector{Any}
+end
+Tables.isrowtable(::Type{EmptyTableWithNames}) = true
+Tables.rows(x::EmptyTableWithNames) = x
+Tables.schema(x::EmptyTableWithNames) = Tables.Schema((:a, :b, :c), Tuple{Float64, Float64, Float64})
+Base.size(x::EmptyTableWithNames) = (0,)
+Base.eltype(x::EmptyTableWithNames) = NamedTuple
+Base.iterate(x::EmptyTableWithNames, st=1) = nothing
+
 @testset "Tables" begin
     df = DataFrame(a=Int64[1, 2, 3], b=[:a, :b, :c])
 
@@ -159,6 +168,10 @@ Base.propertynames(d::DuplicateNamesColumnTable) = (:a, :a, :b)
         @test ct.b !== cat2
         @test ct.a == cat
         @test ct.b == cat == cat2
+
+        # https://github.com/JuliaData/CSV.jl/issues/702
+        df = DataFrame(EmptyTableWithNames())
+        @test names(df) == ["a", "b", "c"]
     end
 end
 

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -57,7 +57,7 @@ struct EmptyTableWithNames <: AbstractVector{Any}
 end
 Tables.isrowtable(::Type{EmptyTableWithNames}) = true
 Tables.rows(x::EmptyTableWithNames) = x
-Tables.schema(x::EmptyTableWithNames) = Tables.Schema((:a, :b, :c), Tuple{Float64, Float64, Float64})
+Tables.schema(x::EmptyTableWithNames) = Tables.Schema((:a, :b, :c), Tuple{Float64, String, Float64})
 Base.size(x::EmptyTableWithNames) = (0,)
 Base.eltype(x::EmptyTableWithNames) = NamedTuple
 Base.iterate(x::EmptyTableWithNames, st=1) = nothing
@@ -171,7 +171,9 @@ Base.iterate(x::EmptyTableWithNames, st=1) = nothing
 
         # https://github.com/JuliaData/CSV.jl/issues/702
         df = DataFrame(EmptyTableWithNames())
+        @test size(df) = (0, 3)
         @test names(df) == ["a", "b", "c"]
+        @test eltype.(eachcol(df)) == [Float64, String, Float64]
     end
 end
 


### PR DESCRIPTION
Fixes https://github.com/JuliaData/CSV.jl/issues/702. A DataFrame
constructor was removed from CSV.jl in its latest release (0.7.6) as
part of new deprecations for decoupling the two packages. What I forgot
was that we were relying on that constructor because of an ambiguity in
the generic DataFrame constructor fallback that mostly uses Tables.jl to
try and turn anything into a DataFrame. The problem is "mostly"; one of
the checks is if the input is an `AbstractVector` of `AbstractVectors`,
which it turns out `CSV.File` is! This is because it's considered an
`AbstractVector` of `Row`s, which themselves are `<: AbstractVector`. So
we were trying to basically take each row of a `CSV.File` and treat each
row as a column in that fallback constructor.

While it was proposed to put the DataFrame constructor back in CSV.jl
for now; that's pretty unsatisfying because we know we're going to
remove the DataFrames deprecation at some point, and when we do, we
want `DataFrame(CSV.File())` to work out of the box.

The fix here is just adding an additional check up front in the fallback
constructor if we already know the input is `Tables.istable(x)`. If so,
we'll avoid these extra corner case checks and just let the Tables.jl
machinery do the work.