### PR TITLE
Replace `tforeach` with `@spawn_for_chunks`

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -16,5 +16,4 @@ getmaxwidths
 ourshow
 ourstrwidth
 @spawn_for_chunks
-tforeach
 ```

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -92,43 +92,6 @@ function split_indices(len::Integer, basesize::Integer)
     return (Int(1 + ((i - 1) * len′) ÷ np):Int((i * len′) ÷ np) for i in 1:np)
 end
 
-"""
-    tforeach(f, x::AbstractArray; basesize::Integer)
-
-Apply function `f` to each entry in `x` in parallel, spawning
-one separate task for each block of at least `basesize` entries.
-
-A number of task higher than `Threads.nthreads()` may be spawned,
-since that can allow for a more efficient load balancing in case
-some threads are busy (nested parallelism).
-"""
-function tforeach(f, x::AbstractArray; basesize::Integer)
-    @assert firstindex(x) == 1
-
-    @static if VERSION >= v"1.4"
-        nt = Threads.nthreads()
-        len = length(x)
-        if nt > 1 && len > basesize
-            @sync for p in split_indices(len, basesize)
-                Threads.@spawn begin
-                    for i in p
-                        f(@inbounds x[i])
-                    end
-                end
-            end
-        else
-            for i in eachindex(x)
-                f(@inbounds x[i])
-            end
-        end
-    else
-        for i in eachindex(x)
-            f(@inbounds x[i])
-        end
-    end
-    return
-end
-
 if VERSION >= v"1.4"
     function _spawn_for_chunks_helper(iter, lbody, basesize)
         lidx = iter.args[1]


### PR DESCRIPTION
It allows keeping the syntax even closer to a normal loop,
and it avoids duplicating functionality. Also simplify `@inbounds`
uses since it work when put in front of `@spawn_for_chunks`.

I've checked that performance is the same.