### PR TITLE
Optimize `completecases` to process only missingable columns

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -776,7 +776,9 @@ end
 function completecases(df::AbstractDataFrame, col::ColumnIndex)
     v = df[!, col]
     if Missing <: eltype(v)
-        return .!ismissing.(v)
+        res = BitVector(undef, size(df, 1))
+        res .= .!ismissing.(v)
+        return res
     else
         return trues(size(df, 1))
     end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -761,19 +761,23 @@ function completecases(df::AbstractDataFrame, col::Colon=:)
                             "data frame with no columns"))
     end
     res = trues(size(df, 1))
+    aux = BitVector(undef, size(df, 1))
     for i in 1:size(df, 2)
-        if Missing <: eltype(df[!, i])
-            res .&= .!ismissing.(df[!, i])
+        v = df[!, i]
+        if Missing <: eltype(v)
+            aux .= .!ismissing.(v)
+            res .&= aux
         end
     end
-    res
+    return res
 end
 
 function completecases(df::AbstractDataFrame, col::ColumnIndex)
-    if Missing <: eltype(df[!, col])
-        .!ismissing.(df[!, col])
+    v = df[!, col]
+    if Missing <: eltype(v)
+        return .!ismissing.(v)
     else
-        trues(size(df, 1))
+        return trues(size(df, 1))
     end
 end
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -765,6 +765,7 @@ function completecases(df::AbstractDataFrame, col::Colon=:)
     for i in 1:size(df, 2)
         v = df[!, i]
         if Missing <: eltype(v)
+            # Disable fused broadcasting as it happens to be much slower
             aux .= .!ismissing.(v)
             res .&= aux
         end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -762,13 +762,20 @@ function completecases(df::AbstractDataFrame, col::Colon=:)
     end
     res = trues(size(df, 1))
     for i in 1:size(df, 2)
-        res .&= .!ismissing.(df[!, i])
+        if Missing <: eltype(df[!, i])
+            res .&= .!ismissing.(df[!, i])
+        end
     end
     res
 end
 
-completecases(df::AbstractDataFrame, col::ColumnIndex) =
-    .!ismissing.(df[!, col])
+function completecases(df::AbstractDataFrame, col::ColumnIndex)
+    if Missing <: eltype(df[!, col])
+        .!ismissing.(df[!, col])
+    else
+        trues(size(df, 1))
+    end
+end
 
 completecases(df::AbstractDataFrame, cols::MultiColumnIndex) =
     completecases(df[!, cols])

--- a/test/data.jl
+++ b/test/data.jl
@@ -136,6 +136,7 @@ end
     @test df1b == df1
 
     @test_throws ArgumentError completecases(DataFrame())
+    @test_throws ArgumentError completecases(DataFrame(x=1:3), Cols())
     @test_throws MethodError completecases(DataFrame(x=1), true)
     @test_throws ArgumentError completecases(df3, :a)
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -117,7 +117,7 @@ end
     df3 = DataFrame(x = Int[1, 2, 3, 4], y = Union{Int, Missing}[1, missing, 2, 3], 
                     z = Missing[missing, missing, missing, missing])
 
-    @test completecases(df2), :] == .!ismissing.(df2.x2)
+    @test completecases(df2) == .!ismissing.(df2.x2)
     @test @inferred(completecases(df3, :x)) == trues(nrow(df3))
     @test completecases(df3, :y) == .!ismissing.(df3.y)
     @test completecases(df3, :z) == completecases(df3, [:z, :x]) ==

--- a/test/data.jl
+++ b/test/data.jl
@@ -114,7 +114,14 @@ end
                     :auto)
     df2 = DataFrame([Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]],
                     :auto)
+    df3 = DataFrame(x = Int[1, 2, 3, 4], y = Union{Int, Missing}[1, missing, 2, 3], 
+                    z = Missing[missing, missing, missing, missing])
 
+    @test df3[completecases(df3, :x), :] ≅ df3
+    @test df3[completecases(df3, :y), :] ≅ df3[[1, 3, 4], :]
+    @test df3[completecases(df3, :z), :] ≅ df3[[], :]
+    @test df3[completecases(df3, [:y, :x]), :] ≅ df3[[1, 3, 4], :]
+    @test df3[completecases(df3, [:z, :x]), :] ≅ df3[[], :]
     @test df2[completecases(df2), :] == df2[[1, 2, 4], :]
     @test dropmissing(df2) == df2[[1, 2, 4], :]
     returned = dropmissing(df1)
@@ -128,6 +135,7 @@ end
 
     @test_throws ArgumentError completecases(DataFrame())
     @test_throws MethodError completecases(DataFrame(x=1), true)
+    @test_throws ArgumentError completecases(df3, :a)
 
     for cols in (:x2, "x2", [:x2], ["x2"], [:x1, :x2], ["x1", "x2"], 2, [2], 1:2,
                  [true, true], [false, true], :,

--- a/test/data.jl
+++ b/test/data.jl
@@ -117,12 +117,14 @@ end
     df3 = DataFrame(x = Int[1, 2, 3, 4], y = Union{Int, Missing}[1, missing, 2, 3], 
                     z = Missing[missing, missing, missing, missing])
 
-    @test df3[completecases(df3, :x), :] ≅ df3
-    @test df3[completecases(df3, :y), :] ≅ df3[[1, 3, 4], :]
-    @test df3[completecases(df3, :z), :] ≅ df3[[], :]
-    @test df3[completecases(df3, [:y, :x]), :] ≅ df3[[1, 3, 4], :]
-    @test df3[completecases(df3, [:z, :x]), :] ≅ df3[[], :]
-    @test df2[completecases(df2), :] == df2[[1, 2, 4], :]
+    @test completecases(df2), :] == .!ismissing.(df2.x2)
+    @test @inferred(completecases(df3, :x)) == trues(nrow(df3))
+    @test completecases(df3, :y) == .!ismissing.(df3.y)
+    @test completecases(df3, :z) == completecases(df3, [:z, :x]) ==
+          completecases(df3, [:x, :z]) == completecases(df3, [:y, :x, :z]) ==
+          falses(nrow(df3))
+    @test @inferred(completecases(df3, [:y, :x])) ==
+          completecases(df3, [:x, :y]) == .!ismissing.(df3.y)
     @test dropmissing(df2) == df2[[1, 2, 4], :]
     returned = dropmissing(df1)
     @test df1 == returned && df1 !== returned


### PR DESCRIPTION
Optimization to two `completecases` methods by only processing _missingable_ columns.
Discussed in #2724 