### PR TITLE
Implement permutedims

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,7 @@
 * add `only` method for `AbstractDataFrame` ([#2449](https://github.com/JuliaData/DataFrames.jl/pull/2449))
 * passing empty sets of columns in `filter`/`filter!` and in `select`/`transform`/`combine`
   with `ByRow` is now accepted ([#2476](https://github.com/JuliaData/DataFrames.jl/pull/2476))
+* add `permutedims` method for `AbstractDataFrame` ([#2447](https://github.com/JuliaData/DataFrames.jl/pull/2447))
 
 ## Deprecated
 

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -57,6 +57,7 @@ vcat
 ```@docs
 stack
 unstack
+permutedims
 ```
 
 ## Sorting

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -392,7 +392,7 @@ julia> df1 = DataFrame(a=["x", "y"], b=[1.0, 2.0], c=[3, 4], d=[true, false])
 │ 1   │ x      │ 1.0     │ 3     │ 1    │
 │ 2   │ y      │ 2.0     │ 4     │ 0    │
 
-julia> permutedims(df1)
+julia> permutedims(df1, 1)
 3×3 DataFrame
 │ Row │ a      │ x       │ y       │
 │     │ String │ Float64 │ Float64 │
@@ -402,12 +402,15 @@ julia> permutedims(df1)
 │ 3   │ d      │ 1.0     │ 0.0     │
 ```
 
-Note that the first column (by default) of the original `df`
+Note that the column indexed by `src_colnames` in the original `df`
 becomes the column names in the permuted result,
 and the column names of the original become a new column.
 Typically, this would be used on columns with homogenous element types,
 since the element types of the other columns
 are the result of `promote_type` on _all_ the permuted columns.
+Note also that, by default, the new column created from the column names
+of the original `df` has the same name as `src_namescol`.
+An optional positional argument `dest_namescol` can alter this:
 
 ```jldoctest reshape
 julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3, 4], d=[true, false])
@@ -418,12 +421,12 @@ julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3, 4], d=[true, false])
 │ 1   │ x      │ 1   │ 3     │ 1    │
 │ 2   │ y      │ two │ 4     │ 0    │
 
-julia> permutedims(df2)
+julia> permutedims(df2, 1, "different_name")
 3×3 DataFrame
-│ Row │ a      │ x   │ y   │
-│     │ String │ Any │ Any │
-├─────┼────────┼─────┼─────┤
-│ 1   │ b      │ 1   │ two │
-│ 2   │ c      │ 3   │ 4   │
-│ 3   │ d      │ 1   │ 0   │
+│ Row │ different_name │ x   │ y   │
+│     │ String         │ Any │ Any │
+├─────┼────────────────┼─────┼─────┤
+│ 1   │ b              │ 1   │ two │
+│ 2   │ c              │ 3   │ 4   │
+│ 3   │ d              │ 1   │ 0   │
 ```

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -384,7 +384,7 @@ julia> first(unstack(x, :Species, :vsum), 6)
 To turn an `AbstractDataFrame` on its side, use [`permutedims`](@ref).
 
 ```jldoctest reshape
-julia> df1 = DataFrame(a=["x", "y"], b=[1.0, 2.0], c=[3, 4], d=[true,false])
+julia> df1 = DataFrame(a=["x", "y"], b=[1.0, 2.0], c=[3, 4], d=[true, false])
 2×4 DataFrame
 │ Row │ a      │ b       │ c     │ d    │
 │     │ String │ Float64 │ Int64 │ Bool │

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -384,7 +384,7 @@ julia> first(unstack(x, :Species, :vsum), 6)
 To turn an `AbstractDataFrame` on its side, use [`permutedims`](@ref).
 
 ```jldoctest reshape
-julia> df1 = DataFrame(a=["x", "y"], b=[1.,2.], c=[3,4], d=[true,false])
+julia> df1 = DataFrame(a=["x", "y"], b=[1.0, 2.0], c=[3, 4], d=[true,false])
 2×4 DataFrame
 │ Row │ a      │ b       │ c     │ d    │
 │     │ String │ Float64 │ Int64 │ Bool │
@@ -409,7 +409,7 @@ Note also that the element types of the other columns
 are the result of `promote_type` on _all_ the permuted columns.
 
 ```jldoctest reshape
-julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3,4], d=[true,false])
+julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3, 4], d=[true, false])
 2×4 DataFrame
 │ Row │ a      │ b   │ c     │ d    │
 │     │ String │ Any │ Int64 │ Bool │

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -405,7 +405,7 @@ julia> permutedims(df1)
 Note that the first column (by default) of the original `df`
 becomes the column names in the permuted result,
 and the column names of the original become a new column.
-Note also that the types of the other columns
+Note also that the element types of the other columns
 are the result of `promote_type` on _all_ the permuted columns.
 
 ```jldoctest reshape

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -380,3 +380,49 @@ julia> first(unstack(x, :Species, :vsum), 6)
 │ 4   │ PetalWidth  │ 0.244       │ 1.326           │ 2.026          │
 │ 5   │ id          │ 25.5        │ 75.5            │ 125.5          │
 ```
+
+To turn an `AbstractDataFrame` on its side, use [`permutedims`](@ref).
+
+```jldoctest reshape
+julia> df1 = DataFrame(a=["x", "y"], b=[1.,2.], c=[3,4], d=[true,false])
+2×4 DataFrame
+│ Row │ a      │ b       │ c     │ d    │
+│     │ String │ Float64 │ Int64 │ Bool │
+├─────┼────────┼─────────┼───────┼──────┤
+│ 1   │ x      │ 1.0     │ 3     │ 1    │
+│ 2   │ y      │ 2.0     │ 4     │ 0    │
+
+julia> permutedims(df1)
+3×3 DataFrame
+│ Row │ a      │ x       │ y       │
+│     │ String │ Float64 │ Float64 │
+├─────┼────────┼─────────┼─────────┤
+│ 1   │ b      │ 1.0     │ 2.0     │
+│ 2   │ c      │ 3.0     │ 4.0     │
+│ 3   │ d      │ 1.0     │ 0.0     │
+```
+
+Note that the first column (by default) of the original `df`
+becomes the column names in the permuted result,
+and the column names of the original become a new column.
+Note also that the types of the other columns
+are the result of `promote_type` on _all_ the permuted columns.
+
+```jldoctest reshape
+julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3,4], d=[true,false])
+2×4 DataFrame
+│ Row │ a      │ b   │ c     │ d    │
+│     │ String │ Any │ Int64 │ Bool │
+├─────┼────────┼─────┼───────┼──────┤
+│ 1   │ x      │ 1   │ 3     │ 1    │
+│ 2   │ y      │ two │ 4     │ 0    │
+
+julia> permutedims(df2)
+3×3 DataFrame
+│ Row │ a      │ x   │ y   │
+│     │ String │ Any │ Any │
+├─────┼────────┼─────┼─────┤
+│ 1   │ b      │ 1   │ two │
+│ 2   │ c      │ 3   │ 4   │
+│ 3   │ d      │ 1   │ 0   │
+```

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -405,7 +405,8 @@ julia> permutedims(df1)
 Note that the first column (by default) of the original `df`
 becomes the column names in the permuted result,
 and the column names of the original become a new column.
-Note also that the element types of the other columns
+Typically, this would be used on columns with homogenous element types,
+since the element types of the other columns
 are the result of `promote_type` on _all_ the permuted columns.
 
 ```jldoctest reshape

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -405,16 +405,30 @@ function transpose1(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variab
     unstack(stack(df,Not(src_namescol), variable_name=dest_namescol), dest_namescol, src_namescol, :value)
 end
 
-function transpose2(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
-    m = permutedims((Matrix(df[!, Not(src_namescol)])))
+function transpose2(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable; copycols=false)
+    m = permutedims(Matrix(df[!, Not(src_namescol)]))
     df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
-    hcat(df2, DataFrame(m, df[!, src_namescol]), copycols=false)
+    hcat(df2, DataFrame(m, df[!, src_namescol]), copycols=copycols)
+end
+
+function transpose2_comprehension(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable; copycols=false)
+    m = permutedims(Matrix(df[!, Not(src_namescol)]))
+    df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
+    hcat(df2, DataFrame([[x for x in col] for col in eachcol(m)], df[!, src_namescol]), copycols=copycols)
 end
 
 function transpose3(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
     df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
     for row in eachrow(df)
         df2[!,row[src_namescol]] = Vector(row[Not(src_namescol)])
+    end
+    return df2
+end
+
+function transpose3_comprehension(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
+    df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
+    for row in eachrow(df)
+        df2[!,row[src_namescol]] =  [x for x in row[Not(src_namescol)]]
     end
     return df2
 end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -428,16 +428,19 @@ permutedims(df2, promote_type=false)
 ````
 """
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex=1,
-    dest_namescol::Union{Symbol, AbstractString}=src_namescol isa Integer ?
-                                                 _names(df)[src_namescol] :
-                                                 src_namescol;
-    makeunique::Bool=false, promote::Symbol=:all)
+                          dest_namescol::Union{Symbol, AbstractString}=src_namescol isa Integer ?
+                                                                       _names(df)[src_namescol] :
+                                                                       src_namescol;
+                          makeunique::Bool=false, promote::Symbol=:all)
 
-    nrow(df) > 0 || throw(ArgumentError("`permutedims` not defined for tables with 0 rows"))
+    nrow(df) > 0 || throw(ArgumentError("`permutedims` not defined for data frame with 0 rows"))
+
 
     df_notsrc = df[!, Not(src_namescol)]
     df_permuted = DataFrame([names(df_notsrc)], [dest_namescol])
-    if promote == :all || ((promote == :none ) && (all(col-> eltype(col) == eltype(first(eachcol(df_notsrc))), eachcol(df_notsrc))))
+
+    an_eltype = eltype(first(eachcol(df_notsrc)))
+    if promote == :all || ((promote == :none ) && (all(col-> eltype(col) == an_eltype, eachcol(df_notsrc))))
         m = permutedims(Matrix(df_notsrc))
         hcat!(df_permuted, DataFrame(m, df[!, src_namescol], makeunique=makeunique), copycols=false)
     elseif promote == :none

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -402,11 +402,28 @@ end
 
 
 """
-    transpose(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable; copycols::Bool=false, makeunique=false, promote_type::Bool=true)
+    transpose(df::AbstractDataFrame, src_namescol=1, dest_namescol=names(df)[src_namescol]; copycols::Bool=false, makeunique=false, promote_type::Bool=true)
 
 Transpose a `DataFrame`, such that rows become columns,
 and the column indexed by `src_namescol` becomes a header.
 
+By default, the type of resulting columns will depend on the promoted type of all input columns.
+Pass `promote_type=false` to make resulting column types depend on the elements of the originating rows,
+though note that this may be substantially slower.
+
+
+# Examples
+
+```julia
+df1 = DataFrame(a=["x", "y"], b=rand(2), c=[1,2], d=rand(Bool,2)) # all types can be promoted to Float64
+df2 = DataFrame(a=["x", "y"], b=[1, "str"], c=[1,2], d=rand(Bool,2))
+
+transpose(df1)
+transpose(df1, promote_type=false)
+
+transpose(df2)
+transpose(df2, promote_type=false)
+````
 """
 function Base.transpose(df::AbstractDataFrame, src_namescol=1, dest_namescol=names(df)[src_namescol]; copycols::Bool=false, makeunique=false, promote_type::Bool=true)
     if promote_type

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -479,16 +479,16 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
                           makeunique::Bool=false)
 
     if src_namescol isa Integer
-        1 <= src_namescol <= ncol(df) || throw(BoundsError("`src_namescol` doesn't exist"))
+        1 <= src_namescol <= ncol(df) || throw(BoundsError(df, src_namescol))
     end
-    eltype(df[!, src_namescol]) <: SymbolOrString || throw(
-        ArgumentError("src_namescol must have eltype `Symbol` or `<:AbstractString`"))
+    eltype(df[!, src_namescol]) <: SymbolOrString ||
+        throw(ArgumentError("src_namescol must have eltype `Symbol` or `<:AbstractString`"))
 
     df_notsrc = df[!, Not(src_namescol)]
     df_permuted = DataFrame(dest_namescol => names(df_notsrc))
 
     if ncol(df_notsrc) == 0
-        df_tmp = DataFrame(Dict(n=>[] for n in df[!, src_namescol]))
+        df_tmp = DataFrame((n=>[] for n in df[!, src_namescol])...)
     else
         m = permutedims(Matrix(df_notsrc))
         df_tmp = rename!(DataFrame(Tables.table(m)), df[!, src_namescol], makeunique=makeunique)
@@ -499,7 +499,7 @@ end
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
                           makeunique::Bool=false)
     if src_namescol isa Integer
-        1 <= src_namescol <= ncol(df) || throw(BoundsError("`src_namescol` doesn't exist"))
+        1 <= src_namescol <= ncol(df) || throw(BoundsError(df, src_namescol))
         dest_namescol = _names(df)[src_namescol]
     else
         dest_namescol = src_namescol

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -413,8 +413,7 @@ Base.transpose(::AbstractDataFrame, args...; kwargs...) =
 
 Turn `df` on its side such that rows become columns
 and the column indexed by `src_namescol` becomes the names of new columns.
-In the resulting `DataFrame`,
-The header of `df` will become the first column
+In the resulting `DataFrame`, column names of `df` will become the first column
 with name specified by `dest_namescol`.
 
 # Arguments
@@ -482,7 +481,7 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
     nrow(df) > 0 || throw(
         ArgumentError("`permutedims` not defined for data frame with 0 rows"))
     eltype(df[!, src_namescol]) <: SymbolOrString || throw(
-            ArgumentError("src_namescol must have eltype `Symbol` or `<:AbstractString`"))
+        ArgumentError("src_namescol must have eltype `Symbol` or `<:AbstractString`"))
 
     df_notsrc = df[!, Not(src_namescol)]
     df_permuted = DataFrame(dest_namescol => names(df_notsrc))
@@ -495,7 +494,7 @@ end
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
                           makeunique::Bool=false)
     if src_namescol isa Integer
-        1 <= src_namescol <= ncol(df) || throw(ArgumentError("`src_namescol` doesn't exist"))
+        1 <= src_namescol <= ncol(df) || throw(BoundsError("`src_namescol` doesn't exist"))
         dest_namescol = _names(df)[src_namescol]
     else
         dest_namescol = src_namescol

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -407,7 +407,7 @@ Base.transpose(::AbstractDataFrame, args...; kwargs...) =
 
 """
     permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
-                dest_namescol::Union{Symbol,Int};
+                dest_namescol::Union{Symbol,AbstractString};
                 makeunique::Bool=false)
     permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex; makeunique::Bool=false)
     permutedims(df::AbstractDataFrame; makeunique::Bool=false)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -426,7 +426,7 @@ with name specified by `dest_namescol`.
   with `_i` (`i` starting at 1 for the first duplicate).
 
 Note: The element types of columns in resulting `DataFrame`
-(other than the first column, which always has element type `String`)
+(other than the first column, w hich always has element type `String`)
 will depend on the element types of _all_ input columns
 based on the result of `promote_type`.
 That is, if the source data frame contains `Int` and `Float64` columns,
@@ -485,12 +485,12 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
     df_permuted = DataFrame(dest_namescol => names(df_notsrc))
 
     if ncol(df_notsrc) == 0
-        df_tmp = DataFrame((n=>[] for n in df[!, src_namescol])...)
+        df_tmp = DataFrame((n=>[] for n in df[!, src_namescol])..., makeunique=makeunique)
     else
         m = permutedims(Matrix(df_notsrc))
         df_tmp = rename!(DataFrame(Tables.table(m)), df[!, src_namescol], makeunique=makeunique)
     end
-    return hcat!(df_permuted, df_tmp, copycols=false)
+    return hcat!(df_permuted, df_tmp, makeunique=makeunique, copycols=false)
 end
 
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex=1;

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -405,9 +405,9 @@ Base.transpose(::AbstractDataFrame, args...; kwargs...) =
     MethodError("`transpose` not defined for `AbstractDataFrame`s. Try `permutedims` instead")
 
 """
-    permutedims(df::AbstractDataFrame [, src_namescol::Union{Int, Symbol, <:AbstractString}
-                    [, dest_namescol::Union{Symbol, AbstractString} ]];
-                    makeunique::Bool=false)
+    permutedims(df::AbstractDataFrame, src_namescol::Union{Int, Symbol, <:AbstractString}
+                [, dest_namescol::Union{Symbol, AbstractString}];
+                makeunique::Bool=false)
 
 Turn `df` on its side such that rows become columns
 and the column indexed by `src_namescol` becomes the names of new columns.
@@ -417,8 +417,7 @@ with name specified by `dest_namescol`.
 # Arguments
 - `df` : the `AbstractDataFrame`
 - `src_namescol` : the column that will become the new header.
-  This column eltype must be `<: Union{String, Symbol}`.
-  Defaults to first column.
+  This column's element type must be `AbstractString` or `Symbol`.
 - `dest_namescol` : the name of the first column in the returned `DataFrame`.
   Defaults to the same name as `src_namescol`.
 - `makeunique` : if `false` (the default), an error will be raised
@@ -426,7 +425,7 @@ with name specified by `dest_namescol`.
   with `_i` (`i` starting at 1 for the first duplicate).
 
 Note: The element types of columns in resulting `DataFrame`
-(other than the first column, w hich always has element type `String`)
+(other than the first column, which always has element type `String`)
 will depend on the element types of _all_ input columns
 based on the result of `promote_type`.
 That is, if the source data frame contains `Int` and `Float64` columns,
@@ -436,7 +435,7 @@ resulting columns will have element type `Float64`. If the source has
 # Examples
 
 ```jldoctest
-julia> df1 = DataFrame(a=["x", "y"], b=[1.,2.], c=[3,4], d=[true,false])
+julia> df1 = DataFrame(a=["x", "y"], b=[1., 2.], c=[3, 4], d=[true,false])
 2×4 DataFrame
 │ Row │ a      │ b       │ c     │ d    │
 │     │ String │ Float64 │ Int64 │ Bool │
@@ -444,7 +443,7 @@ julia> df1 = DataFrame(a=["x", "y"], b=[1.,2.], c=[3,4], d=[true,false])
 │ 1   │ x      │ 1.0     │ 3     │ 1    │
 │ 2   │ y      │ 2.0     │ 4     │ 0    │
 
-julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3,4], d=[true,false])
+julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3, 4], d=[true, false])
 2×4 DataFrame
 │ Row │ a      │ b   │ c     │ d    │
 │     │ String │ Any │ Int64 │ Bool │
@@ -452,7 +451,7 @@ julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3,4], d=[true,false])
 │ 1   │ x      │ 1   │ 3     │ 1    │
 │ 2   │ y      │ two │ 4     │ 0    │
 
-julia> permutedims(df1) # note the column types
+julia> permutedims(df1, 1) # note the column types
 3×3 DataFrame
 │ Row │ a      │ x       │ y       │
 │     │ String │ Float64 │ Float64 │
@@ -461,7 +460,7 @@ julia> permutedims(df1) # note the column types
 │ 2   │ c      │ 3.0     │ 4.0     │
 │ 3   │ d      │ 1.0     │ 0.0     │
 
-julia> permutedims(df2)
+julia> permutedims(df2, 1)
 3×3 DataFrame
 │ Row │ a      │ x   │ y   │
 │     │ String │ Any │ Any │
@@ -472,7 +471,7 @@ julia> permutedims(df2)
 ```
 """
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
-                          dest_namescol::Union{Symbol, <:AbstractString};
+                          dest_namescol::Union{Symbol, AbstractString};
                           makeunique::Bool=false)
 
     if src_namescol isa Integer
@@ -493,7 +492,7 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
     return hcat!(df_permuted, df_tmp, makeunique=makeunique, copycols=false)
 end
 
-function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex=1;
+function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
                           makeunique::Bool=false)
     if src_namescol isa Integer
         1 <= src_namescol <= ncol(df) || throw(BoundsError(index(df), src_namescol))

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -401,34 +401,21 @@ function CategoricalArrays.CategoricalArray(v::RepeatedVector)
 end
 
 
-function transpose1(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
-    unstack(stack(df,Not(src_namescol), variable_name=dest_namescol), dest_namescol, src_namescol, :value)
-end
+"""
+    transpose(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable; copycols::Bool=false, makeunique=false, promote_type::Bool=true)
 
-function transpose2(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable; copycols=false)
-    m = permutedims(Matrix(df[!, Not(src_namescol)]))
-    df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
-    hcat(df2, DataFrame(m, df[!, src_namescol]), copycols=copycols)
-end
+Transpose a `DataFrame`, such that rows become columns,
+and the column indexed by `src_namescol` becomes a header.
 
-function transpose2_comprehension(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable; copycols=false)
-    m = permutedims(Matrix(df[!, Not(src_namescol)]))
-    df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
-    hcat(df2, DataFrame([[x for x in col] for col in eachcol(m)], df[!, src_namescol]), copycols=copycols)
-end
-
-function transpose3(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
-    df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
-    for row in eachrow(df)
-        df2[!,row[src_namescol]] = Vector(row[Not(src_namescol)])
+"""
+function Base.transpose(df::AbstractDataFrame, src_namescol=1, dest_namescol=names(df)[src_namescol]; copycols::Bool=false, makeunique=false, promote_type::Bool=true)
+    if promote_type
+        m = permutedims(Matrix(df[!, Not(src_namescol)]))
+        df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
+        return hcat(df2, DataFrame(m, df[!, src_namescol], makeunique=makeunique), copycols=copycols)
+    else
+        m = permutedims(Matrix{Any}(df[!, Not(src_namescol)]))
+        df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
+        hcat(df2, DataFrame([[x for x in col] for col in eachcol(m)], df[!, src_namescol], makeunique=makeunique), copycols=copycols)
     end
-    return df2
-end
-
-function transpose3_comprehension(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
-    df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
-    for row in eachrow(df)
-        df2[!,row[src_namescol]] =  [x for x in row[Not(src_namescol)]]
-    end
-    return df2
 end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -401,18 +401,20 @@ function CategoricalArrays.CategoricalArray(v::RepeatedVector)
 end
 
 
-transpose1(df::AbstractDataFrame, indexcol=1) = unstack(stack(df,Not(indexcol)), :variable, indexcol,:value)
-
-function transpose2(df::AbstractDataFrame, indexcol=1)
-    m = permutedims(Matrix(df[!, Not(indexcol)]))
-    df2 = DataFrame(variable=names(df[!, Not(indexcol)]))
-    hcat(df2, DataFrame(m, df[!, indexcol], copycols=false), copycols=false)
+function transpose1(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
+    unstack(stack(df,Not(src_namescol), variable_name=dest_namescol), dest_namescol, src_namescol, :value)
 end
 
-function transpose3(df::AbstractDataFrame, indexcol=1)
-    df2 = DataFrame(variable=names(df[!, Not(indexcol)]))
+function transpose2(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
+    m = permutedims((Matrix(df[!, Not(src_namescol)])))
+    df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
+    hcat(df2, DataFrame(m, df[!, src_namescol]), copycols=false)
+end
+
+function transpose3(df::AbstractDataFrame, src_namescol=1, dest_namescol=:variable)
+    df2 = DataFrame([names(df[!, Not(src_namescol)])], [dest_namescol])
     for row in eachrow(df)
-        df2[!,row[indexcol]] = Vector(row[Not(indexcol)])
+        df2[!,row[src_namescol]] = Vector(row[Not(src_namescol)])
     end
     return df2
 end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -405,11 +405,9 @@ Base.transpose(::AbstractDataFrame, args...; kwargs...) =
     MethodError("`transpose` not defined for `AbstractDataFrame`s. Try `permutedims` instead")
 
 """
-    permutedims(df::AbstractDataFrame, src_namescol::Union{Int, Symbol, <:AbstractString},
-                dest_namescol::Union{Symbol,AbstractString};
-                makeunique::Bool=false)
-    permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex; makeunique::Bool=false)
-    permutedims(df::AbstractDataFrame; makeunique::Bool=false)
+    permutedims(df::AbstractDataFrame [, src_namescol::Union{Int, Symbol, <:AbstractString}
+                    [, dest_namescol::Union{Symbol, AbstractString} ]];
+                    makeunique::Bool=false)
 
 Turn `df` on its side such that rows become columns
 and the column indexed by `src_namescol` becomes the names of new columns.
@@ -427,14 +425,13 @@ with name specified by `dest_namescol`.
   if duplicate names are found; if `true`, duplicate names will be suffixed
   with `_i` (`i` starting at 1 for the first duplicate).
 
-Note: The eltypes of columns in resulting `DataFrame`
-(other than the first column, which always has eltype `String`)
-will depend on the eltypes of _all_ input columns
-based on the results of `prote_type`.
-That is, if the source `DataFrame` contains `String` and `Int` columns,
-resulting columns will have eltype `Any`.
-If the source has a mix of numeric types (eg. `Float64` and `Int`),
-columns in resulting `DataFrame` will be promoted to `Float64`.
+Note: The element types of columns in resulting `DataFrame`
+(other than the first column, which always has element type `String`)
+will depend on the element types of _all_ input columns
+based on the result of `promote_type`.
+That is, if the source data frame contains `Int` and `Float64` columns,
+resulting columns will have element type `Float64`. If the source has
+`Int` and `String` columns, resulting columns will have element type `Any`.
 
 # Examples
 
@@ -496,7 +493,7 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
     return hcat!(df_permuted, df_tmp, copycols=false)
 end
 
-function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
+function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex=1;
                           makeunique::Bool=false)
     if src_namescol isa Integer
         1 <= src_namescol <= ncol(df) || throw(BoundsError(index(df), src_namescol))
@@ -506,6 +503,3 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
     end
     return permutedims(df, src_namescol, dest_namescol; makeunique=makeunique)
 end
-
-Base.permutedims(df::AbstractDataFrame; makeunique::Bool=false) =
-    permutedims(df, 1; makeunique=makeunique)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -433,6 +433,8 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex=1,
                                                  src_namescol;
     makeunique::Bool=false, promote::Symbol=:all)
 
+    nrow(df) > 0 || throw(ArgumentError("`permutedims` not defined for tables with 0 rows"))
+
     df_notsrc = df[!, Not(src_namescol)]
     df_permuted = DataFrame([names(df_notsrc)], [dest_namescol])
     if promote == :all || ((promote == :none ) && (all(col-> eltype(col) == eltype(first(eachcol(df_notsrc))), eachcol(df_notsrc))))
@@ -440,7 +442,7 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex=1,
         hcat!(df_permuted, DataFrame(m, df[!, src_namescol], makeunique=makeunique), copycols=false)
     elseif promote == :none
         m = permutedims(Matrix{Any}(df_notsrc))
-        hcat!(df_permuted, DataFrame(collect.(eachcol(m)), df[!, src_namescol], makeunique=make_unique), copycols=false)
+        hcat!(df_permuted, DataFrame([[x for x in col] for col in eachcol(m)], df[!, src_namescol], makeunique=makeunique), copycols=false)
     else
         throw(ArgumentError("Value '$promote' for `promote` not supported"))
     end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -475,7 +475,7 @@ julia> permutedims(df2)
 ```
 """
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
-                          dest_namescol::Union{Symbol, AbstractString};
+                          dest_namescol::Union{Symbol, <:AbstractString};
                           makeunique::Bool=false)
 
     nrow(df) > 0 || throw(

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -399,3 +399,20 @@ function CategoricalArrays.CategoricalArray(v::RepeatedVector)
     res.refs = repeat(res.refs, inner = [v.inner], outer = [v.outer])
     res
 end
+
+
+transpose1(df::AbstractDataFrame, indexcol=1) = unstack(stack(df,Not(indexcol)), :variable, indexcol,:value)
+
+function transpose2(df::AbstractDataFrame, indexcol=1)
+    m = permutedims(Matrix(df[!, Not(indexcol)]))
+    df2 = DataFrame(variable=names(df[!, Not(indexcol)]))
+    hcat(df2, DataFrame(m, df[!, indexcol]))
+end
+
+function transpose3(df::AbstractDataFrame, indexcol=1)
+    df2 = DataFrame(variable=names(df[!, Not(indexcol)]))
+    for row in eachrow(df)
+        df2[!,row[indexcol]] = Vector(row[Not(indexcol)])
+    end
+    return df2
+end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -417,7 +417,7 @@ with name specified by `dest_namescol`.
 # Arguments
 - `df` : the `AbstractDataFrame`
 - `src_namescol` : the column that will become the new header.
-  This column's element type must be `AbstractString`, `Symbol`, or `Int`.
+  This column's element type must be `AbstractString` or `Symbol`.
 - `dest_namescol` : the name of the first column in the returned `DataFrame`.
   Defaults to the same name as `src_namescol`.
 - `makeunique` : if `false` (the default), an error will be raised

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -406,7 +406,7 @@ transpose1(df::AbstractDataFrame, indexcol=1) = unstack(stack(df,Not(indexcol)),
 function transpose2(df::AbstractDataFrame, indexcol=1)
     m = permutedims(Matrix(df[!, Not(indexcol)]))
     df2 = DataFrame(variable=names(df[!, Not(indexcol)]))
-    hcat(df2, DataFrame(m, df[!, indexcol]))
+    hcat(df2, DataFrame(m, df[!, indexcol], copycols=false), copycols=false)
 end
 
 function transpose3(df::AbstractDataFrame, indexcol=1)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -437,15 +437,28 @@ all columns in resulting `DataFrame` will be promoted to `Float64`.
 
 # Examples
 
-```julia
-df1 = DataFrame(a=["x", "y"], b=rand(2), c=[1,2], d=rand(Bool,2))
-df2 = DataFrame(a=["x", "y"], b=[1, "str"], c=[1,2], d=rand(Bool,2))
+```jldoctest
+julia> df1 = DataFrame(a=["x", "y"], b=rand(2), c=[1,2], d=rand(Bool,2));
 
-permutedims(df1)
-permutedims(df1, promote_type=false)
+julia> df2 = DataFrame(a=["x", "y"], b=[1, "str"], c=[1,2], d=rand(Bool,2));
 
-permutedims(df2)
-permutedims(df2, promote_type=false)
+julia> permutedims(df1) # note the column type
+3×3 DataFrame
+│ Row │ a      │ x        │ y        │
+│     │ String │ Float64  │ Float64  │
+├─────┼────────┼──────────┼──────────┤
+│ 1   │ b      │ 0.982197 │ 0.263357 │
+│ 2   │ c      │ 1.0      │ 2.0      │
+│ 3   │ d      │ 0.0      │ 1.0      │
+
+julia> permutedims(df2)
+3×3 DataFrame
+│ Row │ a      │ x   │ y   │
+│     │ String │ Any │ Any │
+├─────┼────────┼─────┼─────┤
+│ 1   │ b      │ 1   │ str │
+│ 2   │ c      │ 1   │ 2   │
+│ 3   │ d      │ 0   │ 0   │
 ````
 """
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -405,12 +405,12 @@ Base.transpose(::AbstractDataFrame, args...; kwargs...) =
     MethodError("`transpose` not defined for `AbstractDataFrame`s. Try `permutedims` instead")
 
 """
-    permutedims(df::AbstractDataFrame, src_namescol::Union{Int, Symbol, <:AbstractString}
-                [, dest_namescol::Union{Symbol, AbstractString}];
+    permutedims(df::AbstractDataFrame, src_namescol::Union{Int, Symbol, AbstractString},
+                [dest_namescol::Union{Symbol, AbstractString}];
                 makeunique::Bool=false)
 
 Turn `df` on its side such that rows become columns
-and the column indexed by `src_namescol` becomes the names of new columns.
+and values in the column indexed by `src_namescol` become the names of new columns.
 In the resulting `DataFrame`, column names of `df` will become the first column
 with name specified by `dest_namescol`.
 
@@ -484,7 +484,8 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
     df_permuted = DataFrame(dest_namescol => names(df_notsrc))
 
     if ncol(df_notsrc) == 0
-        df_tmp = DataFrame((n=>[] for n in df[!, src_namescol])..., makeunique=makeunique)
+        df_tmp = DataFrame(AbstractVector[[] for _ in 1:nrow(df)], df[!, src_namescol],
+                           makeunique=makeunique, copycols=false)
     else
         m = permutedims(Matrix(df_notsrc))
         df_tmp = rename!(DataFrame(Tables.table(m)), df[!, src_namescol], makeunique=makeunique)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -417,7 +417,7 @@ with name specified by `dest_namescol`.
 # Arguments
 - `df` : the `AbstractDataFrame`
 - `src_namescol` : the column that will become the new header.
-  This column's element type must be `AbstractString` or `Symbol`.
+  This column's element type must be `AbstractString`, `Symbol`, or `Int`.
 - `dest_namescol` : the name of the first column in the returned `DataFrame`.
   Defaults to the same name as `src_namescol`.
 - `makeunique` : if `false` (the default), an error will be raised
@@ -443,14 +443,6 @@ julia> df1 = DataFrame(a=["x", "y"], b=[1., 2.], c=[3, 4], d=[true,false])
 │ 1   │ x      │ 1.0     │ 3     │ 1    │
 │ 2   │ y      │ 2.0     │ 4     │ 0    │
 
-julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3, 4], d=[true, false])
-2×4 DataFrame
-│ Row │ a      │ b   │ c     │ d    │
-│     │ String │ Any │ Int64 │ Bool │
-├─────┼────────┼─────┼───────┼──────┤
-│ 1   │ x      │ 1   │ 3     │ 1    │
-│ 2   │ y      │ two │ 4     │ 0    │
-
 julia> permutedims(df1, 1) # note the column types
 3×3 DataFrame
 │ Row │ a      │ x       │ y       │
@@ -460,14 +452,22 @@ julia> permutedims(df1, 1) # note the column types
 │ 2   │ c      │ 3.0     │ 4.0     │
 │ 3   │ d      │ 1.0     │ 0.0     │
 
-julia> permutedims(df2, 1)
+julia> df2 = DataFrame(a=["x", "y"], b=[1, "two"], c=[3, 4], d=[true, false])
+2×4 DataFrame
+│ Row │ a      │ b   │ c     │ d    │
+│     │ String │ Any │ Int64 │ Bool │
+├─────┼────────┼─────┼───────┼──────┤
+│ 1   │ x      │ 1   │ 3     │ 1    │
+│ 2   │ y      │ two │ 4     │ 0    │
+
+julia> permutedims(df2, 1, "different_name")
 3×3 DataFrame
-│ Row │ a      │ x   │ y   │
-│     │ String │ Any │ Any │
-├─────┼────────┼─────┼─────┤
-│ 1   │ b      │ 1   │ two │
-│ 2   │ c      │ 3   │ 4   │
-│ 3   │ d      │ 1   │ 0   │
+│ Row │ different_name │ x   │ y   │
+│     │ String         │ Any │ Any │
+├─────┼────────────────┼─────┼─────┤
+│ 1   │ b              │ 1   │ two │
+│ 2   │ c              │ 3   │ 4   │
+│ 3   │ d              │ 1   │ 0   │
 ```
 """
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -405,7 +405,7 @@ Base.transpose(::AbstractDataFrame, args...; kwargs...) =
     MethodError("`transpose` not defined for `AbstractDataFrame`s. Try `permutedims` instead")
 
 """
-    permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
+    permutedims(df::AbstractDataFrame, src_namescol::Union{Int, Symbol, <:AbstractString},
                 dest_namescol::Union{Symbol,AbstractString};
                 makeunique::Bool=false)
     permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex; makeunique::Bool=false)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -479,7 +479,7 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
                           makeunique::Bool=false)
 
     if src_namescol isa Integer
-        1 <= src_namescol <= ncol(df) || throw(BoundsError(df, src_namescol))
+        1 <= src_namescol <= ncol(df) || throw(BoundsError(index(df), src_namescol))
     end
     eltype(df[!, src_namescol]) <: SymbolOrString ||
         throw(ArgumentError("src_namescol must have eltype `Symbol` or `<:AbstractString`"))
@@ -499,7 +499,7 @@ end
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
                           makeunique::Bool=false)
     if src_namescol isa Integer
-        1 <= src_namescol <= ncol(df) || throw(BoundsError(df, src_namescol))
+        1 <= src_namescol <= ncol(df) || throw(BoundsError(index(df), src_namescol))
         dest_namescol = _names(df)[src_namescol]
     else
         dest_namescol = src_namescol

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -508,7 +508,44 @@ end
 end
 
 @testset "transpose" begin
-    # todo
+    df1 = DataFrame(a=["x", "y"], b=rand(2), c=[1,2], d=rand(Bool,2))
+    df2 = DataFrame(a=["x", "y"], b=[1., "str"], c=[1,2], d=rand(Bool,2))
+    df3 = DataFrame(a=fill("x", 10), b=rand(10), c=rand(Int, 10), d=rand(Bool,10))
+
+    df1_t = transpose(df1)
+    @test size(df1_t,1) == ncol(df1) - 1
+    @test size(df1_t, 2) == nrow(df1) + 1
+    @test names(df1_t) == ["a", "x", "y"]
+    @test eltype(df1_t.x) <: AbstractFloat
+    @test eltype(df1_t.y) <: AbstractFloat
+
+    df1_tp = transpose(df1, promote_type=false)
+    @test size(df1_tp,1) == ncol(df1) - 1
+    @test size(df1_tp, 2) == nrow(df1) + 1
+    @test names(df1_tp) == ["a", "x", "y"]
+    @test Bool <: eltype(df1_tp.x)
+    @test Int <: eltype(df1_tp.x)
+    @test AbstractFloat <: eltype(df1_tp.x)
+
+    df2_t = transpose(df2)
+    @test size(df2_t,1) == ncol(df2) - 1
+    @test size(df2_t, 2) == nrow(df2) + 1
+    @test names(df2_t) == ["a", "x", "y"]
+    @test Any <: eltype(df2_t.x)
+    @test Any <: eltype(df2_t.y)
+
+
+    df2_tp = transpose(df2, promote_type=false)
+    @test size(df2_tp,1) == ncol(df2) - 1
+    @test size(df2_tp, 2) == nrow(df2) + 1
+    @test names(df2_tp) == ["a", "x", "y"]
+    @test Bool <: eltype(df2_tp.x)
+    @test Int <: eltype(df2_tp.x)
+    @test AbstractFloat <: eltype(df2_tp.x)
+    @test Any <: eltype(df2_tp.y)
+
+    @test_throws ArgumentError transpose(df3)
+    @test names(transpose(df3, makeunique=true)) == ["a", "x", ("x_$i" for i in 1:9)...]
 end
 
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -525,6 +525,7 @@ end
         @test Vector(row) == [orignames1[i]; df1[!, orignames1[i]]]
     end
 
+    # All columns should be promoted
     @test eltype(df1_pd.x) == Float64
     @test eltype(df1_pd.y) == Float64
 
@@ -555,14 +556,18 @@ end
     @test permutedims(df4[!, [:a, :b, :c, :e]], :e) ==
           permutedims(df4[!, [:e, :a, :b, :c]]) ==
           permutedims(df4[!, [:a, :b, :c, :f]], :f, :e)
+    # Can permute single-column
+    @test permutedims(df4[!, [:e]]) == DataFrame(e=String[], x=[], y=[])
     # Can't index float Column
     @test_throws ArgumentError permutedims(df4[!, [:a, :b, :c]])
+    @test_throws ArgumentError permutedims(DataFrame(a=Float64[], b=Float64[]))
     # Can't index columns that allow for missing
     @test_throws ArgumentError permutedims(df4[!, [:g, :a, :b, :c]])
     @test_throws ArgumentError permutedims(df4[!, [:h, :a, :b]])
-    # can't permute dfs with 0 rows
-    @test_throws ArgumentError permutedims(DataFrame())
-    @test_throws ArgumentError permutedims(DataFrame(a=String[], b=Float64[]))
+    # Can't permute empty `df` ...
+    @test_throws BoundsError permutedims(DataFrame())
+    # ... but can permute zero-row df
+    @test permutedims(DataFrame(a=String[], b=Float64[])) == DataFrame(a=["b"])
 end
 
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -513,7 +513,7 @@ end
     @test_throws MethodError transpose(df1)
     @test_throws ArgumentError permutedims(df1, :bar)
 
-    df1_pd = permutedims(df1)
+    df1_pd = permutedims(df1, 1)
     @test size(df1_pd, 1) == ncol(df1) - 1
     @test size(df1_pd, 2) == nrow(df1) + 1
     @test names(df1_pd) == ["a", "x", "y"]
@@ -531,7 +531,7 @@ end
 
     df2 = DataFrame(a=["x", "y"], b=[1.0, "str"], c=[1, 2], d=rand(Bool, 2))
 
-    df2_pd = permutedims(df2)
+    df2_pd = permutedims(df2, :a)
     @test size(df2_pd, 1) == ncol(df2) - 1
     @test size(df2_pd, 2) == nrow(df2) + 1
     @test names(df2_pd) == ["a", "x", "y"]
@@ -546,10 +546,10 @@ end
     df3 = DataFrame(a=fill("x", 10), b=rand(10), c=rand(Int, 10), d=rand(Bool, 10))
 
     d3pd_names = ["a", "x", ("x_$i" for i in 1:9)...]
-    @test_throws ArgumentError permutedims(df3)
-    @test names(permutedims(df3, makeunique=true)) == d3pd_names
-    @test_throws ArgumentError permutedims(df3[!, [:a]]) # single column branch
-    @test names(permutedims(df3[!, [:a]], makeunique=true)) == d3pd_names
+    @test_throws ArgumentError permutedims(df3, 1)
+    @test names(permutedims(df3, 1, makeunique=true)) == d3pd_names
+    @test_throws ArgumentError permutedims(df3[!, [:a]], 1) # single column branch
+    @test names(permutedims(df3[!, [:a]], 1, makeunique=true)) == d3pd_names
 
     df4 = DataFrame(a=rand(2), b=rand(2), c=[1, 2], d=[1., missing],
                     e=["x", "y"], f=[:x, :y], # valid src
@@ -557,20 +557,20 @@ end
                     )
 
     @test permutedims(df4[!, [:a, :b, :c, :e]], :e) ==
-          permutedims(df4[!, [:e, :a, :b, :c]]) ==
+          permutedims(df4[!, [:e, :a, :b, :c]], 1) ==
           permutedims(df4[!, [:a, :b, :c, :f]], :f, :e)
     # Can permute single-column
-    @test permutedims(df4[!, [:e]]) == DataFrame(e=String[], x=[], y=[])
+    @test permutedims(df4[!, [:e]], 1) == DataFrame(e=String[], x=[], y=[])
     # Can't index float Column
-    @test_throws ArgumentError permutedims(df4[!, [:a, :b, :c]])
-    @test_throws ArgumentError permutedims(DataFrame(a=Float64[], b=Float64[]))
+    @test_throws ArgumentError permutedims(df4[!, [:a, :b, :c]], 1)
+    @test_throws ArgumentError permutedims(DataFrame(a=Float64[], b=Float64[]), 1)
     # Can't index columns that allow for missing
-    @test_throws ArgumentError permutedims(df4[!, [:g, :a, :b, :c]])
-    @test_throws ArgumentError permutedims(df4[!, [:h, :a, :b]])
+    @test_throws ArgumentError permutedims(df4[!, [:g, :a, :b, :c]], 1)
+    @test_throws ArgumentError permutedims(df4[!, [:h, :a, :b]], 1)
     # Can't permute empty `df` ...
-    @test_throws BoundsError permutedims(DataFrame())
+    @test_throws BoundsError permutedims(DataFrame(), 1)
     # ... but can permute zero-row df
-    @test permutedims(DataFrame(a=String[], b=Float64[])) == DataFrame(a=["b"])
+    @test permutedims(DataFrame(a=String[], b=Float64[]), 1) == DataFrame(a=["b"])
 end
 
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -545,8 +545,11 @@ end
 
     df3 = DataFrame(a=fill("x", 10), b=rand(10), c=rand(Int, 10), d=rand(Bool, 10))
 
+    d3pd_names = ["a", "x", ("x_$i" for i in 1:9)...]
     @test_throws ArgumentError permutedims(df3)
-    @test names(permutedims(df3, makeunique=true)) == ["a", "x", ("x_$i" for i in 1:9)...]
+    @test names(permutedims(df3, makeunique=true)) == d3pd_names
+    @test_throws ArgumentError permutedims(df3[!, [:a]]) # single column branch
+    @test names(permutedims(df3[!, [:a]], makeunique=true)) == d3pd_names
 
     df4 = DataFrame(a=rand(2), b=rand(2), c=[1, 2], d=[1., missing],
                     e=["x", "y"], f=[:x, :y], # valid src

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -525,8 +525,8 @@ end
         @test Vector(row) == [orignames1[i]; df1[!, orignames1[i]]]
     end
 
-    @test eltype(df1_pd.x) <: Float64
-    @test eltype(df1_pd.y) <: Float64
+    @test eltype(df1_pd.x) == Float64
+    @test eltype(df1_pd.y) == Float64
 
     df2 = DataFrame(a=["x", "y"], b=[1., "str"], c=[1, 2], d=rand(Bool, 2))
 
@@ -539,8 +539,8 @@ end
     for (i, row) in enumerate(eachrow(df2_pd))
         @test Vector(row) == [orignames2[i]; df2[!, orignames2[i]]]
     end
-    @test Any <: eltype(df2_pd.x)
-    @test Any <: eltype(df2_pd.y)
+    @test Any == eltype(df2_pd.x)
+    @test Any == eltype(df2_pd.y)
 
     df3 = DataFrame(a=fill("x", 10), b=rand(10), c=rand(Int, 10), d=rand(Bool, 10))
 
@@ -555,9 +555,9 @@ end
     @test permutedims(df4[!, [:a, :b, :c, :e]], :e) ==
           permutedims(df4[!, [:e, :a, :b, :c]]) ==
           permutedims(df4[!, [:a, :b, :c, :f]], :f, :e)
-    # Can't index Float Column
+    # Can't index float Column
     @test_throws ArgumentError permutedims(df4[!, [:a, :b, :c]])
-    # Can't index in the presence of missing
+    # Can't index columns that allow for missing
     @test_throws ArgumentError permutedims(df4[!, [:g, :a, :b, :c]])
     @test_throws ArgumentError permutedims(df4[!, [:h, :a, :b]])
     # can't permute dfs with 0 rows

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -511,7 +511,7 @@ end
     df1 = DataFrame(a=["x", "y"], b=rand(2), c=[1,2], d=rand(Bool,2))
     df2 = DataFrame(a=["x", "y"], b=[1., "str"], c=[1,2], d=rand(Bool,2))
     df3 = DataFrame(a=fill("x", 10), b=rand(10), c=rand(Int, 10), d=rand(Bool,10))
-    df4 = DataFrame(a=rand(2), b=rand(2), c=rand(2), d=["x", "y"], e=[:x, :y], f=[missing, "y"], g=[1,2])
+    df4 = DataFrame(a=rand(2), b=rand(2), c=rand(2), d=["x", "y"], e=[:x, :y], f=[missing, "y"], g=[1,2], h=[1., missing])
 
     @test_throws MethodError transpose(df1)
     @test_throws ArgumentError permutedims(df1, promote=:foo)
@@ -561,7 +561,9 @@ end
             2. DataFrame(a=Int[], b=Float64[])
             3. and cases that should error (e.g. missing column, column with new names that is not Symbol or string etc.)
     =#
-
+    @test_throws MethodError permutedims(df4[!, Not([:d, :e, :f, :g, :h])])
+    @test permutedims(df4[!, Not([:e, :f, :g, :h])], :d) == permutedims(df4[!, Not([:e, :f, :g, :h])], :d, promote=:none)
+    @test_throws ArgumentError permutedims(DataFrame())
 end
 
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -528,7 +528,7 @@ end
     @test eltype(df1_pd.x) == Float64
     @test eltype(df1_pd.y) == Float64
 
-    df2 = DataFrame(a=["x", "y"], b=[1., "str"], c=[1, 2], d=rand(Bool, 2))
+    df2 = DataFrame(a=["x", "y"], b=[1.0, "str"], c=[1, 2], d=rand(Bool, 2))
 
     df2_pd = permutedims(df2)
     @test size(df2_pd, 1) == ncol(df2) - 1

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -507,4 +507,8 @@ end
     @test eltype(typeof(sdf2.value)) === Float64
 end
 
+@testset "transpose" begin
+    # todo
+end
+
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -507,45 +507,61 @@ end
     @test eltype(typeof(sdf2.value)) === Float64
 end
 
-@testset "transpose" begin
+@testset "permute dims" begin
     df1 = DataFrame(a=["x", "y"], b=rand(2), c=[1,2], d=rand(Bool,2))
     df2 = DataFrame(a=["x", "y"], b=[1., "str"], c=[1,2], d=rand(Bool,2))
     df3 = DataFrame(a=fill("x", 10), b=rand(10), c=rand(Int, 10), d=rand(Bool,10))
+    df4 = DataFrame(a=rand(2), b=rand(2), c=rand(2), d=["x", "y"], e=[:x, :y], f=[missing, "y"], g=[1,2])
 
-    df1_t = transpose(df1)
-    @test size(df1_t,1) == ncol(df1) - 1
-    @test size(df1_t, 2) == nrow(df1) + 1
-    @test names(df1_t) == ["a", "x", "y"]
-    @test eltype(df1_t.x) <: AbstractFloat
-    @test eltype(df1_t.y) <: AbstractFloat
+    @test_throws MethodError transpose(df1)
+    @test_throws ArgumentError permutedims(df1, promote=:foo)
 
-    df1_tp = transpose(df1, promote_type=false)
-    @test size(df1_tp,1) == ncol(df1) - 1
-    @test size(df1_tp, 2) == nrow(df1) + 1
-    @test names(df1_tp) == ["a", "x", "y"]
-    @test Bool <: eltype(df1_tp.x)
-    @test Int <: eltype(df1_tp.x)
-    @test AbstractFloat <: eltype(df1_tp.x)
+    df1_pd = permutedims(df1)
+    @test df1_pd
+    @test size(df1_pd, 1) == ncol(df1) - 1
+    @test size(df1_pd, 2) == nrow(df1) + 1
+    @test names(df1_pd) == ["a", "x", "y"]
+    @test eltype(df1_pd.x) <: AbstractFloat
+    @test eltype(df1_pd.y) <: AbstractFloat
 
-    df2_t = transpose(df2)
-    @test size(df2_t,1) == ncol(df2) - 1
-    @test size(df2_t, 2) == nrow(df2) + 1
-    @test names(df2_t) == ["a", "x", "y"]
-    @test Any <: eltype(df2_t.x)
-    @test Any <: eltype(df2_t.y)
+    df1_pdn = permutedims(df1, promote=:none)
+    @test size(df1_pdn, 1) == ncol(df1) - 1
+    @test size(df1_pdn, 2) == nrow(df1) + 1
+    @test names(df1_pdn) == ["a", "x", "y"]
+    @test Bool <: eltype(df1_pdn.x)
+    @test Int <: eltype(df1_pdn.x)
+    @test AbstractFloat <: eltype(df1_pdn.x)
+
+    df2_pd = permutedims(df2)
+    @test size(df2_pd, 1) == ncol(df2) - 1
+    @test size(df2_pd, 2) == nrow(df2) + 1
+    @test names(df2_pd) == ["a", "x", "y"]
+    @test Any <: eltype(df2_pd.x)
+    @test Any <: eltype(df2_pd.y)
 
 
-    df2_tp = transpose(df2, promote_type=false)
-    @test size(df2_tp,1) == ncol(df2) - 1
-    @test size(df2_tp, 2) == nrow(df2) + 1
-    @test names(df2_tp) == ["a", "x", "y"]
-    @test Bool <: eltype(df2_tp.x)
-    @test Int <: eltype(df2_tp.x)
-    @test AbstractFloat <: eltype(df2_tp.x)
-    @test Any <: eltype(df2_tp.y)
+    df2_pdn = permutedims(df2, promote=:none)
+    @test size(df2_pdn, 1) == ncol(df2) - 1
+    @test size(df2_pdn, 2) == nrow(df2) + 1
+    @test names(df2_pdn) == ["a", "x", "y"]
+    @test Bool <: eltype(df2_pdn.x)
+    @test Int <: eltype(df2_pdn.x)
+    @test AbstractFloat <: eltype(df2_pdn.x)
+    @test Any <: eltype(df2_pdn.y)
 
-    @test_throws ArgumentError transpose(df3)
-    @test names(transpose(df3, makeunique=true)) == ["a", "x", ("x_$i" for i in 1:9)...]
+    @test_throws ArgumentError permutedims(df3)
+    @test names(permutedims(df3, makeunique=true)) == ["a", "x", ("x_$i" for i in 1:9)...]
+
+    #=
+    Needs other tests, TODO: https://github.com/JuliaData/DataFrames.jl/pull/2447#discussion_r499123081
+
+        please check:
+
+            1. DataFrame()
+            2. DataFrame(a=Int[], b=Float64[])
+            3. and cases that should error (e.g. missing column, column with new names that is not Symbol or string etc.)
+    =#
+
 end
 
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -25,10 +25,10 @@ const ≅ = isequal
     # first column stays as CategoricalArray in df3
     @test df3 == df4
     #Make sure unstack works with missing values at the start of the value column
-    df[1,:Value] = missing
+    df[1, :Value] = missing
     df2 = unstack(df, :Fish, :Key, :Value)
     #This changes the expected result
-    df4[1,:Mass] = missing
+    df4[1, :Mass] = missing
     @test df2 ≅ df4
 
     df = DataFrame(Fish = CategoricalArray{Union{String, Missing}}(["Bob", "Bob", "Batman", "Batman"]),
@@ -62,11 +62,11 @@ const ≅ = isequal
     @test df3 == df4
     #Make sure unstack works with missing values at the start of the value column
     allowmissing!(df, :Value)
-    df[1,:Value] = missing
+    df[1, :Value] = missing
     df2 = unstack(df, :Fish, :Key, :Value)
     #This changes the expected result
     allowmissing!(df4, :Mass)
-    df4[2,:Mass] = missing
+    df4[2, :Mass] = missing
     @test df2 ≅ df4
 
     df = DataFrame(Fish = ["Bob", "Bob", "Batman", "Batman"],
@@ -89,9 +89,9 @@ const ≅ = isequal
     @test_throws TypeError unstack(df, :Key, :Value, renamecols=Symbol)
 
     # test missing value in grouping variable
-    mdf = DataFrame(id=[missing,1,2,3], a=1:4, b=1:4)
-    @test unstack(stack(mdf, Not(:id)), :id, :variable, :value)[1:3,:] == sort(mdf)[1:3,:]
-    @test unstack(stack(mdf, Not(1)), :id, :variable, :value)[1:3,:] == sort(mdf)[1:3,:]
+    mdf = DataFrame(id=[missing, 1, 2, 3], a=1:4, b=1:4)
+    @test unstack(stack(mdf, Not(:id)), :id, :variable, :value)[1:3, :] == sort(mdf)[1:3, :]
+    @test unstack(stack(mdf, Not(1)), :id, :variable, :value)[1:3, :] == sort(mdf)[1:3, :]
     @test unstack(stack(mdf, Not(:id)), :id, :variable, :value)[:, 2:3] == sort(mdf)[:, 2:3]
     @test unstack(stack(mdf, Not(1)), :id, :variable, :value)[:, 2:3] == sort(mdf)[:, 2:3]
 
@@ -158,7 +158,7 @@ end
     b = unstack(df, :variable, :value)
     @test a ≅ b ≅ DataFrame(id = [1, 2], a = [3, missing], b = [missing, 4])
 
-    df = DataFrame(variable=["x", "x"], value=[missing, missing], id=[1,1])
+    df = DataFrame(variable=["x", "x"], value=[missing, missing], id=[1, 1])
     @test_logs (:warn, "Duplicate entries in unstack at row 2 for key 1 and variable x.") unstack(df, :variable, :value)
     @test_logs (:warn, "Duplicate entries in unstack at row 2 for key 1 and variable x.") unstack(df, :id, :variable, :value)
 end
@@ -225,14 +225,14 @@ end
     @test d1s2 == d1s3
     @test propertynames(d1s) == [:c, :d, :e, :variable, :value]
     @test d1s == d1m
-    d1m = stack(d1[:, [1,3,4]], Not(:a))
+    d1m = stack(d1[:, [1, 3, 4]], Not(:a))
     @test propertynames(d1m) == [:a, :variable, :value]
 
     # Test naming of measure/value columns
     d1s_named = stack(d1, [:a, :b], variable_name=:letter, value_name=:someval)
     @test d1s_named == stack(d1, r"[ab]", variable_name=:letter, value_name=:someval)
     @test propertynames(d1s_named) == [:c, :d, :e, :letter, :someval]
-    d1m_named = stack(d1[:, [1,3,4]], Not(:a), variable_name=:letter, value_name=:someval)
+    d1m_named = stack(d1[:, [1, 3, 4]], Not(:a), variable_name=:letter, value_name=:someval)
     @test propertynames(d1m_named) == [:a, :letter, :someval]
 
     # test empty measures or ids
@@ -270,21 +270,21 @@ end
     @test d1s[!, 5] isa DataFrames.StackedVector
     @test ndims(d1s[!, 5]) == 1
     @test ndims(typeof(d1s[!, 2])) == 1
-    @test d1s[!, 4][[1,24]] == ["a", "b"]
-    @test d1s[!, 5][[1,24]] == [1, 4]
+    @test d1s[!, 4][[1, 24]] == ["a", "b"]
+    @test d1s[!, 5][[1, 24]] == [1, 4]
     @test_throws ArgumentError d1s[!, 4][true]
     @test_throws ArgumentError d1s[!, 5][true]
     @test_throws ArgumentError d1s[!, 4][1.0]
     @test_throws ArgumentError d1s[!, 5][1.0]
 
     d1ss = stack(d1, [:a, :b], view=true)
-    @test d1ss[!, 4][[1,24]] == ["a", "b"]
+    @test d1ss[!, 4][[1, 24]] == ["a", "b"]
     @test d1ss[!, 4] isa DataFrames.RepeatedVector
     d1ss = stack(d1, [:a, :b], view=true, variable_eltype=String)
-    @test d1ss[!, 4][[1,24]] == ["a", "b"]
+    @test d1ss[!, 4][[1, 24]] == ["a", "b"]
     @test d1ss[!, 4] isa DataFrames.RepeatedVector
     d1ss = stack(d1, [:a, :b], view=true, variable_eltype=Symbol)
-    @test d1ss[!, 4][[1,24]] == [:a, :b]
+    @test d1ss[!, 4][[1, 24]] == [:a, :b]
     @test d1ss[!, 4] isa DataFrames.RepeatedVector
 
     # Those tests check indexing RepeatedVector/StackedVector by a vector
@@ -307,7 +307,7 @@ end
     @test d1s2 == d1s3
     @test propertynames(d1s) == [:c, :d, :e, :variable, :value]
     @test d1s == d1m
-    d1m = stack(d1[:, [1,3,4]], Not(:a), view=true)
+    d1m = stack(d1[:, [1, 3, 4]], Not(:a), view=true)
     @test propertynames(d1m) == [:a, :variable, :value]
 
     d1s_named = stack(d1, [:a, :b], variable_name=:letter, value_name=:someval, view=true)
@@ -329,13 +329,13 @@ end
     @test d1us3 == unstack(d1s2)
 
     # test unstack with exactly one key column that is not passed
-    df1 = stack(DataFrame(rand(10,10)))
+    df1 = stack(DataFrame(rand(10, 10)))
     df1[!, :id] = 1:100
     @test size(unstack(df1, :variable, :value)) == (100, 11)
     @test unstack(df1, :variable, :value) ≅ unstack(df1)
 
     # test empty keycol
-    @test_throws ArgumentError unstack(stack(DataFrame(rand(3,2))), :variable, :value)
+    @test_throws ArgumentError unstack(stack(DataFrame(rand(3, 2))), :variable, :value)
 end
 
 @testset "column names duplicates" begin
@@ -494,7 +494,7 @@ end
 end
 
 @testset "test stack eltype" begin
-    df = DataFrame(rand(4,5))
+    df = DataFrame(rand(4, 5))
     sdf = stack(df)
     @test eltype(sdf.variable) === String
     @test eltype(typeof(sdf.variable)) === String
@@ -508,12 +508,7 @@ end
 end
 
 @testset "permutedims" begin
-    df1 = DataFrame(a=["x", "y"], b=rand(2), c=[1,2], d=rand(Bool,2))
-    df2 = DataFrame(a=["x", "y"], b=[1., "str"], c=[1,2], d=rand(Bool,2))
-    df3 = DataFrame(a=fill("x", 10), b=rand(10), c=rand(Int, 10), d=rand(Bool,10))
-    df4 = DataFrame(a=rand(2), b=rand(2), c=[1,2], d=[1., missing],
-                    e=["x", "y"], f=[:x, :y], # valid src
-                    g=[missing, "y"], h=Union{Missing,String}["x","y"])
+    df1 = DataFrame(a=["x", "y"], b=rand(2), c=[1, 2], d=rand(Bool, 2))
 
     @test_throws MethodError transpose(df1)
     @test_throws ArgumentError permutedims(df1, :bar)
@@ -533,6 +528,8 @@ end
     @test eltype(df1_pd.x) <: Float64
     @test eltype(df1_pd.y) <: Float64
 
+    df2 = DataFrame(a=["x", "y"], b=[1., "str"], c=[1, 2], d=rand(Bool, 2))
+
     df2_pd = permutedims(df2)
     @test size(df2_pd, 1) == ncol(df2) - 1
     @test size(df2_pd, 2) == nrow(df2) + 1
@@ -545,17 +542,24 @@ end
     @test Any <: eltype(df2_pd.x)
     @test Any <: eltype(df2_pd.y)
 
+    df3 = DataFrame(a=fill("x", 10), b=rand(10), c=rand(Int, 10), d=rand(Bool, 10))
+
     @test_throws ArgumentError permutedims(df3)
     @test names(permutedims(df3, makeunique=true)) == ["a", "x", ("x_$i" for i in 1:9)...]
 
-    @test permutedims(df4[!, [:a,:b,:c,:e]], :e) ==
-          permutedims(df4[!, [:e,:a,:b,:c]]) ==
-          permutedims(df4[!, [:a,:b,:c,:f]], :f, :e)
+    df4 = DataFrame(a=rand(2), b=rand(2), c=[1, 2], d=[1., missing],
+                    e=["x", "y"], f=[:x, :y], # valid src
+                    g=[missing, "y"], h=Union{Missing, String}["x", "y"] # invalid src
+                    )
+
+    @test permutedims(df4[!, [:a, :b, :c, :e]], :e) ==
+          permutedims(df4[!, [:e, :a, :b, :c]]) ==
+          permutedims(df4[!, [:a, :b, :c, :f]], :f, :e)
     # Can't index Float Column
-    @test_throws ArgumentError permutedims(df4[!, [:a,:b,:c]])
+    @test_throws ArgumentError permutedims(df4[!, [:a, :b, :c]])
     # Can't index in the presence of missing
     @test_throws ArgumentError permutedims(df4[!, [:g, :a, :b, :c]])
-    @test_throws ArgumentError permutedims(df4[!, [:h,:a,:b]])
+    @test_throws ArgumentError permutedims(df4[!, [:h, :a, :b]])
     # can't permute dfs with 0 rows
     @test_throws ArgumentError permutedims(DataFrame())
     @test_throws ArgumentError permutedims(DataFrame(a=String[], b=Float64[]))


### PR DESCRIPTION
Figured I'd get a jumpstart on Hacktoberfest, and this is something I've wanted in DataFrames for a longtime. This is an attempt to address #2420 

## todo
- [x] correct function signature
- [x] docs
- [x] tests

## So far

I implemented 3 versions of `transpose`:

- `transpose1` copies @tbeason 's stack/unstack method from the issue above
- `transpose2` creates a `Matrix` from everything _except_ the indexing column, and does `permutedims` on it
- `transpose3` builds column-by-column by iterating rows

## Benchmarking

```
julia> builddf(n) = DataFrame(a = [randstring(6) for _ in 1:n], b = rand(n), c = rand(Int, n), d = repeat(["x", "y"], inner=n÷2))
builddf (generic function with 1 method)

julia> df1 = builddf(10);

julia> df2 = builddf(100);

julia> df3 = builddf(1000);

julia> @btime DataFrames.transpose1($df1);
  33.565 μs (398 allocations: 32.61 KiB)

julia> @btime DataFrames.transpose2($df1);
  12.637 μs (179 allocations: 17.81 KiB)

julia> @btime DataFrames.transpose3($df1);
  14.723 μs (172 allocations: 16.58 KiB)

julia> @btime DataFrames.transpose1($df2);
  144.708 μs (1083 allocations: 115.92 KiB)

julia> @btime DataFrames.transpose2($df2);
  50.667 μs (650 allocations: 69.75 KiB)

julia> @btime DataFrames.transpose3($df2);
  137.353 μs (1261 allocations: 119.12 KiB)

julia> @btime DataFrames.transpose1($df3);
  1.168 ms (7924 allocations: 976.30 KiB)

julia> @btime DataFrames.transpose2($df3);
  469.847 μs (5678 allocations: 643.34 KiB)

julia> @btime DataFrames.transpose3($df3);
  1.513 ms (20035 allocations: 1.27 MiB)
```

## First impressions

- `transpose1` (stack/unstack) is slower on small `DataFrame`s but scales well.
     - This also has the possible disadvantage that the columns end up sorted, rather than preserving the row order
- `transpose2` is the fastest, but might be harder to fix type issues (see below)
- `transpose3` is pretty fast for small `DataFrame`s but doesn't scale well at all

## Other thoughts

All 3 versions end up with `Any` typed columns, regardless of what's in the resulting column (unless all the columns are the same type). This seems like it might be more easily fixed with 1 and 3. The behavior is also not quite what I was expecting if all of the columns are numerical:

```
julia> df_types = DataFrame(a=[:x, :y, :z], b=rand(3), c=["foo", 2.2, 1])
3×3 DataFrame
│ Row │ a      │ b        │ c   │
│     │ Symbol │ Float64  │ Any │
├─────┼────────┼──────────┼─────┤
│ 1   │ x      │ 0.633028 │ foo │
│ 2   │ y      │ 0.388354 │ 2.2 │
│ 3   │ z      │ 0.134275 │ 1   │

julia> DataFrames.transpose1(df_types)
2×4 DataFrame
│ Row │ variable │ x        │ y        │ z        │
│     │ String   │ Any      │ Any      │ Any      │
├─────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ b        │ 0.633028 │ 0.388354 │ 0.134275 │
│ 2   │ c        │ foo      │ 2.2      │ 1        │

julia> DataFrames.transpose2(df_types)
2×4 DataFrame
│ Row │ variable │ x        │ y        │ z        │
│     │ String   │ Any      │ Any      │ Any      │
├─────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ b        │ 0.633028 │ 0.388354 │ 0.134275 │
│ 2   │ c        │ foo      │ 2.2      │ 1        │

julia> DataFrames.transpose3(df_types)
2×4 DataFrame
│ Row │ variable │ x        │ y        │ z        │
│     │ String   │ Any      │ Any      │ Any      │
├─────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ b        │ 0.633028 │ 0.388354 │ 0.134275 │
│ 2   │ c        │ foo      │ 2.2      │ 1        │

julia> df_floats = DataFrame(a=[:x, :y, :z], b=rand(3), c=rand(3))
3×3 DataFrame
│ Row │ a      │ b        │ c        │
│     │ Symbol │ Float64  │ Float64  │
├─────┼────────┼──────────┼──────────┤
│ 1   │ x      │ 0.941859 │ 0.35769  │
│ 2   │ y      │ 0.404513 │ 0.237959 │
│ 3   │ z      │ 0.649489 │ 0.255324 │

julia> DataFrames.transpose1(df_floats)
2×4 DataFrame
│ Row │ variable │ x        │ y        │ z        │
│     │ String   │ Float64? │ Float64? │ Float64? │
├─────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ b        │ 0.941859 │ 0.404513 │ 0.649489 │
│ 2   │ c        │ 0.35769  │ 0.237959 │ 0.255324 │

julia> DataFrames.transpose2(df_floats)
2×4 DataFrame
│ Row │ variable │ x        │ y        │ z        │
│     │ String   │ Float64  │ Float64  │ Float64  │
├─────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ b        │ 0.941859 │ 0.404513 │ 0.649489 │
│ 2   │ c        │ 0.35769  │ 0.237959 │ 0.255324 │

julia> DataFrames.transpose3(df_floats)
2×4 DataFrame
│ Row │ variable │ x        │ y        │ z        │
│     │ String   │ Float64  │ Float64  │ Float64  │
├─────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ b        │ 0.941859 │ 0.404513 │ 0.649489 │
│ 2   │ c        │ 0.35769  │ 0.237959 │ 0.255324 │

julia> df_number = DataFrame(a=[:x, :y, :z], b=rand(3), c=rand(Int, 3))
3×3 DataFrame
│ Row │ a      │ b         │ c                   │
│     │ Symbol │ Float64   │ Int64               │
├─────┼────────┼───────────┼─────────────────────┤
│ 1   │ x      │ 0.438549  │ 480681029893134526  │
│ 2   │ y      │ 0.489623  │ 172366260093707646  │
│ 3   │ z      │ 0.0132915 │ 3468722734556270181 │

julia> DataFrames.transpose1(df_number)
2×4 DataFrame
│ Row │ variable │ x          │ y          │ z          │
│     │ String   │ Float64?   │ Float64?   │ Float64?   │
├─────┼──────────┼────────────┼────────────┼────────────┤
│ 1   │ b        │ 0.438549   │ 0.489623   │ 0.0132915  │
│ 2   │ c        │ 4.80681e17 │ 1.72366e17 │ 3.46872e18 │

julia> DataFrames.transpose2(df_number)
2×4 DataFrame
│ Row │ variable │ x          │ y          │ z          │
│     │ String   │ Float64    │ Float64    │ Float64    │
├─────┼──────────┼────────────┼────────────┼────────────┤
│ 1   │ b        │ 0.438549   │ 0.489623   │ 0.0132915  │
│ 2   │ c        │ 4.80681e17 │ 1.72366e17 │ 3.46872e18 │

julia> DataFrames.transpose3(df_number)
2×4 DataFrame
│ Row │ variable │ x          │ y          │ z          │
│     │ String   │ Float64    │ Float64    │ Float64    │
├─────┼──────────┼────────────┼────────────┼────────────┤
│ 1   │ b        │ 0.438549   │ 0.489623   │ 0.0132915  │
│ 2   │ c        │ 4.80681e17 │ 1.72366e17 │ 3.46872e18 │
```

Still lots to do here, but I thought it would be worth it to get the ball rolling and see if people have any thoughts. I will probably get back to this in earnest next week.