### PR TITLE
Omit vertical lines with show_row_numbers = false

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -278,12 +278,12 @@ function _show(io::IO,
     # case, we will add this information using the row name column of
     # PrettyTables.jl. Otherwise, we can just use the row number column.
     if (rowid === nothing) || (ncol(df) == 0)
-        show_row_number::Bool = haskey(kwargs, :show_row_number) ? kwargs[:show_row_number] : true
+        show_row_number::Bool = get(kwargs, :show_row_number, true)
         row_names = nothing
 
         # If the columns with row numbers is not shown, then we should not
         # display a vertical line after the first column.
-        vlines = show_row_number ? [1] : Int[]
+        vlines = fill(1, show_row_number)
     else
         nrow(df) != 1 &&
             throw(ArgumentError("rowid may be passed only with a single row data frame"))
@@ -291,7 +291,7 @@ function _show(io::IO,
         # In this case, if the user does not want to show the row number, then
         # we must hide the row name column, which is used to display the
         # `rowid`.
-        if haskey(kwargs, :show_row_number) && !kwargs[:show_row_number]
+        if !get(kwargs, :show_row_number, true)
             row_names = nothing
             vlines = Int[]
         else

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -278,13 +278,28 @@ function _show(io::IO,
     # case, we will add this information using the row name column of
     # PrettyTables.jl. Otherwise, we can just use the row number column.
     if (rowid === nothing) || (ncol(df) == 0)
-        show_row_number = true
+        show_row_number::Bool = haskey(kwargs, :show_row_number) ? kwargs[:show_row_number] : true
         row_names = nothing
+
+        # If the columns with row numbers is not shown, then we should not
+        # display a vertical line after the first column.
+        vlines = show_row_number ? [1] : Int[]
     else
         nrow(df) != 1 &&
             throw(ArgumentError("rowid may be passed only with a single row data frame"))
+
+        # In this case, if the user does not want to show the row number, then
+        # we must hide the row name column, which is used to display the
+        # `rowid`.
+        if haskey(kwargs, :show_row_number) && !kwargs[:show_row_number]
+            row_names = nothing
+            vlines = Int[]
+        else
+            row_names = [string(rowid)]
+            vlines = Int[1]
+        end
+
         show_row_number = false
-        row_names = [string(rowid)]
     end
 
     # Print the table with the selected options.
@@ -312,7 +327,7 @@ function _show(io::IO,
                  show_row_number             = show_row_number,
                  title                       = title,
                  vcrop_mode                  = :middle,
-                 vlines                      = [1],
+                 vlines                      = vlines,
                  kwargs...)
 
     return nothing

--- a/test/show.jl
+++ b/test/show.jl
@@ -689,7 +689,7 @@ end
 end
 
 @testset "Issue #2673 - Vertical line when not showing row numbers" begin
-    df = DataFrame(a=[10,20], b=[30,40], c=[50,60])
+    df = DataFrame(a = Int64[10,20], b = Int64[30,40], c = Int64[50,60])
 
     io = IOContext(IOBuffer())
     show(io, df)

--- a/test/show.jl
+++ b/test/show.jl
@@ -689,7 +689,7 @@ end
 end
 
 @testset "Issue #2673 - Vertical line when not showing row numbers" begin
-    df = DataFrame(a = Int64[10,20], b = Int64[30,40], c = Int64[50,60])
+    df = DataFrame(a = Int64[10, 20], b = Int64[30, 40], c = Int64[50, 60])
 
     io = IOContext(IOBuffer())
     show(io, df)
@@ -704,7 +704,7 @@ end
 
 
     io = IOContext(IOBuffer())
-    show(io, df, show_row_number = false)
+    show(io, df, show_row_number=false)
     str = String(take!(io.io))
     @test str == """
         2×3 DataFrame
@@ -715,7 +715,7 @@ end
             20     40     60"""
 
     io = IOContext(IOBuffer())
-    show(io, df[2,:])
+    show(io, df[2, :])
     str = String(take!(io.io))
     @test str == """
         DataFrameRow
@@ -726,7 +726,7 @@ end
 
 
     io = IOContext(IOBuffer())
-    show(io, df[2,:], show_row_number = false)
+    show(io, df[2, :], show_row_number=false)
     str = String(take!(io.io))
     @test str == """
         DataFrameRow

--- a/test/show.jl
+++ b/test/show.jl
@@ -688,4 +688,52 @@ end
 
 end
 
+@testset "Issue #2673 - Vertical line when not showing row numbers" begin
+    df = DataFrame(a=[10,20], b=[30,40], c=[50,60])
+
+    io = IOContext(IOBuffer())
+    show(io, df)
+    str = String(take!(io.io))
+    @test str == """
+        2×3 DataFrame
+         Row │ a      b      c
+             │ Int64  Int64  Int64
+        ─────┼─────────────────────
+           1 │    10     30     50
+           2 │    20     40     60"""
+
+
+    io = IOContext(IOBuffer())
+    show(io, df, show_row_number = false)
+    str = String(take!(io.io))
+    @test str == """
+        2×3 DataFrame
+         a      b      c
+         Int64  Int64  Int64
+        ─────────────────────
+            10     30     50
+            20     40     60"""
+
+    io = IOContext(IOBuffer())
+    show(io, df[2,:])
+    str = String(take!(io.io))
+    @test str == """
+        DataFrameRow
+         Row │ a      b      c
+             │ Int64  Int64  Int64
+        ─────┼─────────────────────
+           2 │    20     40     60"""
+
+
+    io = IOContext(IOBuffer())
+    show(io, df[2,:], show_row_number = false)
+    str = String(take!(io.io))
+    @test str == """
+        DataFrameRow
+         a      b      c
+         Int64  Int64  Int64
+        ─────────────────────
+            20     40     60"""
+end
+
 end # module


### PR DESCRIPTION
If the user pass the option `show_row_numbers = false` to PrettyTables.jl, then we also need to omit the vertical line in the first column.

Closes #2673