### PR TITLE
Left align pandas comparison tables

### DIFF
--- a/docs/src/man/comparisons.md
+++ b/docs/src/man/comparisons.md
@@ -34,7 +34,7 @@ as row indices rather than a separate `id` column.
 ### Accessing data
 
 | Operation                  | pandas                 | DataFrames.jl                      |
-|----------------------------|------------------------|------------------------------------|
+|:---------------------------|:-----------------------|:-----------------------------------|
 | Cell indexing by location  | `df.iloc[1, 1]`        | `df[2, 2]`                         |
 | Row slicing by location    | `df.iloc[1:3]`         | `df[2:3, :]`                       |
 | Column slicing by location | `df.iloc[:, 1:]`       | `df[:, 2:end]`                     |
@@ -65,7 +65,7 @@ rows having the index value of `'c'`.
 ### Common operations
 
 | Operation                | pandas                                                         | DataFrames.jl                               |
-|--------------------------|----------------------------------------------------------------|---------------------------------------------|
+|:-------------------------|:---------------------------------------------------------------|:--------------------------------------------|
 | Reduce multiple values   | `df['z'].mean(skipna = False)`                                 | `mean(df.z)`                                |
 |                          | `df['z'].mean()`                                               | `mean(skipmissing(df.z))`                   |
 |                          | `df[['z']].agg(['mean'])`                                      | `combine(df, :z => mean ∘ skipmissing)`     |
@@ -101,7 +101,7 @@ which may be processed using the `combine`, `transform`, or `select` functions.
 The following table illustrates some common grouping and aggregation usages.
 
 | Operation                       | pandas                                                                                | DataFrames.jl                                        |
-|---------------------------------|---------------------------------------------------------------------------------------|------------------------------------------------------|
+|:--------------------------------|:--------------------------------------------------------------------------------------|:-----------------------------------------------------|
 | Aggregate by groups             | `df.groupby('grp')['x'].mean()`                                                       | `combine(groupby(df, :grp), :x => mean)`             |
 | Rename column after aggregation | `df.groupby('grp')['x'].mean().rename("my_mean")`                                     | `combine(groupby(df, :grp), :x => mean => :my_mean)` |
 | Add aggregated data as column   | `df.join(df.groupby('grp')['x'].mean(), on='grp', rsuffix='_mean')`                   | `transform(groupby(df, :grp), :x => mean)`           |
@@ -139,7 +139,7 @@ Hence, it performs well when you need to perform lookups repeatedly.
 This section includes more complex examples.
 
 | Operation                              | pandas                                                                       | DataFrames.jl                                             |
-|----------------------------------------|------------------------------------------------------------------------------|-----------------------------------------------------------|
+|:---------------------------------------|:-----------------------------------------------------------------------------|:----------------------------------------------------------|
 | Complex Function                       | `df[['z']].agg(lambda v: np.mean(np.cos(v)))`                                | `combine(df, :z => v -> mean(cos, skipmissing(v)))`       |
 | Aggregate multiple columns             | `df.agg({'x': max, 'y': min})`                                               | `combine(df, :x => maximum, :y => minimum)`               |
 |                                        | `df[['x','y']].mean()`                                                       | `combine(df, [:x, :y] .=> mean)`                          |

--- a/docs/src/man/comparisons.md
+++ b/docs/src/man/comparisons.md
@@ -47,8 +47,8 @@ as row indices rather than a separate `id` column.
 Note that Julia uses 1-based indexing, inclusive on both ends. A special keyword `end` can be used to
 indicate the last index. Likewise, the `begin` keyword can be used to indicate the first index.
 
-In addition, the `findfirst` function is used to find the first match and return the result
-as a single `DataFrameRow` object. In the case that `id` is not unique, you can use the `findall` function
+In addition, when indexing a data frame with the `findfirst` function, a single
+`DataFrameRow` object is returned. In the case that `id` is not unique, you can use the `findall` function
 or boolean indexing instead. It would then return a `DataFrame` object containing all matched rows. The following
 two lines of code are functionally equivalent:
 


### PR DESCRIPTION
PR #2378 got merged but I just realized the pandas comparison tables are all right-aligned. This PR just make them left-aligned.