### PR TITLE
Add broadcasting of selectors to the minilanguage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,11 @@
   target column names and taking column names specified by `source`
   as an argument.
   ([#2897](https://github.com/JuliaData/DataFrames.jl/pull/2897))
+* When using broadcasting in `source .=> transformation .=> destination`
+  transformation specification minilanguage now `All`, `Cols`, `Between`, and
+  `Not` selectors when used as `source` or `destination` are properly expanded
+  to selected column names within the call data frame scope.
+  ([#2918](https://github.com/JuliaData/DataFrames.jl/pull/2918))
 
 ## Bug fixes
 

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -73,6 +73,10 @@ convenience form `nrow => target_cols` it is always interpreted as
 `cols => function`. In particular the following expression `function => target_cols`
 is not a valid transformation specification.
 
+Note! If `cols` or `target_cols` is one of `All`, `Cols`, `Between`, or `Not`
+and is used in a broadcasting context are properly expanded to selected column
+names within the call data frame scope.
+
 All functions have two types of signatures. One of them takes a `GroupedDataFrame`
 as the first argument and an arbitrary number of transformations described above
 as following arguments. The second type of signature is when a `Function` or a `Type`

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -73,9 +73,11 @@ convenience form `nrow => target_cols` it is always interpreted as
 `cols => function`. In particular the following expression `function => target_cols`
 is not a valid transformation specification.
 
-Note! If `cols` or `target_cols` is one of `All`, `Cols`, `Between`, or `Not`
-and is used in a broadcasting context are properly expanded to selected column
-names within the call data frame scope.
+Note! If `cols` or `target_cols` are one of `All`, `Cols`, `Between`, or `Not`,
+broadcasting using `.=>` is supported and is equivalent to broadcasting
+the result of `names(df, cols)` or `names(df, target_cols)`.
+This behaves as if broadcasting happened after replacing the selector
+with selected column names within the data frame scope.
 
 All functions have two types of signatures. One of them takes a `GroupedDataFrame`
 as the first argument and an arbitrary number of transformations described above

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -206,13 +206,13 @@ function broadcast_pair(df::AbstractDataFrame, p::AbstractVecOrMat{<:Pair})
     first_src = first(src)
     if first_src isa Union{InvertedIndices.BroadcastedInvertedIndex,
                            DataAPI.BroadcastedSelector}
-        if any (!=(first_src), src)
+        if any(!=(first_src), src)
             throw(ArgumentError("when broadcasting column selector it must " *
                                 "have a constant value"))
         end
         need_broadcast = true
-        new_names = names(df, first_src)
-        if !(length(new_names) == size(first_src, 1) || size(new_names, 1) == 1)
+        new_names = names(df, first_src.sel)
+        if !(length(new_names) == size(p, 1) || size(p, 1) == 1)
             throw(ArgumentError("broadcasted dimension does not match the " *
                                 "number of selected columns"))
         end
@@ -221,17 +221,17 @@ function broadcast_pair(df::AbstractDataFrame, p::AbstractVecOrMat{<:Pair})
         new_src = src
     end
 
-    second = last.(src)
-    first_second = first(src)
+    second = last.(p)
+    first_second = first(second)
     if first_second isa Union{InvertedIndices.BroadcastedInvertedIndex,
                               DataAPI.BroadcastedSelector}
-        if any (!=(first_second), src)
+        if any(!=(first_second), second)
             throw(ArgumentError("when using broadcasted column selector it " *
                                 "must have a constant value"))
         end
         need_broadcast = true
-        new_names = names(df, first_second)
-        if !(length(new_names) == size(first_second, 1) || size(new_names, 1) == 1)
+        new_names = names(df, first_second.sel)
+        if !(length(new_names) == size(p, 1) || size(p, 1) == 1)
             throw(ArgumentError("broadcasted dimension does not match the " *
                                 "number of selected columns"))
         end
@@ -246,8 +246,8 @@ function broadcast_pair(df::AbstractDataFrame, p::AbstractVecOrMat{<:Pair})
                                         "it must have a constant value"))
                 end
                 need_broadcast = true
-                new_names = names(df, dst)
-                if !(length(new_names) == size(first_second, 1) || size(new_names, 1) == 1)
+                new_names = names(df, dst.sel)
+                if !(length(new_names) == size(p, 1) || size(p, 1) == 1)
                     throw(ArgumentError("broadcasted dimension does not match the " *
                                         "number of selected columns"))
                 end

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -205,7 +205,7 @@ function broadcast_pair(df::AbstractDataFrame, @nospecialize(p::Pair))
 end
 
 # this is needed in broadcasting when one of dimensions has length 0
-# as then broadcasting produces Matrix{Any}
+# as then broadcasting produces Matrix{Any} rather than Matrix{<:Pair}
 broadcast_pair(df::AbstractDataFrame, @nospecialize(p::AbstractMatrix)) =
     isempty(p) ? [] : p
 

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -67,9 +67,11 @@ const TRANSFORMATION_COMMON_RULES =
     `cols => function`. In particular the following expression `function => target_cols`
     is not a valid transformation specification.
 
-    Note! If `cols` or `target_cols` is one of `All`, `Cols`, `Between`, or
-    `Not` and is used in a broadcasting context are properly expanded to
-    selected column names within the call data frame scope.
+    Note! If `cols` or `target_cols` are one of `All`, `Cols`, `Between`, or `Not`,
+    broadcasting using `.=>` is supported and is equivalent to broadcasting
+    the result of `names(df, cols)` or `names(df, target_cols)`.
+    This behaves as if broadcasting happened after replacing the selector
+    with selected column names within the data frame scope.
 
     All functions have two types of signatures. One of them takes a `GroupedDataFrame`
     as the first argument and an arbitrary number of transformations described above

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -201,6 +201,7 @@ function broadcast_pair(df::AbstractDataFrame, @nospecialize(p::Pair))
 end
 
 # this is needed in broadcasting when one of dimensions has length 0
+# as then broadcasting produces Matrix{Any}
 broadcast_pair(df::AbstractDataFrame, @nospecialize(p::AbstractMatrix)) =
     isempty(p) ? [] : p
 
@@ -222,7 +223,7 @@ function broadcast_pair(df::AbstractDataFrame, @nospecialize(p::AbstractVecOrMat
             throw(ArgumentError("broadcasted dimension does not match the " *
                                 "number of selected columns"))
         end
-        new_src = ndims(p) == 1 ? new_names : repeat(new_names, inner=(1, size(p, 2)))
+        new_src = new_names
     else
         new_src = src
     end
@@ -241,7 +242,7 @@ function broadcast_pair(df::AbstractDataFrame, @nospecialize(p::AbstractVecOrMat
             throw(ArgumentError("broadcasted dimension does not match the " *
                                 "number of selected columns"))
         end
-        new_second = ndims(p) == 1 ? new_names : repeat(new_names, inner=(1, size(p, 2)))
+        new_second = new_names
     else
         if first_second isa Pair
             fun, dst = first_second
@@ -257,7 +258,7 @@ function broadcast_pair(df::AbstractDataFrame, @nospecialize(p::AbstractVecOrMat
                     throw(ArgumentError("broadcasted dimension does not match the " *
                                         "number of selected columns"))
                 end
-                new_dst = ndims(p) == 1 ? new_names : repeat(new_names, inner=(1, size(p, 2)))
+                new_dst = new_names
                 new_second = first.(second) .=> new_dst
             else
                 new_second = second

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -67,6 +67,10 @@ const TRANSFORMATION_COMMON_RULES =
     `cols => function`. In particular the following expression `function => target_cols`
     is not a valid transformation specification.
 
+    Note! If `cols` or `target_cols` is one of `All`, `Cols`, `Between`, or
+    `Not` and is used in a broadcasting context are properly expanded to
+    selected column names within the call data frame scope.
+
     All functions have two types of signatures. One of them takes a `GroupedDataFrame`
     as the first argument and an arbitrary number of transformations described above
     as following arguments. The second type of signature is when a `Function` or a `Type`
@@ -905,7 +909,7 @@ julia> select(df, :, [:a, :b] => (a, b) -> a .+ b .- sum(b)/length(b))
    2 │     2      5           2.0
    3 │     3      6           4.0
 
-julia> select(df, names(df) .=> [minimum maximum])
+julia> select(df, All() .=> [minimum maximum])
 3×4 DataFrame
  Row │ a_minimum  b_minimum  a_maximum  b_maximum
      │ Int64      Int64      Int64      Int64
@@ -1243,7 +1247,7 @@ julia> combine(df, :, [:a, :b] => (a, b) -> a .+ b .- sum(b)/length(b))
    2 │     2      5           2.0
    3 │     3      6           4.0
 
-julia> combine(df, names(df) .=> [minimum maximum])
+julia> combine(df, All() .=> [minimum maximum])
 1×4 DataFrame
  Row │ a_minimum  b_minimum  a_maximum  b_maximum
      │ Int64      Int64      Int64      Int64

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -702,10 +702,11 @@ combine(@nospecialize(f::Pair), gd::GroupedDataFrame;
                         "value to be processed as having multiple columns add `=> AsTable` suffix to the pair."))
 
 combine(gd::GroupedDataFrame,
-        @nospecialize(cs::Union{Pair, Base.Callable, ColumnIndex, MultiColumnIndex,
+        @nospecialize(args::Union{Pair, Base.Callable, ColumnIndex, MultiColumnIndex,
                                 AbstractVecOrMat{<:Pair}}...);
         keepkeys::Bool=true, ungroup::Bool=true, renamecols::Bool=true) =
-    _combine_prepare(gd, Ref{Any}(cs), keepkeys=keepkeys, ungroup=ungroup,
+    _combine_prepare(gd, Ref{Any}(map(x -> broadcast_pair(parent(df), x), args)),
+                     keepkeys=keepkeys, ungroup=ungroup,
                      copycols=true, keeprows=false, renamecols=renamecols)
 
 function select(@nospecialize(f::Base.Callable), gd::GroupedDataFrame; copycols::Bool=true,
@@ -716,11 +717,11 @@ function select(@nospecialize(f::Base.Callable), gd::GroupedDataFrame; copycols:
     return select(gd, f, copycols=copycols, keepkeys=keepkeys, ungroup=ungroup)
 end
 
-
 select(gd::GroupedDataFrame, @nospecialize(args::Union{Pair, Base.Callable, ColumnIndex, MultiColumnIndex,
                                                        AbstractVecOrMat{<:Pair}}...);
        copycols::Bool=true, keepkeys::Bool=true, ungroup::Bool=true, renamecols::Bool=true) =
-    _combine_prepare(gd, Ref{Any}(args), copycols=copycols, keepkeys=keepkeys,
+    _combine_prepare(gd, Ref{Any}(map(x -> broadcast_pair(parent(df), x), args)),
+                     copycols=copycols, keepkeys=keepkeys,
                      ungroup=ungroup, keeprows=true, renamecols=renamecols)
 
 function transform(@nospecialize(f::Base.Callable), gd::GroupedDataFrame; copycols::Bool=true,

--- a/test/select.jl
+++ b/test/select.jl
@@ -1817,6 +1817,10 @@ end
           DataFrame(x1=df.x2, x2=df.x2, x3=df.x2)
     @test_throws ArgumentError DataFrames.broadcast_pair(df,
         [Between(:x1, :x2) .=> sin Between(:x2, :x3) .=> sin])
+    @test_throws ArgumentError DataFrames.broadcast_pair(df,
+        [1 .=> Between(:x1, :x2) 1 .=> Between(:x2, :x3)])
+    @test_throws ArgumentError DataFrames.broadcast_pair(df,
+        [1 .=> sum .=> Between(:x1, :x2) 1 .=> sum .=> Between(:x2, :x3)])
     # this is a case that we cannot handle correctly, note that properly
     # this broadcasting operation should error
     @test DataFrames.broadcast_pair(df,Between(:x1, :x2) .=> []) == []
@@ -1824,6 +1828,8 @@ end
     @test_throws ArgumentError DataFrames.broadcast_pair(df,Between(:x1, :x2) .=> [sin cos
                                                                                    sin cos
                                                                                    sin cos])
+    @test_throws ArgumentError DataFrames.broadcast_pair(df,1:3 .=> Between(:x1, :x2))
+    @test_throws ArgumentError DataFrames.broadcast_pair(df,1:3 .=> sum .=> Between(:x1, :x2))
 
 end
 

--- a/test/select.jl
+++ b/test/select.jl
@@ -1823,13 +1823,13 @@ end
         [1 .=> sum .=> Between(:x1, :x2) 1 .=> sum .=> Between(:x2, :x3)])
     # this is a case that we cannot handle correctly, note that properly
     # this broadcasting operation should error
-    @test DataFrames.broadcast_pair(df,Between(:x1, :x2) .=> []) == []
-    @test_throws ArgumentError DataFrames.broadcast_pair(df,Between(:x1, :x2) .=> [sin, cos, sin])
-    @test_throws ArgumentError DataFrames.broadcast_pair(df,Between(:x1, :x2) .=> [sin cos
+    @test DataFrames.broadcast_pair(df, Between(:x1, :x2) .=> []) == []
+    @test_throws ArgumentError DataFrames.broadcast_pair(df, Between(:x1, :x2) .=> [sin, cos, sin])
+    @test_throws ArgumentError DataFrames.broadcast_pair(df, Between(:x1, :x2) .=> [sin cos
                                                                                    sin cos
                                                                                    sin cos])
-    @test_throws ArgumentError DataFrames.broadcast_pair(df,1:3 .=> Between(:x1, :x2))
-    @test_throws ArgumentError DataFrames.broadcast_pair(df,1:3 .=> sum .=> Between(:x1, :x2))
+    @test_throws ArgumentError DataFrames.broadcast_pair(df, 1:3 .=> Between(:x1, :x2))
+    @test_throws ArgumentError DataFrames.broadcast_pair(df, 1:3 .=> sum .=> Between(:x1, :x2))
 
 end
 

--- a/test/select.jl
+++ b/test/select.jl
@@ -1830,7 +1830,6 @@ end
                                                                                    sin cos])
     @test_throws ArgumentError DataFrames.broadcast_pair(df, 1:3 .=> Between(:x1, :x2))
     @test_throws ArgumentError DataFrames.broadcast_pair(df, 1:3 .=> sum .=> Between(:x1, :x2))
-
 end
 
 end # module

--- a/test/select.jl
+++ b/test/select.jl
@@ -1722,4 +1722,27 @@ end
     end
 end
 
+@testset "broadcasting column selectors: All, Cols, Between, Not" begin
+    df = DataFrame(transpose(1:10), :auto)
+    for sel in (All(), Cols(2:8), Between(:x3, :x5), Not(:x1),
+                Cols(), Between(:x5, :x3), Not(:))
+        @test DataFrames.broadcast_pair(df, sel .=> sum) ==
+              (names(df, sel) .=> sum)
+        @test DataFrames.broadcast_pair(df, sel .=> [sum length]) ==
+              (names(df, sel) .=> [sum length])
+        @test DataFrames.broadcast_pair(df, sel .=> sel) ==
+              DataFrames.broadcast_pair(df, names(df, sel) .=> sel) ==
+              DataFrames.broadcast_pair(df, sel .=> names(df, sel)) ==
+              (names(df, sel) .=> names(df, sel))
+        @test DataFrames.broadcast_pair(df, sel .=> sum .=> sel) ==
+              DataFrames.broadcast_pair(df, names(df, sel) .=> sum .=> sel) ==
+              DataFrames.broadcast_pair(df, sel .=> sum .=> names(df, sel)) ==
+              (names(df, sel) .=> sum .=> names(df, sel))
+        @test DataFrames.broadcast_pair(df, sel .=> [sum length] .=> sel) ==
+              DataFrames.broadcast_pair(df, names(df, sel) .=> [sum length] .=> sel) ==
+              DataFrames.broadcast_pair(df, sel .=> [sum length] .=> names(df, sel))
+              (names(df, sel) .=> [sum length] .=> names(df, sel))
+    end
+end
+
 end # module


### PR DESCRIPTION
@nalimilan + @pdeffebach: I am sharing the preview of the functionality making e.g. `Not(:x1) .=> sum` work in the minilanguage.

The core mechanism should be working for intended cases.

What is todo:
- [x] implement expansion engine
- [x] inject the inner mechanics to `select`, `subset` etc. functions that should call it
- [x] add tests of intended use cases
- [x] add tests for target functions
- [x] add tests of corner cases (i.e. to check if we are good if we pass something that is not intended)
- [x] add NEWS.md
- [x] add docstring
- [x] add documentation