### PR TITLE
Add examples for `issorted` docstrings.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -112,7 +112,7 @@
 
 * `delete!` is deprecated in favor of `deleteat!`
   ([#2854](https://github.com/JuliaData/DataFrames.jl/issues/2854))
-* In `sort`, `sort!`, `issorted` and `soerperm` it is now documented
+* In `sort`, `sort!`, `issorted` and `sortperm` it is now documented
   that the result of passing an empty column selector uses lexicographic
   ordering of all columns, but this behavior is deprecated.
   ([#2941](https://github.com/JuliaData/DataFrames.jl/issues/2941))

--- a/NEWS.md
+++ b/NEWS.md
@@ -113,7 +113,8 @@
 * `delete!` is deprecated in favor of `deleteat!`
   ([#2854](https://github.com/JuliaData/DataFrames.jl/issues/2854))
 * In `sort`, `sort!`, `issorted` and `soerperm` it is now documented
-  that passing an empty column selector leads to an undefined result
+  that the result of passing an empty column selector uses lexicographic
+  ordering of all columns, but this behavior is deprecated.
   ([#2941](https://github.com/JuliaData/DataFrames.jl/issues/2941))
 
 ## Planned changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -112,6 +112,9 @@
 
 * `delete!` is deprecated in favor of `deleteat!`
   ([#2854](https://github.com/JuliaData/DataFrames.jl/issues/2854))
+* In `sort`, `sort!`, `issorted` and `soerperm` it is now documented
+  that passing an empty column selector leads to an undefined result
+  ([#2941](https://github.com/JuliaData/DataFrames.jl/issues/2941))
 
 ## Planned changes
 

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -351,7 +351,7 @@ See other methods for a description of other keyword arguments.
 
 # Examples
 ```jldoctest
-julia> df = DataFrame(a = [1,2,3,4], b = [4,3,2,1])
+julia> df = DataFrame(a = [1, 2, 3, 4], b = [4, 3, 2, 1])
 4×2 DataFrame
  Row │ a      b     
      │ Int64  Int64 
@@ -480,7 +480,9 @@ end
 
 Return a permutation vector of row indices of data frame `df` that puts them in
 sorted order according to column(s) `cols`.
-If `cols` were not specified, it returns row indices that sorts `df` lexicographically
+Order on multiple columns is done lexicographically.
+
+If `cols` select no columns, it returns row indices that sorts `df` lexicographically
 (this behaviour is deprecated and will change in future versions).
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -332,7 +332,7 @@ Sort.defalg(df::AbstractDataFrame, o::Ordering; alg=nothing, cols=[]) =
 ########################
 
 """
-    issorted(df::AbstractDataFrame, cols;
+    issorted(df::AbstractDataFrame, cols=All();
              lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward)
 
 Test whether data frame `df` sorted by column(s) `cols`.
@@ -371,7 +371,7 @@ julia> issorted(df, :b, rev=true)
 true
 ```
 """
-function Base.issorted(df::AbstractDataFrame, cols=[];
+function Base.issorted(df::AbstractDataFrame, cols=All();
                        lt=isless, by=identity, rev=false, order=Forward)
     # exclude AbstractVector as in that case cols can contain order(...) clauses
     if cols isa MultiColumnIndex && !(cols isa AbstractVector)
@@ -387,7 +387,7 @@ function Base.issorted(df::AbstractDataFrame, cols=[];
 end
 
 """
-    sort(df::AbstractDataFrame, cols;
+    sort(df::AbstractDataFrame, cols=All();
          alg::Union{Algorithm, Nothing}=nothing, lt=isless, by=identity,
          rev::Bool=false, order::Ordering=Forward, view::Bool=false)
 
@@ -463,14 +463,14 @@ julia> sort(df, [:x, order(:y, rev=true)])
    4 │     3  b
 ```
 """
-@inline function Base.sort(df::AbstractDataFrame, cols=[]; alg=nothing, lt=isless,
+@inline function Base.sort(df::AbstractDataFrame, cols=All(); alg=nothing, lt=isless,
                            by=identity, rev=false, order=Forward, view::Bool=false)
     rowidxs = sortperm(df, cols, alg=alg, lt=lt, by=by, rev=rev, order=order)
     return view ? Base.view(df, rowidxs, :) : df[rowidxs, :]
 end
 
 """
-    sortperm(df::AbstractDataFrame, cols;
+    sortperm(df::AbstractDataFrame, cols=All();
              alg::Union{Algorithm, Nothing}=nothing, lt=isless, by=identity,
              rev::Bool=false, order::Ordering=Forward)
 
@@ -532,7 +532,7 @@ julia> sortperm(df, [:x, order(:y, rev=true)])
  1
 ```
 """
-function Base.sortperm(df::AbstractDataFrame, cols=[];
+function Base.sortperm(df::AbstractDataFrame, cols=All();
                   alg=nothing, lt=isless, by=identity, rev=false, order=Forward)
     if !(by isa Base.Callable || (by isa AbstractVector && eltype(by) <: Base.Callable))
         msg = "'by' must be a Function or a vector of Functions. " *

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -483,13 +483,11 @@ end
 
 Return a permutation vector of row indices of data frame `df` that puts them in
 sorted order according to column(s) `cols`.
-Order on multiple columns is done lexicographically.
-
-If `cols` select no columns, it returns row indices that sorts `df` lexicographically
-(this behaviour is deprecated and will change in future versions).
+Order on multiple columns is computed lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
-If `cols` selects no columns, return permutation vector based on sorting all columns.
+If `cols` selects no columns, return permutation vector based on sorting all columns
+(this behaviour is deprecated and will change in future versions).
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -336,7 +336,7 @@ Sort.defalg(df::AbstractDataFrame, o::Ordering; alg=nothing, cols=[]) =
              lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward)
 
 Test whether data frame `df` sorted by column(s) `cols`.
-If no column is specified, it checks if the `df` is sorted lexicographically.
+If column selector selects no columns, it checks if the `df` is sorted lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 
@@ -395,6 +395,7 @@ Return a data frame containing the rows in `df` sorted by column(s) `cols`.
 Sorting on multiple columns is done lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
+If column selector selects no columns, then the sorting would be done lexicographically.
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending
@@ -478,6 +479,7 @@ sorted order according to column(s) `cols`.
 If `cols` were not specified, it returns row indices that sorts `df` lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
+If column selector selects no columns, it returns row indices that sorts `df` lexicographically.
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -395,7 +395,7 @@ Return a data frame containing the rows in `df` sorted by column(s) `cols`.
 Sorting on multiple columns is done lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
-If column selector selects no columns, then the sorting would be done lexicographically.
+If `cols` selects no columns, sort `df` on all columns.
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -336,7 +336,8 @@ Sort.defalg(df::AbstractDataFrame, o::Ordering; alg=nothing, cols=[]) =
              lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward)
 
 Test whether data frame `df` sorted by column(s) `cols`.
-If `cols` selects no columns, check whether `df` is sorted on all columns.
+If `cols` selects no columns, check whether `df` is sorted on all columns
+(this behaviour is deprecated and will change in future versions).
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 
@@ -395,7 +396,8 @@ Return a data frame containing the rows in `df` sorted by column(s) `cols`.
 Sorting on multiple columns is done lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
-If `cols` selects no columns, sort `df` on all columns.
+If `cols` selects no columns, sort `df` on all columns
+(this behaviour is deprecated and will change in future versions).
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending
@@ -476,7 +478,8 @@ end
 
 Return a permutation vector of row indices of data frame `df` that puts them in
 sorted order according to column(s) `cols`.
-If `cols` were not specified, it returns row indices that sorts `df` lexicographically.
+If `cols` were not specified, it returns row indices that sorts `df` lexicographically
+(this behaviour is deprecated and will change in future versions).
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 If `cols` selects no columns, return permutation vector based on sorting all columns.

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -367,7 +367,7 @@ true
 julia> issorted(df, :b)
 false
 
-julia> issorted(df, :b, rev = true)
+julia> issorted(df, :b, rev=true)
 true
 ```
 """

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -209,6 +209,8 @@ function ordering(df::AbstractDataFrame, cols::AbstractVector, lt::Function,
                   by::Function, rev::Bool, order::Ordering)
 
     if length(cols) == 0
+        Base.depwarn("When empty column selector is passed ordering is done on all colums. " *
+                     "This behavior is deprecated and will change in the future.", :ordering)
         return ordering(df, lt, by, rev, order)
     end
 

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -336,7 +336,7 @@ Sort.defalg(df::AbstractDataFrame, o::Ordering; alg=nothing, cols=[]) =
              lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward)
 
 Test whether data frame `df` sorted by column(s) `cols`.
-If column selector selects no columns, it checks if the `df` is sorted lexicographically.
+If `cols` selects no columns, check whether `df` is sorted on all columns.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -479,7 +479,7 @@ sorted order according to column(s) `cols`.
 If `cols` were not specified, it returns row indices that sorts `df` lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
-If column selector selects no columns, it returns row indices that sorts `df` lexicographically.
+If `cols` selects no columns, return permutation vector based on sorting all columns.
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -336,13 +336,40 @@ Sort.defalg(df::AbstractDataFrame, o::Ordering; alg=nothing, cols=[]) =
              lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward)
 
 Test whether data frame `df` sorted by column(s) `cols`.
+If no column is specified, it checks if the `df` is sorted lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 
 If `rev` is `true`, reverse sorting is performed. To enable reverse sorting
 only for some columns, pass `order(c, rev=true)` in `cols`, with `c` the
 corresponding column index (see example below).
+
 See other methods for a description of other keyword arguments.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(a = [1,2,3,4], b = [4,3,2,1])
+4×2 DataFrame
+ Row │ a      b     
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      4
+   2 │     2      3
+   3 │     3      2
+   4 │     4      1
+
+julia> issorted(df)
+true
+
+julia> issorted(df, :a)
+true
+
+julia> issorted(df, :b)
+false
+
+julia> issorted(df, :b, rev = true)
+true
+```
 """
 function Base.issorted(df::AbstractDataFrame, cols=[];
                        lt=isless, by=identity, rev=false, order=Forward)
@@ -448,6 +475,7 @@ end
 
 Return a permutation vector of row indices of data frame `df` that puts them in
 sorted order according to column(s) `cols`.
+If `cols` were not specified, it returns row indices that sorts `df` lexicographically.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -338,6 +338,7 @@ Sort.defalg(df::AbstractDataFrame, o::Ordering; alg=nothing, cols=[]) =
 Test whether data frame `df` sorted by column(s) `cols`.
 Checking against multiple columns is done lexicographically.
 
+`cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
 If `cols` selects no columns, check whether `df` is sorted on all columns
 (this behaviour is deprecated and will change in future versions).
 

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -336,6 +336,8 @@ Sort.defalg(df::AbstractDataFrame, o::Ordering; alg=nothing, cols=[]) =
              lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward)
 
 Test whether data frame `df` sorted by column(s) `cols`.
+Checking against multiple columns is done lexicographically.
+
 If `cols` selects no columns, check whether `df` is sorted on all columns
 (this behaviour is deprecated and will change in future versions).
 

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -8,7 +8,7 @@ Sort data frame `df` by column(s) `cols`.
 Sorting on multiple columns is done lexicographicallly.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
-If column selector selects no columns, it sorts the `df` lexicographically.
+If `cols` selects no columns, sort `df` on all columns.
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -8,6 +8,7 @@ Sort data frame `df` by column(s) `cols`.
 Sorting on multiple columns is done lexicographicallly.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
+If column selector selects no columns, it sorts the `df` lexicographically.
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -1,6 +1,6 @@
 
 """
-    sort!(df::AbstractDataFrame, cols;
+    sort!(df::AbstractDataFrame, cols=All();
           alg::Union{Algorithm, Nothing}=nothing, lt=isless, by=identity,
           rev::Bool=false, order::Ordering=Forward)
 
@@ -73,7 +73,7 @@ julia> sort!(df, [:x, order(:y, rev=true)])
    4 │     3  b
 ```
 """
-function Base.sort!(df::DataFrame, cols=[]; alg=nothing,
+function Base.sort!(df::DataFrame, cols=All(); alg=nothing,
                     lt=isless, by=identity, rev=false, order=Forward)
     if !(isa(by, Function) || eltype(by) <: Function)
         msg = "'by' must be a Function or a vector of Functions. " *

--- a/src/dataframe/sort.jl
+++ b/src/dataframe/sort.jl
@@ -8,7 +8,8 @@ Sort data frame `df` by column(s) `cols`.
 Sorting on multiple columns is done lexicographicallly.
 
 `cols` can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
-If `cols` selects no columns, sort `df` on all columns.
+If `cols` selects no columns, sort `df` on all columns
+(this behaviour is deprecated and will change in future versions).
 
 If `alg` is `nothing` (the default), the most appropriate algorithm is
 chosen automatically among `TimSort`, `MergeSort` and `RadixSort` depending


### PR DESCRIPTION
I have added a few examples in `issorted` docstrings. And mentioned about lexicographic sorting at `issorted` and `sortperm`.