### PR TITLE
Replaced ParquetFiles.jl with Parquet.jl

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -107,8 +107,8 @@ integrated they are with DataFrames.jl.
       CSVs (using [CSV.jl](https://github.com/JuliaData/CSV.jl)),
       Stata, SPSS, and SAS files (using
       [StatFiles.jl](https://github.com/queryverse/StatFiles.jl)),
-      and reading (though not writing) parquet files
-      (using [ParquetFiles.jl](https://github.com/queryverse/ParquetFiles.jl)).
+      and reading and writing parquet files
+      (using [Parquet.jl](https://github.com/JuliaIO/Parquet.jl)).
 
 While not all of these libraries are tightly integrated with DataFrames.jl,
 because `DataFrame`s are essentially collections of aligned Julia vectors, so it


### PR DESCRIPTION
As there are long-standing issues that makes ParquetFiles unusable see https://github.com/queryverse/ParquetFiles.jl/pulls where ParquetFiles.jl has not updated to Parquet 0.6 and is still relying on Parquet 0.4.

Also, Parquet.jl can read and write Parquet files now and although it is not feature-complete it is a much better alternative to ParuqetFiles.jl now.