### PR TITLE
Deprecate AbstractVector in hcat

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# DataFrames.jl changes on main since last release notes
+# DataFrames.jl v1.2 Release Notes
 
 ## New functionalities
 
@@ -22,6 +22,13 @@
   in internal operations form a continuous block
   ([#2727](https://github.com/JuliaData/DataFrames.jl/pull/2727),
    [#2769](https://github.com/JuliaData/DataFrames.jl/pull/2769))
+
+## Deprecated
+
+* `hcat` of a data frame with a vector is now deprecated to allow consistent
+  handling of horizontal concatenation of data frame with Tables.jl tables
+  in the future
+  ([#2777](https://github.com/JuliaData/DataFrames.jl/pull/2777))
 
 ## Other changes
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1370,7 +1370,7 @@ julia> unique!(df)  # modifies df
     hcat(df::AbstractDataFrame...;
          makeunique::Bool=false, copycols::Bool=true)
 
-Horizontally concatenate `AbstractDataFrames`.
+Horizontally concatenate data frames.
 
 If `makeunique=false` (the default) column names of passed objects must be unique.
 If `makeunique=true` then duplicate column names will be suffixed

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1423,22 +1423,19 @@ true
 """
 Base.hcat(df::AbstractDataFrame; makeunique::Bool=false, copycols::Bool=true) =
     DataFrame(df, copycols=copycols)
-Base.hcat(df::AbstractDataFrame, x; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(DataFrame(df, copycols=copycols), x,
-          makeunique=makeunique, copycols=copycols)
-Base.hcat(x, df::AbstractDataFrame; makeunique::Bool=false, copycols::Bool=true) =
+# TODO: after deprecation remove AbstractVector methods
+Base.hcat(df::AbstractDataFrame, x::AbstractVector; makeunique::Bool=false, copycols::Bool=true) =
+    hcat!(DataFrame(df, copycols=copycols), x, makeunique=makeunique, copycols=copycols)
+Base.hcat(x::AbstractVector, df::AbstractDataFrame; makeunique::Bool=false, copycols::Bool=true) =
     hcat!(x, df, makeunique=makeunique, copycols=copycols)
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame;
           makeunique::Bool=false, copycols::Bool=true) =
     hcat!(DataFrame(df1, copycols=copycols), df2,
           makeunique=makeunique, copycols=copycols)
-Base.hcat(df::AbstractDataFrame, x, y...;
+Base.hcat(df::AbstractDataFrame, x::Union{AbstractVector, AbstractDataFrame},
+          y::Union{AbstractVector, AbstractDataFrame}...;
           makeunique::Bool=false, copycols::Bool=true) =
     hcat!(hcat(df, x, makeunique=makeunique, copycols=copycols), y...,
-          makeunique=makeunique, copycols=copycols)
-Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...;
-          makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(hcat(df1, df2, makeunique=makeunique, copycols=copycols), dfn...,
           makeunique=makeunique, copycols=copycols)
 
 """

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1369,15 +1369,24 @@ julia> unique!(df)  # modifies df
 """
     hcat(df::AbstractDataFrame...;
          makeunique::Bool=false, copycols::Bool=true)
-    hcat(df::AbstractDataFrame..., vs::AbstractVector;
+    hcat(df::AbstractDataFrame, vs::AbstractVector;
          makeunique::Bool=false, copycols::Bool=true)
     hcat(vs::AbstractVector, df::AbstractDataFrame;
          makeunique::Bool=false, copycols::Bool=true)
+    hcat(df::AbstractDataFrame, table;
+         makeunique::Bool=false, copycols::Bool=true)
+    hcat(table, df::AbstractDataFrame;
+         makeunique::Bool=false, copycols::Bool=true)
 
-Horizontally concatenate `AbstractDataFrames` and optionally `AbstractVector`s.
+Horizontally concatenate `AbstractDataFrames` and optionally `AbstractVector`s
+and Tables.jl tables.
 
 If `AbstractVector` is passed then a column name for it is automatically generated
 as `:x1` by default.
+
+If Tables.jl table is passed then a `DataFrame` is constructed from it and then
+a concatenation is performed (a precise rule is that it is accepted to pass any
+object that single positional `DataFrame` constructor allows).
 
 If `makeunique=false` (the default) column names of passed objects must be unique.
 If `makeunique=true` then duplicate column names will be suffixed

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1369,24 +1369,8 @@ julia> unique!(df)  # modifies df
 """
     hcat(df::AbstractDataFrame...;
          makeunique::Bool=false, copycols::Bool=true)
-    hcat(df::AbstractDataFrame, vs::AbstractVector;
-         makeunique::Bool=false, copycols::Bool=true)
-    hcat(vs::AbstractVector, df::AbstractDataFrame;
-         makeunique::Bool=false, copycols::Bool=true)
-    hcat(df::AbstractDataFrame, table;
-         makeunique::Bool=false, copycols::Bool=true)
-    hcat(table, df::AbstractDataFrame;
-         makeunique::Bool=false, copycols::Bool=true)
 
-Horizontally concatenate `AbstractDataFrames` and optionally `AbstractVector`s
-and Tables.jl tables.
-
-If `AbstractVector` is passed then a column name for it is automatically generated
-as `:x1` by default.
-
-If Tables.jl table is passed then a `DataFrame` is constructed from it and then
-a concatenation is performed (a precise rule is that it is accepted to pass any
-object that single positional `DataFrame` constructor allows).
+Horizontally concatenate `AbstractDataFrames`.
 
 If `makeunique=false` (the default) column names of passed objects must be unique.
 If `makeunique=true` then duplicate column names will be suffixed

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1032,19 +1032,22 @@ hcat!(df1::DataFrame, df2::DataFrame;
     invoke(hcat!, Tuple{DataFrame, AbstractDataFrame}, df1, df2,
            makeunique=makeunique, copycols=copycols)::DataFrame
 
-hcat!(df::DataFrame, x::AbstractVector; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(df, DataFrame(AbstractVector[x], [:x1], copycols=false),
-          makeunique=makeunique, copycols=copycols)
-hcat!(x::AbstractVector, df::DataFrame; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(DataFrame(AbstractVector[x], [:x1], copycols=copycols), df,
-          makeunique=makeunique, copycols=copycols)
 hcat!(df::DataFrame, x; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(df, DataFrame(x, copycols=false),
-          makeunique=makeunique, copycols=copycols)
+    throw(ArgumentError("x must AbstractDataFrame"))
 hcat!(x, df::DataFrame; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(DataFrame(x, copycols=copycols), df,
-          makeunique=makeunique, copycols=copycols)
+    throw(ArgumentError("x must AbstractDataFrame"))
 
+function hcat!(df::DataFrame, x::AbstractVector; makeunique::Bool=false, copycols::Bool=true)
+    Base.depwarn("horizontal concatenation of data frame with a vector is deprecated", :hcat!)
+    return hcat!(df, DataFrame(AbstractVector[x], [:x1], copycols=false),
+                 makeunique=makeunique, copycols=copycols)
+end
+
+function hcat!(x::AbstractVector, df::DataFrame; makeunique::Bool=false, copycols::Bool=true)
+    Base.depwarn("horizontal concatenation of data frame with a vector is deprecated", :hcat!)
+    return hcat!(DataFrame(AbstractVector[x], [:x1], copycols=copycols), df,
+                 makeunique=makeunique, copycols=copycols)
+end
 
 # hcat! for 1-n arguments
 hcat!(df::DataFrame; makeunique::Bool=false, copycols::Bool=true) = df

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1012,7 +1012,7 @@ end
 
 ##############################################################################
 ##
-## Hcat specialization
+## hcat!
 ##
 ##############################################################################
 
@@ -1026,47 +1026,29 @@ function hcat!(df1::DataFrame, df2::AbstractDataFrame;
     return df1
 end
 
-# definition required to avoid hcat! ambiguity
-hcat!(df1::DataFrame, df2::DataFrame;
-      makeunique::Bool=false, copycols::Bool=true) =
-    invoke(hcat!, Tuple{DataFrame, AbstractDataFrame}, df1, df2,
-           makeunique=makeunique, copycols=copycols)::DataFrame
-
-hcat!(df::DataFrame, x; makeunique::Bool=false, copycols::Bool=true) =
-    throw(ArgumentError("x must AbstractDataFrame"))
-hcat!(x, df::DataFrame; makeunique::Bool=false, copycols::Bool=true) =
-    throw(ArgumentError("x must AbstractDataFrame"))
+# TODO: after deprecation remove AbstractVector methods
 
 function hcat!(df::DataFrame, x::AbstractVector; makeunique::Bool=false, copycols::Bool=true)
-    Base.depwarn("horizontal concatenation of data frame with a vector is deprecated", :hcat!)
+    Base.depwarn("horizontal concatenation of data frame with a vector is deprecated. " *
+                 "Pass DataFrame(x1=x) instead.", :hcat!)
     return hcat!(df, DataFrame(AbstractVector[x], [:x1], copycols=false),
                  makeunique=makeunique, copycols=copycols)
 end
 
 function hcat!(x::AbstractVector, df::DataFrame; makeunique::Bool=false, copycols::Bool=true)
-    Base.depwarn("horizontal concatenation of data frame with a vector is deprecated", :hcat!)
+    Base.depwarn("horizontal concatenation of data frame with a vector is deprecated. " *
+                 "Pass DataFrame(x1=x) instead.", :hcat!)
     return hcat!(DataFrame(AbstractVector[x], [:x1], copycols=copycols), df,
                  makeunique=makeunique, copycols=copycols)
 end
 
 # hcat! for 1-n arguments
 hcat!(df::DataFrame; makeunique::Bool=false, copycols::Bool=true) = df
-hcat!(a::DataFrame, b, c...; makeunique::Bool=false, copycols::Bool=true) =
+hcat!(a::DataFrame, b::Union{AbstractDataFrame, AbstractVector},
+      c::Union{AbstractDataFrame, AbstractVector}...;
+      makeunique::Bool=false, copycols::Bool=true) =
     hcat!(hcat!(a, b, makeunique=makeunique, copycols=copycols),
           c..., makeunique=makeunique, copycols=copycols)
-
-# hcat
-Base.hcat(df::DataFrame, x; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(copy(df, copycols=copycols), x,
-          makeunique=makeunique, copycols=copycols)
-Base.hcat(df1::DataFrame, df2::AbstractDataFrame;
-          makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(copy(df1, copycols=copycols), df2,
-          makeunique=makeunique, copycols=copycols)
-Base.hcat(df1::DataFrame, df2::AbstractDataFrame, dfn::AbstractDataFrame...;
-          makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(hcat(df1, df2, makeunique=makeunique, copycols=copycols), dfn...,
-          makeunique=makeunique, copycols=copycols)
 
 ##############################################################################
 ##

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1033,15 +1033,18 @@ hcat!(df1::DataFrame, df2::DataFrame;
            makeunique=makeunique, copycols=copycols)::DataFrame
 
 hcat!(df::DataFrame, x::AbstractVector; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(df, DataFrame(AbstractVector[x], [:x1], copycols=copycols),
+    hcat!(df, DataFrame(AbstractVector[x], [:x1], copycols=false),
           makeunique=makeunique, copycols=copycols)
 hcat!(x::AbstractVector, df::DataFrame; makeunique::Bool=false, copycols::Bool=true) =
     hcat!(DataFrame(AbstractVector[x], [:x1], copycols=copycols), df,
           makeunique=makeunique, copycols=copycols)
-hcat!(x, df::DataFrame; makeunique::Bool=false, copycols::Bool=true) =
-    throw(ArgumentError("x must be AbstractVector or AbstractDataFrame"))
 hcat!(df::DataFrame, x; makeunique::Bool=false, copycols::Bool=true) =
-    throw(ArgumentError("x must be AbstractVector or AbstractDataFrame"))
+    hcat!(df, DataFrame(x, copycols=false),
+          makeunique=makeunique, copycols=copycols)
+hcat!(x, df::DataFrame; makeunique::Bool=false, copycols::Bool=true) =
+    hcat!(DataFrame(x, copycols=copycols), df,
+          makeunique=makeunique, copycols=copycols)
+
 
 # hcat! for 1-n arguments
 hcat!(df::DataFrame; makeunique::Bool=false, copycols::Bool=true) = df

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -66,8 +66,8 @@ end
     answer = answer[:, 1:4]
     @test hcat(gd[1], gd[2], makeunique=true) == answer
 
-    @test_throws ArgumentError hcat("a", df, makeunique=true)
-    @test_throws ArgumentError hcat(df, "a", makeunique=true)
+    @test_throws MethodError hcat("a", df, makeunique=true)
+    @test_throws MethodError hcat(df, "a", makeunique=true)
 end
 
 @testset "hcat: copycols" begin

--- a/test/cat.jl
+++ b/test/cat.jl
@@ -3,9 +3,6 @@ module TestCat
 using Test, Random, DataFrames, CategoricalArrays
 const ≅ = isequal
 
-#
-# hcat
-#
 @testset "hcat" begin
     nvint = [1, 2, missing, 4]
     nvstr = ["one", "two", missing, "four"]
@@ -59,15 +56,6 @@ end
     @test hdf[!, 1] !== hdf[!, 3]
     @test hdf[!, 2] == hdf[!, 3]
     @test hdf[!, 2] !== hdf[!, 3]
-    x = [4, 5, 6]
-    hdf = hcat(df, x)
-    @test hdf[!, 1] == df[!, 1]
-    @test hdf[!, 1] !== df[!, 1]
-    @test hdf[!, 2] !== x
-    hdf = hcat(x, df)
-    @test hdf[!, 2] == df[!, 1]
-    @test hdf[!, 2] !== df[!, 1]
-    @test hdf[!, 1] !== x
 end
 
 @testset "hcat ::AbstractDataFrame" begin
@@ -77,36 +65,6 @@ end
     @test hcat(gd..., makeunique=true) == answer
     answer = answer[:, 1:4]
     @test hcat(gd[1], gd[2], makeunique=true) == answer
-end
-
-@testset "hcat ::AbstractDataFrame" begin
-    df = DataFrame(A = repeat('A':'C', inner=4), B = 1:12)
-    gd = groupby(df, :A)
-    answer = DataFrame(A = fill('A', 4), B = 1:4, A_1 = 'B', B_1 = 5:8, A_2 = 'C', B_2 = 9:12)
-    @test hcat(gd..., makeunique=true) == answer
-    answer = answer[:, 1:4]
-    @test hcat(gd[1], gd[2], makeunique=true) == answer
-end
-
-@testset "hcat ::AbstractVectors" begin
-    df = DataFrame()
-    DataFrames.hcat!(df, CategoricalVector{Union{Int, Missing}}(1:10), makeunique=true)
-    @test df[!, 1] == CategoricalVector(1:10)
-    DataFrames.hcat!(df, 1:10, makeunique=true)
-    @test df[!, 2] == collect(1:10)
-    DataFrames.hcat!(df, collect(1:10), makeunique=true)
-    @test df[!, 3] == collect(1:10)
-
-    df = DataFrame()
-    df2 = hcat(CategoricalVector{Union{Int, Missing}}(1:10), df, makeunique=true)
-    @test isempty(df)
-    @test df2[!, 1] == collect(1:10)
-    @test names(df2) == ["x1"]
-    ref_df = copy(df2)
-    df3 = hcat(11:20, df2, makeunique=true)
-    @test df2 == ref_df
-    @test df3[!, 1] == collect(11:20)
-    @test names(df3) == ["x1", "x1_1"]
 
     @test_throws ArgumentError hcat("a", df, makeunique=true)
     @test_throws ArgumentError hcat(df, "a", makeunique=true)
@@ -161,66 +119,7 @@ end
     @test propertynames(df3) == [:a, :b]
     @test df3.a === df1.a
     @test df3.b === dfv.b
-
-    df3 = hcat(df1, x)
-    @test propertynames(df3) == [:a, :x1]
-    @test df3.a == df1.a
-    @test df3.x1 == x
-    @test df3.a !== df1.a
-    @test df3.x1 !== x
-    df3 = hcat(df1, x, copycols=true)
-    @test propertynames(df3) == [:a, :x1]
-    @test df3.a == df1.a
-    @test df3.x1 == x
-    @test df3.a !== df1.a
-    @test df3.x1 !== x
-    df3 = hcat(df1, x, copycols=false)
-    @test propertynames(df3) == [:a, :x1]
-    @test df3.a === df1.a
-    @test df3.x1 === x
-
-    df3 = hcat(x, df1)
-    @test propertynames(df3) == [:x1, :a]
-    @test df3.a == df1.a
-    @test df3.x1 == x
-    @test df3.a !== df1.a
-    @test df3.x1 !== x
-    df3 = hcat(x, df1, copycols=true)
-    @test propertynames(df3) == [:x1, :a]
-    @test df3.a == df1.a
-    @test df3.x1 == x
-    @test df3.a !== df1.a
-    @test df3.x1 !== x
-    df3 = hcat(x, df1, copycols=false)
-    @test propertynames(df3) == [:x1, :a]
-    @test df3.a === df1.a
-    @test df3.x1 === x
-
-    df3 = hcat(dfv, x, df1)
-    @test propertynames(df3) == [:b, :x1, :a]
-    @test df3.a == df1.a
-    @test df3.b == dfv.b
-    @test df3.x1 == x
-    @test df3.a !== df1.a
-    @test df3.b !== dfv.b
-    @test df3.x1 !== x
-    df3 = hcat(dfv, x, df1, copycols=true)
-    @test propertynames(df3) == [:b, :x1, :a]
-    @test df3.a == df1.a
-    @test df3.b == dfv.b
-    @test df3.x1 == x
-    @test df3.a !== df1.a
-    @test df3.b !== dfv.b
-    @test df3.x1 !== x
-    df3 = hcat(dfv, x, df1, copycols=false)
-    @test propertynames(df3) == [:b, :x1, :a]
-    @test df3.a === df1.a
-    @test df3.b === dfv.b
-    @test df3.x1 === x
 end
-#
-# vcat
-#
 
 @testset "vcat" begin
     missing_df = DataFrame()


### PR DESCRIPTION
Preparation for #2776

This is a draft. Finalizing is required, docs update, news update, test update

Things to discuss before I move forward:
1. do we want to add the same to `vcat` (like in `append!`)?
2. the tricky thing is that `hcat(df, table)` and `hcat(table, df)` always produces a `DataFrame`; this could lead to dispatch ambiguities in case if other `table` type also defined `hcat` (and allowed it with `DataFrame`) - what do you think we should do? Maybe only `hcat(df, table)` should be defined and we should use a rule that the first argument governs the dispatch and output type?