### PR TITLE
Faster computation of quantiles in `describe`

### DIFF
--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -668,7 +668,7 @@ end
                                        nothing, nothing, nothing],
                                 min = [1.0, 1.0, "a", "a", Date(2000), 1],
                                 q25 = [1.75, 1.5, nothing, nothing, nothing, nothing],
-                                median = [2.5, 2.0, nothing, nothing, nothing, nothing],
+                                median = [2.5, 2.0, nothing, nothing, VERSION >= v"1.7.0-beta1.2" ? Date(2002) : nothing, nothing],
                                 q75 = [3.25, 2.5, nothing, nothing, nothing, nothing],
                                 max = [4.0, 3.0, "d", "c", Date(2004), 2],
                                 nunique = [nothing, nothing, 4, 3, 4, 2],


### PR DESCRIPTION
Computing all quantiles when we only need the median is signficantly slower (and it's even worse than it should due to https://github.com/JuliaLang/Statistics.jl/issues/84).
Also avoid trying to compute quantiles for string columns since the failure only happens after sorting the vector, which is almost all of the work.

```julia
julia> df = DataFrame(x=string.(rand('a':'k', 10_000)));

# current main
julia> @btime describe(df);
  844.866 μs (147 allocations: 88.03 KiB)

# computing only the median
julia> @btime describe(df);
  480.801 μs (146 allocations: 87.92 KiB)

# not computing the median at all (PR)
julia> @btime describe(df);
  198.739 μs (142 allocations: 9.67 KiB)

julia> df = DataFrame(x=rand(1:10, 10_000));

# current main
julia> @btime describe(df);
  181.266 μs (108 allocations: 85.55 KiB)

# PR
julia> @btime describe(df);
  79.170 μs (100 allocations: 85.19 KiB)
```