### PR TITLE
Allow constructing Matrix from empty dataframe

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1158,7 +1158,7 @@ _filter!_helper_astable(df::AbstractDataFrame, nti::Tables.NamedTupleIterator, f
     delete!(df, _findall((x -> !(f(x)::Bool)).(nti)))
 
 function Base.Matrix(df::AbstractDataFrame)
-    T = reduce(promote_type, (eltype(v) for v in eachcol(df)))
+    T = reduce(promote_type, (eltype(v) for v in eachcol(df)), init=Union{})
     return Matrix{T}(df)
 end
 

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -6,6 +6,7 @@ const ≅ = isequal
 
 @testset "Constructors to Base types" begin
     df = DataFrame()
+    @test isa(Matrix(df), Matrix)
     df[!, :A] = 1:5
     df[!, :B] = 1.0:5.0
     @test isa(Matrix(df), Matrix{Float64})

--- a/test/conversions.jl
+++ b/test/conversions.jl
@@ -6,7 +6,8 @@ const ≅ = isequal
 
 @testset "Constructors to Base types" begin
     df = DataFrame()
-    @test isa(Matrix(df), Matrix)
+    @test Matrix(df) isa Matrix{Union{}}
+    @test size(Matrix(df)) == (0, 0)
     df[!, :A] = 1:5
     df[!, :B] = 1.0:5.0
     @test isa(Matrix(df), Matrix{Float64})


### PR DESCRIPTION
Before:
```
julia> Matrix(DataFrame())
ERROR: ArgumentError: reducing over an empty collection is not allowed
[ stacktrace omitted ]
```

After:
```
julia> Matrix(DataFrame())
0×0 Matrix{Union{}}
```

I chose an eltype of `Union{}` because the element type cannot be determined without any columns, and because it's the natural generalization of the type promotion between the columns.