### PR TITLE
remove escape in Char

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -30,7 +30,7 @@ end
 
 @testset "Basic show test with allrows and allcols" begin
     df = DataFrame(A = Int64[1:4;], B = ["x\"", "∀ε>0: x+ε>x", "z\$", "A\nC"],
-                   C = Float32[1.0, 2.0, 3.0, 4.0], D = ['\'', '∀', '\$', '\n'])
+                   C = Float32[1.0, 2.0, 3.0, 4.0], D = ['\'', '∀', '$', '\n'])
 
     refstr = """
     4×4 DataFrame


### PR DESCRIPTION
`'$'` and `'\$'` are the same, but the latter confuses code parser in VS Code.