### PR TITLE
make update_row_maps! type stable

### DIFF
--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -184,7 +184,9 @@ function update_row_maps!(left_table::AbstractDataFrame,
                           left_ixs::Union{Nothing, RowIndexMap},
                           leftonly_ixs::Union{Nothing, RowIndexMap},
                           right_ixs::Union{Nothing, RowIndexMap},
-                          rightonly_mask::Union{Nothing, Vector{Bool}})
+                          rightonly_mask::Union{Nothing, Vector{Bool}},
+                          right_dict_cols::Tuple{Vararg{AbstractVector}},
+                          left_table_cols::Tuple{Vararg{AbstractVector}})
     # helper functions
     @inline update!(ixs::Nothing, orig_ix::Int, join_ix::Int, count::Int = 1) = nothing
     @inline function update!(ixs::RowIndexMap, orig_ix::Int, join_ix::Int, count::Int = 1)
@@ -205,8 +207,6 @@ function update_row_maps!(left_table::AbstractDataFrame,
         (mask[orig_ixs] .= false)
 
     # iterate over left rows and compose the left<->right index map
-    right_dict_cols = ntuple(i -> right_dict.df[!, i], ncol(right_dict.df))
-    left_table_cols = ntuple(i -> left_table[!, i], ncol(left_table))
     next_join_ix = 1
     for l_ix in 1:nrow(left_table)
         r_ixs = findrows(right_dict, left_table, right_dict_cols, left_table_cols, l_ix)
@@ -248,7 +248,9 @@ function update_row_maps!(left_table::AbstractDataFrame,
     right_ixs = init_map(right_table, map_right)
     rightonly_mask = map_rightonly ? fill(true, nrow(right_table)) : nothing
     update_row_maps!(left_table, right_table, right_dict, left_ixs, leftonly_ixs,
-                     right_ixs, rightonly_mask)
+                     right_ixs, rightonly_mask,
+                     ntuple(i -> right_dict.df[!, i], ncol(right_dict.df)),
+                     ntuple(i -> left_table[!, i], ncol(left_table)))
     if map_rightonly
         rightonly_orig_ixs = findall(rightonly_mask)
         leftonly_ixs_len = leftonly_ixs === nothing ? 0 : length(leftonly_ixs)


### PR DESCRIPTION
I am slowly moving towards #2340. For now a small fix in the "core code", that shaves off some allocations because it makes it type stable and in consequence time. Nothing big, but not problematic to add either (and it should not degrade performance in any scenario).

Benchmarks:

Code setup:
```
using DataFrames
using Random
Random.seed!(1234);

df1 = DataFrame(id1 = rand(1:1000, 1000000), id2 = rand(1:1000, 1000000), x1=1:1000000);
df2 = DataFrame(id1 = rand(1:1000, 1000000), id2 = rand(1:1000, 1000000), x2=1:1000000);
```

Before PR:
```
julia> @benchmark innerjoin($df1, $df2, on=[:id1, :id2])
BenchmarkTools.Trial: 
  memory estimate:  299.87 MiB
  allocs estimate:  3999662
  --------------
  minimum time:     769.417 ms (2.13% GC)
  median time:      815.853 ms (4.77% GC)
  mean time:        830.811 ms (6.42% GC)
  maximum time:     878.898 ms (10.63% GC)
  --------------
  samples:          7
  evals/sample:     1

julia> @benchmark outerjoin($df1, $df2, on=[:id1, :id2])
BenchmarkTools.Trial: 
  memory estimate:  428.35 MiB
  allocs estimate:  3999693
  --------------
  minimum time:     1.083 s (3.58% GC)
  median time:      1.147 s (6.97% GC)
  mean time:        1.154 s (8.42% GC)
  maximum time:     1.233 s (14.65% GC)
  --------------
  samples:          5
  evals/sample:     1
```

After PR:
```
julia> @benchmark innerjoin($df1, $df2, on=[:id1, :id2])
BenchmarkTools.Trial: 
  memory estimate:  132.03 MiB
  allocs estimate:  182
  --------------
  minimum time:     691.800 ms (0.17% GC)
  median time:      715.135 ms (0.46% GC)
  mean time:        719.786 ms (1.93% GC)
  maximum time:     775.350 ms (10.40% GC)
  --------------
  samples:          8
  evals/sample:     1

julia> @benchmark outerjoin($df1, $df2, on=[:id1, :id2])
BenchmarkTools.Trial: 
  memory estimate:  260.51 MiB
  allocs estimate:  213
  --------------
  minimum time:     977.176 ms (0.06% GC)
  median time:      990.954 ms (0.87% GC)
  mean time:        997.370 ms (1.81% GC)
  maximum time:     1.043 s (6.63% GC)
  --------------
  samples:          6
  evals/sample:     1
```

So it is ~10% speedup.