### PR TITLE
Disallow `combine` without any transformations

### DIFF
--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -1175,6 +1175,9 @@ julia> combine(gd, :, AsTable(Not(:a)) => sum, renamecols=false)
 combine(df::AbstractDataFrame, @nospecialize(args...); renamecols::Bool=true) =
     manipulate(df, args..., copycols=true, keeprows=false, renamecols=renamecols)
 
+combine(df::AbstractDataFrame; renamecols::Bool=true) =
+    throw(ArgumentError("At least one transformation must be specified"))
+
 function combine(arg::Base.Callable, df::AbstractDataFrame; renamecols::Bool=true)
     if arg isa Colon
         throw(ArgumentError("First argument to select! must be a transformation if the second argument is a data frame"))

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -675,6 +675,9 @@ combine(gd::GroupedDataFrame,
     _combine_prepare(gd, cs..., keepkeys=keepkeys, ungroup=ungroup,
                      copycols=true, keeprows=false, renamecols=renamecols)
 
+combine(df::GroupedDataFrame; renamecols::Bool=true) =
+    throw(ArgumentError("At least one transformation must be specified"))
+
 function select(f::Base.Callable, gd::GroupedDataFrame; copycols::Bool=true,
                 keepkeys::Bool=true, ungroup::Bool=true, renamecols::Bool=true)
     if f isa Colon

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -918,6 +918,7 @@ end
         combine(gd, :c => (x -> [Dict(:c_sum => sum(x))]) => AsTable)
     @test_throws ArgumentError combine(:c => sum, gd)
     @test_throws ArgumentError combine(:, gd)
+    @test_throws ArgumentError combine(gd)
 
     @test combine(gd, :c => vexp) ==
         combine(gd, :c => vexp => :c_function) ==
@@ -1658,11 +1659,6 @@ end
            1 │     1      1      1
            2 │     2      1      2
            3 │     2      2      3"""
-
-    df = DataFrame(a=[1, 1, 2, 2, 2], b=1:5)
-    gd = groupby_checked(df, :a)
-    @test size(combine(gd)) == (0, 1)
-    @test names(combine(gd)) == ["a"]
 end
 
 @testset "GroupedDataFrame dictionary interface" begin
@@ -2635,10 +2631,7 @@ end
     df = DataFrame(x=[], g=[])
     gdf = groupby_checked(df, :g)
 
-    @test size(combine(gdf)) == (0, 1)
-    @test names(combine(gdf)) == ["g"]
-    @test combine(gdf, keepkeys=false) == DataFrame()
-    @test combine(gdf, ungroup=false) == groupby(DataFrame(g=[]), :g)
+    @test_throws ArgumentError combine(gdf)
     @test size(select(gdf)) == (0, 1)
     @test names(select(gdf)) == ["g"]
     @test groupcols(validate_gdf(select(gdf, ungroup=false))) == [:g]
@@ -2680,12 +2673,7 @@ end
     df = DataFrame(x=[1], g=[1])
     gdf = groupby_checked(df, :g)
 
-    @test size(combine(gdf)) == (0, 1)
-    @test names(combine(gdf)) == ["g"]
-    @test combine(gdf, ungroup=false) isa GroupedDataFrame
-    @test length(combine(gdf, ungroup=false)) == 0
-    @test parent(combine(gdf, ungroup=false)) == DataFrame(g=[])
-    @test combine(gdf, keepkeys=false) == DataFrame()
+    @test_throws ArgumentError combine(gdf)
     @test size(select(gdf)) == (1, 1)
     @test names(select(gdf)) == ["g"]
     @test groupcols(validate_gdf(select(gdf, ungroup=false))) == [:g]
@@ -2714,8 +2702,7 @@ end
     @test select(gdf, :x => (x -> 10x) => :g, keepkeys=false) == DataFrame(g=10)
 
     gdf = gdf[1:0]
-    @test size(combine(gdf)) == (0, 1)
-    @test names(combine(gdf)) == ["g"]
+    @test_throws ArgumentError combine(gdf)
     @test size(combine(x -> DataFrame(z=1), gdf)) == (0, 2)
     @test names(combine(x -> DataFrame(z=1), gdf)) == ["g", "z"]
     @test combine(x -> DataFrame(z=1), gdf, keepkeys=false) == DataFrame(z=[])

--- a/test/select.jl
+++ b/test/select.jl
@@ -1189,6 +1189,8 @@ end
 @testset "combine AbstractDataFrame" begin
     df = DataFrame(x=1:3, y=4:6)
 
+    @test_throws ArgumentError combine(df)
+
     @test combine(x -> Matrix(x), df) == rename(df, [:x1, :x2])
     @test combine(x -> Ref(1:3), df) == DataFrame(x1=[1:3])
     @test combine(df, x -> Ref(1:3)) == DataFrame(x1=[1:3])
@@ -1214,6 +1216,8 @@ end
           DataFrame(y_function = [], x_sum=[])
 
     dfv = view(df, [2, 1], [2, 1])
+
+    @test_throws ArgumentError combine(dfv)
 
     @test combine(x -> Matrix(x), dfv) == rename(dfv, [:x1, :x2])
 


### PR DESCRIPTION
Since `combine(x)` always returns an empty data frame, it can hardly be useful.
All other syntaxes return one or more rows per group so it's not really consistent with them either.

Disallowing this can potentially allow other behaviors in the future if we want, e.g. returning only the grouping keys with one row per group like dplyr.

See also https://stackoverflow.com/questions/66142331/summary-table-of-unique-value-combinations-in-dataframes-jl.

Cc: @bkamins, @kleinschmidt 