### PR TITLE
Add faster semi and antijoin

### DIFF
--- a/benchmarks/join_performance.jl
+++ b/benchmarks/join_performance.jl
@@ -10,7 +10,7 @@ fullgc() = (GC.gc(true); GC.gc(true); GC.gc(true); GC.gc(true))
 @assert ARGS[4] in ["uniq", "dup", "manydup"]
 @assert ARGS[5] in ["sort", "rand"]
 @assert ARGS[6] in ["1", "2"]
-@assert ARGS[7] in ["inner", "left", "right", "outer"]
+@assert ARGS[7] in ["inner", "left", "right", "outer", "semi", "anti"]
 
 @info ARGS
 
@@ -76,7 +76,8 @@ else
 end
 
 const joinfun = Dict("inner" => innerjoin, "left" => leftjoin,
-                     "right" => rightjoin, "outer" => outerjoin)[ARGS[7]]
+                     "right" => rightjoin, "outer" => outerjoin,
+                     "semi" => semijoin, "anti" => antijoin)[ARGS[7]]
 
 if ARGS[6] == "1"
     df1 = DataFrame(id1 = col1)

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -6,3 +6,7 @@ julia runtests.jl 100000 50000000 right
 julia runtests.jl 5000000 10000000 right
 julia runtests.jl 100000 50000000 outer
 julia runtests.jl 5000000 10000000 outer
+julia runtests.jl 100000 50000000 semi
+julia runtests.jl 5000000 10000000 semi
+julia runtests.jl 100000 50000000 anti
+julia runtests.jl 5000000 10000000 anti

--- a/src/join/core.jl
+++ b/src/join/core.jl
@@ -610,13 +610,15 @@ function _semijoin_unsorted(left::AbstractArray, right::AbstractArray{T},
         dict[val_r] = idx_r
     end
 
-    for (idx_l, val_l) in enumerate(left)
+    @inbounds for (idx_l, val_l) in enumerate(left)
         # we know that dict contains only positive values
         idx_r = get(dict, val_l, -1)
-        if right_shorter
-            seen_rows[idx_l] = true
-        else
-            seen_rows[idx_r] = true
+        if idx_r != -1
+            if right_shorter
+                seen_rows[idx_l] = true
+            else
+                seen_rows[idx_r] = true
+            end
         end
     end
     return seen_rows
@@ -760,7 +762,7 @@ function _semijoin_postprocess(left::AbstractArray, dict::Dict{T, Int},
     return seen_rows
 end
 
-function _innerjoin_postprocess_int(left::AbstractVector{<:Union{Integer, Missing}},
+function _semijoin_postprocess_int(left::AbstractVector{<:Union{Integer, Missing}},
                                     dict::Vector{Int},
                                     groups::Vector{Int}, ngroups::Int, right_len::Int,
                                     offset::Int, minv::Int, maxv::Int,

--- a/test/join.jl
+++ b/test/join.jl
@@ -1014,7 +1014,7 @@ end
     end
 end
 
-@testset "innerjoin correctness tests" begin
+@testset "join correctness tests" begin
 
     @test_throws ArgumentError DataFrames.prepare_on_col()
 
@@ -1050,6 +1050,9 @@ end
         df_right = vcat(df_inner, df_right_part)
         df_outer = vcat(df_inner, df_left_part, df_right_part)
 
+        df_semi = df1[[x in Set(df2.id) for x in df1.id], :]
+        df_anti = df1[[!(x in Set(df2.id)) for x in df1.id], :]
+
         df1x = copy(df1)
         df1x.id2 = copy(df1x.id)
         df2x = copy(df2)
@@ -1069,18 +1072,26 @@ end
         df_left2 = copy(df_left)
         df_right2 = copy(df_right)
         df_outer2 = copy(df_outer)
+        df_semi2 = copy(df_semi)
+        df_anti2 = copy(df_anti)
         insertcols!(df_inner2, 3, :id2 => df_inner2.id)
         insertcols!(df_left2, 3, :id2 => df_left2.id)
         insertcols!(df_right2, 3, :id2 => df_right2.id)
         insertcols!(df_outer2, 3, :id2 => df_outer2.id)
+        insertcols!(df_semi2, 3, :id2 => df_semi2.id)
+        insertcols!(df_anti2, 3, :id2 => df_anti2.id)
         df_inner3 = copy(df_inner2)
         df_left3 = copy(df_left2)
         df_right3 = copy(df_right2)
         df_outer3 = copy(df_outer2)
+        df_semi3 = copy(df_semi2)
+        df_anti3 = copy(df_anti2)
         insertcols!(df_inner3, 4, :id3 => df_inner3.id)
         insertcols!(df_left3, 4, :id3 => df_left3.id)
         insertcols!(df_right3, 4, :id3 => df_right3.id)
         insertcols!(df_outer3, 4, :id3 => df_outer3.id)
+        insertcols!(df_semi3, 4, :id3 => df_semi3.id)
+        insertcols!(df_anti3, 4, :id3 => df_anti3.id)
 
         return df_inner ≅ sort(innerjoin(df1, df2, on=:id, matchmissing=:equal), [:x, :y]) &&
                df_inner2 ≅ sort(innerjoin(df1x, df2x, on=[:id, :id2], matchmissing=:equal), [:x, :y]) &&
@@ -1093,7 +1104,13 @@ end
                df_right3 ≅ sort(rightjoin(df1x2, df2x2, on=[:id, :id2, :id3], matchmissing=:equal), [:x, :y]) &&
                df_outer ≅ sort(outerjoin(df1, df2, on=:id, matchmissing=:equal), [:x, :y]) &&
                df_outer2 ≅ sort(outerjoin(df1x, df2x, on=[:id, :id2], matchmissing=:equal), [:x, :y]) &&
-               df_outer3 ≅ sort(outerjoin(df1x2, df2x2, on=[:id, :id2, :id3], matchmissing=:equal), [:x, :y])
+               df_outer3 ≅ sort(outerjoin(df1x2, df2x2, on=[:id, :id2, :id3], matchmissing=:equal), [:x, :y]) &&
+               df_semi ≅ semijoin(df1, df2, on=:id, matchmissing=:equal) &&
+               df_semi2 ≅ semijoin(df1x, df2x, on=[:id, :id2], matchmissing=:equal) &&
+               df_semi3 ≅ semijoin(df1x2, df2x2, on=[:id, :id2, :id3], matchmissing=:equal) &&
+               df_anti ≅ antijoin(df1, df2, on=:id, matchmissing=:equal) &&
+               df_anti2 ≅ antijoin(df1x, df2x, on=[:id, :id2], matchmissing=:equal) &&
+               df_anti3 ≅ antijoin(df1x2, df2x2, on=[:id, :id2, :id3], matchmissing=:equal)
     end
 
     Random.seed!(1234)


### PR DESCRIPTION
Fixes #2340 

This is the last PR for making joins faster.
Here are the benchmarks against 0.22.5 release. As before we are either much faster or comparable.
[semi_022_5.txt](https://github.com/JuliaData/DataFrames.jl/files/6085850/semi_022_5.txt)
[semi_pr.txt](https://github.com/JuliaData/DataFrames.jl/files/6085852/semi_pr.txt)

The only small problem is code duplication. I would prefer to avoid it, but first I wanted to make sure we have thing correct and fast. The problem is that duplicate methods get different arguments and are minimally different (in other words: we use exactly the same high level logic, but collect and pass around different information as the resulting join is different since it involves only left table).