### PR TITLE
[BREAKING] remove CategoricalArrays dependency from joins

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,8 @@
   choose the fast path only when it is safe; this resolves inconsistencies
   with what the same functions not using fast path produce
   ([#2357](https://github.com/JuliaData/DataFrames.jl/pull/2357))
+* joins now return `PooledVector` not `CategoricalVector` in indicator column
+  ([#2505](https://github.com/JuliaData/DataFrames.jl/pull/2505))
 * `GroupKeys` now supports `in` for `GroupKey`, `Tuple`, `NamedTuple` and dictionaries
   ([2392](https://github.com/JuliaData/DataFrames.jl/pull/2392))
 * in `describe` the specification of custom aggregation is now `function => name`;

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -122,9 +122,9 @@ function compose_joined_table(joiner::DataFrameJoiner, kind::Symbol,
         # assign 0x1 to it anyway and these rows are guaranteed to come first
         # (even if they are permuted)
         left_indicator = zeros(UInt32, nrow)
-        left_indicator[axes(all_orig_left_ixs, 1)] .= UInt32(1)
+        left_indicator[axes(all_orig_left_ixs, 1)] .= 1
         right_indicator = zeros(UInt32, nrow)
-        right_indicator[axes(all_orig_right_ixs, 1)] .= UInt32(2)
+        right_indicator[axes(all_orig_right_ixs, 1)] .= 2
         permute!(right_indicator, right_perm)
     end
 
@@ -418,9 +418,9 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
     if indicator !== nothing
         left_indicator .+= right_indicator
         pool = ["left_only", "right_only", "both"]
-        invpool = Dict{String, UInt8}("left_only" => UInt32(1),
-                                      "right_only" => UInt32(2),
-                                      "both" => UInt32(3))
+        invpool = Dict{String, UInt32}("left_only" => 1,
+                                       "right_only" => 2,
+                                       "both" => 3)
         indicatorcol = PooledArray(PooledArrays.RefArray(left_indicator),
                                    invpool, pool)
 

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -416,10 +416,11 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
     end
 
     if indicator !== nothing
-        refs = left_indicator + right_indicator
-        refs_short, invpool, pool = PooledArrays._label(["left_only", "right_only", "both"], String)
-        @assert refs_short == [1, 2, 3]
-        indicatorcol = PooledArray(PooledArrays.RefArray(refs), invpool, pool)
+        left_indicator .+= right_indicator
+        pa_base = PooledArray(["left_only", "right_only", "both"])
+        indicatorcol = PooledArray(PooledArrays.RefArray(left_indicator),
+                                   Dict{String, UInt8}("left_only" => 0x1, "right_only" => 0x2, "both" => 0x3),
+                                   ["left_only", "right_only", "both"])
 
         unique_indicator = indicator
         if makeunique

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -417,8 +417,9 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
 
     if indicator !== nothing
         refs = left_indicator + right_indicator
-        pool = CategoricalPool{String,UInt8}(["left_only", "right_only", "both"])
-        indicatorcol = CategoricalArray{String,1}(refs, pool)
+        refs_short, invpool, pool = PooledArrays._label(["left_only", "right_only", "both"], String)
+        @assert refs_short == [1, 2, 3]
+        indicatorcol = PooledArray(PooledArrays.RefArray(refs), invpool, pool)
 
         unique_indicator = indicator
         if makeunique

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -417,7 +417,6 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
 
     if indicator !== nothing
         left_indicator .+= right_indicator
-        pa_base = PooledArray(["left_only", "right_only", "both"])
         indicatorcol = PooledArray(PooledArrays.RefArray(left_indicator),
                                    Dict{String, UInt8}("left_only" => 0x1, "right_only" => 0x2, "both" => 0x3),
                                    ["left_only", "right_only", "both"])

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -121,10 +121,10 @@ function compose_joined_table(joiner::DataFrameJoiner, kind::Symbol,
         # about the permutation of left data frame in rightjoin as we always
         # assign 0x1 to it anyway and these rows are guaranteed to come first
         # (even if they are permuted)
-        left_indicator = zeros(UInt8, nrow)
-        left_indicator[axes(all_orig_left_ixs, 1)] .= 0x1
-        right_indicator = zeros(UInt8, nrow)
-        right_indicator[axes(all_orig_right_ixs, 1)] .= 0x2
+        left_indicator = zeros(UInt32, nrow)
+        left_indicator[axes(all_orig_left_ixs, 1)] .= UInt32(1)
+        right_indicator = zeros(UInt32, nrow)
+        right_indicator[axes(all_orig_right_ixs, 1)] .= UInt32(2)
         permute!(right_indicator, right_perm)
     end
 
@@ -417,9 +417,12 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
 
     if indicator !== nothing
         left_indicator .+= right_indicator
+        pool = ["left_only", "right_only", "both"]
+        invpool = Dict{String, UInt8}("left_only" => UInt32(1),
+                                      "right_only" => UInt32(2),
+                                      "both" => UInt32(3))
         indicatorcol = PooledArray(PooledArrays.RefArray(left_indicator),
-                                   Dict{String, UInt8}("left_only" => 0x1, "right_only" => 0x2, "both" => 0x3),
-                                   ["left_only", "right_only", "both"])
+                                   invpool, pool)
 
         unique_indicator = indicator
         if makeunique


### PR DESCRIPTION
I have found a dependency on CategoricalArrays in joins also.