### PR TITLE
Add standard deviation and 25% and 75% quantiles to `describe` :detailed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,10 @@
   `Not` selectors when used as `source` or `destination` are properly expanded
   to selected column names within the call data frame scope.
   ([#2918](https://github.com/JuliaData/DataFrames.jl/pull/2918))
+* `describe` now accepts `:detailed` as the `stats` argument
+  to compute standard deviation and quartiles
+  in addition to statistics that are reported by default.
+  ([#2459](https://github.com/JuliaData/DataFrames.jl/pull/2459))
 
 ## Bug fixes
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -549,6 +549,8 @@ where each row represents a variable and each column a summary statistic.
       `:median`, `:q75`, `:max`, `:eltype`, `:nunique`, `:first`, `:last`, and
       `:nmissing`. The default statistics used are `:mean`, `:min`, `:median`,
       `:max`, `:nmissing`, and `:eltype`.
+    - `:detailed` as the only `Symbol` argument to return all statistics
+      except `first` and `last`.
     - `:all` as the only `Symbol` argument to return all statistics.
     - A `function => name` pair where `name` is a `Symbol` or string. This will
       create a column of summary statistics with the provided name.
@@ -633,8 +635,13 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
         predefined_funs = allowed_fields
         i = findfirst(s -> s == :all, stats)
         splice!(stats, i, allowed_fields) # insert in the stats vector to get a good order
-    elseif :all in predefined_funs
-        throw(ArgumentError("`:all` must be the only `Symbol` argument."))
+    elseif predefined_funs == [:detailed]
+        predefined_funs = [:mean, :std, :min, :q25, :median, :q75,
+                           :max, :nunique, :nmissing, :eltype]
+        i = findfirst(s -> s == :detailed, stats)
+        splice!(stats, i, predefined_funs) # insert in the stats vector to get a good order
+    elseif :all in predefined_funs || :detailed in predefined_funs
+        throw(ArgumentError("`:all` and `:detailed` must be the only `Symbol` argument."))
     elseif !issubset(predefined_funs, allowed_fields)
         not_allowed = join(setdiff(predefined_funs, allowed_fields), ", :")
         allowed_msg = "\nAllowed fields are: :" * join(allowed_fields, ", :")

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -686,8 +686,13 @@ end
     # Test that it works with one stats argument
     @test describe_output[:, [:variable, :mean]] == describe(df, :mean)
 
-    # Test that it works with all keyword arguments
+    # Test that it works with :all
     @test describe_output ≅ describe(df, :all)
+
+    # Test that it works with :detailed
+    @test describe_output[:, [:variable, :mean, :std, :min, :q25, :median, :q75,
+                              :max, :nunique, :nmissing, :eltype]] ≅
+        describe(df, :detailed)
 
     # Test that it works on a custom function
     describe_output.test_std = describe_output.std


### PR DESCRIPTION
Dispersion statistics are essential to assess the distribution of a variable.
This is inspired by the [skimr](https://github.com/ropensci/skimr) R package. Note that Stata's `summarize` includes the standard deviation too (but no quantiles, not even the median).

I've been willing to try this for some time. The drawback is that this results in a wider table (~120 characters). skimr only uses one of two decimals and it does'nt print column types, which gives a significantly narrower result (note that the example printed in the doctest below is narrower than the standard case since quantiles are exactly represented with only two decimals). This problem will be alleviated a bit if we stop printing vertical bars (saving up to 18 chars).