### PR TITLE
Fix grouping aggregation slowdown

### DIFF
--- a/src/groupeddataframe/fastaggregates.jl
+++ b/src/groupeddataframe/fastaggregates.jl
@@ -102,7 +102,7 @@ function groupreduce_init(op, condf, adjust,
         end
         # here we are sure that only Base.add_sum or Base.mul_prod are performed
         # so we always fall back to Vector as output column type
-        v = Vector{V}(undef, length(gd))
+        v = Tables.allocatecolumn(V, length(gd))
         fill!(v, x)
         return v
     else

--- a/src/groupeddataframe/fastaggregates.jl
+++ b/src/groupeddataframe/fastaggregates.jl
@@ -100,7 +100,9 @@ function groupreduce_init(op, condf, adjust,
         else
             V = U >: Missing ? Union{typeof(x), Missing} : typeof(x)
         end
-        v = similar(incol, V, length(gd))
+        # here we are sure that only Base.add_sum or Base.mul_prod are performed
+        # so we always fall back to Vector as output column type
+        v = Vector{V}(undef, length(gd))
         fill!(v, x)
         return v
     else

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -3876,4 +3876,14 @@ end
     end
 end
 
+@testset "aggregation of PooledArray" begin
+    df = DataFrame(x=PooledArray(Int32(1):Int32(3)))
+    gdf = groupby_checked(df, :x)
+    df2 = combine(gdf, :x => sum, :x => prod)
+    @test df2 == DataFrame(x=1:3, x_sum=1:3, x_prod=1:3)
+    @test df2.x isa PooledVector{Int32}
+    @test df2.x_sum isa Vector{Int}
+    @test df2.x_prod isa Vector{Int}
+end
+
 end # module


### PR DESCRIPTION
This is related to https://github.com/JuliaData/DataFrames.jl/issues/2564#issuecomment-809177160 problem. I propose to produce a `Vector` always when `add_sum` or `mul_prod` is used. The slowdown was due to the fact that output vector was `similar` to input vector, so if input were `PooledArray` a big slowdown was observed.