### PR TITLE
fix performance issue in multirow split-apply-combine

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# DataFrames.jl v1.1.1 Patch Release Notes
+
+## Performance improvements
+
+* fix performance issue when aggregation function produces multiple rows
+  in split-apply-combine
+  ([XXXX](https://github.com/JuliaData/DataFrames.jl/pull/XXXX))
+
 # DataFrames.jl v1.1 Release Notes
 
 ## Functionality changes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/groupeddataframe/callprocessing.jl
+++ b/src/groupeddataframe/callprocessing.jl
@@ -90,7 +90,7 @@ end
 function do_call(f::Base.Callable, idx::AbstractVector{<:Integer},
                  starts::AbstractVector{<:Integer}, ends::AbstractVector{<:Integer},
                  gd::GroupedDataFrame, incols::Tuple{AbstractVector}, i::Integer)
-    idx = idx[starts[i]:ends[i]]
+    idx = view(idx, starts[i]:ends[i])
     return f(view(incols[1], idx))
 end
 

--- a/src/groupeddataframe/callprocessing.jl
+++ b/src/groupeddataframe/callprocessing.jl
@@ -97,21 +97,21 @@ end
 function do_call(f::Base.Callable, idx::AbstractVector{<:Integer},
                  starts::AbstractVector{<:Integer}, ends::AbstractVector{<:Integer},
                  gd::GroupedDataFrame, incols::NTuple{2, AbstractVector}, i::Integer)
-    idx = idx[starts[i]:ends[i]]
+    idx = view(idx, starts[i]:ends[i])
     return f(view(incols[1], idx), view(incols[2], idx))
 end
 
 function do_call(f::Base.Callable, idx::AbstractVector{<:Integer},
                  starts::AbstractVector{<:Integer}, ends::AbstractVector{<:Integer},
                  gd::GroupedDataFrame, incols::NTuple{3, AbstractVector}, i::Integer)
-    idx = idx[starts[i]:ends[i]]
+    idx = view(idx, starts[i]:ends[i])
     return f(view(incols[1], idx), view(incols[2], idx), view(incols[3], idx))
 end
 
 function do_call(f::Base.Callable, idx::AbstractVector{<:Integer},
                  starts::AbstractVector{<:Integer}, ends::AbstractVector{<:Integer},
                  gd::GroupedDataFrame, incols::NTuple{4, AbstractVector}, i::Integer)
-    idx = idx[starts[i]:ends[i]]
+    idx = view(idx, starts[i]:ends[i])
     return f(view(incols[1], idx), view(incols[2], idx), view(incols[3], idx),
              view(incols[4], idx))
 end
@@ -119,7 +119,7 @@ end
 function do_call(f::Base.Callable, idx::AbstractVector{<:Integer},
                  starts::AbstractVector{<:Integer}, ends::AbstractVector{<:Integer},
                  gd::GroupedDataFrame, incols::Tuple, i::Integer)
-    idx = idx[starts[i]:ends[i]]
+    idx = view(idx, starts[i]:ends[i])
     return f(map(c -> view(c, idx), incols)...)
 end
 
@@ -129,7 +129,7 @@ function do_call(f::Base.Callable, idx::AbstractVector{<:Integer},
     if f isa ByRow && isempty(incols)
         return [f.fun(NamedTuple()) for _ in 1:(ends[i] - starts[i] + 1)]
     else
-        idx = idx[starts[i]:ends[i]]
+        idx = view(idx, starts[i]:ends[i])
         return f(map(c -> view(c, idx), incols))
     end
 end
@@ -137,6 +137,6 @@ end
 function do_call(f::Base.Callable, idx::AbstractVector{<:Integer},
                  starts::AbstractVector{<:Integer}, ends::AbstractVector{<:Integer},
                  gd::GroupedDataFrame, incols::Nothing, i::Integer)
-    idx = idx[starts[i]:ends[i]]
+    idx = view(idx, starts[i]:ends[i])
     return f(view(parent(gd), idx, :))
 end

--- a/src/groupeddataframe/complextransforms.jl
+++ b/src/groupeddataframe/complextransforms.jl
@@ -58,7 +58,6 @@ function _combine_with_first((first,)::Ref{Any},
     let eltys=eltys, n=n # Workaround for julia#15276
         initialcols = ntuple(_ncol(first)) do i
             res = Tables.allocatecolumn(eltys[i], n)
-            sizehint!(res, lgd)
             return res
         end
     end

--- a/src/groupeddataframe/complextransforms.jl
+++ b/src/groupeddataframe/complextransforms.jl
@@ -52,8 +52,13 @@ function _combine_with_first((first,)::Ref{Any},
             throw(ArgumentError("mixing single values and vectors in a named tuple is not allowed"))
         end
     end
+
     idx = idx_agg === NOTHING_IDX_AGG ? Vector{Int}(undef, n) : idx_agg
+    # assume that we will have at least one row per group;
+    # if the user wants to drop some groups this will over-allocate idx
+    # but this use case is uncommon and sizehint! is cheap.
     sizehint!(idx, lgd)
+
     local initialcols
     let eltys=eltys, n=n # Workaround for julia#15276
         initialcols = ntuple(i -> Tables.allocatecolumn(eltys[i], n), _ncol(first))

--- a/src/groupeddataframe/complextransforms.jl
+++ b/src/groupeddataframe/complextransforms.jl
@@ -397,7 +397,13 @@ function _combine_tables_with_first!(first::Union{AbstractDataFrame,
             return _combine_tables_with_first!(rows, newcols, idx, i, j,
                                                f, gd, incols, colnames, firstmulticol)
         end
-        append!(idx, Iterators.repeated(gdidx[starts[i]], _nrow(rows)))
+        growsize = _nrow(rows)
+        if growsize > 0
+            oldsize = length(idx)
+            newsize = oldsize + growsize
+            resize!(idx, newsize)
+            idx[oldsize+1:newsize] .= gdidx[starts[i]]
+        end
     end
     return outcols, colnames
 end

--- a/src/groupeddataframe/complextransforms.jl
+++ b/src/groupeddataframe/complextransforms.jl
@@ -56,10 +56,7 @@ function _combine_with_first((first,)::Ref{Any},
     sizehint!(idx, lgd)
     local initialcols
     let eltys=eltys, n=n # Workaround for julia#15276
-        initialcols = ntuple(_ncol(first)) do i
-            res = Tables.allocatecolumn(eltys[i], n)
-            return res
-        end
+        initialcols = ntuple(i -> Tables.allocatecolumn(eltys[i], n), _ncol(first))
     end
     targetcolnames = tuple(propertynames(first)...)
     if !extrude && first isa Union{AbstractDataFrame,
@@ -407,7 +404,7 @@ function _combine_tables_with_first!(first::Union{AbstractDataFrame,
     return outcols, colnames
 end
 
-@inline function append_const!(idx::Vector{Int}, val, growsize::Int)
+function append_const!(idx::Vector{Int}, val::Int, growsize::Int)
     if growsize > 0
         oldsize = length(idx)
         newsize = oldsize + growsize

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -543,7 +543,7 @@ function _combine(gd::GroupedDataFrame,
         end
         idx_keeprows = prepare_idx_keeprows(gd.idx, gd.starts, gd.ends, nrow(parent(gd)))
     else
-        idx_keeprows = nothing
+        idx_keeprows = Int[]
     end
 
     idx_agg = Ref(NOTHING_IDX_AGG)

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -338,7 +338,7 @@ function _combine_process_pair_symbol(optional_i::Bool,
     if firstmulticol
         throw(ArgumentError("a single value or vector result is required (got $(typeof(firstres)))"))
     end
-    # if idx_agg was not computed yet it is nothing
+    # if idx_agg was not computed yet it is NOTHING_IDX_AGG
     # in this case if we are not passed a vector compute it.
     lock(gd.lazy_lock) do
         if !(firstres isa AbstractVector) && idx_agg[] === NOTHING_IDX_AGG
@@ -667,7 +667,9 @@ function _combine(gd::GroupedDataFrame,
     return idx, DataFrame(outcols, nms, copycols=false)
 end
 
-function reorder_cols!(trans_res, i, col, col_idx, keeprows, idx_keeprows, gd)
+function reorder_cols!(trans_res::Vector{TransformationResult}, i::Integer,
+                       col::AbstractVector, col_idx::Vector{Int}, keeprows::Bool,
+                       idx_keeprows::Vector{Int}, gd::GroupedDataFrame)
     if keeprows && col_idx !== idx_keeprows # we need to reorder the column
         newcol = similar(col)
         # we can probably make it more efficient, but I leave it as an optimization for the future


### PR DESCRIPTION
Resolves https://discourse.julialang.org/t/allocations-and-slow-perf-for-transform-on-groupeddataframes/60594