### PR TITLE
Allow multicolumn transformations for AbstractDataFrame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## Breaking changes
 
+* the rules for transformations passed to `select`/`select!`, `transform`/`transform!`,
+  and `combine` have been made more flexible; in particular now it is allowed to
+  return multiple columns from a transformation function
+  [#2461](https://github.com/JuliaData/DataFrames.jl/pull/2461)
 * CategoricalArrays.jl is no longer reexported: call `using CategoricalArrays`
   to use it [#2404]((https://github.com/JuliaData/DataFrames.jl/pull/2404)).
   In the same vein, the `categorical` and `categorical!` functions

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -55,7 +55,8 @@ The `ByRow` type is a special type used for selection operations to signal that 
 to each element (row) of the selection.
 
 The `AsTable` type is a special type used for selection operations to signal that the columns selected by a wrapped
-selector should be passed as a `NamedTuple` to the function.
+selector should be passed as a `NamedTuple` to the function or to signal that it is requested
+to expand the return value of a transformation into multiple columns.
 
 ## [The design of handling of columns of a `DataFrame`](@id man-columnhandling)
 

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -627,6 +627,14 @@ julia> select(df, :x2, :x2 => ByRow(sqrt)) # transform columns by row
 ├─────┼───────┼─────────┤
 │ 1   │ 3     │ 1.73205 │
 │ 2   │ 4     │ 2.0     │
+
+julia> select(df, AsTable(:) => ByRow(extrema) => [:lo, :hi]) # return multiple columns
+2×2 DataFrame
+│ Row │ lo    │ hi    │
+│     │ Int64 │ Int64 │
+├─────┼───────┼───────┤
+│ 1   │ 1     │ 5     │
+│ 2   │ 2     │ 6     │
 ```
 
 It is important to note that `select` always returns a data frame,

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -224,11 +224,15 @@ _expand_to_table(res::Union{AbstractDataFrame, NamedTuple, DataFrameRow, Abstrac
 function _expand_to_table(res::AbstractVector)
     isempty(res) && return Tables.columntable(res)
     kp1 = keys(res[1])
+    prepend = all(x -> x isa Integer, kp1)
+    if !(prepend || all(x -> x isa Symbol, kp1) || all(x -> x isa AbstractString, kp1))
+        throw(ArgumentError("keys of the returned elements must be " *
+                            "`Symbol`s, strings or integers"))
+    end
     if any(x -> !isequal(keys(x), kp1), res)
         throw(ArgumentError("keys of the returned elements must be identical"))
     end
     newres = DataFrame()
-    prepend = all(x -> x isa Integer, kp1)
     for n in kp1
         newres[!, prepend ? Symbol("x", n) : Symbol(n)] = [x[n] for x in res]
     end

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -373,7 +373,7 @@ function select_transform!(@nospecialize(nc::Union{Base.Callable, Pair{<:Union{I
 
     if res isa Union{AbstractDataFrame, NamedTuple, DataFrameRow, AbstractMatrix}
         if newname isa Symbol
-            throw(ArgumentError("Table returned while a single column return value was requested"))
+            throw(ArgumentError("Table returned but a single output column was expected"))
         end
         colnames = _gen_colnames(res, newname)
         isempty(colnames) && return # nothing to do

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -275,7 +275,7 @@ end
 function _add_col_check_copy(newdf::DataFrame, df::AbstractDataFrame,
                              col_idx::Union{Nothing, Int, AbstractVector{Int}, AsTable},
                              copycols::Bool, @nospecialize(fun),
-                             newname::Symbol, @nospecialize(v))
+                             newname::Symbol, v::AbstractVector)
     cdf = eachcol(df)
     vpar = parent(v)
     parent_cols = col_idx isa AsTable ? col_idx.cols : something(col_idx, 1:ncol(df))

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -195,10 +195,10 @@ function select_transform!(nc::Union{Base.Callable, Pair{<:Union{Int, AbstractVe
         tbl = Tables.columntable(select(df, col_idx.cols, copycols=false))
         if isempty(tbl) && fun isa ByRow
             if isempty(df)
-                T = Base.return_types(fun.fun, ())[1]
+                T = Base.return_types(fun.fun, (NamedTuple{(),Tuple{}},))[1]
                 res = T[]
             else
-                res = [fun.fun() for _ in 1:nrow(df)]
+                res = [fun.fun(NamedTuple()) for _ in 1:nrow(df)]
             end
         else
             res = fun(tbl)

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -70,8 +70,9 @@ function normalize_selection(idx::AbstractIndex,
                              <:Union{Symbol, AbstractString, DataType,
                                      AbstractVector{Symbol}, AbstractVector{<:AbstractString}}}},
                              renamecols::Bool)
-    if last(last(sel)) isa DataType
-        last(last(sel)) === AsTable || throw(ArgumentError("Only DataType supported as target is AsTable"))
+    lls = last(last(sel))
+    if lls isa DataType
+        lls === AsTable || throw(ArgumentError("Only DataType supported as target is AsTable"))
     end
     if first(sel) isa AsTable
         rawc = first(sel).cols
@@ -99,15 +100,17 @@ function normalize_selection(idx::AbstractIndex,
         throw(ArgumentError("at least one column must be passed to a " *
                             "`ByRow` transformation function"))
     end
-    ls = last(sel)
-    if ls isa AbstractString
-        r = Symbol(ls)
-    elseif ls isa AbstractVector{<:AbstractString}
-        r = Symbol.(ls)
+    if lls isa AbstractString
+        r = Symbol(lls)
+    elseif lls isa AbstractVector{<:AbstractString}
+        r = Symbol.(lls)
     else
-        r = ls
+        r = lls
     end
-    return (wanttable ? AsTable(c) : c) => r
+    if r isa AbstractVector{Symbol}
+        allunique(r) || throw(ArgumentError("target column names must be unique"))
+    end
+    return (wanttable ? AsTable(c) : c) => first(last(sel)) => r
 end
 
 function normalize_selection(idx::AbstractIndex,

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -453,11 +453,11 @@ SELECT_ARG_RULES =
     # Rules when `new_column_name` is a `Symbol` or a string or is absent
 
     If `fun` returns a value of type other than `AbstractVector` then it will be
-    broadcasted into a vector matching the target number of rows in the data
+    repeated in a vector matching the target number of rows in the data
     frame, unless its type is one of `AbstractDataFrame`, `NamedTuple`,
     `DataFrameRow`, `AbstractMatrix`, in which case an error is thrown. As a
     particular rule, values wrapped in a `Ref` or a `0`-dimensional
-    `AbstractArray` are unwrapped and then broadcasted.
+    `AbstractArray` are unwrapped and then repeated.
 
     To apply `fun` to each row instead of whole columns, it can be wrapped in a
     `ByRow` struct. In this case if `old_column` is a `Symbol`, a string, or an
@@ -488,7 +488,7 @@ SELECT_ARG_RULES =
     when `args` is a function or a type apply.
 
     If `fun` returns an `AbstractVector` then each element of this vector must
-    support `keys` function that must return a collection of `Symbol`s, strings
+    support the `keys` function, which must return a collection of `Symbol`s, strings
     or integers; the return value of `keys` must be identical for all elements.
     Then as many columns are created as there are elements in the return value
     of the `keys` function. If `new_column_name` is `AsTable` then their names
@@ -521,10 +521,10 @@ SELECT_ARG_RULES =
     If the return value is an `AbstractVector` then it is used as-is. The resulting
     column gets the name `x1`.
 
-    In all other cases the return value is broadcasted into a vector matching
+    In all other cases the return value is repeated in a vector matching
     the target number of rows in the data frame. As a particular rule, values
     wrapped in a `Ref` or a `0`-dimensional `AbstractArray` are unwrapped and
-    then broadcasted. The resulting column gets the name `x1`.
+    then repeated. The resulting column gets the name `x1`.
 
     # Special rules
 

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -438,8 +438,8 @@ SELECT_ARG_RULES =
 
     Columns can be renamed using the `old_column => new_column_name` syntax, and
     transformed using the `old_column => fun => new_column_name` syntax.
-    `new_column_name` must be a `Symbol` or a string, a vector of `Symbol` or
-    string, or `AsTable`, and `fun` a function or a type. If `old_column` is a
+    `new_column_name` must be a `Symbol` or a string, a vector of `Symbol`s or
+    strings, or `AsTable`. `fun` must be a function or a type. If `old_column` is a
     `Symbol`, a string, or an integer then `fun` is applied to the corresponding
     column vector. Otherwise `old_column` can be any column indexing syntax, in
     which case `fun` will be passed the column vectors specified by `old_column`
@@ -450,7 +450,7 @@ SELECT_ARG_RULES =
     Column renaming and transformation operations can be passed wrapped in
     vectors or matrices (this is useful when combined with broadcasting).
 
-    # Rules when `new_column_name` is a `Symbol` or a string or is missing
+    # Rules when `new_column_name` is a `Symbol` or a string or is absent
 
     If `fun` returns a value of type other than `AbstractVector` then it will be
     broadcasted into a vector matching the target number of rows in the data
@@ -465,8 +465,8 @@ SELECT_ARG_RULES =
     broadcasting. Otherwise `old_column` can be any column indexing syntax, in
     which case `fun` will be passed one argument for each of the columns
     specified by `old_column`. If `ByRow` is used it is allowed for
-    `old_column` to select an empty set of columns, in which case no arguments
-    are passed to `fun` for each row.
+    `old_column` to select an empty set of columns, in which case `fun`
+     is called for each row without any arguments.
 
     Column transformation can also be specified using the short `old_column =>
     fun` form. In this case, `new_column_name` is automatically generated as
@@ -479,7 +479,7 @@ SELECT_ARG_RULES =
     It is not allowed to pass `renamecols=false` if `old_column` is empty
     as it would generate an empty column name.
 
-    # Rules when `new_column_name` is a vector of `Symbol` or a string or is `AsTable`
+    # Rules when `new_column_name` is a vector of `Symbol`s or strings or is `AsTable`
 
     In this case it is assumed that `fun` returns multiple columns.
 
@@ -493,36 +493,36 @@ SELECT_ARG_RULES =
     Then as many columns are created as there are elements in the return value
     of the `keys` function and their names are set to be equal to the key names,
     except if `keys` returns integers, in which case they are prefixed by `x`
-    (so the column names are e.g. `x1`, `x2`, ...)
+    (so the column names are e.g. `x1`, `x2`, ...).
 
     If `fun` returns a value of any other type then it is assumed that it is
-    a table conforming to Tables.jl API and the `Tables.columntable` function is
+    a table conforming to the Tables.jl API and the `Tables.columntable` function is
     called on it to get the resulting columns and their names.
 
-    Additionally if `new_column_name` is a vector of `Symbol` or string then column
+    Additionally if `new_column_name` is a vector of `Symbol`s or strings then column
     names produced using the rules above are ignored and replaced by `new_column_name`
-    (the number of columns must be the same as the length `new_column_name` in this case).
+    (the number of columns must be the same as the length of `new_column_name` in this case).
 
     # Rules when element of `args` is a function or a type
 
-    In this case a transformaton is passed `df` as a single argument.
+    In this case the function or type is called with `df` as a single argument.
 
-    If the return value of the transformation is of `AbstractDataFrame`,
+    If the return value of the transformation is one of `AbstractDataFrame`,
     `NamedTuple`, `DataFrameRow` or `AbstractMatrix` then it is treated as
     containing multiple columns. For `AbstractMatrix` column names are generated
     as `x1`, `x2`, etc. For `AbstractDataFrame`, `NamedTuple` of vectors and
     `AbstractMatrix` the columns are taken as is from the returned value. For
     `DataFrameRow` and` NamedTuple` not containing any vectors the returned
-    value is broadcasted a vector matching the target number of rows in the data
+    value is broadcasted to a vector matching the target number of rows in the data
     frame.
 
     If the return value is an `AbstractVector` then it is used as-is. The resulting
-    column gets a name `x1`.
+    column gets the name `x1`.
 
     In all other cases the return value is broadcasted into a vector matching
     the target number of rows in the data frame. As a particular rule, values
     wrapped in a `Ref` or a `0`-dimensional `AbstractArray` are unwrapped and
-    then broadcasted. The resulting column gets a name `x1`.
+    then broadcasted. The resulting column gets the name `x1`.
 
     # Special rules
 
@@ -923,7 +923,7 @@ julia> df = DataFrame(a=1:3, b=4:6, c=7:9)
 │ 3   │ 3     │ 6     │ 9     │
 
 julia> combine(df, AsTable(:) => ByRow(x -> (mean=mean(x), std=std(x))) => :stats,
-                      AsTable(:) => ByRow(x -> (mean=mean(x), std=std(x))) => AsTable)
+               AsTable(:) => ByRow(x -> (mean=mean(x), std=std(x))) => AsTable)
 3×3 DataFrame
 │ Row │ stats                   │ mean    │ std     │
 │     │ NamedTuple…             │ Float64 │ Float64 │

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -484,24 +484,26 @@ SELECT_ARG_RULES =
     In this case it is assumed that `fun` returns multiple columns.
 
     If `fun` returns one of `AbstractDataFrame`, `NamedTuple`, `DataFrameRow`,
-    `AbstractMatrix` then rules described below for `args` being a function or
-    a type apply.
+    `AbstractMatrix` then rules described in the section describing the case
+    when `args` is a function or a type apply.
 
     If `fun` returns an `AbstractVector` then each element of this vector must
     support `keys` function that must return a collection of `Symbol`s, strings
     or integers; the return value of `keys` must be identical for all elements.
     Then as many columns are created as there are elements in the return value
-    of the `keys` function and their names are set to be equal to the key names,
-    except if `keys` returns integers, in which case they are prefixed by `x`
-    (so the column names are e.g. `x1`, `x2`, ...).
+    of the `keys` function. If `new_column_name` is `AsTable` then their names
+    are set to be equal to the key names except if `keys` returns integers, in
+    which case they are prefixed by `x` (so the column names are e.g. `x1`,
+    `x2`, ...). If `new_column_name` is a vector of `Symbol`s or strings then
+    column names produced using the rules above are ignored and replaced by
+    `new_column_name` (the number of columns must be the same as the length of
+    `new_column_name` in this case).
 
-    If `fun` returns a value of any other type then it is assumed that it is
-    a table conforming to the Tables.jl API and the `Tables.columntable` function is
-    called on it to get the resulting columns and their names.
-
-    Additionally if `new_column_name` is a vector of `Symbol`s or strings then column
-    names produced using the rules above are ignored and replaced by `new_column_name`
-    (the number of columns must be the same as the length of `new_column_name` in this case).
+    If `fun` returns a value of any other type then it is assumed that it is a
+    table conforming to the Tables.jl API and the `Tables.columntable` function
+    is called on it to get the resulting columns and their names. The names are
+    retained when `new_column_name` is `AsTable` and are replaced if
+    `new_column_name` is a vector of `Symbol`s or strings.
 
     # Rules when element of `args` is a function or a type
 

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -555,6 +555,14 @@ julia> select!(df, AsTable(:) => ByRow(mean), renamecols=false)
 select!(df::DataFrame, args...; renamecols::Bool=true) =
     _replace_columns!(df, select(df, args..., copycols=false, renamecols=renamecols))
 
+function select!(arg::Function, df::AbstractDataFrame; renamecols::Bool=true)
+    if arg isa Colon
+        throw(ArgumentError("Only transformations are allowed when function is a " *
+                            "frist argument to select!"))
+    end
+    return select!(df, arg)
+end
+
 """
     transform!(df::DataFrame, args...; renamecols::Bool=true)
 
@@ -566,6 +574,14 @@ See [`select!`](@ref) for detailed rules regarding accepted values for `args`.
 """
 transform!(df::DataFrame, args...; renamecols::Bool=true) =
     select!(df, :, args..., renamecols=renamecols)
+
+function transform!(arg::Function, df::AbstractDataFrame; renamecols::Bool=true)
+    if arg isa Colon
+        throw(ArgumentError("Only transformations are allowed when function is a " *
+                            "frist argument to transform!"))
+    end
+    return transform!(df, arg)
+end
 
 """
     select(df::AbstractDataFrame, args...; copycols::Bool=true, renamecols::Bool=true)
@@ -690,6 +706,14 @@ julia> select(df, AsTable(:) => ByRow(mean), renamecols=false)
 select(df::AbstractDataFrame, args...; copycols::Bool=true, renamecols::Bool=true) =
     manipulate(df, args..., copycols=copycols, keeprows=true, renamecols=renamecols)
 
+function select(arg::Function, df::AbstractDataFrame; renamecols::Bool=true)
+    if arg isa Colon
+        throw(ArgumentError("Only transformations are allowed when function is a " *
+                            "frist argument to select"))
+    end
+    return select(df, arg)
+end
+
 """
     transform(df::AbstractDataFrame, args...; copycols::Bool=true, renamecols::Bool=true)
 
@@ -702,6 +726,14 @@ See [`select`](@ref) for detailed rules regarding accepted values for `args`.
 """
 transform(df::AbstractDataFrame, args...; copycols::Bool=true, renamecols::Bool=true) =
     select(df, :, args..., copycols=copycols, renamecols=renamecols)
+
+function transform(arg::Function, df::AbstractDataFrame; renamecols::Bool=true)
+    if arg isa Colon
+        throw(ArgumentError("Only transformations are allowed when function is a " *
+                            "frist argument to transform"))
+    end
+    return transform(df, arg)
+end
 
 """
     combine(df::AbstractDataFrame, args...; renamecols::Bool=true)

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -213,7 +213,7 @@ function _gen_colnames(@nospecialize(res), newname::Union{AbstractVector{Symbol}
         colnames = newname
     end
 
-    # fix the type to avoid unnecesarry compilations of methods
+    # fix the type to avoid unnecessary compilations of methods
     # this should be cheap
     return colnames isa Vector{Symbol} ? colnames : collect(Symbol, colnames)
 end

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -367,7 +367,7 @@ function select_transform!(@nospecialize(nc::Union{Base.Callable, Pair{<:Union{I
     # in _manipulate, therefore in select_transform! such a duplicate should not happen
     res = _transformation_helper(df, col_idx, fun)
 
-    if (newname === AsTable || newname isa AbstractVector{Symbol})
+    if newname === AsTable || newname isa AbstractVector{Symbol}
         res = _expand_to_table(res)
     end
 

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -502,7 +502,7 @@ function _combine_prepare(gd::GroupedDataFrame,
     for p in cs
         if p === nrow
             push!(cs_vec, nrow => :nrow)
-        elseif p isa AbstractVector{<:Pair}
+        elseif p isa AbstractVecOrMat{<:Pair}
             append!(cs_vec, p)
         else
             push!(cs_vec, p)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1977,8 +1977,10 @@ end
           [df DataFrame(x_function=[(-1,), (-2,) ,(-3,) ,(-4,) ,(-5,)],
                         y_function=[(-6,), (-7,) ,(-8,) ,(-9,) ,(-10,)])]
 
-    @test_throws ArgumentError combine(gdf, AsTable([:x, :y]) => ByRow(identity))
-    @test_throws ArgumentError combine(gdf, AsTable([:x, :y]) => ByRow(x -> df[1, :]))
+    @test combine(gdf, AsTable([:x, :y]) => ByRow(identity)) ==
+          DataFrame(g=[1,1,1,2,2], x_y_identity=ByRow(identity)((x=1:5, y=6:10)))
+    @test combine(gdf, AsTable([:x, :y]) => ByRow(x -> df[1, :])) ==
+          DataFrame(g=[1,1,1,2,2], x_y_function=fill(df[1, :], 5))
 end
 
 @testset "test correctness of ungrouping" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2700,12 +2700,8 @@ end
     @test isequal_typed(combine(df, :x => (x -> 1:2) => :y), DataFrame(y=1:2))
     @test isequal_typed(combine(df, :x => (x -> x isa Vector{Int} ? "a" : 'a') => :y),
                         DataFrame(y="a"))
-
-    # in the future this should be DataFrame(nrow=0)
-    @test_throws ArgumentError combine(nrow, df)
-
-    # in the future this should be DataFrame(a=1,b=2)
-    @test_throws ArgumentError combine(sdf -> DataFrame(a=1,b=2), df)
+    @test combine(nrow, df) == DataFrame(nrow=0)
+    @test combine(sdf -> DataFrame(a=1,b=2), df) == DataFrame(a=1,b=2)
 end
 
 @testset "disallowed tuple column selector" begin

--- a/test/select.jl
+++ b/test/select.jl
@@ -734,11 +734,9 @@ end
             @test select(df, :x => ByRow(x -> retval) => AsTable) == DataFrame(;retval...)
         elseif retval isa DataFrame
             @test_throws MethodError select(df, :x => ByRow(x -> retval) => AsTable)
-        else # Matrix; surprising but following the API
-            @test select(df, :x => ByRow(x -> retval) => AsTable) ==
-                  DataFrame(["CartesianIndex($i, $j)" => 1.0 for i in 1:2, j in 1:2]...)
-            @test select(df, :x => ByRow(x -> retval) => [:a, :b, :c, :d]) ==
-                  DataFrame(a=1.0, b=1.0, c=1.0, d=1.0)
+        else # Matrix: wrong type of keys
+            @test_throws ArgumentError select(df, :x => ByRow(x -> retval) => AsTable)
+            @test_throws ArgumentError select(df, :x => ByRow(x -> retval) => [:a, :b, :c, :d])
         end
     end
 
@@ -748,7 +746,7 @@ end
         if retval isa Tuple
             @test select(df, :x => ByRow(x -> retval) => AsTable) == DataFrame(x1=1, x2=2)
         else
-            @test select(df, :x => ByRow(x -> retval) => Symbol.("x", 1:8)) == DataFrame(ones(1, 8))
+            @test_throws ArgumentError select(df, :x => ByRow(x -> retval) => AsTable)
         end
         cdf = copy(df)
         select!(cdf, :x => x -> retval)

--- a/test/select.jl
+++ b/test/select.jl
@@ -1430,6 +1430,79 @@ end
         @test transform!(sdf -> [10 11; 12 13], copy(df)) == DataFrame(a=1:2, b=3:4, c=5:6, x1=[10, 12], x2=[11, 13])
         @test transform!(sdf -> DataFrame(a=10)[1, :], copy(df)) == DataFrame(a=[10, 10], b=3:4, c=5:6)
     end
+
+    @testset "SELECT(DF, => AsTable)" begin
+        for df in (DataFrame(a=1:2, b=3:4, c=5:6), view(DataFrame(a=1:3, b=3:5, c=5:7, d=11:13), 1:2, 1:3))
+            for fun in (select, combine, transform),
+                res in (DataFrame(), DataFrame(a=1,b=2)[1, :], ones(1,1),
+                        (a=1,b=2), (a=[1], b=[2]), (a=1, b=[2]))
+                @test_throws ArgumentError fun(df, :a => x -> res)
+                @test_throws ArgumentError fun(df, :a => (x -> res) => :z)
+            end
+            for res in (DataFrame(x1=1, x2=2)[1, :], (x1=1,x2=2))
+                @test select(df, :a => (x -> res) => AsTable) == DataFrame(x1=[1,1], x2=[2,2])
+                @test transform(df, :a => (x -> res) => AsTable) == [df DataFrame(x1=[1,1], x2=[2,2])]
+                @test combine(df, :a => (x -> res) => AsTable) == DataFrame(x1=[1], x2=[2])
+                @test select(df, :a => (x -> res) => [:p, :q]) == DataFrame(p=[1,1], q=[2,2])
+                @test transform(df, :a => (x -> res) => [:p, :q]) == [df DataFrame(p=[1,1], q=[2,2])]
+                @test combine(df, :a => (x -> res) => [:p, :q]) == DataFrame(p=[1], q=[2])
+                @test_throws ArgumentError select(df, :a => (x -> res) => [:p, :q, :r])
+                @test_throws ArgumentError select(df, :a => (x -> res) => [:p])
+            end
+            for res in (DataFrame(x1=1, x2=2), [1 2], Tables.table([1 2], header=[:x1, :x2]),
+                        (x1=[1], x2=[2]))
+                @test combine(df, :a => (x -> res) => AsTable) == DataFrame(x1=1, x2=2)
+                @test combine(df, :a => (x -> res) => [:p, :q]) == DataFrame(p=1, q=2)
+                @test_throws ArgumentError combine(df, :a => (x -> res) => [:p])
+                @test_throws ArgumentError select(df, :a => (x -> res) => AsTable)
+                @test_throws ArgumentError transform(df, :a => (x -> res) => AsTable)
+            end
+            @test combine(df, :a => ByRow(x -> [x,x+1]),
+                          :a => ByRow(x -> [x, x+1]) => AsTable,
+                          :a => ByRow(x -> [x, x+1]) => [:p, :q],
+                          :a => ByRow(x -> (s=x, t=x+1)) => AsTable,
+                          :a => (x -> (k=x, l=x.+1)) => AsTable,
+                          :a => ByRow(x -> (s=x, t=x+1)) => :z) ==
+                  DataFrame(a_function=[[1, 2], [2, 3]], x1=[1, 2], x2=[2, 3],
+                            p=[1, 2], q=[2, 3], s=[1, 2], t=[2, 3], k=[1, 2], l=[2, 3],
+                            z=[(s=1, t=2), (s=2, t=3)])
+            @test select(df, :a => ByRow(x -> [x,x+1]),
+                         :a => ByRow(x -> [x, x+1]) => AsTable,
+                         :a => ByRow(x -> [x, x+1]) => [:p, :q],
+                         :a => ByRow(x -> (s=x, t=x+1)) => AsTable,
+                         :a => (x -> (k=x, l=x.+1)) => AsTable,
+                         :a => ByRow(x -> (s=x, t=x+1)) => :z) ==
+                  DataFrame(a_function=[[1, 2], [2, 3]], x1=[1, 2], x2=[2, 3],
+                            p=[1, 2], q=[2, 3], s=[1, 2], t=[2, 3], k=[1, 2], l=[2, 3],
+                            z=[(s=1, t=2), (s=2, t=3)])
+            @test transform(df, :a => ByRow(x -> [x,x+1]),
+                            :a => ByRow(x -> [x, x+1]) => AsTable,
+                            :a => ByRow(x -> [x, x+1]) => [:p, :q],
+                            :a => ByRow(x -> (s=x, t=x+1)) => AsTable,
+                            :a => (x -> (k=x, l=x.+1)) => AsTable,
+                            :a => ByRow(x -> (s=x, t=x+1)) => :z) ==
+                  [df DataFrame(a_function=[[1, 2], [2, 3]], x1=[1, 2], x2=[2, 3],
+                                p=[1, 2], q=[2, 3], s=[1, 2], t=[2, 3], k=[1, 2], l=[2, 3],
+                                z=[(s=1, t=2), (s=2, t=3)])]
+            @test_throws ArgumentError select(df, :a => (x -> [(a=1,b=2), (a=1, b=2, c=3)]) => AsTable)
+            @test_throws ArgumentError select(df, :a => (x -> [(a=1,b=2), (a=1, c=3)]) => AsTable)
+            @test_throws ArgumentError combine(df, :a => (x -> (a=1,b=2)) => :x)
+        end
+    end
+
+    @testset "check correctness of duplicate column names" begin
+        for df in (DataFrame(a=1:2, b=3:4, c=5:6), view(DataFrame(a=1:3, b=3:5, c=5:7, d=11:13), 1:2, 1:3))
+            @test select(df, :b, :) == DataFrame(b=3:4, a=1:2, c=5:6)
+            @test select(df, :b => :c, :) == DataFrame(c=3:4, a=1:2, b=3:4)
+            @test_throws ArgumentError select(df, :b => [:c, :d], :)
+            @test_throws ArgumentError select(df, :a, :a => x -> (a=[1,2], b=[3,4]))
+            @test_throws ArgumentError select(df, :a, :a => (x -> (a=[1,2], b=[3,4])) => AsTable)
+            @test select(df, [:b, :a], :a => (x -> (a=[11,12], b=[13,14])) => AsTable, :) ==
+                  DataFrame(b=[13, 14], a=[11, 12], c=[5, 6])
+            @test select(df, [:b, :a], :a => (x -> (a=[11,12], b=[13,14])) => [:b, :a], :) ==
+                  DataFrame(b=[11, 12], a=[13, 14], c=[5, 6])
+        end
+    end
 end
 
 @testset "empty ByRow" begin


### PR DESCRIPTION
This PR partially addresses https://github.com/JuliaData/DataFrames.jl/issues/2410 and https://github.com/JuliaData/DataFrames.jl/issues/2457.

It covers `select` etc. for `AbstractDataFrame`.

If we are OK with the functionality I will update the documentation.

TODO:
* do the same for `select` etc. for `GroupedDataFrame` (this will be a separate PR to keep PRs more atomic)
* add support for `ByRow` with no columns passed to `filter` (also a separate PR)

CC @nalimilan @pdeffebach @matthieugomez - this is a rather complex PR so independent testing (especially for corner cases) would be welcome (if you would have suggestions for types of tests to add please comment and I will add them).