### PR TITLE
add firstindex check and fix a bug in mapcols!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
 
 ## Bug fixes
 
+* DataFrames.jl now checks that passed columns are 1-based as this is a current
+  design assumption; `mapcols!` makes sure not to create columns being
+  `AbstractRange` consistently with other methods that add columns to a `DataFrame`
+  ([#2594](https://github.com/JuliaData/DataFrames.jl/pull/2594))
+
 ## New functionalities
 
 * `firstindex`, `lastindex`, `size`, `ndims`, and `axes` are now consistently defined

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,8 +7,9 @@
 ## Bug fixes
 
 * DataFrames.jl now checks that passed columns are 1-based as this is a current
-  design assumption; `mapcols!` makes sure not to create columns being
-  `AbstractRange` consistently with other methods that add columns to a `DataFrame`
+  design assumption ([#2594](https://github.com/JuliaData/DataFrames.jl/pull/2594))
+* `mapcols!` makes sure not to create columns being `AbstractRange` consistently
+  with other methods that add columns to a `DataFrame`
   ([#2594](https://github.com/JuliaData/DataFrames.jl/pull/2594))
 
 ## New functionalities

--- a/Project.toml
+++ b/Project.toml
@@ -52,4 +52,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
 test = ["Combinatorics", "DataStructures", "DataValues", "Dates", "Logging",
-        "OffsetArrays", Random", "Test", "Unitful"]
+        "OffsetArrays", "Random", "Test", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -45,9 +45,11 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DataValues = "e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Combinatorics", "DataStructures", "DataValues", "Dates", "Logging", "Random", "Test", "Unitful"]
+test = ["Combinatorics", "DataStructures", "DataValues", "Dates", "Logging",
+        "OffsetArrays", Random", "Test", "Unitful"]

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -16,7 +16,9 @@ It is not intended as a fully generic interface for working with tabular data, w
 interfaces defined by [Tables.jl](https://github.com/JuliaData/Tables.jl/) instead.
 
 `DataFrame` is the most fundamental subtype of `AbstractDataFrame`, which stores a set of columns
-as `AbstractVector` objects.
+as `AbstractVector` objects. Indexing of all stored columns must be 1-based. Also, all functions
+exposed by DataFrames.jl API make sure to `collect` passed `AbstractRange` source columns before
+storing them in a `DataFrame`.
 
 `SubDataFrame` is an `AbstractDataFrame` subtype representing a view into a `DataFrame`.
 It stores only a reference to the parent `DataFrame` and information about which rows and columns

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -456,8 +456,7 @@ function mapcols!(f::Union{Function, Type}, df::DataFrame)
     end
 
     for (i, col) in enumerate(vs)
-        fic = firstindex(col)
-        fic != 1 && _onebased_check_error(i, fic)
+        firstindex(col) != 1 && _onebased_check_error(i, col)
     end
 
     @assert length(vs) == ncol(df)

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -440,7 +440,7 @@ function mapcols!(f::Union{Function, Type}, df::DataFrame)
                 throw(ArgumentError("mixing scalars and vectors in mapcols not allowed"))
             end
             seenvector = true
-            push!(vs, fv)
+            push!(vs, fv isa AbstractRange ? collect(fv) : fv)
         else
             if seenvector
                 throw(ArgumentError("mixing scalars and vectors in mapcols not allowed"))
@@ -454,6 +454,16 @@ function mapcols!(f::Union{Function, Type}, df::DataFrame)
     if len_min != len_max
         throw(DimensionMismatch("lengths of returned vectors must be identical"))
     end
+
+    for (i, col) in enumerate(vs)
+        fic = firstindex(col)
+        if fic != 1
+            throw(ArgumentError("Currently DataFrames.jl supports only " *
+                                "columns that use 1-based indexing and " *
+                                "column $i has starting index equal to $fic"))
+        end
+    end
+
     _columns(df) .= vs
 
     return df

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -457,14 +457,14 @@ function mapcols!(f::Union{Function, Type}, df::DataFrame)
 
     for (i, col) in enumerate(vs)
         fic = firstindex(col)
-        if fic != 1
-            throw(ArgumentError("Currently DataFrames.jl supports only " *
-                                "columns that use 1-based indexing and " *
-                                "column $i has starting index equal to $fic"))
-        end
+        fic != 1 && _onebased_check_error(i, fic)
     end
 
-    _columns(df) .= vs
+    @assert length(vs) == ncol(df)
+    raw_columns = _columns(df)
+    for i in 1:ncol(df)
+        raw_columns[i] = vs[i]
+    end
 
     return df
 end

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -415,10 +415,7 @@ function _fix_existing_columns_for_vector(newdf::DataFrame, df::AbstractDataFram
         newdfcols = _columns(newdf)
         for (i, col) in enumerate(newdfcols)
             newcol = fill!(similar(col, lr), first(col))
-            if firstindex(newcol) != 1
-                throw(ArgumentError("Currently DataFrames.jl supports only " *
-                                    "columns that use 1-based indexing"))
-            end
+            firstindex(newcol) != 1 && _onebased_check_error()
             newdfcols[i] = newcol
         end
     end
@@ -1277,10 +1274,7 @@ function _manipulate(df::AbstractDataFrame, @nospecialize(normalized_cs), copyco
                         newdfcols = _columns(newdf)
                         for (i, col) in enumerate(newdfcols)
                             newcol = fill!(similar(col, nrow(df)), first(col))
-                            if firstindex(newcol) != 1
-                                throw(ArgumentError("Currently DataFrames.jl supports only " *
-                                                    "columns that use 1-based indexing"))
-                            end
+                            firstindex(newcol) != 1 && _onebased_check_error()
                             newdfcols[i] = newcol
                         end
                     end

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -414,7 +414,12 @@ function _fix_existing_columns_for_vector(newdf::DataFrame, df::AbstractDataFram
     if allow_resizing_newdf[] && nrow(newdf) == 1
         newdfcols = _columns(newdf)
         for (i, col) in enumerate(newdfcols)
-            newdfcols[i] = fill!(similar(col, lr), first(col))
+            newcol = fill!(similar(col, lr), first(col))
+            if firstindex(newcol) != 1
+                throw(ArgumentError("Currently DataFrames.jl supports only " *
+                                    "columns that use 1-based indexing"))
+            end
+            newdfcols[i] = newcol
         end
     end
     # !allow_resizing_newdf[] && ncol(newdf) == 0
@@ -1271,7 +1276,12 @@ function _manipulate(df::AbstractDataFrame, @nospecialize(normalized_cs), copyco
                     if allow_resizing_newdf[] && nrow(newdf) == 1
                         newdfcols = _columns(newdf)
                         for (i, col) in enumerate(newdfcols)
-                            newdfcols[i] = fill!(similar(col, nrow(df)), first(col))
+                            newcol = fill!(similar(col, nrow(df)), first(col))
+                            if firstindex(newcol) != 1
+                                throw(ArgumentError("Currently DataFrames.jl supports only " *
+                                                    "columns that use 1-based indexing"))
+                            end
+                            newdfcols[i] = newcol
                         end
                     end
                     # here even if keeprows is true all is OK

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -383,7 +383,7 @@ index(df::DataFrame) = getfield(df, :colindex)
 # make sure that:
 # 1. `AbstractRange` columns are not added to a `DataFrame`
 # 2. all inserted columns use 1-based indexing
-# 3. that after several mutating operations on the vector are performed
+# 3. after several mutating operations on the vector are performed
 #    each element (column) has the same length
 # 4. if length of the vector is changed that the index of the `DataFrame`
 #    is adjusted appropriately
@@ -394,7 +394,7 @@ _onebased_check_error() =
                         "that use 1-based indexing"))
 _onebased_check_error(i, fic) =
     throw(ArgumentError("Currently DataFrames.jl supports only " *
-                        "columns that use 1-based indexing and " *
+                        "columns that use 1-based indexing, but " *
                         "column $i has starting index equal to $fic"))
 
 # note: these type assertions are required to pass tests

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -79,6 +79,9 @@ always collected to a `Vector` (even if `copycols=false`). As a general rule
 `AbstractRange` values are always materialized to a `Vector` by all functions in
 DataFrames.jl before being stored in a `DataFrame`.
 
+`DataFrame` can store only columns that use 1-based indexing. Attempting
+to store a vector using non-standard indexing raises an error.
+
 The `DataFrame` type is designed to allow column types to vary and to be
 dynamically changed also after it is constructed. Therefore `DataFrame`s are not
 type stable. For performance-critical code that requires type-stability either

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -209,8 +209,7 @@ struct DataFrame <: AbstractDataFrame
         end
 
         for (i, col) in enumerate(columns)
-            fic = firstindex(col)
-            fic != 1 && _onebased_check_error(i, fic)
+            firstindex(col) != 1 && _onebased_check_error(i, col)
         end
 
         new(convert(Vector{AbstractVector}, columns), colindex)
@@ -392,10 +391,10 @@ _columns(df::DataFrame) = getfield(df, :columns)
 _onebased_check_error() =
     throw(ArgumentError("Currently DataFrames.jl supports only columns " *
                         "that use 1-based indexing"))
-_onebased_check_error(i, fic) =
+_onebased_check_error(i, col) =
     throw(ArgumentError("Currently DataFrames.jl supports only " *
                         "columns that use 1-based indexing, but " *
-                        "column $i has starting index equal to $fic"))
+                        "column $i has starting index equal to $(firstindex(col))"))
 
 # note: these type assertions are required to pass tests
 nrow(df::DataFrame) = ncol(df) > 0 ? length(_columns(df)[1])::Int : 0
@@ -418,8 +417,7 @@ function _check_consistency(df::DataFrame)
     cols, idx = _columns(df), index(df)
 
     for (i, col) in enumerate(cols)
-        fic = firstindex(col)
-        fic != 1 && _onebased_check_error(i, fic)
+        firstindex(col) != 1 && _onebased_check_error(i, col)
     end
 
     ncols = length(cols)

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -571,10 +571,7 @@ function Base.push!(df::DataFrame, dfr::DataFrameRow; cols::Symbol=:setequal,
                 newcol = Tables.allocatecolumn(promote_type(S, T), targetrows)
                 copyto!(newcol, 1, col, 1, nrows)
                 newcol[end] = val
-                if firstindex(newcol) != 1
-                    throw(ArgumentError("Currently DataFrames.jl supports only columns " *
-                                    "that use 1-based indexing"))
-                end
+                firstindex(newcol) != 1 && _onebased_check_error()
                 _columns(df)[i] = newcol
             end
         end
@@ -629,10 +626,7 @@ function Base.push!(df::DataFrame, dfr::DataFrameRow; cols::Symbol=:setequal,
                 newcol = similar(col, promote_type(S, T), targetrows)
                 copyto!(newcol, 1, col, 1, nrows)
                 newcol[end] = val
-                if firstindex(newcol) != 1
-                    throw(ArgumentError("Currently DataFrames.jl supports only columns " *
-                                    "that use 1-based indexing"))
-                end
+                firstindex(newcol) != 1 && _onebased_check_error()
                 _columns(df)[columnindex(df, nm)] = newcol
             end
         end

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -571,6 +571,10 @@ function Base.push!(df::DataFrame, dfr::DataFrameRow; cols::Symbol=:setequal,
                 newcol = Tables.allocatecolumn(promote_type(S, T), targetrows)
                 copyto!(newcol, 1, col, 1, nrows)
                 newcol[end] = val
+                if firstindex(newcol) != 1
+                    throw(ArgumentError("Currently DataFrames.jl supports only columns " *
+                                    "that use 1-based indexing"))
+                end
                 _columns(df)[i] = newcol
             end
         end
@@ -625,6 +629,10 @@ function Base.push!(df::DataFrame, dfr::DataFrameRow; cols::Symbol=:setequal,
                 newcol = similar(col, promote_type(S, T), targetrows)
                 copyto!(newcol, 1, col, 1, nrows)
                 newcol[end] = val
+                if firstindex(newcol) != 1
+                    throw(ArgumentError("Currently DataFrames.jl supports only columns " *
+                                    "that use 1-based indexing"))
+                end
                 _columns(df)[columnindex(df, nm)] = newcol
             end
         end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,6 +1,6 @@
 module TestIndexing
 
-using Test, DataFrames
+using Test, DataFrames. OffsetArrays
 
 @testset "getindex DataFrame" begin
     df = DataFrame(a=1:3, b=4:6, c=7:9)
@@ -2003,6 +2003,36 @@ end
     @test lastindex(gk, 1) == 3
     @test_throws BoundsError lastindex(gk, 2)
     @test_throws BoundsError lastindex(gk, 0)
+end
+
+@testset "Check allowing only 1-based indexing of vectors" begin
+    ov1 = OffsetArray(1:5, 0:4)
+    ov2 = OffsetArray(1:5, 1:5)
+
+    @test_throws ArgumentError DataFrame(a=ov1)
+    @test DataFrame(a=ov2) == DataFrame(a=1:5)
+
+    @test_throws ArgumentError mapcols!(x -> ov1, DataFrame(a=1))
+    @test mapcols!(x -> ov2, DataFrame(a=1)) == DataFrame(a=ov2)
+
+    df = DataFrame(a=1)
+    DataFrames._columns(df)[1] = ov1
+    @test_throws ArgumentError DataFrames._check_consistency(df)
+    DataFrames._columns(df)[1] = ov2
+    DataFrames._check_consistency(df)
+
+    @test_throws ArgumentError df.b = ov1
+    @test_throws ArgumentError insertcols!(df, :b => ov1)
+    @test_throws DimensionMismatch df[!, :b] .= ov1
+
+    # this is consequence of the fact that OffsetArrays wrap AbstractRange in this case
+    @test_throws ErrorException df[:, :a] = ov1
+
+    # this inconsistency is the consequence how setindex! for vector is deifned in Base
+    df = DataFrame(a=5:-1:1)
+    @test_throws ArgumentError df[:, :b] = ov1
+    df[:, :a] = ov1
+    @test df == DataFrame(a=1:5)
 end
 
 end # module

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,6 +1,6 @@
 module TestIndexing
 
-using Test, DataFrames, OffsetArrays
+using Test, DataFrames
 
 @testset "getindex DataFrame" begin
     df = DataFrame(a=1:3, b=4:6, c=7:9)
@@ -2005,34 +2005,8 @@ end
     @test_throws BoundsError lastindex(gk, 0)
 end
 
-@testset "Check allowing only 1-based indexing of vectors" begin
-    ov1 = OffsetArray(1:5, 0:4)
-    ov2 = OffsetArray(1:5, 1:5)
-
-    @test_throws ArgumentError DataFrame(a=ov1)
-    @test DataFrame(a=ov2) == DataFrame(a=1:5)
-
-    @test_throws ArgumentError mapcols!(x -> ov1, DataFrame(a=1))
-    @test mapcols!(x -> ov2, DataFrame(a=1)) == DataFrame(a=ov2)
-
-    df = DataFrame(a=1)
-    DataFrames._columns(df)[1] = ov1
-    @test_throws ArgumentError DataFrames._check_consistency(df)
-    DataFrames._columns(df)[1] = ov2
-    DataFrames._check_consistency(df)
-
-    @test_throws ArgumentError df.b = ov1
-    @test_throws ArgumentError insertcols!(df, :b => ov1)
-    @test_throws DimensionMismatch df[!, :b] .= ov1
-
-    # this is consequence of the fact that OffsetArrays wrap AbstractRange in this case
-    @test_throws ErrorException df[:, :a] = ov1
-
-    # this inconsistency is the consequence how setindex! for vector is deifned in Base
-    df = DataFrame(a=5:-1:1)
-    @test_throws ArgumentError df[:, :b] = ov1
-    df[:, :a] = ov1
-    @test df == DataFrame(a=1:5)
+if VERSION >= v"1.5"
+    include("indexing_offest.jl")
 end
 
 end # module

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -1,6 +1,6 @@
 module TestIndexing
 
-using Test, DataFrames. OffsetArrays
+using Test, DataFrames, OffsetArrays
 
 @testset "getindex DataFrame" begin
     df = DataFrame(a=1:3, b=4:6, c=7:9)

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -2006,7 +2006,7 @@ end
 end
 
 if VERSION >= v"1.5"
-    include("indexing_offest.jl")
+    include("indexing_offset.jl")
 end
 
 end # module

--- a/test/indexing_offset.jl
+++ b/test/indexing_offset.jl
@@ -25,7 +25,7 @@ using Test, DataFrames, OffsetArrays
     # this is consequence of the fact that OffsetArrays wrap AbstractRange in this case
     @test_throws ErrorException df[:, :a] = ov1
 
-    # this inconsistency is the consequence how setindex! for vector is deifned in Base
+    # this inconsistency is the consequence how setindex! for vector is defined in Base
     df = DataFrame(a=5:-1:1)
     @test_throws ArgumentError df[:, :b] = ov1
     df[:, :a] = ov1

--- a/test/indexing_offset.jl
+++ b/test/indexing_offset.jl
@@ -1,0 +1,35 @@
+module TestOffsetIndexing
+
+using Test, DataFrames, OffsetArrays
+
+@testset "Check allowing only 1-based indexing of vectors" begin
+    ov1 = OffsetArray(1:5, 0:4)
+    ov2 = OffsetArray(1:5, 1:5)
+
+    @test_throws ArgumentError DataFrame(a=ov1)
+    @test DataFrame(a=ov2) == DataFrame(a=1:5)
+
+    @test_throws ArgumentError mapcols!(x -> ov1, DataFrame(a=1))
+    @test mapcols!(x -> ov2, DataFrame(a=1)) == DataFrame(a=ov2)
+
+    df = DataFrame(a=1)
+    DataFrames._columns(df)[1] = ov1
+    @test_throws ArgumentError DataFrames._check_consistency(df)
+    DataFrames._columns(df)[1] = ov2
+    DataFrames._check_consistency(df)
+
+    @test_throws ArgumentError df.b = ov1
+    @test_throws ArgumentError insertcols!(df, :b => ov1)
+    @test_throws DimensionMismatch df[!, :b] .= ov1
+
+    # this is consequence of the fact that OffsetArrays wrap AbstractRange in this case
+    @test_throws ErrorException df[:, :a] = ov1
+
+    # this inconsistency is the consequence how setindex! for vector is deifned in Base
+    df = DataFrame(a=5:-1:1)
+    @test_throws ArgumentError df[:, :b] = ov1
+    df[:, :a] = ov1
+    @test df == DataFrame(a=1:5)
+end
+
+end # module

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -69,6 +69,11 @@ end
     @test df_mapcols2 == df_mapcols
     @test df_mapcols2.a !== df_mapcols.a
     @test df_mapcols2.b !== df_mapcols.b
+
+    df = DataFrame(a=1)
+    df = mapcols(x -> 2:2, df)
+    @test df == DataFrame(a=2)
+    @test df.a isa Vector{Int}
 end
 
 @testset "mapcols!" begin
@@ -95,6 +100,11 @@ end
     mapcols!(x -> x, df_mapcols)
     @test a === df_mapcols.a
     @test b === df_mapcols.b
+
+    df = DataFrame(a=1)
+    mapcols!(x -> 2:2, df)
+    @test df == DataFrame(a=2)
+    @test df.a isa Vector{Int}
 end
 
 @testset "SubDataFrame" begin

--- a/test/select.jl
+++ b/test/select.jl
@@ -1598,4 +1598,14 @@ end
                            DataFrame(x1=Int[], x2=[]))
 end
 
+@testset "test resizing via a vector of columns after scalars" begin
+    df = DataFrame(a=1:2)
+    @test combine(df, :a => (x -> 1) => :a1, :a => (x -> 2) => :a2, [:a]) ==
+          DataFrame(a1=1, a2=2, a=1:2)
+    @test select(df, :a => (x -> 1) => :a1, :a => (x -> 2) => :a2, [:a]) ==
+          DataFrame(a1=1, a2=2, a=1:2)
+    @test_throws ArgumentError combine(df, :a => (x -> 1) => :a1, :a => (x -> [2]) => :a2, [:a])
+    @test_throws ArgumentError select(df, :a => (x -> 1) => :a1, :a => (x -> [2]) => :a2, [:a])
+end
+
 end # module


### PR DESCRIPTION
We currently assume that vectors are 1-based in DataFrames.jl. This PR makes sure we check for that. Not checking this will lead to bugs. Also I found some small bug in `mapcols!` in the process related to `AbstractRange` handling.

I think we should decide on this before 1.0 release (it is better to be strict I think now; we can be more flexible later).

I will add tests, NEWS.md and update documentation with this PR after we agree that we want to add these changes.