### PR TITLE
check if AbstractMatrix supports Tables.istable in a constructor

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -16,8 +16,10 @@ DataFrame(columns::NTuple{N,AbstractVector}, names::NTuple{N,Symbol};
           makeunique::Bool=false, copycols::Bool=true)
 DataFrame(columns::NTuple{N,AbstractVector}, names::NTuple{N,<:AbstractString};
           makeunique::Bool=false, copycols::Bool=true)
-DataFrame(columns::Matrix, names::AbstractVector{Symbol}; makeunique::Bool=false)
-DataFrame(columns::Matrix, names::AbstractVector{<:AbstractString};
+DataFrame(columns::AbstractMatrix)
+DataFrame(columns::AbstractMatrix, names::AbstractVector{Symbol};
+          makeunique::Bool=false)
+DataFrame(columns::AbstractMatrix, names::AbstractVector{<:AbstractString};
           makeunique::Bool=false)
 DataFrame(kwargs...)
 DataFrame(pairs::Pair{Symbol,<:Any}...; makeunique::Bool=false, copycols::Bool=true)
@@ -35,7 +37,7 @@ DataFrame(::GroupedDataFrame; keepkeys::Bool=true)
 ```
 
 # Arguments
-- `columns` : a Vector with each column as contents or a Matrix
+- `columns` : a vector with each column as contents or a matrix
 - `names` : the column names
 - `makeunique` : if `false` (the default), an error will be raised
   if duplicates in `names` are found; if `true`, duplicate names will be suffixed
@@ -262,8 +264,15 @@ DataFrame(columns::NTuple{N, AbstractVector}; copycols::Bool=true) where {N} =
     DataFrame(collect(AbstractVector, columns), gennames(length(columns)),
               copycols=copycols)
 
-DataFrame(columns::AbstractMatrix,
-          cnames::AbstractVector{Symbol} = gennames(size(columns, 2));
+DataFrame(columns::T) where {T <: AbstractMatrix} =
+    if Tables.istable(T)
+        fromcolumns(Tables.columns(x), collect(Symbol, Tables.columnnames(cols)),
+                    copycols=true)
+    else
+        DataFrame(columns, gennames(size(columns, 2)))
+    end
+
+DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol};
           makeunique::Bool=false) =
     DataFrame(AbstractVector[columns[:, i] for i in 1:size(columns, 2)], cnames,
               makeunique=makeunique, copycols=false)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -266,7 +266,8 @@ DataFrame(columns::NTuple{N, AbstractVector}; copycols::Bool=true) where {N} =
 
 DataFrame(columns::T) where {T <: AbstractMatrix} =
     if Tables.istable(T)
-        fromcolumns(Tables.columns(x), collect(Symbol, Tables.columnnames(cols)),
+        fromcolumns(Tables.columns(columns),
+                    collect(Symbol, Tables.columnnames(columns)),
                     copycols=true)
     else
         DataFrame(columns, gennames(size(columns, 2)))

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -264,14 +264,15 @@ DataFrame(columns::NTuple{N, AbstractVector}; copycols::Bool=true) where {N} =
     DataFrame(collect(AbstractVector, columns), gennames(length(columns)),
               copycols=copycols)
 
-DataFrame(columns::T) where {T <: AbstractMatrix} =
+function DataFrame(columns::T) where {T <: AbstractMatrix}
     if Tables.istable(T)
-        fromcolumns(Tables.columns(columns),
-                    collect(Symbol, Tables.columnnames(columns)),
-                    copycols=true)
+        return fromcolumns(Tables.columns(columns),
+                           collect(Symbol, Tables.columnnames(columns)),
+                           copycols=true)
     else
-        DataFrame(columns, gennames(size(columns, 2)))
+        return DataFrame(columns, gennames(size(columns, 2)))
     end
+end
 
 DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol};
           makeunique::Bool=false) =

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -264,7 +264,9 @@ DataFrame(columns::NTuple{N, AbstractVector}; copycols::Bool=true) where {N} =
     DataFrame(collect(AbstractVector, columns), gennames(length(columns)),
               copycols=copycols)
 
-function DataFrame(columns::T) where {T <: AbstractMatrix}
+function DataFrame(columns::T; copycols::Bool=true) where {T <: AbstractMatrix}
+    copycols || throw(ArgumentError("copycols=false is not supported with source" *
+                                    "of type $T"))
     if Tables.istable(T)
         return fromcolumns(Tables.columns(columns),
                            collect(Symbol, Tables.columnnames(columns)),
@@ -274,14 +276,18 @@ function DataFrame(columns::T) where {T <: AbstractMatrix}
     end
 end
 
-DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol};
-          makeunique::Bool=false) =
+function DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol};
+          makeunique::Bool=false, copycols::Bool=true)
+    copycols || throw(ArgumentError("copycols=false is not supported with source" *
+                                    "of type $(typeof(columns))"))
+
     DataFrame(AbstractVector[columns[:, i] for i in 1:size(columns, 2)], cnames,
               makeunique=makeunique, copycols=false)
+end
 
 DataFrame(columns::AbstractMatrix, cnames::AbstractVector{<:AbstractString};
-          makeunique::Bool=false) =
-    DataFrame(columns, Symbol.(cnames); makeunique=makeunique)
+          makeunique::Bool=false, copycols::Bool=true) =
+    DataFrame(columns, Symbol.(cnames); makeunique=makeunique, copycols=copycols)
 
 function DataFrame(column_eltypes::AbstractVector{T}, cnames::AbstractVector{Symbol},
                    nrows::Integer=0; makeunique::Bool=false)::DataFrame where T<:Type

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -43,7 +43,7 @@ fromcolumns(x, names; copycols::Bool=true) =
               copycols=copycols)
 
 function DataFrame(x::T; copycols::Bool=true) where {T}
-    if !Tables.istable(x)
+    if !Tables.istable(T)
         if x isa AbstractVector && all(col -> isa(col, AbstractVector), x)
             return DataFrame(Vector{AbstractVector}(x), copycols=copycols)
         elseif (x isa AbstractVector || x isa Tuple) &&

--- a/test/constructors.jl
+++ b/test/constructors.jl
@@ -97,9 +97,9 @@ const ≅ = isequal
     @test df[!, "x1"] == df2[!, "x1"]
     @test df[!, "x2"] == df2[!, "x2"]
 
-    @test_throws MethodError DataFrame([0.0 1.0;
-                                        0.0 1.0;
-                                        0.0 1.0], copycols=false)
+    @test_throws ArgumentError DataFrame([0.0 1.0;
+                                          0.0 1.0;
+                                          0.0 1.0], copycols=false)
 
     df2 = DataFrame([0.0 1.0;
                      0.0 1.0;
@@ -115,9 +115,9 @@ const ≅ = isequal
     @test df[!, :x1] == df2[!, :a]
     @test df[!, :x2] == df2[!, :b]
 
-    @test_throws MethodError DataFrame([0.0 1.0;
-                                        0.0 1.0;
-                                        0.0 1.0], [:a, :b], copycols=false)
+    @test_throws ArgumentError DataFrame([0.0 1.0;
+                                          0.0 1.0;
+                                          0.0 1.0], [:a, :b], copycols=false)
 
     df2 = DataFrame([0.0 1.0;
                      0.0 1.0;
@@ -126,9 +126,9 @@ const ≅ = isequal
     @test df[!, "x1"] == df2[!, "a"]
     @test df[!, "x2"] == df2[!, "b"]
 
-    @test_throws MethodError DataFrame([0.0 1.0;
-                                        0.0 1.0;
-                                        0.0 1.0], ["a", "b"], copycols=false)
+    @test_throws ArgumentError DataFrame([0.0 1.0;
+                                          0.0 1.0;
+                                          0.0 1.0], ["a", "b"], copycols=false)
 
     @test df == DataFrame(x1 = Union{Float64, Missing}[0.0, 0.0, 0.0],
                           x2 = Union{Float64, Missing}[1.0, 1.0, 1.0])
@@ -426,7 +426,7 @@ end
         @test_throws ErrorException DataFrame([1:3, 1], copycols=copycolsarg)
     end
 
-    @test_throws MethodError DataFrame([1 2; 3 4], copycols=false)
+    @test_throws ArgumentError DataFrame([1 2; 3 4], copycols=false)
 end
 
 @testset "column types" begin
@@ -446,7 +446,7 @@ end
     @test size(df) == (2, 2)
     @test df.x1 == [1, 3]
     @test df.x2 == [2, 4]
-    @test_throws MethodError DataFrame([1 2; 3 4], copycols=false)
+    @test_throws ArgumentError DataFrame([1 2; 3 4], copycols=false)
 
 end
 
@@ -522,6 +522,21 @@ end
                                        [:A, :B, :C], [false, false, true], 100)
     @test_throws MethodError DataFrame([Int, String], [:a, :b], [false, true], 3)
     @test_throws MethodError DataFrame([Union{Int, Missing}, Union{Float64, Missing}], 2)
+end
+
+@testset "AbstractMatrix being a table" begin
+    struct M <: AbstractMatrix{Any}
+        df::DataFrame
+    end
+
+    Tables.istable(::Type{M}) = true
+    Tables.columns(x::M) = x.df
+    Tables.columnnames(x::M) = propertynames(x.df)
+
+    df = DataFrame(a=1:2, b=3:4)
+    m = M(df)
+    @test DataFrame(m) == df
+    @test DataFrame(m).a !== df.a
 end
 
 end # module


### PR DESCRIPTION
Fixes #2433

Related https://github.com/JuliaData/Tables.jl/pull/198, https://github.com/mcabbott/AxisKeys.jl/issues/23 and https://github.com/mcabbott/AxisKeys.jl/issues/22.

@rofinn - can you please check if this gives you what you wanted? (note that there is a small issue with column copying but I think it should be resolved on AxisKeys.jl side as noted in https://github.com/mcabbott/AxisKeys.jl/issues/23, as this is a general design principle we use to avoid duplication of copying)