### PR TITLE
Add some clarifying comments on copycols for Tables.jl inputs

### DIFF
--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -78,7 +78,7 @@ signals that a copy of columns doesn't need to be made (this is done by wrapping
 the source table in `Tables.CopiedColumns`).
 [CSV.jl](https://csv.juliadata.org/stable) does this when
 `CSV.read(file, DataFrame)` is called, since columns are built only for the purpose
-of use in a `DataFrame`.
+of use in a `DataFrame` constructor.
 Another example is [`Arrow.Table`](https://arrow.juliadata.org/dev/manual/#Arrow.Table),
 where arrow data is inherently immutable so columns can't be accidentally mutated
 anyway. To be able to mutate arrow data, columns must be materialized,

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -72,9 +72,17 @@ that could perform a transformation without copying the columns). Examples of su
 [`hcat`](@ref), [`filter`](@ref), [`dropmissing`](@ref), `getindex`,
 [`copy`](@ref) or the [`DataFrame`](@ref) constructor mentioned above.
 
-The generic single-argument constructor `DataFrame(table)` has `copycols=nothing` by default, where
-certain Tables.jl-compatible inputs can signal that a copy of columns doesn't need to be made (this
-is done by wrapping the source table in `Tables.CopiedColumns`). [CSV.jl](https://csv.juliadata.org/stable) does this when `CSV.read(file, DataFrame)` is called, since columns are built only for the purpose of use in a `DataFrame`. Another related example is [`Arrow.Table`](https://arrow.juliadata.org/dev/manual/#Arrow.Table), where arrow data is inherently immutable so columns can't be accidentally mutated anyway. To be able to mutate arrow data, mutable columns must be materialized, which can be accomplished via `DataFrame(arrow_table; copycols=true)`.
+The generic single-argument constructor `DataFrame(table)` has `copycols=nothing`
+by default, meaning that columns are copied unless `table`
+signals that a copy of columns doesn't need to be made (this is done by wrapping
+the source table in `Tables.CopiedColumns`).
+[CSV.jl](https://csv.juliadata.org/stable) does this when
+`CSV.read(file, DataFrame)` is called, since columns are built only for the purpose
+of use in a `DataFrame`.
+Another example is [`Arrow.Table`](https://arrow.juliadata.org/dev/manual/#Arrow.Table),
+where arrow data is inherently immutable so columns can't be accidentally mutated
+anyway. To be able to mutate arrow data, columns must be materialized,
+which can be accomplished via `DataFrame(arrow_table, copycols=true)`.
 
 On the contrary, functions that create a view of a `DataFrame` *do not* by definition make copies of
 the columns, and therefore require particular caution. This includes `view`, which returns

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -72,6 +72,10 @@ that could perform a transformation without copying the columns). Examples of su
 [`hcat`](@ref), [`filter`](@ref), [`dropmissing`](@ref), `getindex`,
 [`copy`](@ref) or the [`DataFrame`](@ref) constructor mentioned above.
 
+The generic single-argument constructor `DataFrame(table)` has `copycols=nothing` by default, where
+certain Tables.jl-compatible inputs can signal that a copy of columns doesn't need to be made (this
+is done by wrapping the source table in `Tables.CopiedColumns`). [CSV.jl](https://csv.juliadata.org/stable) does this when `CSV.read(file, DataFrame)` is called, since columns are built only for the purpose of use in a `DataFrame`. Another related example is [`Arrow.Table`](https://arrow.juliadata.org/dev/manual/#Arrow.Table), where arrow data is inherently immutable so columns can't be accidentally mutated anyway. To be able to mutate arrow data, mutable columns must be materialized, which can be accomplished via `DataFrame(arrow_table; copycols=true)`.
+
 On the contrary, functions that create a view of a `DataFrame` *do not* by definition make copies of
 the columns, and therefore require particular caution. This includes `view`, which returns
 a `SubDataFrame` or a `DataFrameRow`, and `groupby`, which returns a `GroupedDataFrame`.

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -16,7 +16,7 @@ DataFrame(kwargs..., copycols::Bool=true)
 DataFrame(columns::AbstractVecOrMat, names::Union{AbstractVector, Symbol};
           makeunique::Bool=false, copycols::Bool=true)
 
-DataFrame(table; copycols::Bool=true)
+DataFrame(table; copycols=nothing)
 DataFrame(::DataFrameRow)
 DataFrame(::GroupedDataFrame; keepkeys::Bool=true)
 ```
@@ -26,7 +26,12 @@ DataFrame(::GroupedDataFrame; keepkeys::Bool=true)
 - `copycols` : whether vectors passed as columns should be copied; by default set
   to `true` and the vectors are copied; if set to `false` then the constructor
   will still copy the passed columns if it is not possible to construct a
-  `DataFrame` without materializing new columns.
+  `DataFrame` without materializing new columns. Note that `copycols=nothing`
+  in the "table" constructor; certain input table types may have already
+  made a copy of columns or the columns are otherwise immutable, in which
+  case columns are not copied by default. To force a copy anyway, or to
+  get mutable columns from an immutable input table (like `Arrow.Table`),
+  just pass `copycols=true` explicitly.
 - `makeunique` : if `false` (the default), an error will be raised
 
 (note that not all constructors support these keyword arguments)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -16,7 +16,7 @@ DataFrame(kwargs..., copycols::Bool=true)
 DataFrame(columns::AbstractVecOrMat, names::Union{AbstractVector, Symbol};
           makeunique::Bool=false, copycols::Bool=true)
 
-DataFrame(table; copycols=nothing)
+DataFrame(table; copycols::Union{Bool, Nothing}=nothing)
 DataFrame(::DataFrameRow)
 DataFrame(::GroupedDataFrame; keepkeys::Bool=true)
 ```
@@ -26,12 +26,12 @@ DataFrame(::GroupedDataFrame; keepkeys::Bool=true)
 - `copycols` : whether vectors passed as columns should be copied; by default set
   to `true` and the vectors are copied; if set to `false` then the constructor
   will still copy the passed columns if it is not possible to construct a
-  `DataFrame` without materializing new columns. Note that `copycols=nothing`
-  in the "table" constructor; certain input table types may have already
-  made a copy of columns or the columns are otherwise immutable, in which
-  case columns are not copied by default. To force a copy anyway, or to
-  get mutable columns from an immutable input table (like `Arrow.Table`),
-  just pass `copycols=true` explicitly.
+  `DataFrame` without materializing new columns. Note the `copycols=nothing`
+  default in the Tables.jl compatible constructor; it is provided as certain
+  input table types may have already made a copy of columns or the columns may
+  otherwise be immutable, in which case columns are not copied by default.
+  To force a copy in such cases, or to get mutable columns from an immutable
+  input table (like `Arrow.Table`), pass `copycols=true` explicitly.
 - `makeunique` : if `false` (the default), an error will be raised
 
 (note that not all constructors support these keyword arguments)


### PR DESCRIPTION
Should help address some confusion in #2799 around `copycols=nothing`
default for `DataFrame` constructor when Tables.jl input is provided.