### PR TITLE
Use refpool optimized method for integer grouping

### DIFF
--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -117,7 +117,7 @@ function _refpool(x::AbstractArray)
     refpool = DataAPI.refpool(x)
     if refpool !== nothing
         return refpool
-    elseif x isa AbstractArray{<:Real} && all(isinteger, x)
+    elseif x isa AbstractArray{<:Real} && !isempty(x) && all(isinteger, x)
         minval, maxval = extrema(x)
         # Threshold chosen with the same rationale as the row_group_slots refpool method:
         # refpool approach is faster but we should not allocate too much memory either

--- a/src/dataframerow/utils.jl
+++ b/src/dataframerow/utils.jl
@@ -275,6 +275,7 @@ function row_group_slots(cols::NTuple{N, AbstractVector},
        anydups
         # In the simplest case, we can work directly with the reference codes
         newcols = (skipmissing && any(refpool -> eltype(refpool) >: Missing, refpools)) ||
+                  !(refarrays isa NTuple{<:Any, AbstractVector}) ||
                   sort ||
                   anydups ? cols : refarrays
         return invoke(row_group_slots,

--- a/test/data.jl
+++ b/test/data.jl
@@ -76,15 +76,14 @@ const ≅ = isequal
     d3 = randn(N)
     d4 = randn(N)
     df7 = DataFrame([d1, d2, d3], [:d1, :d2, :d3])
-    ref_d1 = unique(d1)
 
     #test_group("groupby")
     gd = groupby(df7, :d1)
     @test length(gd) == 2
-    @test gd[1][:, :d2] ≅ d2[d1 .== ref_d1[1]]
-    @test gd[2][:, :d2] ≅ d2[d1 .== ref_d1[2]]
-    @test gd[1][:, :d3] == d3[d1 .== ref_d1[1]]
-    @test gd[2][:, :d3] == d3[d1 .== ref_d1[2]]
+    @test gd[1][:, :d2] ≅ d2[d1 .== 1]
+    @test gd[2][:, :d2] ≅ d2[d1 .== 2]
+    @test gd[1][:, :d3] == d3[d1 .== 1]
+    @test gd[2][:, :d3] == d3[d1 .== 2]
 
     g1 = groupby(df7, [:d1, :d2])
     g2 = groupby(df7, [:d2, :d1])

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -741,6 +741,8 @@ end
     gd = groupby(df, [:x, :y])
     @test !issorted(combine(gd, :x)) # Test that optimized method is not used
     @test isequal_unordered(gd, [groupby(df, [:x2, :y2])...])
+
+    @test isempty(groupby(DataFrame(x=Int[]), :x))
 end
 
 @testset "grouping with three keys" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -52,7 +52,7 @@ function validate_gdf(ogd::GroupedDataFrame)
     else
         @assert length(gd.starts) == length(gd.ends) == 0
     end
-    @assert isempty(gd.idx) || isperm(gd.idx)
+    @assert isperm(gd.idx)
     @assert length(gd.idx) == length(gd.groups) == nrow(parent(gd))
 
     # checking that groups field is consistent with other fields
@@ -786,11 +786,11 @@ end
     groups = rand(1:3, 100)
     for v in (big(0), missing)
         @test groupby_checked(DataFrame(x=[big(typemax(Int))+10, v,
-                                        big(typemin(Int))-1][groups]), :x) ≅
+                                           big(typemin(Int))-1][groups]), :x) ≅
             groupby_checked(DataFrame(x=Any[big(typemax(Int))+10, v,
                                             big(typemin(Int))-1][groups]), :x)
         @test groupby_checked(DataFrame(x=[big(typemax(Int))-10, v,
-                                        big(typemin(Int))+10][groups]), :x) ≅
+                                           big(typemin(Int))+10][groups]), :x) ≅
             groupby_checked(DataFrame(x=Any[big(typemax(Int))-10, v,
                                             big(typemin(Int))+10][groups]), :x)
     end


### PR DESCRIPTION
main:
```julia
julia> using DataFrames, BenchmarkTools

julia> df = DataFrame(x=rand(1:10, 100_000), y=rand(10:20, 100_000));

julia> @btime groupby(df, :x);
  730.118 μs (31 allocations: 2.53 MiB)

julia> @btime groupby(df, [:x, :y]);
  1.091 ms (38 allocations: 2.53 MiB)

julia> df = DataFrame(x=rand(1:1000, 100_000), y=rand(1000:2000, 100_000));

julia> @btime groupby(df, :x);
  1.009 ms (31 allocations: 2.53 MiB)

julia> @btime groupby(df, [:x, :y]);
  2.690 ms (38 allocations: 2.53 MiB)
```

PR (updated to latest commits):
```julia
jjulia> using DataFrames, BenchmarkTools

julia> df = DataFrame(x=rand(1:10, 100_000), y=rand(10:20, 100_000));

julia> @btime groupby(df, :x);
  186.219 μs (58 allocations: 784.46 KiB)

julia> @btime groupby(df, [:x, :y]);
  296.452 μs (85 allocations: 785.84 KiB)

julia> df = DataFrame(x=rand(1:1000, 100_000), y=rand(1000:2000, 100_000));

julia> @btime groupby(df, :x);
  187.802 μs (58 allocations: 785.43 KiB)

# Too many combinations, falling back to generic method
julia> @btime groupby(df, [:x, :y]);
  2.982 ms (98 allocations: 2.53 MiB)
```