### PR TITLE
Zero after decimal

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,3 +58,5 @@ Thanks for taking the plunge!
 * Don't explicitly parameterize types unless it's necessary
 * Never leave things without type qualifications. Use an explicit `::Any`.
 * Order method definitions from most specific to least specific type constraints
+* Always include a digit after decimal when writing a float, e.g. `[1.0, 2.0]`
+  rather than `[1., 2.]`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,3 +60,5 @@ Thanks for taking the plunge!
 * Order method definitions from most specific to least specific type constraints
 * Always include a digit after decimal when writing a float, e.g. `[1.0, 2.0]`
   rather than `[1., 2.]`
+* In docstrings, optional arguments, including separators and spaces, are surrounded by brackets,
+  e.g. `mymethod(required[, optional1[, optional2] ]; kwargs...)`

--- a/docs/src/man/querying_frameworks.md
+++ b/docs/src/man/querying_frameworks.md
@@ -32,7 +32,7 @@ names of columns using only their names and that chaining is performed using the
 julia> using DataFrames, DataFramesMeta
 
 julia> df = DataFrame(name=["John", "Sally", "Roger"],
-                      age=[54., 34., 79.],
+                      age=[54.0, 34.0, 79.0],
                       children=[0, 2, 4])
 3×3 DataFrame
  Row │ name    age      children
@@ -138,7 +138,7 @@ A simple example of a query looks like this:
 julia> using DataFrames, Query
 
 julia> df = DataFrame(name=["John", "Sally", "Roger"],
-                      age=[54., 34., 79.],
+                      age=[54.0, 34.0, 79.0],
                       children=[0, 2, 4])
 3×3 DataFrame
  Row │ name    age      children

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -625,7 +625,7 @@ end
     @test_throws ArgumentError permutedims(df3[!, [:a]], 1) # single column branch
     @test names(permutedims(df3[!, [:a]], 1, makeunique=true)) == d3pd_names
 
-    df4 = DataFrame(a=rand(2), b=rand(2), c=[1, 2], d=[1., missing],
+    df4 = DataFrame(a=rand(2), b=rand(2), c=[1, 2], d=[1.0, missing],
                     e=["x", "y"], f=[:x, :y], # valid src
                     g=[missing, "y"], h=Union{Missing, String}["x", "y"] # invalid src
                     )

--- a/test/show.jl
+++ b/test/show.jl
@@ -506,11 +506,11 @@ end
 end
 
 @testset "Floating point alignment" begin
-    df = DataFrame(a = [i == 2 ? missing : 10^i for i = -7:1.:7],
+    df = DataFrame(a = [i == 2 ? missing : 10^i for i = -7:1.0:7],
                    b = Int64.(1:1:15),
                    c = [i % 2 == 0 for i = 1:15],
-                   d = [i == 2 ? "test" : 10^i for i = -7:1.:7],
-                   e = [i == 2 ? -0.0 : i == 3 ? +0.0 : 10^i for i = -7:1.:7])
+                   d = [i == 2 ? "test" : 10^i for i = -7:1.0:7],
+                   e = [i == 2 ? -0.0 : i == 3 ? +0.0 : 10^i for i = -7:1.0:7])
 
     io = IOBuffer()
     show(io, df)
@@ -573,7 +573,7 @@ end
 
     df = DataFrame(This_is_a_very_big_name = [10.0^i for i = -5:1:5],
                    This_is_smaller = 1.0:2:22,
-                   T = 100001:1.:100011)
+                   T = 100001:1.0:100011)
 
     io = IOBuffer()
     show(io, df)

--- a/test/tabletraits.jl
+++ b/test/tabletraits.jl
@@ -9,11 +9,11 @@ TableTraits.supports_get_columns_copy_using_missing(::ColumnSource) = true
 TableTraits.isiterabletable(::ColumnSource) = true
 
 function TableTraits.get_columns_copy_using_missing(x::ColumnSource)
-    return (a=[1,2,3], b=[4.,5.,6.], c=["A", "B", "C"])
+    return (a=[1,2,3], b=[4.0,5.0,6.0], c=["A", "B", "C"])
 end
 
 @testset "TableTraits" begin
-    df = DataFrame(a=[1,2,3], b=[1.,missing,3.])
+    df = DataFrame(a=[1,2,3], b=[1.0,missing,3.0])
     @test IteratorInterfaceExtensions.isiterable(df)
     @test TableTraits.isiterabletable(df)
     @test collect(IteratorInterfaceExtensions.getiterator(df)) ==
@@ -28,7 +28,7 @@ end
 
     @test size(df)==(3,3)
     @test df.a==[1,2,3]
-    @test df.b==[4.,5.,6.]
+    @test df.b==[4.0,5.0,6.0]
     @test df.c==["A", "B", "C"]
 end
 


### PR DESCRIPTION
This is the third of 3 PRs replacing #2488 now that the big reorg has happened. These should not change or add any functionality, but are instead intended to unify some style conventions.

Here, I add zeros after decimals when floats are manually written. These were found by doing find/replace for `(\d)\.(\D)` => `$1.0$2`, though I had to manually go through and accept the replacements because there are a lot of things like `df1.col`.

In addition, this PR includes addition to `CONTRIBUTING.md` for #2547 