### PR TITLE
Update ci.yml in preparation of Julia 1.6 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         version:
           - '1.0'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:


### PR DESCRIPTION
Since Julia 1.6 will be a new LTS I propose to add it to our tests. With GitHub Actions this is painless. I would still keep Julia 1.0 in the tests as it does not hurt and it seems we will be able to support it for some time still.