### PR TITLE
Avoid performance bottleneck corner case in grouping

### DIFF
--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -120,7 +120,7 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     @assert groups === nothing || length(groups) == length(cols[1])
     rhashes, missings = hashrows(cols, skipmissing)
     # inspired by Dict code from base cf. https://github.com/JuliaData/DataTables.jl/pull/17#discussion_r102481481
-    # but using open addressing with a table with as many slots as rows times 5/4 to avoid performance degradation
+    # but using open addressing with a table with 5/4 as many slots as rows to avoid performance degradation
     # in a corner case of groups having exactly one row
     sz = Base._tablesz((length(rhashes) * 5) >> 2)
     @assert sz >= length(rhashes)

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -123,7 +123,7 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     # but using open addressing with a table with at least 5/4 as many slots as rows
     # (rounded up to nearest power of 2) to avoid performance degradation
     # in a corner case of groups having exactly one row
-    sz = max((5 * length(rhashes)) >> 2, 16)
+    sz = max(1 + ((5 * length(rhashes)) >> 2), 16)
     sz = 1 << (8 * sizeof(sz) - leading_zeros(sz - 1))
     @assert 4 * sz >= 5 * length(rhashes)
     szm1 = sz-1

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -120,7 +120,8 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     @assert groups === nothing || length(groups) == length(cols[1])
     rhashes, missings = hashrows(cols, skipmissing)
     # inspired by Dict code from base cf. https://github.com/JuliaData/DataTables.jl/pull/17#discussion_r102481481
-    # but using open addressing with a table with 5/4 as many slots as rows to avoid performance degradation
+    # but using open addressing with a table with at least 5/4 as many slots as rows
+    # (rounded up to nearest power of 2) to avoid performance degradation
     # in a corner case of groups having exactly one row
     sz = max((5 * length(rhashes)) >> 4, 16)
     sz = 1 << (8 * sizeof(sz) - leading_zeros(sz - 1))

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -120,8 +120,9 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     @assert groups === nothing || length(groups) == length(cols[1])
     rhashes, missings = hashrows(cols, skipmissing)
     # inspired by Dict code from base cf. https://github.com/JuliaData/DataTables.jl/pull/17#discussion_r102481481
-    # but using open addressing with a table with as many slots as rows
-    sz = Base._tablesz(length(rhashes))
+    # but using open addressing with a table with as many slots as rows times 5/4 to avoid performance degradation
+    # in a corner case of groups having exactly one row
+    sz = Base._tablesz((length(rhashes) * 5) >> 2)
     @assert sz >= length(rhashes)
     szm1 = sz-1
     gslots = zeros(Int, sz)

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -122,7 +122,8 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     # inspired by Dict code from base cf. https://github.com/JuliaData/DataTables.jl/pull/17#discussion_r102481481
     # but using open addressing with a table with 5/4 as many slots as rows to avoid performance degradation
     # in a corner case of groups having exactly one row
-    sz = Base._tablesz((length(rhashes) * 5) >> 2)
+    sz = max((5 * length(rhashes)) >> 4, 16)
+    sz = 1 << (8 * sizeof(sz) - leading_zeros(sz - 1))
     @assert sz >= length(rhashes)
     szm1 = sz-1
     gslots = zeros(Int, sz)

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -123,9 +123,9 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
     # but using open addressing with a table with at least 5/4 as many slots as rows
     # (rounded up to nearest power of 2) to avoid performance degradation
     # in a corner case of groups having exactly one row
-    sz = max((5 * length(rhashes)) >> 4, 16)
+    sz = max((5 * length(rhashes)) >> 2, 16)
     sz = 1 << (8 * sizeof(sz) - leading_zeros(sz - 1))
-    @assert sz >= length(rhashes)
+    @assert 4 * sz >= 5 * length(rhashes)
     szm1 = sz-1
     gslots = zeros(Int, sz)
     # If missings are to be skipped, they will all go to group 0,


### PR DESCRIPTION
Fixes #2591 

I ended up adding 5/4 (and not 9/8) multiplier based on the following benchmark. But the difference is not big, so we can also do 9/8.

5/4 timings
```
julia> using DataFrames

julia> df = DataFrame(value=[string(i) for i in 1:2^24+1]);

julia> @time groupby(df, :value);
  1.740594 seconds (31 allocations: 512.002 MiB, 24.71% gc time)

julia> let sub_df = df[1:end-1, :]
               @time groupby(sub_df, :value)
              end;
  1.266897 seconds (31 allocations: 512.002 MiB)

julia> for mul in 17/16:1/16:3/2
           let sub_df = df[1:trunc(Int, nrow(df)/mul), :]
                   @info mul
                   @time groupby(sub_df, :value)
                  end;
       end
[ Info: 1.0625
  1.624300 seconds (31 allocations: 496.943 MiB, 28.38% gc time)
[ Info: 1.125
  1.341545 seconds (31 allocations: 483.558 MiB, 19.32% gc time)
[ Info: 1.1875
  1.008878 seconds (31 allocations: 471.581 MiB)
[ Info: 1.25
  1.943192 seconds (31 allocations: 332.802 MiB, 6.48% gc time)
[ Info: 1.3125
  1.519996 seconds (31 allocations: 323.050 MiB)
[ Info: 1.375
  1.393743 seconds (31 allocations: 314.184 MiB, 4.65% gc time)
[ Info: 1.4375
  1.318744 seconds (31 allocations: 306.089 MiB, 9.39% gc time)
[ Info: 1.5
  1.054291 seconds (31 allocations: 298.669 MiB)
```

9/8 timings:
```
julia> using DataFrames

julia> df = DataFrame(value=[string(i) for i in 1:2^24+1]);

julia> @time groupby(df, :value);
  1.814414 seconds (31 allocations: 512.002 MiB, 27.04% gc time)

julia> let sub_df = df[1:end-1, :]
               @time groupby(sub_df, :value)
              end;
  1.618591 seconds (31 allocations: 512.002 MiB, 20.38% gc time)

julia> for mul in 17/16:1/16:3/2
           let sub_df = df[1:trunc(Int, nrow(df)/mul), :]
                   @info mul
                   @time groupby(sub_df, :value)
                  end;
       end
[ Info: 1.0625
  1.186058 seconds (31 allocations: 496.943 MiB)
[ Info: 1.125
  3.625120 seconds (31 allocations: 355.558 MiB, 13.12% gc time)
[ Info: 1.1875
  2.275897 seconds (31 allocations: 343.581 MiB)
[ Info: 1.25
  1.947091 seconds (31 allocations: 332.802 MiB, 6.55% gc time)
[ Info: 1.3125
  1.541772 seconds (31 allocations: 323.050 MiB)
[ Info: 1.375
  1.438355 seconds (31 allocations: 314.184 MiB, 5.16% gc time)
[ Info: 1.4375
  1.186710 seconds (31 allocations: 306.089 MiB)
[ Info: 1.5
  1.086378 seconds (31 allocations: 298.669 MiB)
```

performance on `main`:
```
julia> using DataFrames

julia> df = DataFrame(value=[string(i) for i in 1:2^24+1]);

julia> @time groupby(df, :value);
  1.719748 seconds (31 allocations: 512.002 MiB, 25.06% gc time)

julia> # commented out as it does not finish in any reasonable time
       # let sub_df = df[1:end-1, :]
       #        @time groupby(sub_df, :value)
       #       end;
       for mul in 17/16:1/16:3/2
           let sub_df = df[1:trunc(Int, nrow(df)/mul), :]
                   @info mul
                   @time groupby(sub_df, :value)
                  end;
       end
[ Info: 1.0625
  5.628504 seconds (31 allocations: 368.943 MiB)
[ Info: 1.125
  3.342812 seconds (31 allocations: 355.558 MiB, 7.32% gc time)
[ Info: 1.1875
  2.371484 seconds (31 allocations: 343.581 MiB, 5.72% gc time)
[ Info: 1.25
  1.802911 seconds (31 allocations: 332.802 MiB)
[ Info: 1.3125
  1.538709 seconds (31 allocations: 323.050 MiB)
[ Info: 1.375
  1.386885 seconds (31 allocations: 314.184 MiB, 3.95% gc time)
[ Info: 1.4375
  1.202291 seconds (31 allocations: 306.089 MiB)
[ Info: 1.5
  1.223126 seconds (31 allocations: 298.669 MiB, 12.36% gc time)
```