### PR TITLE
Correctly handle functors when auto-generating column names

### DIFF
--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -120,8 +120,13 @@ function gennames(n::Integer)
 end
 
 function funname(f)
-    n = nameof(f)
-    String(n)[1] == '#' ? :function : n
+    try
+        n = nameof(f)
+        return String(n)[1] == '#' ? :function : n
+    catch
+        # handle the case of functors that do not support nameof
+        return :function
+    end
 end
 
 funname(c::ComposedFunction) = Symbol(funname(c.outer), :_, funname(c.inner))

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -120,10 +120,10 @@ function gennames(n::Integer)
 end
 
 function funname(f)
-    try
+    if applicable(nameof, f)
         n = nameof(f)
         return String(n)[1] == '#' ? :function : n
-    catch
+    else
         # handle the case of functors that do not support nameof
         return :function
     end

--- a/test/select.jl
+++ b/test/select.jl
@@ -2346,14 +2346,14 @@ end
     @test_throws ArgumentError DataFrames.broadcast_pair(df, 1:3 .=> sum .=> Between(:x1, :x2))
 end
 
+struct Identity
+end
+
+function (::Identity)(x)
+    return x
+end
+
 @testset "correct handling of functors" begin
-    struct Identity
-    end
-
-    function (::Identity)(x)
-        return x
-    end
-
     i = Identity()
     df = DataFrame(x=1:3)
     @test_throws ArgumentError combine(df, :x => i) # i is not Callable

--- a/test/select.jl
+++ b/test/select.jl
@@ -2346,4 +2346,18 @@ end
     @test_throws ArgumentError DataFrames.broadcast_pair(df, 1:3 .=> sum .=> Between(:x1, :x2))
 end
 
+@testset "correct handling of functors" begin
+    struct Identity
+    end
+
+    function (::Identity)(x)
+        return x
+    end
+
+    i = Identity()
+    df = DataFrame(x=1:3)
+    @test_throws ArgumentError combine(df, :x => i) # i is not Callable
+    @test combine(df, :x => identity∘i) == DataFrame(x_identity_function=1:3)
+end
+
 end # module


### PR DESCRIPTION
An interesting corner-case fix of:
```
julia> struct Identity
       end

julia> function (::Identity)(x)
           return x
       end

julia> i = Identity()
Identity()

julia> df = DataFrame(x=1:3)
3×1 DataFrame
 Row │ x
     │ Int64
─────┼───────
   1 │     1
   2 │     2
   3 │     3

julia> combine(df, :x => identity∘i)
ERROR: MethodError: no method matching nameof(::Identity)
Closest candidates are:
  nameof(::Module) at reflection.jl:16
  nameof(::DataType) at reflection.jl:214
  nameof(::UnionAll) at reflection.jl:215
  ...
Stacktrace:
 [1] funname(f::Identity)
```