### PR TITLE
get rid of convert to core Julia types for GroupKey

### DIFF
--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -533,16 +533,9 @@ Construct a `NamedTuple` with the same contents as the [`GroupKey`](@ref).
 """
 Base.copy(key::GroupKey) = NamedTuple(key)
 
-Base.convert(::Type{NamedTuple}, key::GroupKey) = NamedTuple(key)
-Base.convert(::Type{Tuple}, key::GroupKey) = Tuple(key)
+Base.Vector(key::GroupKey) = [v for v in key]
+Base.Vector{T}(key::GroupKey) where T = T[v for v in key]
 
-Base.convert(::Type{Vector}, key::GroupKey) = [v for v in key]
-Base.convert(::Type{Vector{T}}, key::GroupKey) where T = T[v for v in key]
-Base.Vector(key::GroupKey) = convert(Vector, key)
-Base.Vector{T}(key::GroupKey) where T = convert(Vector{T}, key)
-
-Base.convert(::Type{Array}, key::GroupKey) = Vector(key)
-Base.convert(::Type{Array{T}}, key::GroupKey) where {T} = Vector{T}(key)
 Base.Array(key::GroupKey) = Vector(key)
 Base.Array{T}(key::GroupKey) where {T} = Vector{T}(key)
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1773,26 +1773,20 @@ end
         @test propertynames(key, true) == cols
         @test values(key) ≅ values(nt)
 
-        # (Named)Tuple conversion
+        # (Named)Tuple constructors
         @test Tuple(key) ≅ values(nt)
-        @test convert(Tuple, key) ≅ values(nt)
         @test NamedTuple(key) ≅ nt
-        @test convert(NamedTuple, key) ≅ nt
         @test copy(key) ≅ nt
 
-        # other conversions
+        # other constructors
         @test Vector(key) ≅ collect(nt)
         @test eltype(Vector(key)) === eltype([v for v in key])
-        @test convert(Vector, key) ≅ collect(nt)
         @test Array(key) ≅ collect(nt)
         @test eltype(Array(key)) === eltype([v for v in key])
-        @test convert(Array, key) ≅ collect(nt)
         @test Vector{Any}(key) ≅ collect(nt)
         @test eltype(Vector{Any}(key)) === Any
-        @test convert(Vector{Any}, key) ≅ collect(nt)
         @test Array{Any}(key) ≅ collect(nt)
         @test eltype(Array{Any}(key)) === Any
-        @test convert(Array{Any}, key) ≅ collect(nt)
 
         # Iteration
         @test collect(key) ≅ collect(nt)


### PR DESCRIPTION
Fixes #2666 

The fact that the only thing that has to be done was to remove explicit `convert` calls, means that this is likely not too bad.