### PR TITLE
Don't match on AbstractVector type parameter due to compiler crash

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.21.6"
+version = "0.21.7"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -969,7 +969,7 @@ function copyto_widen!(res::AbstractVector{T}, x::AbstractVector) where T
 end
 
 function groupreduce!(res::AbstractVector, f, op, condf, adjust, checkempty::Bool,
-                      incol::AbstractVector{T}, gd::GroupedDataFrame) where {T}
+                      incol::AbstractVector, gd::GroupedDataFrame)
     n = length(gd)
     if adjust !== nothing || checkempty
         counts = zeros(Int, n)
@@ -1001,7 +1001,7 @@ function groupreduce!(res::AbstractVector, f, op, condf, adjust, checkempty::Boo
         end
         @inbounds for gix in eachindex(res)
             if !isassigned(res, gix)
-                res[gix] = initf(nonmissingtype(T))
+                res[gix] = initf(nonmissingtype(eltype(incol)))
             end
         end
     end


### PR DESCRIPTION
Fixes #2382. Same issue and fix as
https://github.com/JuliaData/DataFrames.jl/issues/2326.