### PR TITLE
Add canonical URL to manual

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
     doctest = false,
     clean = false,
     sitename = "DataFrames.jl",
-    format = Documenter.HTML(),
+    format = Documenter.HTML(canonical = "https://juliadata.github.io/DataFrames.jl/stable/"),
     pages = Any[
         "Introduction" => "index.md",
         "User Guide" => Any[


### PR DESCRIPTION
This prevents search engines from pointing to outdated releases. The same change should be applied to HTML files for older releases.

Currently Google seems to point to the latest release, but this is safer.