### PR TITLE
do not use collect in describe

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -522,9 +522,8 @@ column `:nmissing` will report the number of missing values of that variable.
 
 If custom functions are provided, they are called repeatedly with the vector
 corresponding to each column as the only argument. For columns allowing for
-missing values, the vector is wrapped in a call to `skipmissing`: custom
-functions must therefore support such objects (and not only vectors), and cannot
-access missing values.
+missing values, the vector is wrapped in a call to `skipmissing` and then
+`collect`ed: therefore custom functions cannot access missing values.
 
 # Examples
 ```julia
@@ -610,7 +609,7 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
     # An array of Dicts for summary statistics
     col_stats_dicts = map(eachcol(df)) do col
         if eltype(col) >: Missing
-            t = skipmissing(col)
+            t = collect(skipmissing(col))
             d = get_stats(t, predefined_funs)
             get_stats!(d, t, custom_funs)
         else
@@ -649,7 +648,7 @@ end
 # Compute summary statistics
 # use a dict because we dont know which measures the user wants
 # Outside of the `describe` function due to something with 0.7
-function get_stats(col::Union{AbstractVector,Base.SkipMissing}, stats::AbstractVector{Symbol})
+function get_stats(col::AbstractVector, stats::AbstractVector{Symbol})
     d = Dict{Symbol, Any}()
 
     if :q25 in stats || :median in stats || :q75 in stats
@@ -687,8 +686,7 @@ function get_stats(col::Union{AbstractVector,Base.SkipMissing}, stats::AbstractV
     return d
 end
 
-function get_stats!(d::Dict, col::Union{AbstractVector,Base.SkipMissing},
-                    stats::AbstractVector{<:Pair})
+function get_stats!(d::Dict, col::AbstractVector, stats::AbstractVector{<:Pair})
     for stat in stats
         d[stat[2]] = try stat[1](col) catch end
     end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -571,7 +571,7 @@ DataAPI.describe(df::AbstractDataFrame,
 
 DataAPI.describe(df::AbstractDataFrame; cols=:) =
     _describe(select(df, cols, copycols=false),
-              [:mean, :min, :median, :max, :nmissing, :eltype])
+              Any[:mean, :min, :median, :max, :nmissing, :eltype])
 
 function _describe(df::AbstractDataFrame, stats::AbstractVector)
     predefined_funs = Symbol[s for s in stats if s isa Symbol]
@@ -591,7 +591,7 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
         throw(ArgumentError(":$not_allowed not allowed." * allowed_msg))
     end
 
-    custom_funs = Pair[s[1] => Symbol(s[2]) for s in stats if s isa Pair]
+    custom_funs = Any[s[1] => Symbol(s[2]) for s in stats if s isa Pair]
 
     ordered_names = [s isa Symbol ? s : Symbol(last(s)) for s in stats]
 
@@ -609,7 +609,7 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
     # An array of Dicts for summary statistics
     col_stats_dicts = map(eachcol(df)) do col
         if eltype(col) >: Missing
-            t = collect(skipmissing(col))
+            t = skipmissing(col)
             d = get_stats(t, predefined_funs)
             get_stats!(d, t, custom_funs)
         else
@@ -648,7 +648,8 @@ end
 # Compute summary statistics
 # use a dict because we dont know which measures the user wants
 # Outside of the `describe` function due to something with 0.7
-function get_stats(col::AbstractVector, stats::AbstractVector{Symbol})
+function get_stats(@nospecialize(col::Union{AbstractVector, Base.SkipMissing}),
+                   stats::AbstractVector{Symbol})
     d = Dict{Symbol, Any}()
 
     if :q25 in stats || :median in stats || :q75 in stats
@@ -686,7 +687,8 @@ function get_stats(col::AbstractVector, stats::AbstractVector{Symbol})
     return d
 end
 
-function get_stats!(d::Dict, col::AbstractVector, stats::AbstractVector{<:Pair})
+function get_stats!(d::Dict, @nospecialize(col::Union{AbstractVector, Base.SkipMissing}),
+                    stats::Vector{Any})
     for stat in stats
         d[stat[2]] = try stat[1](col) catch end
     end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -610,7 +610,7 @@ function _describe(df::AbstractDataFrame, stats::AbstractVector)
     # An array of Dicts for summary statistics
     col_stats_dicts = map(eachcol(df)) do col
         if eltype(col) >: Missing
-            t = collect(skipmissing(col))
+            t = skipmissing(col)
             d = get_stats(t, predefined_funs)
             get_stats!(d, t, custom_funs)
         else
@@ -649,7 +649,7 @@ end
 # Compute summary statistics
 # use a dict because we dont know which measures the user wants
 # Outside of the `describe` function due to something with 0.7
-function get_stats(col::AbstractVector, stats::AbstractVector{Symbol})
+function get_stats(col::Union{AbstractVector,Base.SkipMissing}, stats::AbstractVector{Symbol})
     d = Dict{Symbol, Any}()
 
     if :q25 in stats || :median in stats || :q75 in stats
@@ -687,7 +687,8 @@ function get_stats(col::AbstractVector, stats::AbstractVector{Symbol})
     return d
 end
 
-function get_stats!(d::Dict, col::AbstractVector, stats::AbstractVector{<:Pair})
+function get_stats!(d::Dict, col::Union{AbstractVector,Base.SkipMissing},
+                    stats::AbstractVector{<:Pair})
     for stat in stats
         d[stat[2]] = try stat[1](col) catch end
     end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -522,8 +522,9 @@ column `:nmissing` will report the number of missing values of that variable.
 
 If custom functions are provided, they are called repeatedly with the vector
 corresponding to each column as the only argument. For columns allowing for
-missing values, the vector is wrapped in a call to `skipmissing` and then
-`collect`ed: therefore custom functions cannot access missing values.
+missing values, the vector is wrapped in a call to `skipmissing`: custom
+functions must therefore support such objects (and not only vectors), and cannot
+access missing values.
 
 # Examples
 ```julia


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2693

@pdeffebach - some tests (correctness and performance) would be welcome if you can spare some time.

In my opinion this change should be OK, as rather the called functions should add support for `skipmissing` value passed - and I would rather fix this limitation if possible.