### PR TITLE
make Tables.columns(df) return eachcol(df)

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -1,6 +1,6 @@
 Tables.istable(::Type{<:AbstractDataFrame}) = true
 Tables.columnaccess(::Type{<:AbstractDataFrame}) = true
-Tables.columns(df::AbstractDataFrame) = df
+Tables.columns(df::AbstractDataFrame) = eachcol(df)
 Tables.rowaccess(::Type{<:AbstractDataFrame}) = true
 Tables.rows(df::AbstractDataFrame) = eachrow(df)
 Tables.rowtable(df::AbstractDataFrame) = Tables.rowtable(Tables.columntable(df))


### PR DESCRIPTION
Fixes #2636 

In the end I decided only to change the return value of `Tables.columns` to `DataFrameColumns` to ensure iteration is supported for it.
I did not go for `DataFrameColumns <: Tables.AbstractColumns` as it did not seem necessary (it would only add `haskey` and `get` methods - we can always add this support later if needed).