### PR TITLE
Use standard Tables.Schema constructor instead of constructing directly

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -21,7 +21,7 @@ end
 Tables.columnindex(df::Union{AbstractDataFrame, DataFrameRow}, idx::AbstractString) =
     columnindex(df, Symbol(idx))
 
-Tables.schema(df::AbstractDataFrame) = Tables.Schema{Tuple(_names(df)), Tuple{[eltype(col) for col in eachcol(df)]...}}()
+Tables.schema(df::AbstractDataFrame) = Tables.Schema(_names(df), [eltype(col) for col in eachcol(df)])
 Tables.materializer(df::AbstractDataFrame) = DataFrame
 
 Tables.getcolumn(df::AbstractDataFrame, i::Int) = df[!, i]


### PR DESCRIPTION
This is part of fixing errors like
https://github.com/JuliaData/CSV.jl/issues/635 in addition to the
changes to support really wide tables in
https://github.com/JuliaData/Tables.jl/pull/241. Luckily, there aren't
many cases I've found across Tables.jl implementations that make working
with really wide tables impossible, but this was a key place where for
really wide tables, we want the names/types to be stored as `Vector`s
instead of `Tuple`/`Tuple{}` in `Tables.Schema`. This shouldn't have any
noticeable change/affect for non-wide DataFrames and should be covered
by existing tests.