### PR TITLE
fix delete! for versions of Julia 1.6.2 or earlier

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# DataFrames.jl v1.2.1 Patch Release Notes
+
+## Bug fixes
+
+* Add workaround for `deleteat!` bug in Julia Base in `delete!` function
+  ([#2820](https://github.com/JuliaData/DataFrames.jl/issues/2820))
+
 # DataFrames.jl v1.2 Release Notes
 
 ## New functionalities

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -973,7 +973,6 @@ function Base.delete!(df::DataFrame, inds)
 
     # we require ind to be stored and unique like in Base
     # otherwise an error will be thrown and the data frame will get corrupted
-
     return _delete!_helper(df, inds)
 end
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -966,8 +966,14 @@ function Base.delete!(df::DataFrame, inds)
         throw(BoundsError(df, (inds, :)))
     end
 
+    # workaround https://github.com/JuliaLang/julia/pull/41646
+    if VERSION <= v"1.6.2" && inds isa UnitRange{<:Integer}
+        inds = collect(inds)
+    end
+
     # we require ind to be stored and unique like in Base
     # otherwise an error will be thrown and the data frame will get corrupted
+
     return _delete!_helper(df, inds)
 end
 
@@ -976,6 +982,10 @@ function Base.delete!(df::DataFrame, inds::AbstractVector{Bool})
         throw(BoundsError(df, (inds, :)))
     end
     drop = _findall(inds)
+    # workaround https://github.com/JuliaLang/julia/pull/41646
+    if VERSION <= v"1.6.2" && drop isa UnitRange{<:Integer}
+        drop = collect(drop)
+    end
     return _delete!_helper(df, drop)
 end
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -199,7 +199,7 @@ end
     @test nrow(df) == 6
 
     df = DataFrame(a= Vector{Union{Bool,Missing}}(missing, 10^4));
-    delete!(df, [false; trues(nrow(df)-6); falses(5)])
+    delete!(df, [false; trues(nrow(df) - 6); falses(5)])
     @test nrow(df) == 6
 end
 

--- a/test/data.jl
+++ b/test/data.jl
@@ -114,7 +114,7 @@ end
                     :auto)
     df2 = DataFrame([Union{Int, Missing}[1, 2, 3, 4], ["one", "two", missing, "four"]],
                     :auto)
-    df3 = DataFrame(x = Int[1, 2, 3, 4], y = Union{Int, Missing}[1, missing, 2, 3], 
+    df3 = DataFrame(x = Int[1, 2, 3, 4], y = Union{Int, Missing}[1, missing, 2, 3],
                     z = Missing[missing, missing, missing, missing])
 
     @test completecases(df2) == .!ismissing.(df2.x2)
@@ -190,6 +190,17 @@ end
     df = DataFrame(b=b)
     @test eltype(dropmissing(df).b) == Int
     @test eltype(dropmissing!(df).b) == Int
+end
+
+@testset "delete! https://github.com/JuliaLang/julia/pull/41646 bug workaround" begin
+    # these tests will crash Julia if they are not correct
+    df = DataFrame(a= Vector{Union{Bool,Missing}}(missing, 10^4));
+    delete!(df, 2:(nrow(df) - 5))
+    @test nrow(df) == 6
+
+    df = DataFrame(a= Vector{Union{Bool,Missing}}(missing, 10^4));
+    delete!(df, [false; trues(nrow(df)-6); falses(5)])
+    @test nrow(df) == 6
 end
 
 @testset "dropmissing and unique view kwarg test" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2819.

I will make a release once this is merged.

Notice that currently this PR will fail on nightly, but soon it will pass thanks to https://github.com/JuliaLang/julia/pull/41646 (but I would not wait for Julia Base with merging this PR).

After this PR is merged I will make a patch release.