### PR TITLE
Optional args style

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -300,7 +300,7 @@ rename(df::AbstractDataFrame, args...) = rename!(copy(df), args...)
 rename(f::Function, df::AbstractDataFrame) = rename!(f, copy(df))
 
 """
-    size(df::AbstractDataFrame, [dim])
+    size(df::AbstractDataFrame[, dim])
 
 Return a tuple containing the number of rows and columns of `df`.
 Optionally a dimension `dim` can be specified, where `1` corresponds to rows

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -1,5 +1,5 @@
 """
-    stack(df::AbstractDataFrame, [measure_vars], [id_vars];
+    stack(df::AbstractDataFrame [, measure_vars [, id_vars] ];
           variable_name=:variable, value_name=:value,
           view::Bool=false, variable_eltype::Type=String)
 

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -1,5 +1,5 @@
 """
-    stack(df::AbstractDataFrame [, measure_vars [, id_vars] ];
+    stack(df::AbstractDataFrame[, measure_vars[, id_vars] ];
           variable_name=:variable, value_name=:value,
           view::Bool=false, variable_eltype::Type=String)
 

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -415,7 +415,7 @@ function _show(io::IO,
 end
 
 """
-    show([io::IO,] df::AbstractDataFrame;
+    show([io::IO, ]df::AbstractDataFrame;
          allrows::Bool = !get(io, :limit, false),
          allcols::Bool = !get(io, :limit, false),
          allgroups::Bool = !get(io, :limit, false),

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -660,7 +660,7 @@ end
 ##############################################################################
 
 """
-    insertcols!(df::DataFrame, [col], (name=>val)::Pair...;
+    insertcols!(df::DataFrame[, col], (name=>val)::Pair...;
                 makeunique::Bool=false, copycols::Bool=true)
 
 Insert a column into a data frame in place. Return the updated `DataFrame`.

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -318,7 +318,7 @@ end
 Base.view(r::DataFrameRow, ::Colon) = r
 
 """
-    size(dfr::DataFrameRow, [dim])
+    size(dfr::DataFrameRow[, dim])
 
 Return a 1-tuple containing the number of elements of `dfr`.
 If an optional dimension `dim` is specified, it must be `1`, and the number of


### PR DESCRIPTION
This is the second of 3 PRs replacing #2488 now that the big reorg has happened. These should not change or add any functionality, but are instead intended to unify some style conventions.

Here, I deal with optional arguments in docstrings. There isn't a strong convention here - I looked through Base docstrings, and their style is inconsistent as well. One thing that does seem consistent is that multiple optional arguments have nested brackets, eg `[, opt1[, opt2] ]`. There aren't many examples in this package, but the principle I went with is that everything that is optional (including separators and spaces) should be inside brackets. So eg

```
foo(required[, opt])
bar([opt, ]required)
```

For multiple optional args, I did the same thing, with nested brackets. One thing that may or may not be controversial is that I put spaces between closing brackets.

```
baz(required[, opt1[, opt2] ])
```

There are examples and counterexamples of all of these things in Base, and I could not find a style guide that specifies ([here's the section](https://github.com/invenia/BlueStyle#documentation) in blue style as example).

