### PR TITLE
fix setproperty! for data frame

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -499,10 +499,12 @@ Base.setproperty!(df::DataFrame, col_ind::Symbol, v::AbstractVector) =
     (df[!, col_ind] = v)
 Base.setproperty!(df::DataFrame, col_ind::AbstractString, v::AbstractVector) =
     (df[!, col_ind] = v)
-Base.setproperty!(::AbstractDataFrame, ::Symbol, ::Any) =
-    throw(ArgumentError("it is only allowed to pass a vector as a column of a DataFrame"))
-Base.setproperty!(::AbstractDataFrame, ::AbstractString, ::Any) =
-    throw(ArgumentError("it is only allowed to pass a vector as a column of a DataFrame"))
+Base.setproperty!(::DataFrame, col_ind::Symbol, v::Any) =
+    throw(ArgumentError("It is only allowed to pass a vector as a column of a DataFrame." *
+                        "Instead use `df[!, col_ind] .= v` if you want to use broadcasting."))
+Base.setproperty!(::DataFrame, col_ind::AbstractString, v::Any) =
+    throw(ArgumentError("It is only allowed to pass a vector as a column of a DataFrame." *
+                        "Instead use `df[!, col_ind] .= v` if you want to use broadcasting."))
 
 # df[SingleRowIndex, SingleColumnIndex] = Single Item
 function Base.setindex!(df::DataFrame, v::Any, row_ind::Integer, col_ind::ColumnIndex)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -499,6 +499,10 @@ Base.setproperty!(df::DataFrame, col_ind::Symbol, v::AbstractVector) =
     (df[!, col_ind] = v)
 Base.setproperty!(df::DataFrame, col_ind::AbstractString, v::AbstractVector) =
     (df[!, col_ind] = v)
+Base.setproperty!(::AbstractDataFrame, ::Symbol, ::Any) =
+    throw(ArgumentError("it is only allowed to pass a vector as a column of a DataFrame"))
+Base.setproperty!(::AbstractDataFrame, ::AbstractString, ::Any) =
+    throw(ArgumentError("it is only allowed to pass a vector as a column of a DataFrame"))
 
 # df[SingleRowIndex, SingleColumnIndex] = Single Item
 function Base.setindex!(df::DataFrame, v::Any, row_ind::Integer, col_ind::ColumnIndex)

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -149,6 +149,15 @@ end
 Base.@propagate_inbounds Base.setindex!(sdf::SubDataFrame, val::Any, rowinds::Bool, colinds::Any) =
     throw(ArgumentError("invalid row index of type Bool"))
 
+Base.setproperty!(::SubDataFrame, ::Symbol, ::Any) =
+    throw(ArgumentError("Replacing or adding of columns of a SubDataFrame is not allowed." *
+                        "Instead use `df[:, col_ind] = v` or `df[:, col_ind] .= v` " *
+                        "to perform an in-place assignment."))
+Base.setproperty!(::SubDataFrame, ::AbstractString, ::Any) =
+    throw(ArgumentError("Replacing or adding of columns of a SubDataFrame is not allowed." *
+                        "Instead use `df[:, col_ind] = v` or `df[:, col_ind] .= v` " *
+                        "to perform an in-place assignment."))
+
 ##############################################################################
 ##
 ## Miscellaneous

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1837,4 +1837,15 @@ end
     end
 end
 
+@testset "setproperty! corner cases" begin
+    df = DataFrame(a=1)
+    @test_throws ArgumentError df.a = 1
+    @test_throws ArgumentError df."a" = 1
+    dfv = @view df[:, :]
+    @test_throws ArgumentError dfv.a = [1]
+    @test_throws ArgumentError dfv."a" = [1]
+    @test_throws ArgumentError dfv.a = 1
+    @test_throws ArgumentError dfv."a" = 1
+end
+
 end # module


### PR DESCRIPTION
Without it if you pass incorrect types a default `setproperty!` method is invoked (user would have to try very hard to exploit this, but still I think it is better to throw an informative error in this case). The problem was hidden earlier by deprecations.

Before:
```
julia> df = DataFrame(a=1);

julia> dfv = @view df[:, :];

julia> @edit dfv.parent = DataFrame();

julia> df.a = 1
ERROR: type DataFrame has no field a
Stacktrace:
 [1] setproperty!(::DataFrame, ::Symbol, ::Int64) at ./Base.jl:34
 [2] top-level scope at REPL[12]:1

julia> dfv.parent = DataFrame();
ERROR: setfield! immutable struct of type SubDataFrame cannot be changed
Stacktrace:
 [1] setproperty!(::SubDataFrame{DataFrame,DataFrames.Index,Base.OneTo{Int64}}, ::Symbol, ::DataFrame) at ./Base.jl:34
 [2] top-level scope at REPL[5]:1
```