### PR TITLE
Normalize references to LINQ in docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -76,11 +76,11 @@ integrated they are with DataFrames.jl.
       A Julia wrapper around the full Python scikit-learn machine learning library.
       Not well integrated with DataFrames.jl, but can be combined using StatsModels.jl.
     - [AutoMLPipeline](https://github.com/IBM/AutoMLPipeline.jl):
-      A package that makes it trivial to create complex ML 
-      pipeline structures using simple expressions. It leverages 
-      on the built-in macro programming features of Julia to 
-      symbolically process, manipulate pipeline expressions, 
-      and makes it easy to discover optimal structures for 
+      A package that makes it trivial to create complex ML
+      pipeline structures using simple expressions. It leverages
+      on the built-in macro programming features of Julia to
+      symbolically process, manipulate pipeline expressions,
+      and makes it easy to discover optimal structures for
       machine learning regression and classification.
     - Deep learning:
       [KNet.jl](https://denizyuret.github.io/Knet.jl/stable/tutorial/#Introduction-to-Knet-1)
@@ -108,7 +108,7 @@ integrated they are with DataFrames.jl.
       framework for data wrangling that works with a range of libraries, including
       DataFrames.jl, other tabular data libraries (more on those below), and even
       non-tabular data. Provides many convenience functions analogous to those in
-      dplyr in R or [linq](https://en.wikipedia.org/wiki/Language_Integrated_Query).
+      dplyr in R or [LINQ](https://en.wikipedia.org/wiki/Language_Integrated_Query).
     - You can find more on both of these packages in the
       [Data manipulation frameworks](@ref) section of this manual.
 - **And More!**

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -872,7 +872,7 @@ julia> transform(df, AsTable(:) .=>
 While the DataFrames.jl package provides basic data manipulation capabilities,
 users are encouraged to use querying frameworks for more convenient and powerful operations:
 - the [Query.jl](https://github.com/davidanthoff/Query.jl) package provides a
-[LINQ](https://msdn.microsoft.com/en-us/library/bb397926.aspx)-like interface to a large number of data sources
+[LINQ](https://en.wikipedia.org/wiki/Language_Integrated_Query)-like interface to a large number of data sources
 - the [DataFramesMeta.jl](https://github.com/JuliaStats/DataFramesMeta.jl)
 package provides interfaces similar to LINQ and [dplyr](https://dplyr.tidyverse.org)
 


### PR DESCRIPTION
Just a small tweak to ensure the documentation is consistent in the capitalization and target link of the references to LINQ. Besides the two ocurrences that this PR changes, there's an additional one in [`docs/src/man/querying_frameworks.md`](https://github.com/JuliaData/DataFrames.jl/blob/6d1347983b67e93d50df847d2d8546a4c9a8cfd4/docs/src/man/querying_frameworks.md).