### PR TITLE
Modifying the Base.sizeof() to handle AbstractDataFrame

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -335,6 +335,9 @@ function Base.size(df::AbstractDataFrame, i::Integer)
     end
 end
 
+# obtain the total size of `df`.
+Base.sizeof(df::AbstractDataFrame) = sum(sizeof.(eachcol(df)))
+
 Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0 || size(df, 2) == 0
 
 if VERSION < v"1.6"


### PR DESCRIPTION
I thought it would be nice to have a function to calculate the size, in bytes, of a data frame.