### PR TITLE
[BREAKING] Use DataAPI.refpool for optimized grouping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,7 +35,7 @@ test = ["DataStructures", "DataValues", "Dates", "Logging", "Random", "Test"]
 
 [compat]
 julia = "1"
-CategoricalArrays = "0.8"
+CategoricalArrays = "0.8.3"
 Compat = "2.2, 3"
 DataAPI = "1.2"
 InvertedIndices = "1"

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -161,7 +161,6 @@ function row_group_slots(cols::NTuple{N,<:AbstractVector},
     # and this method needs to allocate a groups vector anyway
     @assert groups !== nothing && all(col -> length(col) == length(groups), cols)
 
-    refpools = map(DataAPI.refpool, cols)
     refs = map(DataAPI.refarray, cols)
     missinginds = map(refpools) do refpool
         eltype(refpool) >: Missing ?
@@ -189,7 +188,7 @@ function row_group_slots(cols::NTuple{N,<:AbstractVector},
     # so it makes sense to allocate more memory for better performance,
     # but it needs to remain reasonable compared with the size of the data frame.
     anydups = !all(allunique, refpools)
-    if prod(Int128.(ngroupstup)) > typemax(Int) ||
+    if prod(big.(ngroupstup)) > typemax(Int) ||
        ngroups > 2 * length(groups) ||
        anydups
         # In the simplest case, we can work directly with the reference codes

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -160,7 +160,8 @@ function groupby(df::AbstractDataFrame, cols;
 
     groups = Vector{Int}(undef, nrow(df))
     ngroups, rhashes, gslots, sorted =
-        row_group_slots(ntuple(i -> sdf[!, i], ncol(sdf)), Val(false), groups, skipmissing)
+        row_group_slots(ntuple(i -> sdf[!, i], ncol(sdf)), Val(false),
+                        groups, skipmissing, sort)
 
     gd = GroupedDataFrame(df, copy(_names(sdf)), groups, nothing, nothing, nothing, ngroups, nothing,
                           Threads.ReentrantLock())

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -694,6 +694,22 @@ end
     end
 end
 
+@testset "grouping refarray with fallback" begin
+    # The high number of categories compared to the number of rows triggers the use
+    # of the fallback grouping method
+    for x in ([3, 1, 2], [3, 1, missing])
+        df = DataFrame(x=categorical(x, levels=10000:-1:1),
+                       x2=categorical(x, levels=3:-1:1),
+                       y=[1, 2, 3])
+        for skipmissing in (true, false)
+            @test groupby(df, :x, sort=true, skipmissing=skipmissing) ≅
+                groupby(df, :x, sort=true, skipmissing=skipmissing)
+            @test isequal_unordered(groupby(df, :x, skipmissing=skipmissing),
+                                    collect(AbstractDataFrame, groupby(df, :x, skipmissing=skipmissing)))
+        end
+    end
+end
+
 @testset "grouping with three keys" begin
     # We need many rows so that optimized CategoricalArray method is used
     xv = rand(["A", "B", missing], 100)


### PR DESCRIPTION
Generalize existing optimized `row_group_slots` method for `CategoricalArray` and `PooledArray` so that it can be used for other array types for which `DataAPI.refpool` returns an `AbstractVector`. This allows dropping the dependency on CategoricalArrays in this part of the code.

Also refactor the method to be faster when not sorting. In that case, we do not need to build a map between reference codes and groups (indexing into it is slow when the number of groups is very large). `CategoricalArray` is no longer special cased: when `sort=false`, levels are still sorted, but `missing` appears first.

Add more tests to cover weird combinations.


Some benchmarks:
```julia
df = DataFrame(x=PooledArray(rand(1:ngroups, N)), y=rand(N));

## 10M rows and 1k groups
# Current
julia> @btime groupby(df, :x);
  51.310 ms (35 allocations: 76.31 MiB)

julia> @btime groupby(df, :x, sort=true);
  62.972 ms (71 allocations: 76.34 MiB)

julia> @btime combine(groupby(df, :x), :y => sum);
  67.693 ms (216 allocations: 76.39 MiB)

julia> @btime combine(groupby(df, :x, sort=true), :y => sum);
  78.816 ms (252 allocations: 76.42 MiB)

# This PR
julia> @btime groupby(df, :x);
  43.987 ms (50 allocations: 76.35 MiB)

julia> @btime groupby(df, :x, sort=true);
  48.425 ms (55 allocations: 76.38 MiB)

julia> @btime combine(groupby(df, :x), :y => sum);
  59.312 ms (231 allocations: 76.43 MiB)

julia> @btime combine(groupby(df, :x, sort=true), :y => sum);
  63.025 ms (236 allocations: 76.46 MiB)


## 1G rows and 10M groups
# Current
julia> @time groupby(df, :x);
129.936916 seconds (7.60 M allocations: 7.907 GiB, 0.54% gc time)

julia> @time groupby(df, :x, sort=true);
163.077585 seconds (1.76 M allocations: 8.575 GiB)

julia> @time combine(groupby(df, :x), :y => sum);
165.301710 seconds (8.78 M allocations: 8.456 GiB, 0.39% gc time)

julia> @time combine(groupby(df, :x, sort=true), :y => sum);
193.600132 seconds (1.03 M allocations: 9.014 GiB)


# This PR
julia> @time groupby(df, :x);
 39.474096 seconds (96 allocations: 7.740 GiB)

julia> @time groupby(df, :x, sort=true);
134.739279 seconds (76.63 k allocations: 8.042 GiB, 0.51% gc time)

julia> @time combine(groupby(df, :x), :y => sum);
 72.631447 seconds (5.17 M allocations: 8.475 GiB)

julia> @time combine(groupby(df, :x, sort=true), :y => sum);
167.185490 seconds (293 allocations: 8.511 GiB, 0.97% gc time)
```