### PR TITLE
make hashrows_col! not depend on CategoricalArrays.jl

### DIFF
--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -51,19 +51,8 @@ function hashrows_col_pool!(h::Vector{UInt},
         end
 
         fi = firstindex(rp)
-        if fi == 1
-            @inbounds for (i, ref) in enumerate(DataAPI.refarray(v))
-                h[i] = hashes[ref]
-            end
-        elseif fi == 0
-            @inbounds for (i, ref) in enumerate(DataAPI.refarray(v))
-                h[i] = hashes[ref+1]
-            end
-        else
-            # currently no implementation of DataAPI.jl interface hits this branch
-            @inbounds for (i, ref) in enumerate(DataAPI.refarray(v))
-                h[i] = hashes[ref+1-fi]
-            end
+        @inbounds for (i, ref) in enumerate(DataAPI.refarray(v))
+            h[i] = hashes[ref+1-fi]
         end
     else
         @inbounds for (i, x) in enumerate(v)

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -43,8 +43,8 @@ function hashrows_col!(h::Vector{UInt},
                        firstcol::Bool)
     # When hashing the first column, no need to take into account previous hash,
     # which is always zero
-    # also when there are more than 90% of refs in the pool than the length of the
-    # vector avoid using this path. 90% is picked heuristically
+    # also when the number of values in the pool is more than half the length
+    # of the vector avoid using this path. 50% is roughly based on benchmarks
     if firstcol && 2 * length(rp) < length(v)
         hashes = Vector{UInt}(undef, length(rp))
         @inbounds for (i, v) in zip(eachindex(hashes), rp)

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -45,14 +45,14 @@ function hashrows_col!(h::Vector{UInt},
     # which is always zero
     # also when there are more than 90% of refs in the pool than the length of the
     # vector avoid using this path. 90% is picked heuristically
-    if firstcol && length(rp) < 0.9length(v)
+    if firstcol && 2 * length(rp) < length(v)
         hashes = Vector{UInt}(undef, length(rp))
         @inbounds for (i, v) in zip(eachindex(hashes), rp)
             hashes[i] = hash(v)
         end
 
         fi = firstindex(rp)
-        # here we rely on the fact that `DataAPI.refpool` supports a continuous
+        # here we rely on the fact that `DataAPI.refpool` has a continuous
         # block of indices
         @inbounds for (i, ref) in enumerate(DataAPI.refarray(v))
             h[i] = hashes[ref+1-fi]

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -3174,7 +3174,7 @@ end
 end
 
 @testset "hashing of pooled vectors" begin
-    # test both hashrow calculation paths - the of pool length thereshold is 50%
+    # test both hashrow calculation paths - the of pool length threshold is 50%
     for x in ([1:9; fill(1, 101)], [1:100;],
               [1:9; fill(missing, 101)], [1:99; missing])
         x1 = PooledArray(x);

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -3174,8 +3174,9 @@ end
 end
 
 @testset "hashing of pooled vectors" begin
-    for x in ([1:900; fill(1, 101)], [1:902; fill(1, 99)],
-              [1:900; fill(missing, 101)], [1:902; fill(missing, 99)])
+    # test both hashrow calculation paths - the of pool length thereshold is 50%
+    for x in ([1:9; fill(1, 101)], [1:100;],
+              [1:9; fill(missing, 101)], [1:99; missing])
         x1 = PooledArray(x);
         x2 = categorical(x);
         @test DataFrames.hashrows((x,), false) ==

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -3173,4 +3173,18 @@ end
                     :min => min.(df.y, df.z), :max => max.(df.y, df.z), :y => df.y) |> sort
 end
 
+@testset "hashing of pooled vectors" begin
+    for x in ([1:900; fill(1, 101)], [1:902; fill(1, 99)],
+              [1:900; fill(missing, 101)], [1:902; fill(missing, 99)])
+        x1 = PooledArray(x);
+        x2 = categorical(x);
+        @test DataFrames.hashrows((x,), false) ==
+              DataFrames.hashrows((x1,), false) ==
+              DataFrames.hashrows((x2,), false)
+        @test DataFrames.hashrows((x,), true) ==
+              DataFrames.hashrows((x1,), true) ==
+              DataFrames.hashrows((x2,), true)
+    end
+end
+
 end # module


### PR DESCRIPTION
@nalimilan - this follows your suggestion in https://github.com/JuliaData/DataFrames.jl/issues/2506#issuecomment-723066223.

It is not fully in line with DataAPI.jl API (but I propose - as already mentioned to make that API stricter and require `DataAPI.refpool` to be `AbstractVector`).

If we agree on the proposal I will add more tests.