### PR TITLE
Add link to CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ DataFrames.jl
 =============
 
 [![Coverage Status](http://codecov.io/github/JuliaData/DataFrames.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaData/DataFrames.jl?branch=master)
-![CI Testing](https://github.com/JuliaData/DataFrames.jl/workflows/CI/badge.svg)
+[![CI Testing](https://github.com/JuliaData/DataFrames.jl/workflows/CI/badge.svg)](https://github.com/JuliaData/DataFrames.jl/actions?query=workflow%3ACI+branch%3Amaster)
 
 Tools for working with tabular data in Julia.
 


### PR DESCRIPTION
Not sure whether that's the best link but I couldn't find one in the official documentation.

(I've canceled CI.)