### PR TITLE
Improve inference in `vcat`

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1552,16 +1552,10 @@ function Base.reduce(::typeof(vcat),
                                 Tuple{Vararg{AbstractDataFrame}}};
                      cols::Union{Symbol, AbstractVector{Symbol},
                      AbstractVector{<:AbstractString}}=:setequal)
-    isempty(dfs) && return _vcat(AbstractDataFrame[]; cols=cols)
-    DF = eltype(dfs)
-    if isconcretetype(DF)
-        return _vcat(DF[df for df in dfs if ncol(df) != 0]; cols=cols)
-    else
-        return _vcat(AbstractDataFrame[df for df in dfs if ncol(df) != 0]; cols=cols)
-    end
+    return _vcat(AbstractDataFrame[df for df in dfs if ncol(df) != 0]; cols=cols)
 end
 
-function _vcat(dfs::AbstractVector{<:AbstractDataFrame};
+function _vcat(dfs::AbstractVector{AbstractDataFrame};
                cols::Union{Symbol, AbstractVector{Symbol},
                            AbstractVector{<:AbstractString}}=:setequal)
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1547,16 +1547,24 @@ Base.vcat(dfs::AbstractDataFrame...;
                       AbstractVector{<:AbstractString}}=:setequal) =
     reduce(vcat, dfs; cols=cols)
 
-function Base.reduce(::typeof(vcat),
-            dfs::Union{AbstractVector{DF},
-                       Tuple{Vararg{DF}}};
-            cols::Union{Symbol, AbstractVector{Symbol},
-                        AbstractVector{<:AbstractString}}=:setequal) where DF<:AbstractDataFrame
-    if @isdefined(DF) && isconcretetype(DF)
-        return _vcat(DF[df for df in dfs if ncol(df) != 0]; cols=cols)
-    else
-        return _vcat(AbstractDataFrame[df for df in dfs if ncol(df) != 0]; cols=cols)
+if Base.VERSION >= v"1.5"
+    function Base.reduce(::typeof(vcat),
+                         dfs::Union{AbstractVector{DF},Tuple{Vararg{DF}}};
+                         cols::Union{Symbol, AbstractVector{Symbol},
+                                     AbstractVector{<:AbstractString}}=:setequal) where DF<:AbstractDataFrame
+        if @isdefined(DF) && isconcretetype(DF)
+            return _vcat(DF[df for df in dfs if ncol(df) != 0]; cols=cols)
+        else
+            return _vcat(AbstractDataFrame[df for df in dfs if ncol(df) != 0]; cols=cols)
+        end
     end
+else
+    Base.reduce(::typeof(vcat),
+                dfs::Union{AbstractVector{<:AbstractDataFrame},
+                           Tuple{Vararg{AbstractDataFrame}}};
+                cols::Union{Symbol, AbstractVector{Symbol},
+                AbstractVector{<:AbstractString}}=:setequal) =
+        _vcat([df for df in dfs if ncol(df) != 0]; cols=cols)
 end
 
 function _vcat(dfs::AbstractVector{<:AbstractDataFrame};

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1547,24 +1547,18 @@ Base.vcat(dfs::AbstractDataFrame...;
                       AbstractVector{<:AbstractString}}=:setequal) =
     reduce(vcat, dfs; cols=cols)
 
-if Base.VERSION >= v"1.5"
-    function Base.reduce(::typeof(vcat),
-                         dfs::Union{AbstractVector{DF},Tuple{Vararg{DF}}};
-                         cols::Union{Symbol, AbstractVector{Symbol},
-                                     AbstractVector{<:AbstractString}}=:setequal) where DF<:AbstractDataFrame
-        if @isdefined(DF) && isconcretetype(DF)
-            return _vcat(DF[df for df in dfs if ncol(df) != 0]; cols=cols)
-        else
-            return _vcat(AbstractDataFrame[df for df in dfs if ncol(df) != 0]; cols=cols)
-        end
+function Base.reduce(::typeof(vcat),
+                     dfs::Union{AbstractVector{<:AbstractDataFrame},
+                                Tuple{Vararg{AbstractDataFrame}}};
+                     cols::Union{Symbol, AbstractVector{Symbol},
+                     AbstractVector{<:AbstractString}}=:setequal)
+    isempty(dfs) && return _vcat(AbstractDataFrame[]; cols=cols)
+    DF = eltype(dfs)
+    if isconcretetype(DF)
+        return _vcat(DF[df for df in dfs if ncol(df) != 0]; cols=cols)
+    else
+        return _vcat(AbstractDataFrame[df for df in dfs if ncol(df) != 0]; cols=cols)
     end
-else
-    Base.reduce(::typeof(vcat),
-                dfs::Union{AbstractVector{<:AbstractDataFrame},
-                           Tuple{Vararg{AbstractDataFrame}}};
-                cols::Union{Symbol, AbstractVector{Symbol},
-                AbstractVector{<:AbstractString}}=:setequal) =
-        _vcat([df for df in dfs if ncol(df) != 0]; cols=cols)
 end
 
 function _vcat(dfs::AbstractVector{<:AbstractDataFrame};

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1023,7 +1023,7 @@ end
 
 _filter_helper(f, cols...)::BitVector = ((x...) -> f(x...)::Bool).(cols...)
 
-@inline function Base.filter((cols, f)::Pair{<:AsTable}, df::AbstractDataFrame;
+@inline function Base.filter((cols, f)::Pair{AsTable}, df::AbstractDataFrame;
                              view::Bool=false)
     df_tmp = select(df, cols.cols, copycols=false)
     if ncol(df_tmp) == 0

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1549,7 +1549,7 @@ Base.vcat(dfs::AbstractDataFrame...;
 
 function Base.reduce(::typeof(vcat),
                      dfs::Union{AbstractVector{<:AbstractDataFrame},
-                                Tuple{Vararg{AbstractDataFrame}}};
+                                Tuple{AbstractDataFrame, Vararg{AbstractDataFrame}}};
                      cols::Union{Symbol, AbstractVector{Symbol},
                      AbstractVector{<:AbstractString}}=:setequal)
     return _vcat(AbstractDataFrame[df for df in dfs if ncol(df) != 0]; cols=cols)

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -484,7 +484,7 @@ function prepare_idx_keeprows(idx::AbstractVector{<:Integer},
 end
 
 function _combine(gd::GroupedDataFrame,
-                  @nospecialize(cs_norm::Vector{Any}), optional_transform::Vector{Bool},
+                  cs_norm::Vector{Any}, optional_transform::Vector{Bool},
                   copycols::Bool, keeprows::Bool, renamecols::Bool)
     if isempty(cs_norm)
         if keeprows && nrow(parent(gd)) > 0 && minimum(gd.groups) == 0

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -422,7 +422,7 @@ Base.@propagate_inbounds SubIndex(parent::AbstractIndex, cols) =
     SubIndex(parent, parent[cols])
 
 Base.length(x::SubIndex) = length(x.cols)
-Base.names(x::SubIndex) = string.(_names(x))
+Base.names(x::SubIndex) = string.(_names(x))::Vector{String}
 _names(x::SubIndex) = view(_names(x.parent), x.cols)
 
 function Base.haskey(x::SubIndex, key::Symbol)


### PR DESCRIPTION
Master:
```julia
julia> @time include("cat.jl")
Test Summary: | Pass  Total
...
 13.921540 seconds (30.55 M allocations: 1.835 GiB, 3.81% gc time, 97.72% compilation time)
```

This PR:
```julia
 12.296551 seconds (28.88 M allocations: 1.728 GiB, 3.05% gc time, 97.42% compilation time)
```

This is of course from a fresh session in both cases, and all the gains are to inference time on first use.

The idea is that improvements in inference quality let your precompile statements do you more good because they reach deeper into the call stack. It may be helpful to outline some of the principles that guide these changes:
- the change to `reduce` tries to "standardize" the types that get passed to `_vcat`; any `DF` that is fully concrete can be specialized, otherwise we standardize on `AbstractDataFrame` (which is already used in some places) as the fallback. This reduces the number of times you have to infer `_vcat` for abstract types.
- `_vcat` had some inference problems from the infamous julia#15276
- methods that get called for `AbstractDataFrame` are likely to return poorly-inferred types (they may be well-inferred for any concrete subtype, but poorly inferred for the abstract type). However, in some cases you can fix them, as exemplified by annotating the return type of `names`. This stabilizes a lot of `_vcat`'s body when `dfs::Vector{AbstractDataFrame}`.

There is one part of `_vcat` that is still poorly inferred: https://github.com/JuliaData/DataFrames.jl/blob/8645651e30785fbedca82a9f125d21d1f27a726e/src/abstractdataframe/abstractdataframe.jl#L1617-L1623

Basically anything that uses `newcols` is uninferrable. I didn't know enough to fix it. However, if that `Iterators.repeated` is just going to be expanded to a `Vector{Missing}` anyway (I'm not sure it will), then just writing it in terms of `fill` instead might fix it. Another option would be to annotate the type of `newcols` itself, or to annotate `lens` as a `Vector{Int}`. However, I expect these to be relatively minor gains.

I discovered these through a combination of `@snoopi`,`@snoopi_deep` (which still needs documentation), and of course Cthulhu (which sadly seems to have broken on 1.6 in the last few days, see https://github.com/JuliaDebug/Cthulhu.jl/issues/100. For the moment one has to diagnose problems on 1.5 and analyze the impact of improvements on 1.6).