### PR TITLE
make sort kwarg in groupby more flexible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,12 +8,15 @@
   - `true` sorts groups by key columns;
   - `false` creates groups in the order of their appearance in the parent data
     frame;
-  The old behavior was that the `sort` keyword argument allowed only `Bool` values
-  and if `false` was passed (which was the default) it corresponded to current
-  behavior when `nothing` is passed. Therefore only the user visible change is
-  when `sort=false` is passed explicitly as now instead of the order being
-  undefined it is guaranteed that the groups are in order of their appearance
-  in the parent data frame.
+  In previous versions, the `sort` keyword argument allowed only `Bool` values
+  and `false` (which was the default) corresponded to the new
+  behavior when `nothing` is passed. Therefore only the user visible change
+  affecting existing code is when `sort=false` is passed explicitly.
+  The order of groups was undefined in that case, but in practice
+  groups were already created in their order of appearance, *except*
+  when grouping columns implemented the `DataAPI.refpool` API
+  (notably `PooledArray` and `CategoricalArray`) or when they contained only
+  integers in a small range.
   ([#2812](https://github.com/JuliaData/DataFrames.jl/pull/2812))
 
 # DataFrames.jl v1.2 Release Notes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# DataFrames.jl v1.3 Release Notes
+
+## New functionalities
+
+* in the `groupby` function the `sort` keyword argument now allows three values
+  - `nothing` (the default) leaves the order of groups undefined and allows
+    `groupby` to pick the fastest available grouping algorithm;
+  - `true` sorts groups by key columns;
+  - `false` creates groups in the order of their appearance in the parent data
+    frame;
+  The old behavior was that the `sort` keyword argument allowed only `Bool` values
+  and if `false` was passed (which was the default) it corresponded to current
+  behavior when `nothing` is passed. Therefore only the user visible change is
+  when `sort=false` is passed explicitly as now instead of the order being
+  undefined it is guaranteed that the groups are in order of their appearance
+  in the parent data frame.
+  ([#2812](https://github.com/JuliaData/DataFrames.jl/pull/2812))
+
 # DataFrames.jl v1.2 Release Notes
 
 ## New functionalities

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1255,7 +1255,7 @@ function nonunique(df::AbstractDataFrame)
         throw(ArgumentError("finding duplicate rows in data frame with no " *
                             "columns is not allowed"))
     end
-    gslots = row_group_slots(ntuple(i -> df[!, i], ncol(df)), Val(true), false, nothing)[3]
+    gslots = row_group_slots(ntuple(i -> df[!, i], ncol(df)), Val(true), false, false, nothing)[3]
     # unique rows are the first encountered group representatives,
     # nonunique are everything else
     res = fill(true, nrow(df))

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1255,7 +1255,7 @@ function nonunique(df::AbstractDataFrame)
         throw(ArgumentError("finding duplicate rows in data frame with no " *
                             "columns is not allowed"))
     end
-    gslots = row_group_slots(ntuple(i -> df[!, i], ncol(df)), Val(true), false, false, nothing)[3]
+    gslots = row_group_slots(ntuple(i -> df[!, i], ncol(df)), Val(true), nothing, false, nothing)[3]
     # unique rows are the first encountered group representatives,
     # nonunique are everything else
     res = fill(true, nrow(df))

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1255,7 +1255,7 @@ function nonunique(df::AbstractDataFrame)
         throw(ArgumentError("finding duplicate rows in data frame with no " *
                             "columns is not allowed"))
     end
-    gslots = row_group_slots(ntuple(i -> df[!, i], ncol(df)), Val(true))[3]
+    gslots = row_group_slots(ntuple(i -> df[!, i], ncol(df)), Val(true), false, nothing)[3]
     # unique rows are the first encountered group representatives,
     # nonunique are everything else
     res = fill(true, nrow(df))

--- a/src/groupeddataframe/utils.jl
+++ b/src/groupeddataframe/utils.jl
@@ -258,12 +258,12 @@ function row_group_slots(cols::NTuple{N, AbstractVector},
                                    Missings.EachReplaceMissing{
                                        <:AbstractVector{<:Union{Real, Missing}}}}},
                          hash::Val{false},
-                         groups::Union{Vector{Int}, Nothing},
+                         groups::Vector{Int},
                          skipmissing::Bool,
                          sort::Bool)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool} where N
     # Computing neither hashes nor groups isn't very useful,
     # and this method needs to allocate a groups vector anyway
-    @assert groups !== nothing && all(col -> length(col) == length(groups), cols)
+    @assert all(col -> length(col) == length(groups), cols)
 
     missinginds = map(refpools) do refpool
         eltype(refpool) >: Missing ?

--- a/src/groupeddataframe/utils.jl
+++ b/src/groupeddataframe/utils.jl
@@ -182,10 +182,10 @@ end
 # Optional `groups` vector is set to the group indices of each row (starting at 1)
 # With skipmissing=true, rows with missing values are attributed index 0.
 function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
-                         hash::Val = Val(true),
-                         groups::Union{Vector{Int}, Nothing} = nothing,
-                         skipmissing::Bool = false,
-                         sort::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
+                         hash::Val,
+                         groups::Union{Vector{Int}, Nothing},
+                         skipmissing::Bool,
+                         sort::Bool)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
     rpa = refpool_and_array.(cols)
     if sort === false
         refpools = nothing
@@ -201,10 +201,10 @@ end
 function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
                          refpools::Any,  # Ignored
                          refarrays::Any, # Ignored
-                         hash::Val = Val(true),
-                         groups::Union{Vector{Int}, Nothing} = nothing,
-                         skipmissing::Bool = false,
-                         sort::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
+                         hash::Val,
+                         groups::Union{Vector{Int}, Nothing},
+                         skipmissing::Bool,
+                         sort::Bool)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
     @assert groups === nothing || length(groups) == length(cols[1])
     rhashes, missings = hashrows(cols, skipmissing)
     # inspired by Dict code from base cf. https://github.com/JuliaData/DataTables.jl/pull/17#discussion_r102481481
@@ -258,9 +258,9 @@ function row_group_slots(cols::NTuple{N, AbstractVector},
                                    Missings.EachReplaceMissing{
                                        <:AbstractVector{<:Union{Real, Missing}}}}},
                          hash::Val{false},
-                         groups::Union{Vector{Int}, Nothing} = nothing,
-                         skipmissing::Bool = false,
-                         sort::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool} where N
+                         groups::Union{Vector{Int}, Nothing},
+                         skipmissing::Bool,
+                         sort::Bool)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool} where N
     # Computing neither hashes nor groups isn't very useful,
     # and this method needs to allocate a groups vector anyway
     @assert groups !== nothing && all(col -> length(col) == length(groups), cols)

--- a/src/groupeddataframe/utils.jl
+++ b/src/groupeddataframe/utils.jl
@@ -187,9 +187,14 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
                          skipmissing::Bool = false,
                          sort::Bool = false)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
     rpa = refpool_and_array.(cols)
-    refpools = first.(rpa)
-    refarrays = last.(rpa)
-    row_group_slots(cols, refpools, refarrays, hash, groups, skipmissing, sort)
+    if sort === false
+        refpools = nothing
+        refarrays = nothing
+    else
+        refpools = first.(rpa)
+        refarrays = last.(rpa)
+    end
+    row_group_slots(cols, refpools, refarrays, hash, groups, skipmissing, sort === true)
 end
 
 # Generic fallback method based on open adressing hash table

--- a/src/groupeddataframe/utils.jl
+++ b/src/groupeddataframe/utils.jl
@@ -185,7 +185,7 @@ function row_group_slots(cols::Tuple{Vararg{AbstractVector}},
                          hash::Val,
                          groups::Union{Vector{Int}, Nothing},
                          skipmissing::Bool,
-                         sort::Bool)::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
+                         sort::Union{Bool, Nothing})::Tuple{Int, Vector{UInt}, Vector{Int}, Bool}
     rpa = refpool_and_array.(cols)
     if sort === false
         refpools = nothing

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -217,7 +217,7 @@ end
         @test combine(f8, gd) == sres4
 
         # combine() with ungroup without and with groups sorting
-        for dosort in (false, true)
+        for dosort in (false, true, nothing)
             gd = groupby_checked(df, cols, sort=dosort)
             v = validate_gdf(combine(d -> d[:, [:x]], gd, ungroup=false))
             @test length(gd) == length(v)
@@ -1876,7 +1876,7 @@ end
                        b = repeat(1:2, inner=6), c = 1:12)
     Random.seed!(1234)
     for df in [df_ref, df_ref[randperm(nrow(df_ref)), :]], grpcols = [[:a, :b], :a, :b],
-        dosort in [true, false], doskipmissing in [true, false]
+        dosort in (true, false, nothing), doskipmissing in (true, false)
 
         gd = groupby_checked(df, grpcols, sort=dosort, skipmissing=doskipmissing)
 
@@ -2214,7 +2214,7 @@ end
     df_ref = DataFrame(rand(10, 4), :auto)
     df_ref.g = shuffle!([1, 2, 2, 3, 3, 3, 4, 4, 4, 4])
 
-    for i in 0:nrow(df_ref), dosort in [true, false], dokeepkeys in [true, false]
+    for i in 0:nrow(df_ref), dosort in (true, false, nothing), dokeepkeys in (true, false)
         df = df_ref[1:i, :]
         gdf = groupby_checked(df, :g, sort=dosort)
         @test combine(gdf, :x1 => sum => :x1, :x2 => identity => :x2,
@@ -2460,7 +2460,7 @@ end
 @testset "select and transform GroupedDataFrame" begin
     for df in (DataFrame(g=[3, 1, 1, missing], x=1:4, y=5:8),
                DataFrame(g=categorical([3, 1, 1, missing]), x=1:4, y=5:8)),
-        dosort in (true, false)
+        dosort in (true, false, nothing)
 
         gdf = groupby_checked(df, :g, sort=dosort, skipmissing=false)
 
@@ -2539,7 +2539,7 @@ end
     Random.seed!(1)
     for df in (DataFrame(g=rand(1:20, 1000), x=rand(1000), id=1:1000),
                DataFrame(g=categorical(rand(1:20, 1000)), x=rand(1000), id=1:1000)),
-        dosort in (true, false)
+        dosort in (true, false, nothing)
 
         gdf = groupby_checked(df, :g, sort=dosort)
 
@@ -2549,7 +2549,7 @@ end
         @test res1.x_mean + res1.x_function ≈ df.x
 
         res2 = combine(gdf, :x => mean, :x => x -> x .- mean(x), :id)
-        @test unique(res2.g) == sort(unique(df.g))
+        @test sort(unique(res2.g)) == sort(unique(df.g))
         for i in unique(res2.g)
             @test issorted(filter(:g => x -> x == i, res2).id)
         end
@@ -2559,7 +2559,7 @@ end
 @testset "select! and transform! GroupedDataFrame" begin
     for df in (DataFrame(g=[3, 1, 1, missing], x=1:4, y=5:8),
                DataFrame(g=categorical([3, 1, 1, missing]), x=1:4, y=5:8)),
-        dosort in (true, false)
+        dosort in (true, false, nothing)
 
         @test_throws MethodError select!(groupby_checked(view(df, :, :), :g), :x)
         @test_throws MethodError transform!(groupby_checked(view(df, :, :), :g), :x)
@@ -3779,32 +3779,32 @@ end
 # validate_gdf function defined in this testset
 @testset "subset! tests" begin
     df = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4]);
-    gd = groupby(df, :a);
+    gd = groupby_checked(df, :a);
     subset!(gd, :b => x -> x .> first(x))
     validate_gdf(gd)
-    @test gd == groupby(df, :a)
+    @test gd == groupby_checked(df, :a)
     @test sort!(unique(gd.groups)) == 1:length(gd)
 
     df = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4]);
-    gd = groupby(df, :a)[[2, 1]];
+    gd = groupby_checked(df, :a)[[2, 1]];
     subset!(gd, :b => x -> x .> first(x))
     validate_gdf(gd)
-    @test gd == groupby(df, :a)[[2, 1]]
+    @test gd == groupby_checked(df, :a)[[2, 1]]
     @test sort!(unique(gd.groups)) == 1:length(gd)
 
     df = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4]);
-    gd = groupby(df, :a);
+    gd = groupby_checked(df, :a);
     subset!(gd, :a => x -> x .== 1)
     validate_gdf(gd)
     @test sort!(unique(gd.groups)) == 1:length(gd)
-    @test gd == groupby(df, :a)
+    @test gd == groupby_checked(df, :a)
 
     df = DataFrame(a = [1, 1, 2, 2], b = [1, 2, 3, 4]);
-    gd = groupby(df, :a)[[2, 1]];
+    gd = groupby_checked(df, :a)[[2, 1]];
     subset!(gd, :b => x -> x .== 1)
     validate_gdf(gd)
     @test sort!(unique(gd.groups)) == 1:length(gd)
-    @test gd == groupby(df, :a)
+    @test gd == groupby_checked(df, :a)
 
     function issubsequence(v1, v2, l1, l2)
         l1 == 0 && return true
@@ -3816,21 +3816,21 @@ end
     for n in 1:10, j in 1:10, _ in 1:100
         df = DataFrame(a=rand(1:j, n))
         # need to sort to ensure grouping algorithm stability
-        gd = groupby(df, :a, sort=true)
+        gd = groupby_checked(df, :a, sort=true)
         subset!(gd, :a => ByRow(x -> rand() < 0.5))
         validate_gdf(gd)
         @test sort!(unique(gd.groups)) == 1:length(gd)
-        @test gd == groupby(df, :a, sort=true)
+        @test gd == groupby_checked(df, :a, sort=true)
 
         # below we do not have a well defined order so just validate gd
         df = DataFrame(a=rand(1:j, n))
-        gd = groupby(df, :a)
+        gd = groupby_checked(df, :a)
         subset!(gd, :a => ByRow(x -> rand() < 0.5))
         validate_gdf(gd)
         @test sort!(unique(gd.groups)) == 1:length(gd)
 
         df = DataFrame(a=rand(1:j, n))
-        gd = groupby(df, :a)
+        gd = groupby_checked(df, :a)
         p = randperm(length(gd))
         gd = gd[p]
         superseq = [first(x.a) for x in gd]
@@ -3844,9 +3844,107 @@ end
 
 @testset "consistency check" begin
     df = DataFrame(a=1)
-    gdf = groupby(df, :a)
+    gdf = groupby_checked(df, :a)
     push!(df, [2])
     @test_throws AssertionError gdf[1]
+end
+
+@testset "check sort keyword argument of groupby" begin
+    df = DataFrame(id=[3, 1, 2])
+    gd = groupby_checked(df, :id, sort=nothing)
+    @test Vector.(keys(gd)) == [[1], [2], [3]]
+    gd = groupby_checked(df, :id, sort=true)
+    @test Vector.(keys(gd)) == [[1], [2], [3]]
+    gd = groupby_checked(df, :id, sort=false)
+    @test Vector.(keys(gd)) == [[3], [1], [2]]
+
+    df = DataFrame(id=[300, 1, 2])
+    gd = groupby_checked(df, :id, sort=nothing)
+    @test Vector.(keys(gd)) == [[300], [1], [2]]
+    gd = groupby_checked(df, :id, sort=true)
+    @test Vector.(keys(gd)) == [[1], [2], [300]]
+    gd = groupby_checked(df, :id, sort=false)
+    @test Vector.(keys(gd)) == [[300], [1], [2]]
+
+    df = DataFrame(id=["3", "1", "2"])
+    gd = groupby_checked(df, :id, sort=nothing)
+    @test Vector.(keys(gd)) == [["3"], ["1"], ["2"]]
+    gd = groupby_checked(df, :id, sort=true)
+    @test Vector.(keys(gd)) == [["1"], ["2"], ["3"]]
+    gd = groupby_checked(df, :id, sort=false)
+    @test Vector.(keys(gd)) == [["3"], ["1"], ["2"]]
+
+    df.id = PooledArray(df.id)
+    gd = groupby_checked(df, :id, sort=nothing)
+    @test Vector.(keys(gd)) == [["3"], ["1"], ["2"]]
+    gd = groupby_checked(df, :id, sort=true)
+    @test Vector.(keys(gd)) == [["1"], ["2"], ["3"]]
+    gd = groupby_checked(df, :id, sort=false)
+    @test Vector.(keys(gd)) == [["3"], ["1"], ["2"]]
+
+    # for PooledVector sorted=true is not the same as sorted=nothing
+    df.id[1] = "300"
+    df.id[3] = "200"
+    gd = groupby_checked(df, :id, sort=nothing)
+    @test Vector.(keys(gd)) == [["1"], ["300"], ["200"]]
+    gd = groupby_checked(df, :id, sort=true)
+    @test Vector.(keys(gd)) == [["1"], ["200"], ["300"]]
+    gd = groupby_checked(df, :id, sort=false)
+    @test Vector.(keys(gd)) == [["300"], ["1"], ["200"]]
+
+    # for CategoricalVector sorted=true is the same as sorted=nothing
+    df = DataFrame(id=categorical(["1", "2", "3"], ordered=true))
+    levels!(df.id, ["2", "1", "3"])
+    gd = groupby_checked(df, :id, sort=nothing)
+    @test Vector.(keys(gd)) == [["2"], ["1"], ["3"]]
+    gd = groupby_checked(df, :id, sort=true)
+    @test Vector.(keys(gd)) == [["2"], ["1"], ["3"]]
+    gd = groupby_checked(df, :id, sort=false)
+    @test Vector.(keys(gd)) == [["1"], ["2"], ["3"]]
+
+    df = DataFrame(id1=[2, 2, 1, 1], id2=[1, 2, 2, 1])
+    gd = groupby_checked(df, [:id1, :id2], sort=nothing)
+    @test Vector.(keys(gd)) == [[1, 1], [1, 2], [2, 1], [2, 2]]
+    gd = groupby_checked(df, [:id1, :id2], sort=true)
+    @test Vector.(keys(gd)) == [[1, 1], [1, 2], [2, 1], [2, 2]]
+    gd = groupby_checked(df, [:id1, :id2], sort=false)
+    @test Vector.(keys(gd)) == [[2, 1], [2, 2], [1, 2], [1, 1]]
+
+    df = DataFrame(id1=[200, 200, 1, 1], id2=[1, 2, 2, 1])
+    gd = groupby_checked(df, [:id1, :id2], sort=nothing)
+    @test Vector.(keys(gd)) == [[200, 1], [200, 2], [1, 2], [1, 1]]
+    gd = groupby_checked(df, [:id1, :id2], sort=true)
+    @test Vector.(keys(gd)) == [[1, 1], [1, 2], [200, 1], [200, 2]]
+    gd = groupby_checked(df, [:id1, :id2], sort=false)
+    @test Vector.(keys(gd)) == [[200, 1], [200, 2], [1, 2], [1, 1]]
+
+    df = DataFrame(id=[3, 1, missing, 2])
+    gd = groupby_checked(df, :id, sort=nothing, skipmissing=true)
+    @test Vector.(keys(gd)) == [[1], [2], [3]]
+    gd = groupby_checked(df, :id, sort=true, skipmissing=true)
+    @test Vector.(keys(gd)) == [[1], [2], [3]]
+    gd = groupby_checked(df, :id, sort=false, skipmissing=true)
+    @test Vector.(keys(gd)) == [[3], [1], [2]]
+    gd = groupby_checked(df, :id, sort=nothing)
+    @test Vector.(keys(gd)) ≅ [[1], [2], [3], [missing]]
+    gd = groupby_checked(df, :id, sort=true)
+    @test Vector.(keys(gd)) ≅ [[1], [2], [3], [missing]]
+    gd = groupby_checked(df, :id, sort=false)
+    @test Vector.(keys(gd)) ≅ [[3], [1], [missing], [2]]
+
+    df = DataFrame(id=[300, missing, 1, 2])
+    gd = groupby_checked(df, :id, sort=nothing, skipmissing=true)
+    @test Vector.(keys(gd)) == [[300], [1], [2]]
+    gd = groupby_checked(df, :id, sort=true, skipmissing=true)
+    @test Vector.(keys(gd)) == [[1], [2], [300]]
+    gd = groupby_checked(df, :id, sort=false, skipmissing=true)
+    @test Vector.(keys(gd)) == [[300], [1], [2]]
+    gd = groupby_checked(df, :id, sort=nothing)
+    @test Vector.(keys(gd)) ≅ [[300], [missing], [1], [2]]
+    gd = groupby_checked(df, :id, sort=true)
+    @test Vector.(keys(gd)) ≅ [[1], [2], [300], [missing]]
+    gd = groupby_checked(df, :id, sort=false)
+    @test Vector.(keys(gd)) ≅ [[300], [missing], [1], [2]]
 end
 
 end # module

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -3882,7 +3882,7 @@ end
     gd = groupby_checked(df, :id, sort=false)
     @test Vector.(keys(gd)) == [["3"], ["1"], ["2"]]
 
-    # for PooledVector sorted=true is not the same as sorted=nothing
+    # for PooledVector sort=true is not the same as sort=nothing
     df.id[1] = "300"
     df.id[3] = "200"
     gd = groupby_checked(df, :id, sort=nothing)
@@ -3892,7 +3892,7 @@ end
     gd = groupby_checked(df, :id, sort=false)
     @test Vector.(keys(gd)) == [["300"], ["1"], ["200"]]
 
-    # for CategoricalVector sorted=true is the same as sorted=nothing
+    # for CategoricalVector sort=true is the same as sort=nothing
     df = DataFrame(id=categorical(["1", "2", "3"], ordered=true))
     levels!(df.id, ["2", "1", "3"])
     gd = groupby_checked(df, :id, sort=nothing)


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2762.

If we accept it then:
* by default we use the fastest algorithm
* if user passes `sort=false` explicitly then groups are created in order of appearance
* if user passes `sort=true` then groups are sorted

If we agree to add this extension I will add tests and NEWS.md entry and finalize this PR.