### PR TITLE
Add general fast aggregation for wide tables with collect

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -90,7 +90,8 @@
 * for selected common transformation specifications like e.g.
   `AsTable(...) => ByRow(sum)` use a custom implementations that
   lead to lower compilation latency and faster computation
-  ([#2869](https://github.com/JuliaData/DataFrames.jl/pull/2869))
+  ([#2869](https://github.com/JuliaData/DataFrames.jl/pull/2869)),
+  ([#2919](https://github.com/JuliaData/DataFrames.jl/pull/2919))
 
 # DataFrames.jl v1.2.2 Patch Release Notes
 

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -82,7 +82,6 @@ repeat
 repeat!
 select
 select!
-table_transformation
 transform
 transform!
 vcat

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -17,6 +17,7 @@ ourshow
 ourstrwidth
 @spawn_for_chunks
 default_table_transformation
+table_transformation
 isreduction
 ```
 

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -18,15 +18,5 @@ ourstrwidth
 @spawn_for_chunks
 default_table_transformation
 table_transformation
-isreduction
+isreadonly
 ```
-
-When `AsTable` is used as source column selector in the
-`source => function => target` mini-language supported by `select` and related
-functions it is possible to override the default processing performed by
-function `function` by adding a [`table_transformation`](@ref) method for this
-function. This is most useful for custom reductions over columns of `NamedTuple`
-created by `AsTable`, especially in cases when the user expects that very many
-columns (over 1000 as a rule of thumb) would be selected by `AsTable` selector in which
-case avoiding creation of `NamedTuple` object significantly reduces compilation
-time (which is often longer than computation time in such cases).

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -17,6 +17,7 @@ ourshow
 ourstrwidth
 @spawn_for_chunks
 default_table_transformation
+isreduction
 ```
 
 When `AsTable` is used as source column selector in the

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -116,6 +116,12 @@ else
     end
 end
 
+if isdefined(Base, :ComposedFunction) # Julia >= 1.6.0-DEV.85
+    using Base: ComposedFunction
+else
+    using Compat: ComposedFunction
+end
+
 include("other/utils.jl")
 include("other/index.jl")
 

--- a/src/abstractdataframe/selectionfast.jl
+++ b/src/abstractdataframe/selectionfast.jl
@@ -17,7 +17,8 @@ It is guaranteed that `df_sel` has at least one column.
 The main use of special `table_transformation` methods is to provide more
 efficient than the default implementations of requested `fun` transformation.
 
-This function is part of the public API of DataFrames.jl.
+This function might become a part of the public API of DataFrames.jl in the
+future, currently it should be considered experimental.
 
 Fast paths are implemented within DataFrames.jl for the following functions `fun`:
 * `sum`, `ByRow(sum), `ByRow(sum∘skipmissing)`
@@ -56,13 +57,14 @@ table_transformation(df_sel::AbstractDataFrame, fun) =
 """
     isreduction(fun)
 
-Trait returning a `Bool` indicator if function `fun` is a reduction.
-Reduction function guarantees not to modify nor return in any form the passed
-argument. By default it returns `false`.
+Trait returning a `Bool` indicator if function `fun` is a reduction. Reduction
+function guarantees not to modify nor return in any form the passed argument. By
+default it returns `false`.
 
-This function is part of the public API of DataFrames.jl. Adding a method
-to `isreduction` for a specific function `fun` will improve performance
-of `AsTable(...) => ByRow(fun∘collect)` operation.
+This function might become a part of the public API of DataFrames.jl in the
+future, currently it should be considered experimental. Adding a method to
+`isreduction` for a specific function `fun` will improve performance of
+`AsTable(...) => ByRow(fun∘collect)` operation.
 """
 isreduction(::Any) = false
 isreduction(::typeof(sum)) = true

--- a/src/abstractdataframe/selectionfast.jl
+++ b/src/abstractdataframe/selectionfast.jl
@@ -23,6 +23,9 @@ Fast paths are implemented within DataFrames.jl for the following functions `fun
 * `sum`, `ByRow(sum), `ByRow(sum∘skipmissing)`
 * `length`, `ByRow(length)`, `ByRow(length∘skipmissing)`
 * `mean`, `ByRow(mean), `ByRow(mean∘skipmissing)`
+* `ByRow(var), `ByRow(var∘skipmissing)`
+* `ByRow(std), `ByRow(std∘skipmissing)`
+* `ByRow(median), `ByRow(median∘skipmissing)`
 * `minimum`, `ByRow(minimum)`, `ByRow(minimum∘skipmissing)`
 * `maximum`, `ByRow(maximum)`, `ByRow(maximum∘skipmissing)`
 * `fun∘collect` and `ByRow(fun∘collect)` where `fun` is any function
@@ -387,3 +390,18 @@ end
 function table_transformation(df_sel::AbstractDataFrame, ::typeof(maximum))
     return reduce(max, map(identity, eachcol(df_sel)))
 end
+
+table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(std))) =
+    table_transformation(df_sel, ByRow(std∘collect))
+table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(std∘skipmissing))) =
+    table_transformation(df_sel, ByRow(std∘skipmissing∘collect))
+
+table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(var))) =
+    table_transformation(df_sel, ByRow(var∘collect))
+table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(var∘skipmissing))) =
+    table_transformation(df_sel, ByRow(var∘skipmissing∘collect))
+
+table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(median))) =
+    table_transformation(df_sel, ByRow(median∘collect))
+table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(median∘skipmissing))) =
+    table_transformation(df_sel, ByRow(median∘skipmissing∘collect))

--- a/src/abstractdataframe/selectionfast.jl
+++ b/src/abstractdataframe/selectionfast.jl
@@ -55,38 +55,38 @@ table_transformation(df_sel::AbstractDataFrame, fun) =
     default_table_transformation(df_sel, fun)
 
 """
-    isreduction(fun)
+    isreadonly(fun)
 
-Trait returning a `Bool` indicator if function `fun` is a reduction. Reduction
-function guarantees not to modify nor return in any form the passed argument. By
-default it returns `false`.
+Trait returning a `Bool` indicator if function `fun` is only reading the passed
+argument. Such a function guarantees not to modify nor return in any form the
+passed argument. By default `false` is returned.
 
 This function might become a part of the public API of DataFrames.jl in the
 future, currently it should be considered experimental. Adding a method to
-`isreduction` for a specific function `fun` will improve performance of
+`isreadonly` for a specific function `fun` will improve performance of
 `AsTable(...) => ByRow(fun∘collect)` operation.
 """
-isreduction(::Any) = false
-isreduction(::typeof(sum)) = true
-isreduction(::typeof(sum∘skipmissing)) = true
-isreduction(::typeof(length)) = true
-isreduction(::typeof(mean)) = true
-isreduction(::typeof(mean∘skipmissing)) = true
-isreduction(::typeof(var)) = true
-isreduction(::typeof(var∘skipmissing)) = true
-isreduction(::typeof(std)) = true
-isreduction(::typeof(std∘skipmissing)) = true
-isreduction(::typeof(median)) = true
-isreduction(::typeof(median∘skipmissing)) = true
-isreduction(::typeof(minimum)) = true
-isreduction(::typeof(minimum∘skipmissing)) = true
-isreduction(::typeof(maximum)) = true
-isreduction(::typeof(maximum∘skipmissing)) = true
-isreduction(::typeof(prod)) = true
-isreduction(::typeof(prod∘skipmissing)) = true
-isreduction(::typeof(first)) = true
-isreduction(::typeof(first∘skipmissing)) = true
-isreduction(::typeof(last)) = true
+isreadonly(::Any) = false
+isreadonly(::typeof(sum)) = true
+isreadonly(::typeof(sum∘skipmissing)) = true
+isreadonly(::typeof(length)) = true
+isreadonly(::typeof(mean)) = true
+isreadonly(::typeof(mean∘skipmissing)) = true
+isreadonly(::typeof(var)) = true
+isreadonly(::typeof(var∘skipmissing)) = true
+isreadonly(::typeof(std)) = true
+isreadonly(::typeof(std∘skipmissing)) = true
+isreadonly(::typeof(median)) = true
+isreadonly(::typeof(median∘skipmissing)) = true
+isreadonly(::typeof(minimum)) = true
+isreadonly(::typeof(minimum∘skipmissing)) = true
+isreadonly(::typeof(maximum)) = true
+isreadonly(::typeof(maximum∘skipmissing)) = true
+isreadonly(::typeof(prod)) = true
+isreadonly(::typeof(prod∘skipmissing)) = true
+isreadonly(::typeof(first)) = true
+isreadonly(::typeof(first∘skipmissing)) = true
+isreadonly(::typeof(last)) = true
 
 """
     default_table_transformation(df_sel::AbstractDataFrame, fun)
@@ -116,7 +116,7 @@ function default_table_transformation(df_sel::AbstractDataFrame, fun)
         end
         v = Vector{T}(undef, ncol(df_sel))
         cols = collect(cT, eachcol(df_sel))
-        reduction = isreduction(fun.fun.outer)
+        reduction = isreadonly(fun.fun.outer)
         return _fast_row_aggregate_collect(fun.fun.outer, v, cols, reduction)
     elseif fun isa ComposedFunction{<:Any, typeof(collect)}
         # this will narrow down eltype of the resulting vector

--- a/src/abstractdataframe/selectionfast.jl
+++ b/src/abstractdataframe/selectionfast.jl
@@ -63,7 +63,7 @@ The `df_sel` argument is a data frame storing columns selected by
 function default_table_transformation(df_sel::AbstractDataFrame, fun)
     if fun isa ByRow && fun.fun isa ComposedFunction{<:Any, typeof(collect)}
         vT = unique(typeof.(eachcol(df_sel)))
-        if length(vT) == 1 # homogenous type
+        if length(vT) == 1 # homogeneous type
             T = eltype(vT[1])
             cT = vT[1]
         elseif length(vT) == 2 # small union
@@ -77,7 +77,7 @@ function default_table_transformation(df_sel::AbstractDataFrame, fun)
         cols = collect(cT, eachcol(df_sel))
         return _fast_row_aggregate_collect(fun.fun.outer, v, cols)
     elseif fun isa ComposedFunction{<:Any, typeof(collect)}
-        # this will narrow down eltype of a resulting vector
+        # this will narrow down eltype of the resulting vector
         # but will not perform conversion
         return fun(map(identity, eachcol(df_sel)))
     else
@@ -402,6 +402,6 @@ table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(var∘skipmissing
     table_transformation(df_sel, ByRow(var∘skipmissing∘collect))
 
 table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(median))) =
-    table_transformation(df_sel, ByRow(median∘collect))
+    table_transformation(df_sel, ByRow(median!∘collect))
 table_transformation(df_sel::AbstractDataFrame, ::typeof(ByRow(median∘skipmissing))) =
     table_transformation(df_sel, ByRow(median∘skipmissing∘collect))

--- a/src/abstractdataframe/selectionfast.jl
+++ b/src/abstractdataframe/selectionfast.jl
@@ -67,7 +67,8 @@ function default_table_transformation(df_sel::AbstractDataFrame, fun)
             T = eltype(vT[1])
             cT = vT[1]
         elseif length(vT) == 2 # small union
-            T = Union{eltype(vT[1]), eltype(vT[2])}
+            # Base.promote_typejoin is used wen collecting NamedTuple elements
+            T = Base.promote_typejoin(eltype(vT[1]), eltype(vT[2]))
             cT = Union{vT[1], vT[2]}
         else # large union
             # use Base.promote_typejoin to make sure that in case all columns

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -17,8 +17,8 @@ that should be expanded  into multiple columns using `keys` to get column names.
 ```jldoctest
 julia> df1 = DataFrame(a=1:3, b=11:13)
 3×2 DataFrame
- Row │ a      b     
-     │ Int64  Int64 
+ Row │ a      b
+     │ Int64  Int64
 ─────┼──────────────
    1 │     1     11
    2 │     2     12
@@ -26,8 +26,8 @@ julia> df1 = DataFrame(a=1:3, b=11:13)
 
 julia> df2 = select(df1, AsTable([:a, :b]) => ByRow(identity))
 3×1 DataFrame
- Row │ a_b_identity    
-     │ NamedTuple…     
+ Row │ a_b_identity
+     │ NamedTuple…
 ─────┼─────────────────
    1 │ (a = 1, b = 11)
    2 │ (a = 2, b = 12)
@@ -35,21 +35,21 @@ julia> df2 = select(df1, AsTable([:a, :b]) => ByRow(identity))
 
 julia> select(df2, :a_b_identity => AsTable)
 3×2 DataFrame
- Row │ a      b     
-     │ Int64  Int64 
+ Row │ a      b
+     │ Int64  Int64
 ─────┼──────────────
    1 │     1     11
    2 │     2     12
    3 │     3     13
 
 julia> select(df1, AsTable([:a, :b]) => ByRow(nt -> map(x -> x^2, nt)) => AsTable)
-3×2 DataFrame       
- Row │ a      b     
-     │ Int64  Int64 
+3×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
 ─────┼──────────────
-   1 │     1    121 
-   2 │     4    144 
-   3 │     9    169 
+   1 │     1    121
+   2 │     4    144
+   3 │     9    169
 ```
 """
 struct AsTable
@@ -122,12 +122,6 @@ end
 function funname(f)
     n = nameof(f)
     String(n)[1] == '#' ? :function : n
-end
-
-if isdefined(Base, :ComposedFunction) # Julia >= 1.6.0-DEV.85
-    using Base: ComposedFunction
-else
-    using Compat: ComposedFunction
 end
 
 funname(c::ComposedFunction) = Symbol(funname(c.outer), :_, funname(c.inner))

--- a/test/select.jl
+++ b/test/select.jl
@@ -2083,6 +2083,20 @@ end
         end
     end
 
+    for df in (df1, df2, df3, df4)
+        dfv = view(df, 2:10, 2:101)
+        for x in (df, dfv), fun in (std, var, median)
+            if df === df2 || df === df4
+                # mixing Int and Float64 invokes a different implementation of these functions
+                @test combine(x, AsTable(r"x") => ByRow(fun∘skipmissing) => :res) ≈
+                    combine(x, AsTable(r"x") => ByRow(x -> (fun∘skipmissing)(x)) => :res)
+            else
+                @test combine(x, AsTable(r"x") => ByRow(fun∘skipmissing) => :res) ≃
+                    combine(x, AsTable(r"x") => ByRow(x -> (fun∘skipmissing)(x)) => :res)
+            end
+        end
+    end
+
     df3 .= coalesce.(df3, 0.0)
     df4 .= coalesce.(df4, 0.0)
 
@@ -2096,6 +2110,20 @@ end
             else
                 @test combine(x, AsTable(r"x") => ByRow(fun∘collect) => :res) ≃
                     combine(x, AsTable(r"x") => ByRow(x -> (fun∘collect)(x)) => :res)
+            end
+        end
+    end
+
+    for df in (df1, df2, df3, df4)
+        dfv = view(df, 2:10, 2:101)
+        for x in (df, dfv), fun in (std, var, median)
+            if fun !== median
+                # mixing Int and Float64 invokes a different implementation of these functions
+                @test combine(x, AsTable(r"x") => ByRow(fun) => :res) ≈
+                    combine(x, AsTable(r"x") => ByRow(x -> fun(x)) => :res)
+            else
+                @test combine(x, AsTable(r"x") => ByRow(fun) => :res) ≃
+                    combine(x, AsTable(r"x") => ByRow(x -> fun(x)) => :res)
             end
         end
     end

--- a/test/select.jl
+++ b/test/select.jl
@@ -2175,9 +2175,11 @@ end
     @test combine(df4, AsTable(All()) => ByRow(eltype∘collect) => :res) ≃
             combine(df4, AsTable(All()) => ByRow(x -> (eltype∘collect)(x)) => :res) ≃
             DataFrame(res=[Union{Int, Missing}, Union{Int, Missing}])
+    # T is Any under Julia 1.0, but Union{Missing, Integer} currently
+    T = Base.promote_typejoin(Missing, Base.promote_typejoin(Int, UInt8))
     @test combine(df5, AsTable(All()) => ByRow(eltype∘collect) => :res) ≃
             combine(df5, AsTable(All()) => ByRow(x -> (eltype∘collect)(x)) => :res) ≃
-            DataFrame(res=[Union{Integer, Missing}, Union{Integer, Missing}])
+            DataFrame(res=[T, T])
 
     df = DataFrame(x=1:2, y=PooledArray(1:2), z=view([1, 2], 1:2), copycols=false)
     df2 = DataFrame(rand(1:10, 10, 10_000), :auto)

--- a/test/select.jl
+++ b/test/select.jl
@@ -2151,7 +2151,7 @@ end
               combine(df, AsTable(All()) => ByRow(x -> x |> collect |> fun) => :res)
     end
 
-    # test promotion over more than two distinct types of columns
+    # test promotion for two or more distinct types of columns
     df = DataFrame(x=[true, false], y=1:2, z=1.0:2.0)
     df2 = DataFrame(rand(1:10, 10, 10_000), :auto)
     df2.y = 1.0:10.0
@@ -2166,6 +2166,18 @@ end
               combine(df, AsTable(All()) => ByRow(x -> (eltype∘collect)(x)) => :res) ≃
               DataFrame(res=[Real, Real])
     end
+
+    df4 = DataFrame(rand(1:10, 2, 1000), :auto)
+    df4.y = fill(missing, 2)
+    df5 = copy(df4)
+    df5.z = fill(0x0, 2)
+
+    @test combine(df4, AsTable(All()) => ByRow(eltype∘collect) => :res) ≃
+            combine(df4, AsTable(All()) => ByRow(x -> (eltype∘collect)(x)) => :res) ≃
+            DataFrame(res=[Union{Int, Missing}, Union{Int, Missing}])
+    @test combine(df5, AsTable(All()) => ByRow(eltype∘collect) => :res) ≃
+            combine(df5, AsTable(All()) => ByRow(x -> (eltype∘collect)(x)) => :res) ≃
+            DataFrame(res=[Union{Integer, Missing}, Union{Integer, Missing}])
 
     df = DataFrame(x=1:2, y=PooledArray(1:2), z=view([1, 2], 1:2), copycols=false)
     df2 = DataFrame(rand(1:10, 10, 10_000), :auto)

--- a/test/select.jl
+++ b/test/select.jl
@@ -2067,7 +2067,7 @@ end
 
     for df in (df1, df2, df3, df4)
         dfv = view(df, 2:10, 2:101)
-        for x in (df, dfv), fun in (sum, prod, first, x -> x[1] - x[2])
+        for x in (df, dfv), fun in (sum, prod, first, x -> first(x) - sum(x))
             @test combine(x, AsTable(r"x") => ByRow(fun∘collect) => :res) ≃
                   combine(x, AsTable(r"x") => ByRow(x -> (fun∘collect)(x)) => :res)
             @test combine(x, AsTable(r"x") => ByRow(fun∘skipmissing∘collect) => :res) ≃

--- a/test/select.jl
+++ b/test/select.jl
@@ -2140,8 +2140,8 @@ end
     end
 
     # test of fast reductions
-    for df in (DataFrame(rand(10, 100), :auto),
-               DataFrame(rand([1:10; missing], 10, 100), :auto)),
+    for df in (DataFrame(rand(5, 10), :auto),
+               DataFrame(rand([1:10; missing], 5, 10), :auto)),
         fun in (sum, sum∘skipmissing, length,
                 mean, mean∘skipmissing, var, var∘skipmissing,
                 std, std∘skipmissing, median, median∘skipmissing,


### PR DESCRIPTION
This PR finishes the issue of wide aggregations I think.
The idea is to special case composition with `collect` so the benefit is that we do not introduce any new syntax to the minilanguage.

With this PR:
```
julia> using DataFrames

julia> using Statistics

julia> df = DataFrame(rand(100, 10_000), :auto);

julia> @time combine(df, AsTable(:) => std∘collect);
  1.174799 seconds (2.79 M allocations: 200.640 MiB, 6.38% gc time, 97.97% compilation time)

julia> @time combine(df, AsTable(:) => std∘collect);
  0.024292 seconds (49.67 k allocations: 35.170 MiB, 38.42% gc time)

julia> @time combine(df, AsTable(:) => ByRow(std∘collect));
  0.394846 seconds (888.92 k allocations: 51.886 MiB, 2.47% gc time, 96.65% compilation time)

julia> @time combine(df, AsTable(:) => ByRow(std∘collect));
  0.013849 seconds (19.17 k allocations: 1.288 MiB)
```

On DataFrames.jl 1.2.2:
```
julia> using DataFrames

julia> using Statistics

julia> df = DataFrame(rand(100, 10_000), :auto);

julia> @time combine(df, AsTable(:) => std∘collect);
  9.210553 seconds (3.98 M allocations: 236.613 MiB, 0.91% gc time, 99.63% compilation time)

julia> @time combine(df, AsTable(:) => std∘collect);
  0.034955 seconds (59.37 k allocations: 36.159 MiB, 32.80% gc time)

julia> @time combine(df, AsTable(:) => ByRow(std∘collect));
 10.378314 seconds (2.54 M allocations: 150.910 MiB, 0.31% gc time, 98.69% compilation time)

julia> @time combine(df, AsTable(:) => ByRow(std∘collect));
  0.099637 seconds (1.02 M allocations: 78.263 MiB, 5.47% gc time)
```