### PR TITLE
Enable multithreading in hashrows_col!

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -15,5 +15,6 @@ gennames
 getmaxwidths
 ourshow
 ourstrwidth
+@spawn_for_chunks
 tforeach
 ```

--- a/src/groupeddataframe/utils.jl
+++ b/src/groupeddataframe/utils.jl
@@ -5,7 +5,7 @@ function hashrows_col!(h::Vector{UInt},
                        v::AbstractVector{T},
                        rp::Nothing,
                        firstcol::Bool) where T
-    @splittasks 1_000_000 for i in eachindex(h)
+    @spawn_for_chunks 1_000_000 for i in eachindex(h)
         @inbounds begin
             el = v[i]
             h[i] = hash(el, h[i])
@@ -33,18 +33,18 @@ function hashrows_col!(h::Vector{UInt},
         fira = firstindex(ra)
 
         hashes = Vector{UInt}(undef, length(rp))
-        @splittasks 1_000_000 for i in eachindex(hashes)
+        @spawn_for_chunks 1_000_000 for i in eachindex(hashes)
             @inbounds hashes[i] = hash(rp[i+firp-1])
         end
 
         # here we rely on the fact that `DataAPI.refpool` has a continuous
         # block of indices
-        @splittasks 1_000_000  for i in eachindex(h)
+        @spawn_for_chunks 1_000_000  for i in eachindex(h)
             @inbounds ref = ra[i+fira-1]
             @inbounds h[i] = hashes[ref+1-firp]
         end
     else
-        @splittasks 1_000_000 for i in eachindex(h, v)
+        @spawn_for_chunks 1_000_000 for i in eachindex(h, v)
             @inbounds h[i] = hash(v[i], h[i])
         end
     end

--- a/src/groupeddataframe/utils.jl
+++ b/src/groupeddataframe/utils.jl
@@ -5,7 +5,7 @@ function hashrows_col!(h::Vector{UInt},
                        v::AbstractVector{T},
                        rp::Nothing,
                        firstcol::Bool) where T
-    tforeach(eachindex(h), basesize=1_000_000) do i
+    @splittasks 1_000_000 for i in eachindex(h)
         @inbounds begin
             el = v[i]
             h[i] = hash(el, h[i])
@@ -33,18 +33,18 @@ function hashrows_col!(h::Vector{UInt},
         fira = firstindex(ra)
 
         hashes = Vector{UInt}(undef, length(rp))
-        tforeach(eachindex(hashes), basesize=1_000_000) do i
+        @splittasks 1_000_000 for i in eachindex(hashes)
             @inbounds hashes[i] = hash(rp[i+firp-1])
         end
 
         # here we rely on the fact that `DataAPI.refpool` has a continuous
         # block of indices
-        tforeach(eachindex(h), basesize=1_000_000) do i
+        @splittasks 1_000_000  for i in eachindex(h)
             @inbounds ref = ra[i+fira-1]
             @inbounds h[i] = hashes[ref+1-firp]
         end
     else
-        tforeach(eachindex(h, v), basesize=1_000_000) do i
+        @splittasks 1_000_000 for i in eachindex(h, v)
             @inbounds h[i] = hash(v[i], h[i])
         end
     end

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -174,6 +174,17 @@ else
     end
 end
 
+"""
+    @spawn_for_chunks basesize for i in range ... end
+
+Parallelize a `for` loop by spawning separate tasks
+iterating each over a chunk of at least `basesize` elements
+in `range`.
+
+A number of task higher than `Threads.nthreads()` may be spawned,
+since that can allow for a more efficient load balancing in case
+some threads are busy (nested parallelism).
+"""
 macro spawn_for_chunks(basesize, ex)
     if !(isa(ex, Expr) && ex.head === :for)
         throw(ArgumentError("@spawn_for_chunks requires a `for` loop expression"))

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -130,7 +130,7 @@ function tforeach(f, x::AbstractArray; basesize::Integer)
 end
 
 if VERSION >= v"1.4"
-    function _spawn_for_chunksfor(iter, lbody, basesize)
+    function _spawn_for_chunks_helper(iter, lbody, basesize)
         lidx = iter.args[1]
         range = iter.args[2]
         quote
@@ -159,7 +159,7 @@ if VERSION >= v"1.4"
         end
     end
 else
-    function _spawn_for_chunksfor(iter, lbody, basesize)
+    function _spawn_for_chunks_helper(iter, lbody, basesize)
         lidx = iter.args[1]
         range = iter.args[2]
         quote
@@ -192,7 +192,7 @@ macro spawn_for_chunks(basesize, ex)
     if !(ex.args[1] isa Expr && ex.args[1].head === :(=))
         throw(ArgumentError("nested outer loops are not currently supported by @spawn_for_chunks"))
     end
-    return _spawn_for_chunksfor(ex.args[1], ex.args[2], basesize)
+    return _spawn_for_chunks_helper(ex.args[1], ex.args[2], basesize)
 end
 
 function _nt_like_hash(v, h::UInt)

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -155,7 +155,7 @@ if VERSION >= v"1.4"
                     end
                 end
             end
-            return nothing
+            nothing
         end
     end
 else
@@ -169,7 +169,7 @@ else
                     $(esc(lbody))
                 end
             end
-            return nothing
+            nothing
         end
     end
 end

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -130,7 +130,7 @@ function tforeach(f, x::AbstractArray; basesize::Integer)
 end
 
 if VERSION >= v"1.4"
-    function _splittasksfor(iter, lbody, basesize)
+    function _spawn_for_chunksfor(iter, lbody, basesize)
         lidx = iter.args[1]
         range = iter.args[2]
         quote
@@ -159,7 +159,7 @@ if VERSION >= v"1.4"
         end
     end
 else
-    function _splittasksfor(iter, lbody, basesize)
+    function _spawn_for_chunksfor(iter, lbody, basesize)
         lidx = iter.args[1]
         range = iter.args[2]
         quote
@@ -174,14 +174,14 @@ else
     end
 end
 
-macro splittasks(basesize, ex)
+macro spawn_for_chunks(basesize, ex)
     if !(isa(ex, Expr) && ex.head === :for)
-        throw(ArgumentError("@splittasks requires a `for` loop expression"))
+        throw(ArgumentError("@spawn_for_chunks requires a `for` loop expression"))
     end
     if !(ex.args[1] isa Expr && ex.args[1].head === :(=))
-        throw(ArgumentError("nested outer loops are not currently supported by @splittasks"))
+        throw(ArgumentError("nested outer loops are not currently supported by @spawn_for_chunks"))
     end
-    return _splittasksfor(ex.args[1], ex.args[2], basesize)
+    return _spawn_for_chunksfor(ex.args[1], ex.args[2], basesize)
 end
 
 function _nt_like_hash(v, h::UInt)


### PR DESCRIPTION
This is somewhat faster for large number of rows (by about 20% for 10M rows and 10 threads), but a bit slower when the number of rows is lower than the threshold (so that a single thread is used). Not sure whether something can be done about it, nor whether the improvement in some cases is worth the loss in others.

```julia
julia> using Revise, DataFrames, BenchmarkTools

julia> for n in (1000, 10_000_000)
           df = DataFrame(x=rand(string.(1000000:1000010), n));
           @btime groupby($df, :x);

          # Benchmark directly the changes
           h = similar(df.x, UInt);
           n = similar(df.x, Bool);
           @btime DataFrames.hashrows_col!($h, $n, $df.x, nothing, true);
       end

# main
  21.105 μs (29 allocations: 34.05 KiB)
  12.211 μs (0 allocations: 0 bytes)
  335.166 ms (32 allocations: 280.59 MiB)
  122.653 ms (0 allocations: 0 bytes)

# PR
  26.041 μs (29 allocations: 34.05 KiB)
  16.291 μs (0 allocations: 0 bytes)
  258.437 ms (107 allocations: 280.60 MiB)
  18.463 ms (74 allocations: 5.72 KiB)
```