### PR TITLE
[BREAKING] Return 0 missing count for columns of nonmissing type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "c:\\Users\\ngudat\\.julia\\dev\\DataFrames.jl"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "c:\\Users\\ngudat\\.julia\\dev\\DataFrames.jl"
-}

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -476,10 +476,7 @@ number of unique values in a column. If a column's base type derives from `Real`
 `:nunique` will return `nothing`s.
 
 Missing values are filtered in the calculation of all statistics, however the
-column `:nmissing` will report the number of missing values of that variable. If
-the column does not allow missing values, `nothing` is returned. Consequently,
-`nmissing = 0` indicates that the column allows missing values, but does not
-currently contain any.
+column `:nmissing` will report the number of missing values of that variable.
 
 If custom functions are provided, they are called repeatedly with the vector
 corresponding to each column as the only argument. For columns allowing for
@@ -494,11 +491,11 @@ julia> df = DataFrame(i=1:10, x=0.1:0.1:1.0, y='a':'j');
 julia> describe(df)
 3×7 DataFrame
 │ Row │ variable │ mean   │ min │ median │ max │ nmissing │ eltype   │
-│     │ Symbol   │ Union… │ Any │ Union… │ Any │ Nothing  │ DataType │
+│     │ Symbol   │ Union… │ Any │ Union… │ Any │ Int64    │ DataType │
 ├─────┼──────────┼────────┼─────┼────────┼─────┼──────────┼──────────┤
-│ 1   │ i        │ 5.5    │ 1   │ 5.5    │ 10  │          │ Int64    │
-│ 2   │ x        │ 0.55   │ 0.1 │ 0.55   │ 1.0 │          │ Float64  │
-│ 3   │ y        │        │ 'a' │        │ 'j' │          │ Char     │
+│ 1   │ i        │ 5.5    │ 1   │ 5.5    │ 10  │ 0        │ Int64    │
+│ 2   │ x        │ 0.55   │ 0.1 │ 0.55   │ 1.0 │ 0        │ Float64  │
+│ 3   │ y        │        │ 'a' │        │ 'j' │ 0        │ Char     │
 
 julia> describe(df, :min, :max)
 3×3 DataFrame

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -580,7 +580,7 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
         end
 
         if :nmissing in predefined_funs
-            d[:nmissing] = eltype(col) >: Missing ? count(ismissing, col) : nothing
+            d[:nmissing] = count(ismissing, col)
         end
 
         if :first in predefined_funs

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -640,7 +640,7 @@ end
                                 q75 = [3.25, 2.5, nothing, nothing, nothing, nothing],
                                 max = [4.0, 3.0, "d", "c", Date(2004), 2],
                                 nunique = [nothing, nothing, 4, 3, 4, 2],
-                                nmissing = [nothing, 1, nothing, 1, nothing, nothing],
+                                nmissing = [0, 1, 0, 1, 0, 0],
                                 first = [1, 1, "a", "a", Date(2000), 1],
                                 last = [4, missing, "d", missing, Date(2004), 2],
                                 eltype = [Int, Union{Missing, Int}, String,


### PR DESCRIPTION
This came up on Slack - as the `eltype` is printed in the returned table, there's little additional information in returning `nothing`, as the user can see from `eltype` whether the columns allows `missing` or not. Returning 0 here makes sorting the table on this column easier. 