### PR TITLE
Reduce number of tests in the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,23 @@ jobs:
   exclude:
     - os: osx
       arch: i386
+    - julia 1.0
+      os: linux
+      arch: i386
+    - julia 1.0
+      os: osx
+    - julia 1.0
+      os: windows
+    - julia nightly
+      os: linux
+      arch: i386
   allow_failures:
     - julia: nightly
   include:
     - stage: "Documentation"
-      julia: 1.0
+      julia: 1
       os: linux
+      arch: amd64
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
                                     Pkg.instantiate()'


### PR DESCRIPTION
Currently CI takes ~75 minutes to finish. Also the practice has shown that what we essentially need is:
- test all options on current release
- test all platforms on x64 nightly (to report bugs back to Julia Base, as they happen on different platforms)
- just run one test on LTS 1.0 (as things that stop working are not platform specific)

I would like to open a discussion if we go this way.