### PR TITLE
Split methods to reduce compile cost of argument diversity

### DIFF
--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -37,6 +37,16 @@ function _combine_prepare(gd::GroupedDataFrame,
             push!(cs_vec, p)
         end
     end
+    return _combine_prepare(gd, cs_vec, keepkeys, ungroup, copycols, keeprows, renamecols)
+end
+
+# This is split from the above to reduce the argument type-diversity and thus the need for multiple inference
+# specialization of the bulk of the method. (@nospecialize only directly affects codegen, not the running of inference,
+# although it can indirectly affect inference by eliminating specialization of call sites.)
+function _combine_prepare(gd::GroupedDataFrame,
+                          cs_vec::Vector{Any},
+                          keepkeys::Bool, ungroup::Bool, copycols::Bool,
+                          keeprows::Bool, renamecols::Bool)
     if any(x -> x isa Pair && first(x) isa Tuple, cs_vec)
         x = cs_vec[findfirst(x -> first(x) isa Tuple, cs_vec)]
         # an explicit error is thrown as this was allowed in the past


### PR DESCRIPTION
The cost of compilation is very roughly proportional to the product
"method complexity" * "number of specializations." Reducing either
factor can therefore reduce compile latency. This splits five methods:

- _combine_with_first
- _combine_rows_with_first
- _combine_tables_with_first
- groupreduce!
- _combine_prepare

into two pieces, one of which receives lower argument diversity and thus
has fewer specializations. The remaining piece is therefore smaller
and thus has lower "method complexity." Together these changes reduce
the time needed to run the "grouping.jl" test file by about 15%,
from 283s to 248s.

There might be even better ways to do this (e.g., refactor so that
argument diversity is reduced at an early stage in the call chain),
but as a neophyte unfamiliar with the package internals this seemed
like a safe and easy way to make improvements, with the only cost being
a slight "uglification."

--------------------

This is one of the steps (#2559 was another) in a [blog post](https://github.com/JuliaLang/www.julialang.org/pull/1093) I'm working on describing new tools in Julia 1.6 and SnoopCompile to diagnose and address sources of compiler latency (direct link to preview: https://julialang.netlify.app/previews/pr1093/blog/2020/12/package_latency/). This is different from, but complementary to, the invalidations work. I hope you don't mind being used as a guinea pig; some of the reasons why I chose DataFrames are described in the blog.

There will be one or two more PRs that I'll submit later. 