### PR TITLE
fix repeat and some other minor issues

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1676,7 +1676,9 @@ julia> repeat(df, inner = 2, outer = 3)
   12 │     2      4
 ```
 """
-function Base.repeat(df::AbstractDataFrame; inner::Integer = 1, outer::Integer = 1)
+function Base.repeat(df::AbstractDataFrame;
+                     inner::Union{Signed, Unsigned} = 1,
+                     outer::Union{Signed, Unsigned} = 1)
     inner < 0 && throw(ArgumentError("inner keyword argument must be non-negative"))
     outer < 0 && throw(ArgumentError("outer keyword argument must be non-negative"))
     return mapcols(x -> repeat(x, inner = inner, outer = outer), df)
@@ -1709,7 +1711,7 @@ julia> repeat(df, 2)
    4 │     2      4
 ```
 """
-function Base.repeat(df::AbstractDataFrame, count::Integer)
+function Base.repeat(df::AbstractDataFrame, count::Union{Signed, Unsigned})
     count < 0 && throw(ArgumentError("count must be non-negative"))
     return mapcols(x -> repeat(x, count), df)
 end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1676,12 +1676,10 @@ julia> repeat(df, inner = 2, outer = 3)
   12 │     2      4
 ```
 """
-function Base.repeat(df::AbstractDataFrame;
-                     inner::Union{Signed, Unsigned} = 1,
-                     outer::Union{Signed, Unsigned} = 1)
+function Base.repeat(df::AbstractDataFrame; inner::Integer=1, outer::Integer=1)
     inner < 0 && throw(ArgumentError("inner keyword argument must be non-negative"))
     outer < 0 && throw(ArgumentError("outer keyword argument must be non-negative"))
-    return mapcols(x -> repeat(x, inner = inner, outer = outer), df)
+    return mapcols(x -> repeat(x, inner = Int(inner), outer = Int(outer)), df)
 end
 
 """
@@ -1711,9 +1709,9 @@ julia> repeat(df, 2)
    4 │     2      4
 ```
 """
-function Base.repeat(df::AbstractDataFrame, count::Union{Signed, Unsigned})
+function Base.repeat(df::AbstractDataFrame, count::Integer)
     count < 0 && throw(ArgumentError("count must be non-negative"))
-    return mapcols(x -> repeat(x, count), df)
+    return mapcols(x -> repeat(x, Int(count)), df)
 end
 
 ##############################################################################

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1616,7 +1616,7 @@ julia> df
 function repeat!(df::DataFrame; inner::Integer = 1, outer::Integer = 1)
     inner < 0 && throw(ArgumentError("inner keyword argument must be non-negative"))
     outer < 0 && throw(ArgumentError("outer keyword argument must be non-negative"))
-    return mapcols!(x -> repeat(x, inner = inner, outer = outer), df)
+    return mapcols!(x -> repeat(x, inner = Int(inner), outer = Int(outer)), df)
 end
 
 """
@@ -1648,7 +1648,7 @@ julia> repeat(df, 2)
 """
 function repeat!(df::DataFrame, count::Integer)
     count < 0 && throw(ArgumentError("count must be non-negative"))
-    return mapcols!(x -> repeat(x, count), df)
+    return mapcols!(x -> repeat(x, Int(count)), df)
 end
 
 # This is not exactly copy! as in general we allow axes to be different

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -987,7 +987,7 @@ end
         @test levels(df.c4) == levels(v)
         @test levels(df.c4) !== levels(v)
         df[!, :c5] .= (x->v[2]).(v)
-        @test unique(df.c5) == [get(v[2])]
+        @test unique(df.c5) == [unwrap(v[2])]
         @test df.c5 isa CategoricalVector
         @test levels(df.c5) == levels(v)
     end

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -295,6 +295,9 @@ end
 
     if VERSION > v"1.6"
         @test_throws ArgumentError SubDataFrame(sdf, Integer[true, true, true], :)
+    else
+        @test SubDataFrame(sdf, Integer[true, true, true], :) ==
+              SubDataFrame(sdf, [1, 1, 1], :)
     end
 end
 

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -293,7 +293,9 @@ end
     @test_throws ArgumentError SubDataFrame(sdf, true, :)
     @test_throws ArgumentError SubDataFrame(sdf, Integer[true], 1)
 
-    @test_throws ArgumentError SubDataFrame(sdf, Integer[true, true, true], :)
+    if VERSION > v"1.6"
+        @test_throws ArgumentError SubDataFrame(sdf, Integer[true, true, true], :)
+    end
 end
 
 end # module

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -293,8 +293,7 @@ end
     @test_throws ArgumentError SubDataFrame(sdf, true, :)
     @test_throws ArgumentError SubDataFrame(sdf, Integer[true], 1)
 
-    # this is an error in Julia Base
-    SubDataFrame(sdf, Integer[true, true, true], :) == SubDataFrame(sdf, [1, 1, 1], :)
+    @test_throws ArgumentError SubDataFrame(sdf, Integer[true, true, true], :)
 end
 
 end # module

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -16,7 +16,7 @@ end
     @test repeat(view(df, 1:2, :), 2) == ref
 
     @test size(repeat(df, 0)) == (0, 2)
-    @test size(repeat(df, false)) == (0, 2)
+    @test_throws MethodError repeat(df, false)
     @test_throws ArgumentError repeat(df, -1)
 end
 
@@ -29,9 +29,8 @@ end
 
     @test size(repeat(df, inner = 2, outer = 0)) == (0, 2)
     @test size(repeat(df, inner = 0, outer = 3)) == (0, 2)
-    @test size(repeat(df, inner = 2, outer = false)) == (0, 2)
-    @test size(repeat(df, inner = false, outer = 3)) == (0, 2)
-
+    @test_throws MethodError repeat(df, inner = 2, outer = false)
+    @test_throws MethodError repeat(df, inner = false, outer = 3)
     @test_throws ArgumentError repeat(df, inner = 2, outer = -1)
     @test_throws ArgumentError repeat(df, inner = -1, outer = 3)
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -16,7 +16,7 @@ end
     @test repeat(view(df, 1:2, :), 2) == ref
 
     @test size(repeat(df, 0)) == (0, 2)
-    @test_throws MethodError repeat(df, false)
+    @test size(repeat(df, false)) == (0, 2)
     @test_throws ArgumentError repeat(df, -1)
 end
 
@@ -29,8 +29,8 @@ end
 
     @test size(repeat(df, inner = 2, outer = 0)) == (0, 2)
     @test size(repeat(df, inner = 0, outer = 3)) == (0, 2)
-    @test_throws MethodError repeat(df, inner = 2, outer = false)
-    @test_throws MethodError repeat(df, inner = false, outer = 3)
+    @test size(repeat(df, inner = 2, outer = false)) == (0, 2)
+    @test size(repeat(df, inner = false, outer = 3)) == (0, 2)
     @test_throws ArgumentError repeat(df, inner = 2, outer = -1)
     @test_throws ArgumentError repeat(df, inner = -1, outer = 3)
 end


### PR DESCRIPTION
Some fixes after https://github.com/JuliaLang/julia/pull/31829.
Mainly restricting the signature of `repeat`.

Additionally one dangling `get` to `unwrap` for CategoricalArrays.jl compatibility I missed earlier.

@mbauman

The https://github.com/JuliaLang/julia/pull/31829 broke the following thing in Julia Base that was not covered by tests (fortunately we had appropriate tests in DataFrames.jl):
```
julia> x = [1,2,3]
3-element Vector{Int64}:
 1
 2
 3

julia> repeat(x, inner=1,outer=1)
3-element Vector{Int64}:
 1
 2
 3

julia> repeat(x, inner=1,outer=false) # it works but I think it should be an error
Int64[]

julia> repeat(x, inner=false,outer=1) # previously it worked
ERROR: ArgumentError: invalid index: false of type Bool
```