### PR TITLE
correct signature of merge for AbstractIndex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,14 @@
   integers in a small range.
   ([#2812](https://github.com/JuliaData/DataFrames.jl/pull/2812))
 
+# DataFrames.jl v1.2.2 Patch Release Notes
+
+## Bug fixes
+
+* fix a bug in `crossjoin` if the first argument is `SubDataFrame` and
+  `makeunique=true`
+  ([#2826](https://github.com/JuliaData/DataFrames.jl/issues/2826))
+
 # DataFrames.jl v1.2.1 Patch Release Notes
 
 ## Bug fixes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -132,7 +132,7 @@ function Base.merge!(x::Index, y::AbstractIndex; makeunique::Bool=false)
     return x
 end
 
-Base.merge(x::Index, y::AbstractIndex; makeunique::Bool=false) =
+Base.merge(x::AbstractIndex, y::AbstractIndex; makeunique::Bool=false) =
     merge!(copy(x), y, makeunique=makeunique)
 
 function Base.delete!(x::Index, idx::Integer)

--- a/test/index.jl
+++ b/test/index.jl
@@ -509,9 +509,9 @@ end
     @test merge(i1, si22) isa Index
     @test names(merge(i1, si22)) == ["a", "b", "c", "d", "e"]
     @test merge(si11, i2) isa Index
-    @test names(merge(si1, i2)) == ["a", "b", "c", "d", "e"]
+    @test names(merge(si11, i2)) == ["a", "b", "c", "d", "e"]
     @test merge(si11, si22) isa Index
-    @test names(merge(si1, si22)) == ["a", "b", "d", "e"]
+    @test names(merge(si11, si22)) == ["a", "b", "d", "e"]
     @test_throws ArgumentError merge(si12, si21)
     @test merge(si12, si21, makeunique=true) isa Index
     @test names(merge(si12, si21, makeunique=true)) == ["b", "c", "c_1", "d"]

--- a/test/index.jl
+++ b/test/index.jl
@@ -492,4 +492,36 @@ end
     @test DataFrames.index(dfv)[[:a, :c]] == [1, 2]
 end
 
+@testset "merge" begin
+    i1 = Index([:a, :b, :c])
+    si11 = SubIndex(i1, 1:2)
+    si12 = SubIndex(i1, 2:3)
+    i2 = Index([:c, :d, :e])
+    si21 = SubIndex(i2, 1:2)
+    si22 = SubIndex(i2, 2:3)
+
+    @test_throws ArgumentError merge(i1, i2)
+    @test merge(i1, i2, makeunique=true) isa Index
+    @test names(merge(i1, i2, makeunique=true)) == ["a", "b", "c", "c_1", "d", "e"]
+    @test_throws ArgumentError merge(i1, si21)
+    @test merge(i1, si21, makeunique=true) isa Index
+    @test names(merge(i1, si21, makeunique=true)) == ["a", "b", "c", "c_1", "d"]
+    @test merge(i1, si22) isa Index
+    @test names(merge(i1, si22)) == ["a", "b", "c", "d", "e"]
+    @test merge(si11, i2) isa Index
+    @test names(merge(si1, i2)) == ["a", "b", "c", "d", "e"]
+    @test merge(si11, si22) isa Index
+    @test names(merge(si1, si22)) == ["a", "b", "d", "e"]
+    @test_throws ArgumentError merge(si12, si21)
+    @test merge(si12, si21, makeunique=true) isa Index
+    @test names(merge(si12, si21, makeunique=true)) == ["b", "c", "c_1", "d"]
+
+    df = DataFrame(a=1)
+    dfv = view(df, 1:1, 1:1)
+    @test_throws ArgumentError crossjoin(df, df)
+    @test_throws ArgumentError crossjoin(dfv, dfv)
+    @test crossjoin(df, df, makeunique=true) == DataFrame(a=1, a_1=1)
+    @test crossjoin(dfv, dfv, makeunique=true) == DataFrame(a=1, a_1=1)
+end
+
 end # module


### PR DESCRIPTION
`merge` implementation was super old and it turns out we even did not have proper tests of it. I have added them now. `merge` is used only in `crossjoin` now, and the problem appeared when one tries to do a `crossjoin` of two `SubDataFrame`s with `makeunique=true`. This is also added to the tests