### PR TITLE
make schema(df) faster by using less allocation

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -21,7 +21,7 @@ end
 Tables.columnindex(df::Union{AbstractDataFrame, DataFrameRow}, idx::AbstractString) =
     columnindex(df, Symbol(idx))
 
-Tables.schema(df::AbstractDataFrame) = Tables.Schema(propertynames(df), eltype.(eachcol(df)))
+Tables.schema(df::AbstractDataFrame) = Tables.Schema{Tuple(_names(df)), Tuple{[eltype(col) for col in eachcol(df)]...}}()
 Tables.materializer(df::AbstractDataFrame) = DataFrame
 
 Tables.getcolumn(df::AbstractDataFrame, i::Int) = df[!, i]


### PR DESCRIPTION
```julia
julia> using DataFrames, Tables, BenchmarkTools
[ Info: Precompiling DataFrames [a93c6f00-e57d-5684-b7b6-d8193f3e46c0]

julia> X = DataFrame(randn(1000, 10000));

julia> @btime Tables.schema($X); #master
  10.189 ms (9505 allocations: 774.17 KiB)

julia> @btime Tables.schema($X); # this PR
  1.336 ms (12 allocations: 469.45 KiB)
```