### PR TITLE
Remove type parameters in DataFrameJoiner

### DIFF
--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -10,11 +10,11 @@ const OnType = Union{SymbolOrString, NTuple{2,Symbol}, Pair{Symbol,Symbol},
                      Pair{<:AbstractString, <:AbstractString}}
 
 # helper structure for DataFrames joining
-struct DataFrameJoiner{DF1<:AbstractDataFrame, DF2<:AbstractDataFrame}
-    dfl::DF1
-    dfr::DF2
-    dfl_on::DF1
-    dfr_on::DF2
+struct DataFrameJoiner
+    dfl::AbstractDataFrame
+    dfr::AbstractDataFrame
+    dfl_on::AbstractDataFrame
+    dfr_on::AbstractDataFrame
     left_on::Vector{Symbol}
     right_on::Vector{Symbol}
 

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -18,8 +18,8 @@ struct DataFrameJoiner
     left_on::Vector{Symbol}
     right_on::Vector{Symbol}
 
-    function DataFrameJoiner{DF1, DF2}(dfl::DF1, dfr::DF2,
-                                       on::Union{<:OnType, AbstractVector}) where {DF1, DF2}
+    function DataFrameJoiner(dfl::AbstractDataFrame, dfr::AbstractDataFrame,
+                             on::Union{<:OnType, AbstractVector})
         on_cols = isa(on, AbstractVector) ? on : [on]
         left_on = Symbol[]
         right_on = Symbol[]
@@ -44,10 +44,6 @@ struct DataFrameJoiner
         new(dfl, dfr, dfl[!, left_on], dfr[!, right_on], left_on, right_on)
     end
 end
-
-DataFrameJoiner(dfl::DF1, dfr::DF2, on::Union{<:OnType, AbstractVector}) where
-    {DF1<:AbstractDataFrame, DF2<:AbstractDataFrame} =
-    DataFrameJoiner{DF1,DF2}(dfl, dfr, on)
 
 # helper map between the row indices in original and joined table
 struct RowIndexMap

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -345,7 +345,7 @@ end
 
 # Find index of a row in gd that matches given row by content, 0 if not found
 function findrow(gd::RowGroupDict,
-                 df::DataFrame,
+                 df::AbstractDataFrame,
                  gd_cols::Tuple{Vararg{AbstractVector}},
                  df_cols::Tuple{Vararg{AbstractVector}},
                  row::Int)
@@ -370,7 +370,7 @@ end
 # Find indices of rows in 'gd' that match given row by content.
 # return empty set if no row matches
 function findrows(gd::RowGroupDict,
-                  df::DataFrame,
+                  df::AbstractDataFrame,
                   gd_cols::Tuple{Vararg{AbstractVector}},
                   df_cols::Tuple{Vararg{AbstractVector}},
                   row::Int)

--- a/test/join.jl
+++ b/test/join.jl
@@ -887,7 +887,7 @@ end
     @test_throws ArgumentError join(df1, df2, on=:id, kind=:inner)
 end
 
-@testset "Make DataFrameJoiner rely on AbstractDataFrame" begin
+@testset "join mixing DataFrame and SubDataFrame" begin
     df1 = DataFrame(a=[1, 2, 3], b=[4, 5, 6])
     df1_copy = df1[df1.a .> 1, :]
     df1_view1 = @view df1[df1.a .> 1, :]
@@ -896,7 +896,6 @@ end
     @test innerjoin(df1_copy, df2, on=:a) ==
           innerjoin(df1_view1, df2, on=:a) ==
           innerjoin(df1_view2, df2, on=:a)
-
 end
 
 end # module

--- a/test/join.jl
+++ b/test/join.jl
@@ -887,4 +887,16 @@ end
     @test_throws ArgumentError join(df1, df2, on=:id, kind=:inner)
 end
 
+@testset "Make DataFrameJoiner rely on AbstractDataFrame" begin
+    df1 = DataFrame(a=[1, 2, 3], b=[4, 5, 6])
+    df1_copy = df1[df1.a .> 1, :]
+    df1_view1 = @view df1[df1.a .> 1, :]
+    df1_view2 = @view df1[df1.a .> 1, 1:2]
+    df2 = DataFrame(a=[1, 2, 3], c=[7, 8, 9])
+    @test innerjoin(df1_copy, df2, on=:a) ==
+          innerjoin(df1_view1, df2, on=:a) ==
+          innerjoin(df1_view2, df2, on=:a)
+
+end
+
 end # module


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2502

The problem is that `SubDataFrame` is `UnionAll`. Now I propose to have a container of abstract types, but I think it is OK, as it will save some compilation time + data frame is type unstable anyway.