### PR TITLE
check if column order is correct in aggregations

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -144,9 +144,10 @@ include("abstractdataframe/io.jl")
 include("abstractdataframe/sort.jl")
 include("dataframe/sort.jl")
 
-include("deprecated.jl")
-
 include("other/tables.jl")
+include("other/names.jl")
+
+include("deprecated.jl")
 
 include("other/precompile.jl")
 precompile()

--- a/src/dataframerow/dataframerow.jl
+++ b/src/dataframerow/dataframerow.jl
@@ -452,20 +452,6 @@ Base.merge(a::DataFrameRow, itr) = merge(NamedTuple(a), itr)
 
 Base.hash(r::DataFrameRow, h::UInt) = _nt_like_hash(r, h)
 
-_getnames(x::DataFrameRow) = _names(x)
-_getnames(x::NamedTuple) = propertynames(x)
-
-# this is required as == does not allow for comparison between tuples and vectors
-function _equal_names(r1, r2)
-    n1 = _getnames(r1)
-    n2 = _getnames(r2)
-    length(n1) == length(n2) || return false
-    for (a, b) in zip(n1, n2)
-        a == b || return false
-    end
-    return true
-end
-
 for eqfun in (:isequal, :(==)),
     (leftarg, rightarg) in ((:DataFrameRow, :DataFrameRow),
                             (:DataFrameRow, :NamedTuple),

--- a/src/groupeddataframe/complextransforms.jl
+++ b/src/groupeddataframe/complextransforms.jl
@@ -4,9 +4,6 @@ _nrow(x::NamedTuple{<:Any, <:Tuple{Vararg{AbstractVector}}}) =
 _ncol(df::AbstractDataFrame) = ncol(df)
 _ncol(x::Union{NamedTuple, DataFrameRow}) = length(x)
 
-_getnames(x::AbstractDataFrame) = _names(x)
-_getnames(x::Any) = throw(ArgumentError("names not defined for argument of type $(typeof(x))"))
-
 function _combine_multicol(firstres, fun::Base.Callable, gd::GroupedDataFrame,
                            incols::Union{Nothing, AbstractVector, Tuple, NamedTuple})
     firstmulticol = firstres isa MULTI_COLS_TYPE

--- a/src/groupeddataframe/complextransforms.jl
+++ b/src/groupeddataframe/complextransforms.jl
@@ -82,7 +82,7 @@ function fill_row!(row, outcols::NTuple{N, AbstractVector},
                    colnames::NTuple{N, Symbol}) where N
     if !_names_match(row, colnames)
         throw(ArgumentError("return value must have the same column names " *
-                           "for all groups (got $colnames and $(propertynames(row)))"))
+                            "for all groups (got $colnames and $(propertynames(row)))"))
     end
     @inbounds for j in colstart:length(outcols)
         col = outcols[j]
@@ -315,7 +315,7 @@ function append_rows!(rows, outcols::NTuple{N, AbstractVector},
                       colstart::Integer, colnames::NTuple{N, Symbol}) where N
 if !_names_match(rows, colnames)
         throw(ArgumentError("return value must have the same column names " *
-                           "for all groups (got $colnames and $(propertynames(row)))"))
+                            "for all groups (got $colnames and $(propertynames(rows)))"))
     end
     @inbounds for j in colstart:length(outcols)
         col = outcols[j]

--- a/src/groupeddataframe/complextransforms.jl
+++ b/src/groupeddataframe/complextransforms.jl
@@ -304,7 +304,6 @@ end
 
 _get_col(rows::AbstractDataFrame, j::Int) = rows[!, j]
 _get_col(rows::NamedTuple{<:Any, <:Tuple{Vararg{AbstractVector}}}, j::Int) = rows[j]
-_get_col(rows::Any, j::Int) = throw(ArgumentError(ERROR_ROW_COUNT))
 
 function append_rows!(rows, outcols::NTuple{N, AbstractVector},
                       colstart::Integer, colnames::NTuple{N, Symbol}) where N

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -523,8 +523,6 @@ Base.getproperty(key::GroupKey, p::AbstractString) = getproperty(key, Symbol(p))
 
 Base.hash(key::GroupKey, h::UInt) = _nt_like_hash(key, h)
 
-_getnames(x::GroupKey) = parent(x).cols
-
 for eqfun in (:isequal, :(==)),
     (leftarg, rightarg) in ((:GroupKey, :GroupKey),
                             (:DataFrameRow, :GroupKey),

--- a/src/other/names.jl
+++ b/src/other/names.jl
@@ -1,0 +1,17 @@
+# common utilities for getting and comparing column names
+
+_getnames(x::NamedTuple) = propertynames(x)
+_getnames(x::AbstractDataFrame) = _names(x)
+_getnames(x::DataFrameRow) = _names(x)
+_getnames(x::GroupKey) = parent(x).cols
+
+# this function is needed as == does not allow for comparison between tuples and vectors
+function _equal_names(r1, r2)
+    n1 = _getnames(r1)
+    n2 = _getnames(r2)
+    length(n1) == length(n2) || return false
+    for (a, b) in zip(n1, n2)
+        a == b || return false
+    end
+    return true
+end

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -438,9 +438,22 @@ end
 
     # Test return values with columns in different orders
     @test_throws ArgumentError combine(d -> d.x == [1] ? (x1=1, x2=3) : (x2=2, x1=4), gdf)
-    @test_throws ArgumentError  combine(d -> d.x == [1] ? d[1, [1, 2]] : d[1, [2, 1]], gdf)
-    @test_throws ArgumentError combine(d -> d.x == [1] ? (x1=1, x2=3) : (x2=2, x1=4), gdf)
-    @test combine(d -> d.x == [1] ?  : , gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? d[1, [1, 2]] : d[1, [2, 1]], gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? (x1=[1], x2=[3]) : (x2=[2], x1=[4]), gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? [1 3] : (x2=[2], x1=[4]), gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? d[1:1, [1, 2]] : d[1:1, [2, 1]], gdf)
+    # but this should work
+    @test combine(d -> d.x == [1] ? [1 3] : (x1=[2], x2=[4]), gdf) == DataFrame(x=1:3, x1=[1, 2, 2], x2=[3, 4, 4])
+
+    # wrong mixing tests
+    @test_throws ArgumentError combine(d -> d.x == [1] ? d[1:1, :] : d[1, :], gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? d[1, :] : d[1:1, :], gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? [1 2] : d[1, :], gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? d[1, :] : [1 2], gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? d[1:1, :] : NamedTuple(d[1, :]), gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? NamedTuple(d[1, :]) : d[1:1, :], gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? Tables.columntable(d[1:1, :]) : NamedTuple(d[1, :]), gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? NamedTuple(d[1, :]) : Tables.columntable(d[1:1, :]), gdf)
 
     # Test with NamedTuple with columns of incompatible lengths
     @test_throws DimensionMismatch combine(d -> (x1=[1], x2=[3, 4]), gdf)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -437,10 +437,10 @@ end
     @test res.b ≅ [missing, "a", "a"]
 
     # Test return values with columns in different orders
-    @test combine(d -> d.x == [1] ? (x1=1, x2=3) : (x2=2, x1=4), gdf) ==
-        DataFrame(x=1:3, x1=[1, 4, 4], x2=[3, 2, 2])
-    @test combine(d -> d.x == [1] ? DataFrame(x1=1, x2=3) : DataFrame(x2=2, x1=4), gdf) ==
-        DataFrame(x=1:3, x1=[1, 4, 4], x2=[3, 2, 2])
+    @test_throws ArgumentError combine(d -> d.x == [1] ? (x1=1, x2=3) : (x2=2, x1=4), gdf)
+    @test_throws ArgumentError  combine(d -> d.x == [1] ? d[1, [1, 2]] : d[1, [2, 1]], gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? (x1=1, x2=3) : (x2=2, x1=4), gdf)
+    @test combine(d -> d.x == [1] ?  : , gdf)
 
     # Test with NamedTuple with columns of incompatible lengths
     @test_throws DimensionMismatch combine(d -> (x1=[1], x2=[3, 4]), gdf)


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2424

I still need to update tests and docs (which will also make sure we have no bug in my code :smile:). I will do it later this weekend.

The benchmarks are.

Setup:
```
julia> df = DataFrame(x = 1:10^6);

julia> gdf = groupby(df, :x);

julia> f(x) = return (a=x[1], b=x[1]+1)
f (generic function with 1 method)
```

this PR:
```
julia> @benchmark combine($gdf, :x => f => AsTable)
BenchmarkTools.Trial: 
  memory estimate:  129.72 MiB
  allocs estimate:  1000280
  --------------
  minimum time:     225.386 ms (1.09% GC)
  median time:      242.938 ms (2.17% GC)
  mean time:        252.185 ms (5.65% GC)
  maximum time:     349.955 ms (27.36% GC)
  --------------
  samples:          20
  evals/sample:     1
```

0.22.6 release:
```
julia> @benchmark combine($gdf, :x => f => AsTable)
BenchmarkTools.Trial: 
  memory estimate:  358.56 MiB
  allocs estimate:  10998173
  --------------
  minimum time:     261.659 ms (6.93% GC)
  median time:      300.361 ms (7.92% GC)
  mean time:        337.227 ms (15.66% GC)
  maximum time:     443.614 ms (23.25% GC)
  --------------
  samples:          15
  evals/sample:     1
```

so we:
1. improve performance a bit
2. significantly cut down allocations
3. avoid a bug described in #2424