### PR TITLE
avoid allocation when negating BitArray

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -911,7 +911,9 @@ julia> dropmissing!(df3, [:x, :y])
 function dropmissing!(df::AbstractDataFrame,
                       cols::Union{ColumnIndex, MultiColumnIndex}=:;
                       disallowmissing::Bool=true)
-    delete!(df, (!).(completecases(df, cols)))
+    inds = completecases(df, cols)                                  
+    inds .= .!(inds)
+    delete!(df, inds)
     disallowmissing && disallowmissing!(df, cols)
     df
 end


### PR DESCRIPTION
avoid allocation when negating BitArray in `dropmissing!` method