### PR TITLE
code layout improvements

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -424,8 +424,13 @@ applied to all pairs of columns stored in `df1` and `df2` returns `true`.
 function Base.isapprox(df1::AbstractDataFrame, df2::AbstractDataFrame;
                        atol::Real=0, rtol::Real=atol>0 ? 0 : √eps(),
                        nans::Bool=false, norm::Function=norm)
-    size(df1) == size(df2) || throw(DimensionMismatch("dimensions must match: a has dims $(size(df1)), b has dims $(size(df2))"))
-    isequal(index(df1), index(df2)) || throw(ArgumentError("column names of passed data frames do not match"))
+    if size(df1) != size(df2)
+        throw(DimensionMismatch("dimensions must match: a has dims " *
+                                "$(size(df1)), b has dims $(size(df2))"))
+    end
+    if !isequal(index(df1), index(df2))
+        throw(ArgumentError("column names of passed data frames do not match"))
+    end
     return all(isapprox.(eachcol(df1), eachcol(df2), atol=atol, rtol=rtol, nans=nans, norm=norm))
 end
 ##############################################################################
@@ -911,7 +916,7 @@ julia> dropmissing!(df3, [:x, :y])
 function dropmissing!(df::AbstractDataFrame,
                       cols::Union{ColumnIndex, MultiColumnIndex}=:;
                       disallowmissing::Bool=true)
-    inds = completecases(df, cols)                                  
+    inds = completecases(df, cols)
     inds .= .!(inds)
     delete!(df, inds)
     disallowmissing && disallowmissing!(df, cols)
@@ -1198,8 +1203,8 @@ nonunique(df, 1)
 """
 function nonunique(df::AbstractDataFrame)
     if ncol(df) == 0
-        throw(ArgumentError("finding duplicate rows in data frame with no" *
-                            " columns is not allowed"))
+        throw(ArgumentError("finding duplicate rows in data frame with no " *
+                            "columns is not allowed"))
     end
     gslots = row_group_slots(ntuple(i -> df[!, i], ncol(df)), Val(true))[3]
     # unique rows are the first encountered group representatives,
@@ -1853,8 +1858,8 @@ function flatten(df::AbstractDataFrame,
         if any(x -> length(x[1]) != x[2], zip(v, lengths))
             r = findfirst(x -> x != 0, length.(v) .- lengths)
             colnames = _names(df)
-            throw(ArgumentError("Lengths of iterables stored in columns :$(colnames[col1])" *
-                                " and :$(colnames[col]) are not the same in row $r"))
+            throw(ArgumentError("Lengths of iterables stored in columns :$(colnames[col1]) " *
+                                "and :$(colnames[col]) are not the same in row $r"))
         end
     end
 

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -21,8 +21,8 @@ Base.summary(dfrs::DataFrameRows) = "$(length(dfrs))-element DataFrameRows"
 Base.summary(io::IO, dfrs::DataFrameRows) = print(io, summary(dfrs))
 
 Base.iterate(::AbstractDataFrame) =
-    error("AbstractDataFrame is not iterable. Use eachrow(df) to get a row iterator" *
-          " or eachcol(df) to get a column iterator")
+    error("AbstractDataFrame is not iterable. Use eachrow(df) to get a row iterator " *
+          "or eachcol(df) to get a column iterator")
 
 """
     eachrow(df::AbstractDataFrame)

--- a/src/abstractdataframe/join.jl
+++ b/src/abstractdataframe/join.jl
@@ -462,8 +462,8 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
 
         if hasproperty(joined, unique_indicator)
             throw(ArgumentError("joined data frame already has column " *
-                                ":$unique_indicator. Pass makeunique=true to" *
-                                " make it unique using a suffix automatically."))
+                                ":$unique_indicator. Pass makeunique=true to " *
+                                "make it unique using a suffix automatically."))
         end
         joined[!, unique_indicator] = indicatorcol
     else
@@ -594,8 +594,8 @@ function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
                    renamecols::Pair=identity => identity,
                    matchmissing::Symbol=:error)
     if !all(x -> x isa Union{Function, AbstractString, Symbol}, renamecols)
-        throw(ArgumentError("renamecols keyword argument must be a `Pair`" *
-                            " containing functions, strings, or `Symbol`s"))
+        throw(ArgumentError("renamecols keyword argument must be a `Pair` " *
+                            "containing functions, strings, or `Symbol`s"))
     end
     return _join(df1, df2, on=on, kind=:inner, makeunique=makeunique,
                  indicator=nothing, validate=validate,
@@ -731,8 +731,8 @@ function leftjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
          validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
          renamecols::Pair=identity => identity, matchmissing::Symbol=:error)
     if !all(x -> x isa Union{Function, AbstractString, Symbol}, renamecols)
-        throw(ArgumentError("renamecols keyword argument must be a `Pair`" *
-                            " containing functions, strings, or `Symbol`s"))
+        throw(ArgumentError("renamecols keyword argument must be a `Pair` " *
+                            "containing functions, strings, or `Symbol`s"))
     end
     return _join(df1, df2, on=on, kind=:left, makeunique=makeunique,
                  indicator=indicator, validate=validate,
@@ -860,8 +860,8 @@ function rightjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
           validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
           renamecols::Pair=identity => identity, matchmissing::Symbol=:error)
     if !all(x -> x isa Union{Function, AbstractString, Symbol}, renamecols)
-        throw(ArgumentError("renamecols keyword argument must be a `Pair`" *
-                            " containing functions, strings, or `Symbol`s"))
+        throw(ArgumentError("renamecols keyword argument must be a `Pair` " *
+                            "containing functions, strings, or `Symbol`s"))
     end
     return _join(df1, df2, on=on, kind=:right, makeunique=makeunique,
                  indicator=indicator, validate=validate,
@@ -1000,8 +1000,8 @@ function outerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
           validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
           renamecols::Pair=identity => identity, matchmissing::Symbol=:error)
     if !all(x -> x isa Union{Function, AbstractString, Symbol}, renamecols)
-        throw(ArgumentError("renamecols keyword argument must be a `Pair`" *
-                            " containing functions, strings, or `Symbol`s"))
+        throw(ArgumentError("renamecols keyword argument must be a `Pair` " *
+                            "containing functions, strings, or `Symbol`s"))
     end
     return _join(df1, df2, on=on, kind=:outer, makeunique=makeunique,
                  indicator=indicator, validate=validate,

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -395,8 +395,8 @@ function _unstack(df::AbstractDataFrame, rowkeys::AbstractVector{Int},
     colref_map = df[col_group_row_idxs, colkey]
 
     if any(ismissing, colref_map) && !allowmissing
-        throw(ArgumentError("Missing value in variable :$(_names(df)[colkey])." *
-                            " Pass `allowmissing=true` to skip missings."))
+        throw(ArgumentError("Missing value in variable :$(_names(df)[colkey]). " *
+                            "Pass `allowmissing=true` to skip missings."))
     end
 
     unstacked_val = [similar_missing(valuecol, Nrow) for i in 1:Ncol]

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -164,8 +164,8 @@ struct DataFrame <: AbstractDataFrame
         if length(columns) == length(colindex) == 0
             return new(AbstractVector[], Index())
         elseif length(columns) != length(colindex)
-            throw(DimensionMismatch("Number of columns ($(length(columns))) and number of" *
-                                    " column names ($(length(colindex))) are not equal"))
+            throw(DimensionMismatch("Number of columns ($(length(columns))) and number of " *
+                                    "column names ($(length(colindex))) are not equal"))
         end
 
         len = -1
@@ -198,8 +198,8 @@ struct DataFrame <: AbstractDataFrame
                 columns[i] = fill!(Tables.allocatecolumn(typeof(x), len), x)
             else
                 if col isa AbstractArray
-                    throw(ArgumentError("adding AbstractArray other than AbstractVector" *
-                                        " as a column of a data frame is not allowed"))
+                    throw(ArgumentError("adding AbstractArray other than AbstractVector " *
+                                        "as a column of a data frame is not allowed"))
                 end
                 columns[i] = fill!(Tables.allocatecolumn(typeof(col), len), col)
             end
@@ -274,8 +274,8 @@ function DataFrame(; kwargs...)
                     throw(ArgumentError("the `copycols` keyword argument must be Boolean"))
                 end
             elseif kw === :makeunique
-                    throw(ArgumentError("the `makeunique` keyword argument is not allowed" *
-                                        " in DataFrame(; kwargs...) constructor"))
+                    throw(ArgumentError("the `makeunique` keyword argument is not allowed " *
+                                        "in DataFrame(; kwargs...) constructor"))
             else
                 push!(cnames, kw)
                 push!(columns, val)
@@ -549,10 +549,10 @@ Base.setproperty!(df::DataFrame, col_ind::Symbol, v::AbstractVector) =
 Base.setproperty!(df::DataFrame, col_ind::AbstractString, v::AbstractVector) =
     (df[!, col_ind] = v)
 Base.setproperty!(::DataFrame, col_ind::Symbol, v::Any) =
-    throw(ArgumentError("It is only allowed to pass a vector as a column of a DataFrame." *
+    throw(ArgumentError("It is only allowed to pass a vector as a column of a DataFrame. " *
                         "Instead use `df[!, col_ind] .= v` if you want to use broadcasting."))
 Base.setproperty!(::DataFrame, col_ind::AbstractString, v::Any) =
-    throw(ArgumentError("It is only allowed to pass a vector as a column of a DataFrame." *
+    throw(ArgumentError("It is only allowed to pass a vector as a column of a DataFrame. " *
                         "Instead use `df[!, col_ind] .= v` if you want to use broadcasting."))
 
 # df[SingleRowIndex, SingleColumnIndex] = Single Item
@@ -572,8 +572,8 @@ for T in MULTICOLUMNINDEX_TUPLE
                                   col_inds::$T)
         idxs = index(df)[col_inds]
         if length(v) != length(idxs)
-            throw(DimensionMismatch("$(length(idxs)) columns were selected but the assigned" *
-                                    " collection contains $(length(v)) elements"))
+            throw(DimensionMismatch("$(length(idxs)) columns were selected but the assigned " *
+                                    "collection contains $(length(v)) elements"))
         end
         for (i, x) in zip(idxs, v)
             df[row_ind, i] = x
@@ -642,9 +642,9 @@ for T1 in (:AbstractVector, :Not, :Colon, :(typeof(!))),
                                   col_inds::$T2)
         idxs = index(df)[col_inds]
         if size(mx, 2) != length(idxs)
-            throw(DimensionMismatch("number of selected columns ($(length(idxs)))" *
-                                    " and number of columns in" *
-                                    " matrix ($(size(mx, 2))) do not match"))
+            throw(DimensionMismatch("number of selected columns ($(length(idxs))) " *
+                                    "and number of columns in " *
+                                    "matrix ($(size(mx, 2))) do not match"))
         end
         for (j, col) in enumerate(idxs)
             df[row_inds, col] = (row_inds === !) ? mx[:, j] : view(mx, :, j)
@@ -825,8 +825,8 @@ function insertcols!(df::DataFrame, col::Int=ncol(df)+1; makeunique::Bool=false,
     end
     if !isempty(name_cols)
         # an explicit error is thrown as keyword argument was supported in the past
-        throw(ArgumentError("inserting colums using a keyword argument is not supported," *
-                            " pass a Pair as a positional argument instead"))
+        throw(ArgumentError("inserting colums using a keyword argument is not supported, " *
+                            "pass a Pair as a positional argument instead"))
     end
     return df
 end
@@ -1317,15 +1317,15 @@ function Base.push!(df::DataFrame, row::Union{AbstractDict, NamedTuple};
                                 "is not allowed as it is unordered"))
         elseif length(row) != ncol(df) || any(x -> x[1] != x[2], zip(keys(row), _names(df)))
             throw(ArgumentError("when `cols == :orderequal` pushed row must " *
-                                "have the same column names and in the" *
-                                " same order as the target data frame"))
+                                "have the same column names and in the " *
+                                "same order as the target data frame"))
         end
     elseif cols === :setequal
         # Only check for equal lengths if :setequal is selected,
         # as an error will be thrown below if some names don't match
         if length(row) != ncols
             # an explicit error is thrown as this was allowed in the past
-            throw(ArgumentError("`push!` with `cols` equal to `:setequal`" *
+            throw(ArgumentError("`push!` with `cols` equal to `:setequal` " *
                                 "requires `row` to have the same number of elements " *
                                 "as the number of columns in `df`."))
         end
@@ -1479,10 +1479,10 @@ julia> push!(df, NamedTuple(), cols=:subset)
 function Base.push!(df::DataFrame, row::Any; promote::Bool=false)
     if !(row isa Union{Tuple, AbstractArray})
         # an explicit error is thrown as this was allowed in the past
-        throw(ArgumentError("`push!` does not allow passing collections of type" *
-                            " $(typeof(row)) to be pushed into a DataFrame. Only" *
-                            " `Tuple`, `AbstractArray`, `AbstractDict`, `DataFrameRow`" *
-                            " and `NamedTuple` are allowed."))
+        throw(ArgumentError("`push!` does not allow passing collections of type " *
+                            "$(typeof(row)) to be pushed into a DataFrame. Only " *
+                            "`Tuple`, `AbstractArray`, `AbstractDict`, `DataFrameRow` " *
+                            "and `NamedTuple` are allowed."))
     end
     nrows, ncols = size(df)
     targetrows = nrows + 1

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -231,8 +231,8 @@ for T in MULTICOLUMNINDEX_TUPLE
                                   col_inds::$(T))
         idxs = index(df)[col_inds]
         if length(v) != length(idxs)
-            throw(DimensionMismatch("$(length(idxs)) columns were selected but the assigned" *
-                                    " collection contains $(length(v)) elements"))
+            throw(DimensionMismatch("$(length(idxs)) columns were selected but the assigned " *
+                                    "collection contains $(length(v)) elements"))
         end
 
         if v isa AbstractDict
@@ -475,8 +475,8 @@ function Base.isless(r1::DataFrameRow, r2::DataFrameRow)
     if _names(r1) != _names(r2)
         mismatch = findfirst(i -> _names(r1)[i] != _names(r2)[i], 1:length(r1))
         throw(ArgumentError("compared DataFrameRows must have the same colum " *
-                            "names but they differ in column number $mismatch" *
-                            " where the names are :$(names(r1)[mismatch]) and " *
+                            "names but they differ in column number $mismatch " *
+                            "where the names are :$(names(r1)[mismatch]) and " *
                             ":$(_names(r2)[mismatch]) respectively"))
     end
     for (a,b) in zip(r1, r2)

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -40,8 +40,8 @@ function _combine_prepare(gd::GroupedDataFrame,
     if any(x -> x isa Pair && first(x) isa Tuple, cs_vec)
         x = cs_vec[findfirst(x -> first(x) isa Tuple, cs_vec)]
         # an explicit error is thrown as this was allowed in the past
-        throw(ArgumentError("passing a Tuple $(first(x)) as column selector is not supported" *
-                            ", use a vector $(collect(first(x))) instead"))
+        throw(ArgumentError("passing a Tuple $(first(x)) as column selector is not " *
+                            "supported, use a vector $(collect(first(x))) instead"))
     end
 
     cs_norm = []
@@ -226,8 +226,8 @@ function _combine_process_noop(cs_i::Pair{<:Union{Int, AbstractVector{Int}}, Pai
     source_cols = first(cs_i)
     out_col_name = last(last(cs_i))
     if length(source_cols) != 1
-        throw(ArgumentError("Exactly one column can be transformed to one output column" *
-                            " when using identity transformation"))
+        throw(ArgumentError("Exactly one column can be transformed to one output column " *
+                            "when using identity transformation"))
     end
     outcol = parentdf[!, first(source_cols)]
 

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -16,7 +16,7 @@ const MULTICOLUMNINDEX_TUPLE = (:AbstractVector, :Regex, :Not, :Between, :All, :
 
 const COLUMNINDEX_STR = "`Symbol`, string or integer"
 const MULTICOLUMNINDEX_STR = "`:`, `Cols`, `All`, `Between`, `Not`, a regular expression, " *
-                          "or a vector of `Symbol`s, strings or integers"
+                             "or a vector of `Symbol`s, strings or integers"
 
 struct Index <: AbstractIndex   # an OrderedDict would be nice here...
     lookup::Dict{Symbol, Int}      # name => names array position

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -15,8 +15,8 @@ const MultiColumnIndex = Union{AbstractVector, Regex, Not, Between, All, Cols, C
 const MULTICOLUMNINDEX_TUPLE = (:AbstractVector, :Regex, :Not, :Between, :All, :Cols, :Colon)
 
 const COLUMNINDEX_STR = "`Symbol`, string or integer"
-const MULTICOLUMNINDEX_STR = "`:`, `Cols`, `All`, `Between`, `Not`, a regular expression," *
-                          " or a vector of `Symbol`s, strings or integers"
+const MULTICOLUMNINDEX_STR = "`:`, `Cols`, `All`, `Between`, `Not`, a regular expression, " *
+                          "or a vector of `Symbol`s, strings or integers"
 
 struct Index <: AbstractIndex   # an OrderedDict would be nice here...
     lookup::Dict{Symbol, Int}      # name => names array position
@@ -46,8 +46,8 @@ function rename!(x::Index, nms::AbstractVector{Symbol}; makeunique::Bool=false)
         if length(unique(nms)) != length(nms)
             dup = unique(nms[nonunique(DataFrame(nms=nms))])
             dupstr = join(string.(':', dup), ", ", " and ")
-            msg = "Duplicate variable names: $dupstr. Pass makeunique=true" *
-                  " to make them unique using a suffix automatically."
+            msg = "Duplicate variable names: $dupstr. Pass makeunique=true " *
+                  "to make them unique using a suffix automatically."
             throw(ArgumentError(msg))
         end
     end
@@ -224,8 +224,8 @@ end
 
 @inline function Base.getindex(x::AbstractIndex, idx::AbstractVector{<:Integer})
     if any(v -> v isa Bool, idx)
-        throw(ArgumentError("Bool values except for AbstractVector{Bool} are not" *
-                            " allowed for column indexing"))
+        throw(ArgumentError("Bool values except for AbstractVector{Bool} are not " *
+                            "allowed for column indexing"))
     end
     return getindex(x, Vector{Int}(idx))
 end
@@ -318,8 +318,8 @@ function add_names(ind::Index, add_ind::AbstractIndex; makeunique::Bool=false)
     if length(dups) > 0
         if !makeunique
             dupstr = join(string.(':', unique(u[dups])), ", ", " and ")
-            msg = "Duplicate variable names: $dupstr. Pass makeunique=true" *
-                  " to make them unique using a suffix automatically."
+            msg = "Duplicate variable names: $dupstr. Pass makeunique=true " *
+                  "to make them unique using a suffix automatically."
             throw(ArgumentError(msg))
         end
     end

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -48,8 +48,8 @@ end
 
 Base.@propagate_inbounds function SubDataFrame(parent::DataFrame, rows::AbstractVector{Bool}, cols)
     if length(rows) != nrow(parent)
-        throw(ArgumentError("invalid length of `AbstractVector{Bool}` row index" *
-                            " (got $(length(rows)), expected $(nrow(parent)))"))
+        throw(ArgumentError("invalid length of `AbstractVector{Bool}` row index " *
+                            "(got $(length(rows)), expected $(nrow(parent)))"))
     end
     return SubDataFrame(parent, findall(rows), cols)
 end
@@ -150,11 +150,11 @@ Base.@propagate_inbounds Base.setindex!(sdf::SubDataFrame, val::Any, rowinds::Bo
     throw(ArgumentError("invalid row index of type Bool"))
 
 Base.setproperty!(::SubDataFrame, ::Symbol, ::Any) =
-    throw(ArgumentError("Replacing or adding of columns of a SubDataFrame is not allowed." *
+    throw(ArgumentError("Replacing or adding of columns of a SubDataFrame is not allowed. " *
                         "Instead use `df[:, col_ind] = v` or `df[:, col_ind] .= v` " *
                         "to perform an in-place assignment."))
 Base.setproperty!(::SubDataFrame, ::AbstractString, ::Any) =
-    throw(ArgumentError("Replacing or adding of columns of a SubDataFrame is not allowed." *
+    throw(ArgumentError("Replacing or adding of columns of a SubDataFrame is not allowed. " *
                         "Instead use `df[:, col_ind] = v` or `df[:, col_ind] .= v` " *
                         "to perform an in-place assignment."))
 


### PR DESCRIPTION
I wanted to fix this problems in error printing (missing space in both cases):
```
julia> df = DataFrame(a=1)
1×1 DataFrame
 Row │ a     
     │ Int64 
─────┼───────
   1 │     1

julia> push!(df, (a=1, b=2))
ERROR: ArgumentError: `push!` with `cols` equal to `:setequal`requires `row` to have the same number of elements as the number of columns in `df`.

julia> dfv = @view df[:, :]
1×1 SubDataFrame
 Row │ a     
     │ Int64 
─────┼───────
   1 │     1

julia> dfv.x = [1]
ERROR: ArgumentError: Replacing or adding of columns of a SubDataFrame is not allowed.Instead use `df[:, col_ind] = v` or `df[:, col_ind] .= v` to perform an in-place assignment.
```

So I also reviewed the whole source code to make sure that we always use a space at the end of the line when we break it.
+ I changed very long lines in `isapprox`.

This PR does not change anything from the functionality perspective.