### PR TITLE
Use multithreading in row_group_slots refarray method

### DIFF
--- a/benchmarks/grouping_performance.jl
+++ b/benchmarks/grouping_performance.jl
@@ -1,0 +1,23 @@
+using DataFrames
+using CategoricalArrays
+using PooledArrays
+using BenchmarkTools
+
+
+# `refpool`/`refarray` optimized grouping method
+for k in (10, 10_000), n in (100, 100_000, 10_000_000)
+    for x in (PooledArray(rand(1:k, n)),
+              CategoricalArray(rand(1:n, 10_000_000)),
+              PooledArray(rand([missing; 1:n], 10_000_000)),
+              CategoricalArray(rand([missing; 1:n], 10_000_000)))
+        df = DataFrame(x=x)
+        @btime groupby($df, :x)
+
+        # Skipping missing values
+        @btime groupby($df, :x, skipmissing=true)
+
+        # Empty group which requires adjusting group indices
+        replace!(df.x, 5 => 6)
+        @btime groupby($df, :x)
+    end
+end

--- a/benchmarks/grouping_performance.jl
+++ b/benchmarks/grouping_performance.jl
@@ -2,22 +2,51 @@ using DataFrames
 using CategoricalArrays
 using PooledArrays
 using BenchmarkTools
+using Random
 
+Random.seed!(1)
+
+grouping_benchmarks = BenchmarkGroup()
 
 # `refpool`/`refarray` optimized grouping method
+refpool_benchmarks = grouping_benchmarks["refpool"] = BenchmarkGroup()
+
 for k in (10, 10_000), n in (100, 100_000, 10_000_000)
     for x in (PooledArray(rand(1:k, n)),
               CategoricalArray(rand(1:n, 10_000_000)),
               PooledArray(rand([missing; 1:n], 10_000_000)),
               CategoricalArray(rand([missing; 1:n], 10_000_000)))
         df = DataFrame(x=x)
-        @btime groupby($df, :x)
+
+        refpool_benchmarks[k, n, nameof(typeof(x)), "skipmissing=false"] =
+            @benchmarkable groupby($df, :x)
 
         # Skipping missing values
-        @btime groupby($df, :x, skipmissing=true)
+        refpool_benchmarks[k, n, nameof(typeof(x)), "skipmissing=true"] =
+            @benchmarkable groupby($df, :x, skipmissing=true)
 
         # Empty group which requires adjusting group indices
         replace!(df.x, 5 => 6)
-        @btime groupby($df, :x)
+        refpool_benchmarks[k, n, nameof(typeof(x)), "empty group"] =
+            @benchmarkable groupby($df, :x)
     end
 end
+
+# If a cache of tuned parameters already exists, use it, otherwise, tune and cache
+# the benchmark parameters. Reusing cached parameters is faster and more reliable
+# than re-tuning `suite` every time the file is included.
+paramspath = joinpath(dirname(@__FILE__), "params.json")
+
+if isfile(paramspath)
+    loadparams!(grouping_benchmarks, BenchmarkTools.load(paramspath)[1], :evals);
+else
+    tune!(grouping_benchmarks)
+    BenchmarkTools.save(paramspath, params(grouping_benchmarks));
+end
+
+grouping_results = run(grouping_benchmarks, verbose=true)
+# using Serialization
+# serialize("grouping_results.jls", grouping_results)
+# leaves(judge(median(grouping_results1), median(grouping_results2)))
+# leaves(regressions(judge(median(grouping_results1), median(grouping_results2))))
+# leaves(improvements(judge(median(grouping_results1), median(grouping_results2))))

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -15,4 +15,5 @@ gennames
 getmaxwidths
 ourshow
 ourstrwidth
+tforeach
 ```

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -88,8 +88,8 @@ funname(c::ComposedFunction) = Symbol(funname(c.outer), :_, funname(c.inner))
 # This method ensures balanced sizes by avoiding a small last chunk
 function split_indices(len::Integer, basesize::Integer)
     len′ = Int64(len) # Avoid overflow on 32-bit machines
-    np = max(1, div(len′, basesize))
-    return ((1 + ((i - 1) * len′) ÷ np):((i * len′) ÷ np) for i in 1:np)
+    np = max(1, div(len, basesize))
+    return (Int(1 + ((i - 1) * len′) ÷ np):Int((i * len′) ÷ np) for i in 1:np)
 end
 
 """
@@ -103,7 +103,7 @@ since that can allow for a more efficient load balancing in case
 some threads are busy (nested parallelism).
 """
 function tforeach(f, x::AbstractArray; basesize::Integer)
-    Base.require_one_based_indexing(x)
+    @assert firstindex(x) == 1
 
     @static if VERSION >= v"1.4"
         nt = Threads.nthreads()

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -3831,4 +3831,22 @@ end
                         ((x, y, z) -> x[1] <= 5 ? unwrap(y[1]) : unwrap(z[1])) => :res)
 end
 
+@testset "groupby multithreading" begin
+    for x in (PooledArray(rand(1:10, 1_100_000)),
+              PooledArray(rand([1:9; missing], 1_100_000))),
+        y in (PooledArray(rand(["a", "b", "c", "d"], 1_100_000)),
+              PooledArray(rand(["a"; "b"; "c"; missing], 1_100_000)))
+        df = DataFrame(x=x, y=y)
+
+        # Checks are done by groupby_checked
+        @test length(groupby_checked(df, :x)) == 10
+        @test length(groupby_checked(df, :x, skipmissing=true)) ==
+            length(unique(skipmissing(x)))
+
+        @test length(groupby_checked(df, [:x, :y])) == 40
+        @test length(groupby_checked(df, [:x, :y], skipmissing=true)) ==
+            length(unique(skipmissing(x))) * length(unique(skipmissing(y)))
+    end
+end
+
 end # module

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -101,4 +101,17 @@ end
     @test fetch(t) === true
 end
 
+@testset "split_indices" begin
+    for len in 0:12
+        basesize = 10
+        x = DataFrames.split_indices(len, basesize)
+
+        @test length(x) == max(1, div(len, basesize))
+        @test reduce(vcat, x) == 1:len
+        vmin, vmax = extrema(length, x)
+        @test vmin + 1 == vmax || vmin == vmax
+        @test len < basesize || vmin >= basesize
+    end
+end
+
 end # module

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -108,7 +108,7 @@ end
 
         @test length(x) == max(1, div(len, basesize))
         @test reduce(vcat, x) === 1:len
-        vmin, vmax = extrema(length, x)
+        vmin, vmax = extrema(length(v) for v in x)
         @test vmin + 1 == vmax || vmin == vmax
         @test len < basesize || vmin >= basesize
     end
@@ -120,7 +120,7 @@ end
     @test length(x) == div(len, basesize)
     @test x[1][1] === 1
     @test x[end][end] === Int(len)
-    vmin, vmax = extrema(length, x)
+    vmin, vmax = extrema(length(v) for v in x)
     @test vmin + 1 == vmax || vmin == vmax
     @test len < basesize || vmin >= basesize
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -107,11 +107,22 @@ end
         x = DataFrames.split_indices(len, basesize)
 
         @test length(x) == max(1, div(len, basesize))
-        @test reduce(vcat, x) == 1:len
+        @test reduce(vcat, x) === 1:len
         vmin, vmax = extrema(length, x)
         @test vmin + 1 == vmax || vmin == vmax
         @test len < basesize || vmin >= basesize
     end
+
+    # Check overflow on 32-bit
+    len = typemax(Int32)
+    basesize = 100_000_000
+    x = collect(DataFrames.split_indices(len, basesize))
+    @test length(x) == div(len, basesize)
+    @test x[1][1] === 1
+    @test x[end][end] === Int(len)
+    vmin, vmax = extrema(length, x)
+    @test vmin + 1 == vmax || vmin == vmax
+    @test len < basesize || vmin >= basesize
 end
 
 end # module


### PR DESCRIPTION
main:
```julia
julia> using Revise, DataFrames, PooledArrays, BenchmarkTools

julia> x = PooledArray(rand(1:10, 10_000_000));

julia> df = DataFrame(x=x);

julia> @btime groupby(df, :x);
  40.742 ms (38 allocations: 76.30 MiB)

julia> df.x[df.x .== 5] .= 6; # Empty group

julia> @btime groupby(df, :x);
  52.488 ms (39 allocations: 76.30 MiB)

julia> x = PooledArray(rand([missing; 1:10], 10_000_000));

julia> df = DataFrame(x=x);

julia> @btime groupby(df, :x);
  42.955 ms (42 allocations: 76.30 MiB)

julia> @btime groupby(df, :x, skipmissing=true);
  63.951 ms (42 allocations: 76.30 MiB)
```

PR with two threads:
```julia
julia> using Revise, DataFrames, PooledArrays, BenchmarkTools

julia> x = PooledArray(rand(1:10, 10_000_000));

julia> df = DataFrame(x=x);

julia> @btime groupby(df, :x);
  25.053 ms (113 allocations: 76.30 MiB)

julia> df.x[df.x .== 5] .= 6; # Empty group

julia> @btime groupby(df, :x);
  41.185 ms (114 allocations: 76.30 MiB)

julia> x = PooledArray(rand([missing; 1:10], 10_000_000));

julia> df = DataFrame(x=x);

julia> @btime groupby(df, :x);
  26.842 ms (116 allocations: 76.30 MiB)

julia> @btime groupby(df, :x, skipmissing=true);
  36.391 ms (116 allocations: 76.30 MiB)
```