### PR TITLE
let argument cols in names() also works on contents rather than just names

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -88,7 +88,8 @@ end
 
 Base.names(df::AbstractDataFrame, T::Type) =
     [String(n) for (n, c) in pairs(eachcol(df)) if eltype(c) <: T]
-Base.names(df::AbstractDataFrame, fun::Function) = filter!(fun, names(df))
+#Base.names(df::AbstractDataFrame, fun::Function) = filter!(fun, names(df))
+Base.names(df::AbstractDataFrame, fun::Function, predicate = 0) = predicate == 0 ? filter!(fun, names(df)) : names(df, fun.(eachcol(df)))
 
 # _names returns Vector{Symbol} without copying
 _names(df::AbstractDataFrame) = _names(index(df))

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -62,7 +62,7 @@ abstract type AbstractDataFrame end
 
 """
     names(df::AbstractDataFrame)
-    names(df::AbstractDataFrame, cols)
+    names(df::AbstractDataFrame, cols, content::Bool = false)
 
 Return a freshly allocated `Vector{String}` of names of columns contained in `df`.
 
@@ -74,6 +74,8 @@ selector (this is useful in particular with regular expressions, `Cols`, `Not`, 
   are returned
 * a `Function` predicate taking the column name as a string and returning `true`
   for columns that should be kept
+
+`content` is only specified to `true` when a predicate `Function` is applied on columns rather than names of them.
 
 See also [`propertynames`](@ref) which returns a `Vector{Symbol}`.
 """
@@ -89,7 +91,7 @@ end
 Base.names(df::AbstractDataFrame, T::Type) =
     [String(n) for (n, c) in pairs(eachcol(df)) if eltype(c) <: T]
 #Base.names(df::AbstractDataFrame, fun::Function) = filter!(fun, names(df))
-Base.names(df::AbstractDataFrame, fun::Function, predicate = 0) = predicate == 0 ? filter!(fun, names(df)) : names(df, fun.(eachcol(df)))
+Base.names(df::AbstractDataFrame, fun::Function, content::Bool = false) = content == false ? filter!(fun, names(df)) : names(df, fun.(eachcol(df)))
 
 # _names returns Vector{Symbol} without copying
 _names(df::AbstractDataFrame) = _names(index(df))

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -90,7 +90,6 @@ end
 
 Base.names(df::AbstractDataFrame, T::Type) =
     [String(n) for (n, c) in pairs(eachcol(df)) if eltype(c) <: T]
-#Base.names(df::AbstractDataFrame, fun::Function) = filter!(fun, names(df))
 Base.names(df::AbstractDataFrame, fun::Function, content::Bool = false) = content == false ? filter!(fun, names(df)) : names(df, fun.(eachcol(df)))
 
 # _names returns Vector{Symbol} without copying


### PR DESCRIPTION
Trying to fix #2747. 

When a predicate function is applied, by setting another argument `content`  from `false` to `true`, it works for contents rather than names.

```
julia> df1 = DataFrame([missing 1 2 3; missing 2 missing 4; 1 4 2 5], :auto)
3×4 DataFrame
 Row │ x1       x2      x3       x4
     │ Int64?   Int64?  Int64?   Int64?
─────┼──────────────────────────────────
   1 │ missing       1        2       3
   2 │ missing       2  missing       4
   3 │       1       4        2       5

julia> names(df1, (function(x) x isa String end))
4-element Vector{String}:
 "x1"
 "x2"
 "x3"
 "x4"

julia> names(df1, (function(x) x isa String end), true)
String[]

julia> names(df1, (function(col) mean(skipmissing(col)) >= 4 end), true)
1-element Vector{String}:
 "x4"
```

This additional argument `content` seems not that good, but right now I do not have a better idea.