### PR TITLE
add Tables.materializer for types methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,9 @@
   (notably `PooledArray` and `CategoricalArray`) or when they contained only
   integers in a small range.
   ([#2812](https://github.com/JuliaData/DataFrames.jl/pull/2812))
+* `Tables.materializer` when passed the following types or their subtypes:
+  `AbstractDataFrame`, `DataFrameRows`, `DataFrameColumns` returns `DataFrame`.
+  ([#2839](https://github.com/JuliaData/DataFrames.jl/pull/2839))
 
 # DataFrames.jl v1.2.2 Patch Release Notes
 

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -22,7 +22,7 @@ Tables.columnindex(df::Union{AbstractDataFrame, DataFrameRow}, idx::AbstractStri
     columnindex(df, Symbol(idx))
 
 Tables.schema(df::AbstractDataFrame) = Tables.Schema(_names(df), [eltype(col) for col in eachcol(df)])
-Tables.materializer(df::AbstractDataFrame) = DataFrame
+Tables.materializer(::Type{<:AbstractDataFrame}) = DataFrame
 
 Tables.getcolumn(df::AbstractDataFrame, i::Int) = df[!, i]
 Tables.getcolumn(df::AbstractDataFrame, nm::Symbol) = df[!, nm]
@@ -82,8 +82,8 @@ Tables.schema(itr::Union{DataFrameRows, DataFrameColumns}) = Tables.schema(paren
 Tables.rowtable(itr::Union{DataFrameRows, DataFrameColumns}) = Tables.rowtable(parent(itr))
 Tables.namedtupleiterator(itr::Union{DataFrameRows, DataFrameColumns}) =
     Tables.namedtupleiterator(parent(itr))
-Tables.materializer(itr::Union{DataFrameRows, DataFrameColumns}) =
-    Tables.materializer(parent(itr))
+Tables.materializer(::Type{<:Union{DataFrameRows, DataFrameColumns}}) =
+    DataFrame
 
 Tables.getcolumn(itr::Union{DataFrameRows, DataFrameColumns}, i::Int) =
     Tables.getcolumn(parent(itr), i)

--- a/test/tables.jl
+++ b/test/tables.jl
@@ -305,4 +305,22 @@ end
     @test DataFrame(Any[SubString("a", 1) => [1]]) == DataFrame(a=1)
 end
 
+@testset "materializer" begin
+    df = DataFrame(a=1)
+    sdf1 = view(df, :, :)
+    sdf2 = view(df, 1:1, 1:1)
+    ec = eachcol(df)
+    er = eachrow(df)
+
+    for x in (df, sdf1, sdf2, ec, er)
+        @test DataFrame === @inferred Tables.materializer(x)
+        @test DataFrame === @inferred Tables.materializer(typeof(x))
+    end
+
+    @test DataFrame === @inferred Tables.materializer(AbstractDataFrame)
+    @test DataFrame === @inferred Tables.materializer(SubDataFrame)
+    @test DataFrame === @inferred Tables.materializer(DataFrames.DataFrameRows)
+    @test DataFrame === @inferred Tables.materializer(DataFrames.DataFrameColumns)
+end
+
 end # module


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2833

Implement `Tables.materializer` on types rather than on values, as when passed values it will fall back to types anyway.