### PR TITLE
Add makeunique to Tables.jl DataFrame constructor

### DIFF
--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -45,17 +45,18 @@ fromcolumns(x, names; copycols::Union{Nothing, Bool}=nothing) =
 fromcolumns(x::Tables.CopiedColumns, names; copycols::Union{Nothing, Bool}=nothing) =
     fromcolumns(Tables.source(x), names; copycols=something(copycols, false))
 
-function DataFrame(x::T; copycols::Union{Nothing, Bool}=nothing) where {T}
+function DataFrame(x::T; copycols::Union{Nothing, Bool}=nothing,
+                   makeunique::Bool=false) where {T}
     if !Tables.istable(x) && x isa AbstractVector && !isempty(x)
         # here we handle eltypes not specific enough to be dispatched
         # to other DataFrames constructors taking vector of `Pair`s
         if all(v -> v isa Pair{Symbol, <:AbstractVector}, x) ||
             all(v -> v isa Pair{<:AbstractString, <:AbstractVector}, x)
             return DataFrame(AbstractVector[last(v) for v in x], [first(v) for v in x],
-                             copycols=something(copycols, true))
+                             copycols=something(copycols, true), makeunique=makeunique)
         end
     end
-    cols = Tables.columns(x)
+    cols = Tables.columns(x, makeunique=true)
     names = collect(Symbol, Tables.columnnames(cols))
     return fromcolumns(cols, names, copycols=copycols)
 end

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -56,7 +56,7 @@ function DataFrame(x::T; copycols::Union{Nothing, Bool}=nothing,
                              copycols=something(copycols, true), makeunique=makeunique)
         end
     end
-    cols = Tables.columns(x, makeunique=true)
+    cols = makeunique ? Tables.columns(x, makeunique=true) : Tables.columns(x)
     names = collect(Symbol, Tables.columnnames(cols))
     return fromcolumns(cols, names, copycols=copycols)
 end


### PR DESCRIPTION
This is WIP as it requires changes to `Tables.columns` (so that it can accept `makeunique` kwarg).

See https://discourse.julialang.org/t/sqlite-query-with-duplicate-column-names-dataframe/64518 for a related discussion.

@quinnj - do you think it is feasible to change `Tables.columns` implementation? In particular the challenge is that we are post 1.0 in Tables.jl and some custom packages might already have implemented `Tables.columns` without this kwarg.
Or maybe there is some other better solution? You know Tables.jl design best.