### PR TITLE
better error for rename! and improved docstring

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -226,7 +226,7 @@ Each name is changed at most once. Permutation of names is allowed.
 
 # Arguments
 - `df` : the `AbstractDataFrame`; if it is a `SubDataFrame` then renaming is
-  only allowed if view column selector was a `:`.
+  only allowed if it was created using `:` as a column selector.
 - `d` : an `AbstractDict` or an `AbstractVector` of `Pair`s that maps
   the original names or column numbers to new names
 - `f` : a function which for each column takes the old name as a `String`

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -225,7 +225,8 @@ Create a new data frame that is a copy of `df` with changed column names.
 Each name is changed at most once. Permutation of names is allowed.
 
 # Arguments
-- `df` : the `AbstractDataFrame`
+- `df` : the `AbstractDataFrame`; if it is a `SubDataFrame` then renaming is
+  only allowed if view column selector was a `:`.
 - `d` : an `AbstractDict` or an `AbstractVector` of `Pair`s that maps
   the original names or column numbers to new names
 - `f` : a function which for each column takes the old name as a `String`

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -442,3 +442,15 @@ function Base.getindex(x::SubIndex, idx::Union{AbstractVector{Symbol},
     allunique(idx) || throw(ArgumentError("Elements of $idx must be unique"))
     return [x[i] for i in idx]
 end
+
+rename!(x::SubIndex, nms::AbstractVector{Symbol}; makeunique::Bool=false) =
+    throw(ArgumentError("rename! is not supported for views other than created " *
+                        "with Colon as a column selector"))
+
+rename!(x::SubIndex, nms::AbstractVector{Pair{Symbol, Symbol}}) =
+    throw(ArgumentError("rename! is not supported for views other than created " *
+                        "with Colon as a column selector"))
+
+rename!(f::Function, x::SubIndex) =
+    throw(ArgumentError("rename! is not supported for views other than created " *
+                        "with Colon as a column selector"))

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1023,61 +1023,71 @@ end
 end
 
 @testset "rename" begin
-    df = DataFrame(A = 1:3, B = 'A':'C')
-    @test names(rename(df, :A => :A_1)) == ["A_1", "B"]
-    @test names(df) == ["A", "B"]
-    @test names(rename(df, :A => :A_1, :B => :B_1)) == ["A_1", "B_1"]
-    @test names(df) == ["A", "B"]
-    @test names(rename(df, [:A => :A_1, :B => :B_1])) == ["A_1", "B_1"]
-    @test names(df) == ["A", "B"]
-    @test names(rename(df, Dict(:A => :A_1, :B => :B_1))) == ["A_1", "B_1"]
-    @test names(df) == ["A", "B"]
-    @test names(rename(lowercase, df)) == ["a", "b"]
-    @test names(df) == ["A", "B"]
+    for asview in (false, true)
+        df = DataFrame(A = 1:3, B = 'A':'C')
+        asview && (df = view(df, :, :))
+        @test names(rename(df, :A => :A_1)) == ["A_1", "B"]
+        @test names(df) == ["A", "B"]
+        @test names(rename(df, :A => :A_1, :B => :B_1)) == ["A_1", "B_1"]
+        @test names(df) == ["A", "B"]
+        @test names(rename(df, [:A => :A_1, :B => :B_1])) == ["A_1", "B_1"]
+        @test names(df) == ["A", "B"]
+        @test names(rename(df, Dict(:A => :A_1, :B => :B_1))) == ["A_1", "B_1"]
+        @test names(df) == ["A", "B"]
+        @test names(rename(lowercase, df)) == ["a", "b"]
+        @test names(df) == ["A", "B"]
 
-    @test rename!(df, :A => :A_1) === df
-    @test propertynames(df) == [:A_1, :B]
-    @test rename!(df, :A_1 => :A_2, :B => :B_2) === df
-    @test propertynames(df) == [:A_2, :B_2]
-    @test rename!(df, [:A_2 => :A_3, :B_2 => :B_3]) === df
-    @test propertynames(df) == [:A_3, :B_3]
-    @test rename!(df, Dict(:A_3 => :A_4, :B_3 => :B_4)) === df
-    @test propertynames(df) == [:A_4, :B_4]
-    @test rename!(lowercase, df) === df
-    @test propertynames(df) == [:a_4, :b_4]
+        @test rename!(df, :A => :A_1) === df
+        @test propertynames(df) == [:A_1, :B]
+        @test rename!(df, :A_1 => :A_2, :B => :B_2) === df
+        @test propertynames(df) == [:A_2, :B_2]
+        @test rename!(df, [:A_2 => :A_3, :B_2 => :B_3]) === df
+        @test propertynames(df) == [:A_3, :B_3]
+        @test rename!(df, Dict(:A_3 => :A_4, :B_3 => :B_4)) === df
+        @test propertynames(df) == [:A_4, :B_4]
+        @test rename!(lowercase, df) === df
+        @test propertynames(df) == [:a_4, :b_4]
 
-    df = DataFrame(A = 1:3, B = 'A':'C', C = [:x, :y, :z])
-    @test rename!(df, :A => :B, :B => :A) === df
-    @test propertynames(df) == [:B, :A, :C]
-    @test rename!(df, :A => :B, :B => :A, :C => :D) === df
-    @test propertynames(df) == [:A, :B, :D]
-    @test rename!(df, :A => :B, :B => :C, :D => :A) === df
-    @test propertynames(df) == [:B, :C, :A]
-    @test rename!(df, :A => :C, :B => :A, :C => :B) === df
-    @test propertynames(df) == [:A, :B, :C]
-    @test rename!(df, :A => :A, :B => :B, :C => :C) === df
-    @test propertynames(df) == [:A, :B, :C]
+        df = DataFrame(A = 1:3, B = 'A':'C', C = [:x, :y, :z])
+        asview && (df = view(df, :, :))
+        @test rename!(df, :A => :B, :B => :A) === df
+        @test propertynames(df) == [:B, :A, :C]
+        @test rename!(df, :A => :B, :B => :A, :C => :D) === df
+        @test propertynames(df) == [:A, :B, :D]
+        @test rename!(df, :A => :B, :B => :C, :D => :A) === df
+        @test propertynames(df) == [:B, :C, :A]
+        @test rename!(df, :A => :C, :B => :A, :C => :B) === df
+        @test propertynames(df) == [:A, :B, :C]
+        @test rename!(df, :A => :A, :B => :B, :C => :C) === df
+        @test propertynames(df) == [:A, :B, :C]
 
-    cdf = copy(df)
-    @test_throws ArgumentError rename!(df, :X => :Y)
-    @test df == cdf
-    @test_throws ArgumentError rename!(df, :A => :X, :X => :Y)
-    @test df == cdf
-    @test_throws ArgumentError rename!(df, :A => :B)
-    @test df == cdf
-    @test_throws ArgumentError rename!(df, :A => :X, :A => :X)
-    @test df == cdf
-    @test_throws ArgumentError rename!(df, :A => :X, :A => :Y)
-    @test df == cdf
-    @test_throws ArgumentError rename!(df, :A => :X, :B => :X)
-    @test df == cdf
-    @test_throws ArgumentError rename!(df, :A => :B, :B => :A, :C => :B)
-    @test df == cdf
-    @test_throws ArgumentError rename!(df, :A => :B, :B => :A, :A => :X)
-    @test df == cdf
+        cdf = copy(df)
+        @test_throws ArgumentError rename!(df, :X => :Y)
+        @test df == cdf
+        @test_throws ArgumentError rename!(df, :A => :X, :X => :Y)
+        @test df == cdf
+        @test_throws ArgumentError rename!(df, :A => :B)
+        @test df == cdf
+        @test_throws ArgumentError rename!(df, :A => :X, :A => :X)
+        @test df == cdf
+        @test_throws ArgumentError rename!(df, :A => :X, :A => :Y)
+        @test df == cdf
+        @test_throws ArgumentError rename!(df, :A => :X, :B => :X)
+        @test df == cdf
+        @test_throws ArgumentError rename!(df, :A => :B, :B => :A, :C => :B)
+        @test df == cdf
+        @test_throws ArgumentError rename!(df, :A => :B, :B => :A, :A => :X)
+        @test df == cdf
 
-    df = DataFrame(A=1)
-    @test rename(x -> 1, df) == DataFrame(Symbol("1") => 1)
+        df = DataFrame(A=1)
+        asview && (df = view(df, :, :))
+        @test rename(x -> 1, df) == DataFrame(Symbol("1") => 1)
+    end
+
+    sdf = view(DataFrame(ones(2,3)), 1:2, 1:3)
+    @test_throws ArgumentError rename!(uppercase, sdf)
+    @test_throws ArgumentError rename!(sdf, :x1 => :y1)
+    @test_throws ArgumentError rename!(sdf, [:a, :b, :c])
 end
 
 @testset "flexible rename arguments" begin


### PR DESCRIPTION
Currently rename! on `SubDataFrame` either worked or failed with `MethodError` which was not very clear. This PR clarifies this.

I opt to allow `rename!` for `SubDataFrame` with `Index`, as this is consistent with what we discuss in https://github.com/JuliaData/DataFrames.jl/issues/2211 (i.e. to make `SubDataFrame` created with `:` special).