### PR TITLE
Put longer type into th title argument in HTML show

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@
 
 * `text/plain` rendering of columns containing complex numbers is now improved
   ([#2756](https://github.com/JuliaData/DataFrames.jl/pull/2756))
+* in `text/html` display of a data frame show full type information when
+  hovering over the shortened type with a mouse
+  ([#2774](https://github.com/JuliaData/DataFrames.jl/pull/2774))
 
 # DataFrames.jl v1.1.1 Patch Release Notes
 

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -157,6 +157,10 @@ function html_escape(cell::AbstractString)
     cell = replace(cell, "&"=>"&amp;")
     cell = replace(cell, "<"=>"&lt;")
     cell = replace(cell, ">"=>"&gt;")
+    # Replace quotes so that the resulting string could also be used in the attributes of
+    # HTML tags
+    cell = replace(cell, "\""=>"&quot;")
+    cell = replace(cell, "'"=>"&apos;")
     return cell
 end
 

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -195,10 +195,15 @@ function _show(io::IO, ::MIME"text/html", df::AbstractDataFrame;
     if eltypes
         write(io, "<tr>")
         write(io, "<th></th>")
-        ct = batch_compacttype(Any[eltype(df[!, idx]) for idx in 1:mxcol])
+        # We put a longer string for the type into the title argument of the <th> element,
+        # which the users can hover over. The limit of 256 characters is arbitrary, but
+        # we want some maximum limit, since the types can sometimes get really-really long.
+        types = Any[eltype(df[!, idx]) for idx in 1:mxcol]
+        ct, ct_title = batch_compacttype(types), batch_compacttype(types, 256)
         for j in 1:mxcol
             s = html_escape(ct[j])
-            write(io, "<th>$s</th>")
+            title = html_escape(ct_title[j])
+            write(io, "<th title=\"$title\">$s</th>")
         end
         write(io, "</tr>")
     end

--- a/test/dataframerow.jl
+++ b/test/dataframerow.jl
@@ -433,7 +433,7 @@ end
 
     @test sprint(show, "text/html", dfr) == "<p>DataFrameRow (2 columns)</p><table class=\"data-frame\">" *
                                "<thead><tr><th></th><th>b</th><th>c</th></tr>" *
-                               "<tr><th></th><th>String</th><th>Int64</th></tr></thead>" *
+                               "<tr><th></th><th title=\"String\">String</th><th title=\"Int64\">Int64</th></tr></thead>" *
                                "<tbody><tr><th>2</th>" *
                                "<td>b</td><td>0</td></tr></tbody></table>"
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1465,11 +1465,11 @@ end
         "<p><b>GroupedDataFrame with 4 groups based on key: A</b></p>" *
         "<p><i>First Group (1 row): A = 1</i></p><table class=\"data-frame\">" *
         "<thead><tr><th></th><th>A</th><th>B</th><th>C</th></tr><tr><th></th>" *
-        "<th>Int64</th><th>String</th><th>Float32</th></tr></thead>" *
-        "<tbody><tr><th>1</th><td>1</td><td>x\"</td><td>1.0</td></tr></tbody>" *
+        "<th title=\"Int64\">Int64</th><th title=\"String\">String</th><th title=\"Float32\">Float32</th></tr></thead>" *
+        "<tbody><tr><th>1</th><td>1</td><td>x&quot;</td><td>1.0</td></tr></tbody>" *
         "</table><p>&vellip;</p><p><i>Last Group (1 row): A = 4</i></p>" *
         "<table class=\"data-frame\"><thead><tr><th></th><th>A</th><th>B</th><th>C</th></tr>" *
-        "<tr><th></th><th>Int64</th><th>String</th><th>Float32</th></tr></thead>" *
+        "<tr><th></th><th title=\"Int64\">Int64</th><th title=\"String\">String</th><th title=\"Float32\">Float32</th></tr></thead>" *
         "<tbody><tr><th>1</th><td>4</td><td>A\\nC</td><td>4.0</td></tr></tbody></table>"
 
     @test sprint(show, "text/latex", gd) == """
@@ -1511,9 +1511,9 @@ end
 
     @test sprint(show, "text/html", gd) ==
         "<p><b>$summary_str</b></p><p><i>" *
-        "First Group (1 row): a = :&amp;, b = \"&amp;\"</i></p>" *
+        "First Group (1 row): a = :&amp;, b = &quot;&amp;&quot;</i></p>" *
         "<table class=\"data-frame\"><thead><tr><th></th><th>a</th><th>b</th></tr>" *
-        "<tr><th></th><th>Symbol</th><th>String</th></tr></thead><tbody><tr><th>1</th>" *
+        "<tr><th></th><th title=\"Symbol\">Symbol</th><th title=\"String\">String</th></tr></thead><tbody><tr><th>1</th>" *
         "<td>&amp;</td><td>&amp;</td></tr></tbody></table>"
 
     @test sprint(show, "text/latex", gd) == """

--- a/test/io.jl
+++ b/test/io.jl
@@ -52,7 +52,7 @@ end
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr>" *
-                 "<tr><th></th><th>String</th><th>Float64?</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead><tbody>" *
                  "<p>2 rows × 2 columns</p>" *
                  "<tr><th>1</th><td>Suzy</td><td>1.5</td></tr>" *
                  "<tr><th>2</th><td>Amir</td><td><em>missing</em></td></tr></tbody></table>"
@@ -63,7 +63,7 @@ end
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr>" *
-                 "<tr><th></th><th>String</th><th>Float64?</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead><tbody>" *
                  "<p>2 rows × 2 columns</p>" *
                  "<tr><th>1</th><td><em>#undef</em></td><td>1.5</td></tr>" *
                  "<tr><th>2</th><td><em>#undef</em></td><td><em>missing</em></td></tr></tbody></table>"
@@ -74,7 +74,7 @@ end
     @test str == "<p>2×2 DataFrameRows</p>" *
                  "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr>" *
-                 "<tr><th></th><th>String</th><th>Float64?</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead><tbody>" *
                  "<tr><th>1</th><td><em>#undef</em></td><td>1.5</td></tr>" *
                  "<tr><th>2</th><td><em>#undef</em></td><td><em>missing</em></td></tr></tbody></table>"
 
@@ -84,7 +84,7 @@ end
     @test str == "<p>2×2 DataFrameColumns</p>" *
                  "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr>" *
-                 "<tr><th></th><th>String</th><th>Float64?</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead><tbody>" *
                  "<tr><th>1</th><td><em>#undef</em></td><td>1.5</td></tr>" *
                  "<tr><th>2</th><td><em>#undef</em></td><td><em>missing</em></td></tr></tbody></table>"
 
@@ -93,7 +93,7 @@ end
     str = String(take!(io))
     @test str == "<p>DataFrameRow (2 columns)</p><table class=\"data-frame\">" *
                  "<thead><tr><th></th><th>Fish</th><th>Mass</th></tr><tr><th></th>" *
-                 "<th>String</th><th>Float64?</th></tr></thead><tbody><tr><th>1</th>" *
+                 "<th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead><tbody><tr><th>1</th>" *
                  "<td><em>#undef</em></td><td>1.5</td></tr></tbody></table>"
 
     io = IOBuffer()
@@ -101,7 +101,7 @@ end
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr>" *
-                 "<tr><th></th><th>String</th><th>Float64?</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead><tbody>" *
                  "<tr><th>1</th><td><em>#undef</em></td><td>1.5</td></tr>" *
                  "<tr><th>2</th><td><em>#undef</em></td><td><em>missing</em></td></tr></tbody></table>"
 
@@ -110,7 +110,7 @@ end
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr>" *
-                 "<tr><th></th><th>String</th><th>Float64?</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead><tbody>" *
                  "<tr><th>1</th><td><em>#undef</em></td><td>1.5</td></tr>" *
                  "<tr><th>2</th><td><em>#undef</em></td><td><em>missing</em></td></tr></tbody></table>"
 
@@ -119,7 +119,7 @@ end
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>Fish</th><th>Mass</th></tr>" *
-                 "<tr><th></th><th>String</th><th>Float64?</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead><tbody>" *
                  "<tr><th>1</th><td><em>#undef</em></td><td>1.5</td></tr>" *
                  "<tr><th>2</th><td><em>#undef</em></td><td><em>missing</em></td></tr></tbody></table>"
 
@@ -127,7 +127,7 @@ end
     show(io, MIME"text/html"(), df[1, :], summary=false)
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th></th><th>Fish</th>" *
-                 "<th>Mass</th></tr><tr><th></th><th>String</th><th>Float64?</th></tr></thead>" *
+                 "<th>Mass</th></tr><tr><th></th><th title=\"String\">String</th><th title=\"Union{Missing, Float64}\">Float64?</th></tr></thead>" *
                  "<tbody><tr><th>1</th><td><em>#undef</em></td><td>1.5</td></tr></tbody></table>"
 
     @test_throws ArgumentError DataFrames._show(stdout, MIME("text/html"),
@@ -144,7 +144,7 @@ end
 
     @test repr(MIME("text/html"), df) ==
         "<table class=\"data-frame\"><thead><tr><th></th><th>A</th><th>B</th></tr><tr><th></th>" *
-        "<th>Int64</th><th>MD…</th></tr></thead><tbody><p>4 rows × 2 columns</p><tr><th>1</th>" *
+        "<th title=\"Int64\">Int64</th><th title=\"Markdown.MD\">MD…</th></tr></thead><tbody><p>4 rows × 2 columns</p><tr><th>1</th>" *
         "<td>1</td><td><div class=\"markdown\">" *
         "<p><a href=\"http://juliadata.github.io/DataFrames.jl\">DataFrames.jl</a>" *
         "</p>\n</div></td></tr><tr><th>2</th><td>4</td><td><div class=\"markdown\">" *
@@ -153,6 +153,27 @@ end
         "<td>16</td><td><div class=\"markdown\"><p><em>A</em>b<strong>A</strong></p>"*
         "\n</div></td></tr></tbody></table>"
 
+    # Test that single and double quotes get escaped properly
+    struct Foo{T} end
+    df = DataFrame(
+        xs = ["'", "\"", "<foo>'</bar>"],
+        ys = [Foo{'\''}(), Foo{'"'}, Foo{Symbol("\"'")}()],
+        zs = Foo{'"'}[Foo{'"'}(), Foo{'"'}(), Foo{'"'}()],
+    )
+    io = IOBuffer()
+    show(io, "text/html", df)
+    str = String(take!(io))
+    @test str ==
+        "<table class=\"data-frame\"><thead>"*
+            "<tr><th></th><th>xs</th><th>ys</th><th>zs</th></tr>"*
+            "<tr><th></th><th title=\"String\">String</th><th title=\"Any\">Any</th><th title=\"Main.TestIO.Foo{&apos;&quot;&apos;}\">Foo…</th></tr>"*
+        "</thead><tbody>"*
+            "<p>3 rows × 3 columns</p>"*
+            "<tr><th>1</th><td>&apos;</td><td>Foo{&apos;\\\\&apos;&apos;}()</td><td>Foo{&apos;&quot;&apos;}()</td></tr>"*
+            "<tr><th>2</th><td>&quot;</td><td>Foo{&apos;&quot;&apos;}</td><td>Foo{&apos;&quot;&apos;}()</td></tr>"*
+            "<tr><th>3</th><td>&lt;foo&gt;&apos;&lt;/bar&gt;</td>"*
+            "<td>Foo{Symbol(&quot;\\\\&quot;&apos;&quot;)}()</td><td>Foo{&apos;&quot;&apos;}()</td></tr>"*
+        "</tbody></table>"
 end
 
 # test limit attribute of IOContext is used
@@ -291,7 +312,7 @@ end
     @test sprint(show,"text/html",df) ==
         "<table class=\"data-frame\"><thead>" *
             "<tr><th></th><th>A</th><th>B</th></tr>" *
-            "<tr><th></th><th>Int64</th><th>MD…</th></tr>" *
+            "<tr><th></th><th title=\"Int64\">Int64</th><th title=\"Markdown.MD\">MD…</th></tr>" *
         "</thead>" *
         "<tbody>" * "<p>8 rows × 2 columns</p>" *
         "<tr><th>1</th><td>1</td><td><div class=\"markdown\">" *
@@ -455,7 +476,7 @@ end
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>A</th><th>B</th></tr>" *
-                 "<tr><th></th><th>Int32</th><th>String</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"Int32\">Int32</th><th title=\"String\">String</th></tr></thead><tbody>" *
                  "<p>3 rows × 2 columns</p>" *
                  "<tr><th>1</th><td>1</td><td>x</td></tr>" *
                  "<tr><th>2</th><td>2</td><td>y</td></tr><tr><th>3</th><td>3</td><td>z</td></tr></tbody></table>"
@@ -465,7 +486,7 @@ end
     str = String(take!(io))
     @test str == "<p>3×2 DataFrameColumns</p><table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>A</th><th>B</th></tr>" *
-                 "<tr><th></th><th>Int32</th><th>String</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"Int32\">Int32</th><th title=\"String\">String</th></tr></thead><tbody>" *
                  "<tr><th>1</th><td>1</td><td>x</td></tr>" *
                  "<tr><th>2</th><td>2</td><td>y</td></tr><tr><th>3</th><td>3</td><td>z</td></tr></tbody></table>"
 
@@ -474,7 +495,7 @@ end
     str = String(take!(io))
     @test str == "<p>3×2 DataFrameRows</p><table class=\"data-frame\"><thead><tr><th>" *
                  "</th><th>A</th><th>B</th></tr>" *
-                 "<tr><th></th><th>Int32</th><th>String</th></tr></thead><tbody>" *
+                 "<tr><th></th><th title=\"Int32\">Int32</th><th title=\"String\">String</th></tr></thead><tbody>" *
                  "<tr><th>1</th><td>1</td><td>x</td></tr>" *
                  "<tr><th>2</th><td>2</td><td>y</td></tr><tr><th>3</th><td>3</td><td>z</td></tr></tbody></table>"
 
@@ -584,7 +605,7 @@ end
     show(io, MIME("text/html"), df)
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th></th><th>A</th><th>B</th></tr>" *
-                 "<tr><th></th><th>Int64</th><th>Any</th></tr></thead>" *
+                 "<tr><th></th><th title=\"Int64\">Int64</th><th title=\"Any\">Any</th></tr></thead>" *
                  "<tbody><p>9 rows × 2 columns</p>" *
                  "<tr><th>1</th><td>1</td><td><em>9×2 DataFrame</em></td></tr>" *
                  "<tr><th>2</th><td>2</td><td><em>2-element DataFrameRow</em></td></tr>" *
@@ -668,7 +689,7 @@ end
     show(io, MIME("text/html"), df)
     str = String(take!(io))
     @test str == "<table class=\"data-frame\"><thead><tr><th></th><th>x</th></tr>" *
-                 "<tr><th></th><th>String</th></tr></thead>" *
+                 "<tr><th></th><th title=\"String\">String</th></tr></thead>" *
                  "<tbody><p>1 rows × 1 columns</p><tr><th>1</th>" *
                  "<td>01234567890123456789012345678901234567890123456789" *
                  "01234567890123456789012345678901234567890123456789</td>"*

--- a/test/io.jl
+++ b/test/io.jl
@@ -169,36 +169,36 @@ end
     show(io, "text/html", df)
     str = String(take!(io))
     @test str ==
-        "<table class=\"data-frame\"><thead>"*
-            "<tr>"*
-                "<th></th>"*
-                "<th>xs</th>"*
-                "<th>ys</th>"*
-                "<th>zs</th>"*
-            "</tr><tr>"*
-                "<th></th>"*
-                "<th title=\"String\">String</th>"*
-                "<th title=\"Any\">Any</th>"*
-                "<th title=\"QuoteTestType{&apos;&quot;&apos;}\">QuoteTe…</th>"*
-            "</tr>"*
-        "</thead><tbody>"*
-            "<p>3 rows × 3 columns</p>"*
-            "<tr>"*
-                "<th>1</th>"*
-                "<td>&apos;</td>"*
-                "<td>QuoteTestType{&apos;\\\\&apos;&apos;}()</td>"*
-                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>"*
-            "</tr><tr>"*
-                "<th>2</th>"*
-                "<td>&quot;</td>"*
-                "<td>QuoteTestType{&apos;&quot;&apos;}</td>"*
-                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>"*
-            "</tr><tr>"*
-                "<th>3</th>"*
-                "<td>&lt;foo&gt;&apos;&lt;/bar&gt;</td>"*
-                "<td>QuoteTestType{Symbol(&quot;\\\\&quot;&apos;&quot;)}()</td>"*
-                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>"*
-            "</tr>"*
+        "<table class=\"data-frame\"><thead>" *
+            "<tr>" *
+                "<th></th>" *
+                "<th>xs</th>" *
+                "<th>ys</th>" *
+                "<th>zs</th>" *
+            "</tr><tr>" *
+                "<th></th>" *
+                "<th title=\"String\">String</th>" *
+                "<th title=\"Any\">Any</th>" *
+                "<th title=\"QuoteTestType{&apos;&quot;&apos;}\">QuoteTe…</th>" *
+            "</tr>" *
+        "</thead><tbody>" *
+            "<p>3 rows × 3 columns</p>" *
+            "<tr>" *
+                "<th>1</th>" *
+                "<td>&apos;</td>" *
+                "<td>QuoteTestType{&apos;\\\\&apos;&apos;}()</td>" *
+                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>" *
+            "</tr><tr>" *
+                "<th>2</th>" *
+                "<td>&quot;</td>" *
+                "<td>QuoteTestType{&apos;&quot;&apos;}</td>" *
+                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>" *
+            "</tr><tr>" *
+                "<th>3</th>" *
+                "<td>&lt;foo&gt;&apos;&lt;/bar&gt;</td>" *
+                "<td>QuoteTestType{Symbol(&quot;\\\\&quot;&apos;&quot;)}()</td>" *
+                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>" *
+            "</tr>" *
         "</tbody></table>"
 end
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,6 +1,12 @@
+# This type is for testing the escaping of quotes in HTML output. It needs to be
+# outside of the module so that Julia 1.0 would not complain about the type
+# being defined in local scope.
+struct QuoteTestType{T} end
+
 module TestIO
 
 using Test, DataFrames, CategoricalArrays, Dates, Markdown
+import Main: QuoteTestType
 
 # Test LaTeX export
 @testset "LaTeX export" begin
@@ -154,11 +160,10 @@ end
         "\n</div></td></tr></tbody></table>"
 
     # Test that single and double quotes get escaped properly
-    struct Foo{T} end
     df = DataFrame(
         xs = ["'", "\"", "<foo>'</bar>"],
-        ys = [Foo{'\''}(), Foo{'"'}, Foo{Symbol("\"'")}()],
-        zs = Foo{'"'}[Foo{'"'}(), Foo{'"'}(), Foo{'"'}()],
+        ys = [QuoteTestType{'\''}(), QuoteTestType{'"'}, QuoteTestType{Symbol("\"'")}()],
+        zs = QuoteTestType{'"'}[QuoteTestType{'"'}(), QuoteTestType{'"'}(), QuoteTestType{'"'}()],
     )
     io = IOBuffer()
     show(io, "text/html", df)
@@ -174,25 +179,25 @@ end
                 "<th></th>"*
                 "<th title=\"String\">String</th>"*
                 "<th title=\"Any\">Any</th>"*
-                "<th title=\"Main.TestIO.Foo{&apos;&quot;&apos;}\">Foo…</th>"*
+                "<th title=\"QuoteTestType{&apos;&quot;&apos;}\">QuoteTe…</th>"*
             "</tr>"*
         "</thead><tbody>"*
             "<p>3 rows × 3 columns</p>"*
             "<tr>"*
                 "<th>1</th>"*
                 "<td>&apos;</td>"*
-                "<td>Foo{&apos;\\\\&apos;&apos;}()</td>"*
-                "<td>Foo{&apos;&quot;&apos;}()</td>"*
+                "<td>QuoteTestType{&apos;\\\\&apos;&apos;}()</td>"*
+                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>"*
             "</tr><tr>"*
                 "<th>2</th>"*
                 "<td>&quot;</td>"*
-                "<td>Foo{&apos;&quot;&apos;}</td>"*
-                "<td>Foo{&apos;&quot;&apos;}()</td>"*
+                "<td>QuoteTestType{&apos;&quot;&apos;}</td>"*
+                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>"*
             "</tr><tr>"*
                 "<th>3</th>"*
                 "<td>&lt;foo&gt;&apos;&lt;/bar&gt;</td>"*
-                "<td>Foo{Symbol(&quot;\\\\&quot;&apos;&quot;)}()</td>"*
-                "<td>Foo{&apos;&quot;&apos;}()</td>"*
+                "<td>QuoteTestType{Symbol(&quot;\\\\&quot;&apos;&quot;)}()</td>"*
+                "<td>QuoteTestType{&apos;&quot;&apos;}()</td>"*
             "</tr>"*
         "</tbody></table>"
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -165,14 +165,35 @@ end
     str = String(take!(io))
     @test str ==
         "<table class=\"data-frame\"><thead>"*
-            "<tr><th></th><th>xs</th><th>ys</th><th>zs</th></tr>"*
-            "<tr><th></th><th title=\"String\">String</th><th title=\"Any\">Any</th><th title=\"Main.TestIO.Foo{&apos;&quot;&apos;}\">Foo…</th></tr>"*
+            "<tr>"*
+                "<th></th>"*
+                "<th>xs</th>"*
+                "<th>ys</th>"*
+                "<th>zs</th>"*
+            "</tr><tr>"*
+                "<th></th>"*
+                "<th title=\"String\">String</th>"*
+                "<th title=\"Any\">Any</th>"*
+                "<th title=\"Main.TestIO.Foo{&apos;&quot;&apos;}\">Foo…</th>"*
+            "</tr>"*
         "</thead><tbody>"*
             "<p>3 rows × 3 columns</p>"*
-            "<tr><th>1</th><td>&apos;</td><td>Foo{&apos;\\\\&apos;&apos;}()</td><td>Foo{&apos;&quot;&apos;}()</td></tr>"*
-            "<tr><th>2</th><td>&quot;</td><td>Foo{&apos;&quot;&apos;}</td><td>Foo{&apos;&quot;&apos;}()</td></tr>"*
-            "<tr><th>3</th><td>&lt;foo&gt;&apos;&lt;/bar&gt;</td>"*
-            "<td>Foo{Symbol(&quot;\\\\&quot;&apos;&quot;)}()</td><td>Foo{&apos;&quot;&apos;}()</td></tr>"*
+            "<tr>"*
+                "<th>1</th>"*
+                "<td>&apos;</td>"*
+                "<td>Foo{&apos;\\\\&apos;&apos;}()</td>"*
+                "<td>Foo{&apos;&quot;&apos;}()</td>"*
+            "</tr><tr>"*
+                "<th>2</th>"*
+                "<td>&quot;</td>"*
+                "<td>Foo{&apos;&quot;&apos;}</td>"*
+                "<td>Foo{&apos;&quot;&apos;}()</td>"*
+            "</tr><tr>"*
+                "<th>3</th>"*
+                "<td>&lt;foo&gt;&apos;&lt;/bar&gt;</td>"*
+                "<td>Foo{Symbol(&quot;\\\\&quot;&apos;&quot;)}()</td>"*
+                "<td>Foo{&apos;&quot;&apos;}()</td>"*
+            "</tr>"*
         "</tbody></table>"
 end
 


### PR DESCRIPTION
Adds a `title` argument to the types in the HTML output, so that we would get the full type (up to 256 characters) when hovering over the shortened type with a mouse:

![Screenshot from 2021-05-24 14-15-24](https://user-images.githubusercontent.com/147757/119290897-92961d00-bca1-11eb-8fe9-440ac2ae5121.png)
