### PR TITLE
Use ComposedFunction public API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,7 +36,7 @@ test = ["DataStructures", "DataValues", "Dates", "Logging", "Random", "Test"]
 [compat]
 julia = "1"
 CategoricalArrays = "0.8"
-Compat = "2.2, 3"
+Compat = "3.17"
 DataAPI = "1.2"
 InvertedIndices = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -79,12 +79,7 @@ end
 if isdefined(Base, :ComposedFunction) # Julia >= 1.6.0-DEV.85
     using Base: ComposedFunction
 else
-    const ComposedFunction = let h = identity ∘ convert
-        @assert h.f === identity
-        @assert h.g === convert
-        getfield(parentmodule(typeof(h)), nameof(typeof(h)))
-    end
-    @assert identity ∘ convert isa ComposedFunction
+    using Compat: ComposedFunction
 end
 
-funname(c::ComposedFunction) = Symbol(funname(c.f), :_, funname(c.g))
+funname(c::ComposedFunction) = Symbol(funname(c.outer), :_, funname(c.inner))


### PR DESCRIPTION
As of https://github.com/JuliaLang/julia/pull/37517, `ComposedFunction` becomes a public API and the fields are renamed to `.outer` and `.inner`. This PR uses Compat 3.17 https://github.com/JuliaLang/Compat.jl/pull/720 to make DataFrames work with the new API for all Julia 1.x.