### PR TITLE
Add row indexing to filter docstring and examples.

### DIFF
--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -15,7 +15,7 @@ The following rules explain target functionality of how `getindex`, `setindex!`,
 `view`, and broadcasting are intended to work with `DataFrame`, `SubDataFrame`
 and `DataFrameRow` objects.
 
-The following types are a valid column index:
+The following values are a valid column index:
 * a value, later denoted as `col`:
     * a `Symbol`;
     * an `AbstractString`;
@@ -31,7 +31,7 @@ The following types are a valid column index:
     * a regular expression, which gets expanded to a vector of matching column
       names;
     * a `Not` expression (see
-      [InvertedIndices.jl](https://github.com/mbauman/InvertedIndices.jl));
+      [InvertedIndices.jl](https://github.com/JuliaData/InvertedIndices.jl));
       `Not(idx)` selects all indices not in the passed `idx`;
     * a `Cols` expression (see
       [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl)); `Cols(idxs...)`
@@ -48,7 +48,7 @@ The following types are a valid column index:
       all columns, equivalent to `:`;
     * a literal colon `:` (selects all columns).
 
-The following types are a valid row index:
+The following values are a valid row index:
 * a value, later denoted as `row`:
     * an `Integer` that is not `Bool`;
 * a vector, later denoted as `rows`:
@@ -56,8 +56,8 @@ The following types are a valid row index:
       `AbstractVector{<:Integer}`);
     * a vector of `Bool` (must be a subtype of `AbstractVector{Bool}`);
     * a `Not` expression; (see
-      [InvertedIndices.jl](https://github.com/mbauman/InvertedIndices.jl));
-    * a literal colon `:` (selects all columns);
+      [InvertedIndices.jl](https://github.com/JuliaData/InvertedIndices.jl));
+    * a literal colon `:` (selects all columns with copying);
     * an literal exclamation mark `!` (selects all columns without copying).
 
 Additionally it is allowed to index into an `AbstractDataFrame` using a

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -15,7 +15,7 @@ The following rules explain target functionality of how `getindex`, `setindex!`,
 `view`, and broadcasting are intended to work with `DataFrame`, `SubDataFrame`
 and `DataFrameRow` objects.
 
-The rules for a valid type of index into a column are the following:
+The following types are a valid column index:
 * a value, later denoted as `col`:
     * a `Symbol`;
     * an `AbstractString`;
@@ -31,7 +31,7 @@ The rules for a valid type of index into a column are the following:
     * a regular expression, which gets expanded to a vector of matching column
       names;
     * a `Not` expression (see
-      [InvertedIndices.jl](https://github.com/mbauman/InvertedIndices.jl)); the
+      [InvertedIndices.jl](https://github.com/mbauman/InvertedIndices.jl));
       `Not(idx)` selects all indices not in the passed `idx`;
     * a `Cols` expression (see
       [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl)); `Cols(idxs...)`
@@ -42,22 +42,23 @@ The rules for a valid type of index into a column are the following:
       selected.
     * a `Between` expression (see
       [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl));
-      `Between(first, last)` selects the columns between `first` and `last`;
+      `Between(first, last)` selects the columns between `first` and `last` inclusively;
     * an `All` expression (see
       [DataAPI.jl](https://github.com/JuliaData/DataAPI.jl)); `All()` selects
       all columns, equivalent to `:`;
-    * a colon literal `:`.
+    * a literal colon `:` (selects all columns).
 
-The rules for a valid type of index into a row are the following:
+The following types are a valid row index:
 * a value, later denoted as `row`:
     * an `Integer` that is not `Bool`;
 * a vector, later denoted as `rows`:
     * a vector of `Integer` other than `Bool` (does not have to be a subtype of
       `AbstractVector{<:Integer}`);
-    * a vector of `Bool` that has to be a subtype of `AbstractVector{Bool}`;
-    * a `Not` expression;
-    * a colon literal `:`;
-* an exclamation mark `!`.
+    * a vector of `Bool` (must be a subtype of `AbstractVector{Bool}`);
+    * a `Not` expression; (see
+      [InvertedIndices.jl](https://github.com/mbauman/InvertedIndices.jl));
+    * a literal colon `:` (selects all columns);
+    * an literal exclamation mark `!` (selects all columns without copying).
 
 Additionally it is allowed to index into an `AbstractDataFrame` using a
 two-dimensional `CartesianIndex`.

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -58,7 +58,7 @@ The following values are a valid row index:
     * a `Not` expression (see
       [InvertedIndices.jl](https://github.com/JuliaData/InvertedIndices.jl));
     * a literal colon `:` (selects all rows with copying);
-    * an literal exclamation mark `!` (selects all rows without copying).
+    * a literal exclamation mark `!` (selects all rows without copying).
 
 Additionally it is allowed to index into an `AbstractDataFrame` using a
 two-dimensional `CartesianIndex`.

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -57,8 +57,8 @@ The following are a valid row index:
     * a vector of `Bool` (must be a subtype of `AbstractVector{Bool}`);
     * a `Not` expression (see
       [InvertedIndices.jl](https://github.com/JuliaData/InvertedIndices.jl));
-    * a literal colon `:` (selects all columns with copying);
-    * an literal exclamation mark `!` (selects all columns without copying).
+    * a literal colon `:` (selects all rows with copying);
+    * an literal exclamation mark `!` (selects all rows without copying).
 
 Additionally it is allowed to index into an `AbstractDataFrame` using a
 two-dimensional `CartesianIndex`.

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -15,8 +15,8 @@ The following rules explain target functionality of how `getindex`, `setindex!`,
 `view`, and broadcasting are intended to work with `DataFrame`, `SubDataFrame`
 and `DataFrameRow` objects.
 
-The following are a valid column index:
-* a value, later denoted as `col`:
+The following values are a valid column index:
+* a scalar, later denoted as `col`:
     * a `Symbol`;
     * an `AbstractString`;
     * an `Integer` that is not `Bool`;
@@ -48,8 +48,8 @@ The following are a valid column index:
       all columns, equivalent to `:`;
     * a literal colon `:` (selects all columns).
 
-The following are a valid row index:
-* a value, later denoted as `row`:
+The following values are a valid row index:
+* a scalar, later denoted as `row`:
     * an `Integer` that is not `Bool`;
 * a vector, later denoted as `rows`:
     * a vector of `Integer` that are not `Bool` (does not have to be a subtype of

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -15,7 +15,7 @@ The following rules explain target functionality of how `getindex`, `setindex!`,
 `view`, and broadcasting are intended to work with `DataFrame`, `SubDataFrame`
 and `DataFrameRow` objects.
 
-The following values are a valid column index:
+The following are a valid column index:
 * a value, later denoted as `col`:
     * a `Symbol`;
     * an `AbstractString`;
@@ -48,7 +48,7 @@ The following values are a valid column index:
       all columns, equivalent to `:`;
     * a literal colon `:` (selects all columns).
 
-The following values are a valid row index:
+The following are a valid row index:
 * a value, later denoted as `row`:
     * an `Integer` that is not `Bool`;
 * a vector, later denoted as `rows`:

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -25,11 +25,11 @@ The following are a valid column index:
       `AbstractVector{Symbol}`);
     * a vector of `AbstractString` (does not have to be a subtype of
       `AbstractVector{<:AbstractString}`);
-    * a vector of `Integer` other than `Bool` (does not have to be a subtype of
+    * a vector of `Integer` that are not `Bool` (does not have to be a subtype of
       `AbstractVector{<:Integer}`);
-    * a vector of `Bool` that has to be a subtype of `AbstractVector{Bool}`;
-    * a regular expression, which gets expanded to a vector of matching column
-      names;
+    * a vector of `Bool` (must be a subtype of `AbstractVector{Bool}`);
+    * a [regular expression](https://docs.julialang.org/en/v1/manual/strings/#Regular-Expressions) (will be expanded to a vector of matching column
+      names);
     * a `Not` expression (see
       [InvertedIndices.jl](https://github.com/JuliaData/InvertedIndices.jl));
       `Not(idx)` selects all indices not in the passed `idx`;
@@ -52,10 +52,10 @@ The following are a valid row index:
 * a value, later denoted as `row`:
     * an `Integer` that is not `Bool`;
 * a vector, later denoted as `rows`:
-    * a vector of `Integer` other than `Bool` (does not have to be a subtype of
+    * a vector of `Integer` that are not `Bool` (does not have to be a subtype of
       `AbstractVector{<:Integer}`);
     * a vector of `Bool` (must be a subtype of `AbstractVector{Bool}`);
-    * a `Not` expression; (see
+    * a `Not` expression (see
       [InvertedIndices.jl](https://github.com/JuliaData/InvertedIndices.jl));
     * a literal colon `:` (selects all columns with copying);
     * an literal exclamation mark `!` (selects all columns without copying).

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -50,8 +50,6 @@ The rules for a valid type of index into a column are the following:
 
 The rules for a valid type of index into a row are the following:
 * a value, later denoted as `row`:
-    * a `Symbol`;
-    * an `AbstractString`;
     * an `Integer` that is not `Bool`;
 * a vector, later denoted as `rows`:
     * a vector of `Integer` other than `Bool` (does not have to be a subtype of

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -992,6 +992,7 @@ Return a data frame containing only rows from `df` for which `fun` returns
 `true`.
 
 If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
+Column selectors may be used to index `DataFrameRow`s inside `fun`.
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -992,8 +992,7 @@ Return a data frame containing only rows from `df` for which `fun` returns
 `true`.
 
 If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
-(Individual elements may be accessed by indexing the passed `DataFrameRow`s
-with column selectors inside the definition of `fun`.)
+Elements of a `DataFrameRow` may be accessed with dot syntax or column indexing inside `fun`.
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an
@@ -1121,9 +1120,8 @@ _filter_helper_astable(f, nti::Tables.NamedTupleIterator)::BitVector = (x -> f(x
 
 Remove rows from data frame `df` for which `fun` returns `false`.
 
-If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
-(Individual elements may be accessed by indexing the passed `DataFrameRow`s
-with column selectors inside the definition of `fun`.)
+    If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
+    Elements of a `DataFrameRow` may be accessed with dot syntax or column indexing inside `fun`.
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -992,7 +992,8 @@ Return a data frame containing only rows from `df` for which `fun` returns
 `true`.
 
 If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
-(Column selectors may be used to index `DataFrameRow`s inside `fun`.)
+(Individual elements may be accessed by indexing the passed `DataFrameRow`s
+with column selectors inside the definition of `fun.)
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an
@@ -1121,7 +1122,8 @@ _filter_helper_astable(f, nti::Tables.NamedTupleIterator)::BitVector = (x -> f(x
 Remove rows from data frame `df` for which `fun` returns `false`.
 
 If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
-(Column selectors may be used to index `DataFrameRow`s inside `fun`.)
+(Individual elements may be accessed by indexing the passed `DataFrameRow`s
+with column selectors inside the definition of `fun.)
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1037,7 +1037,7 @@ julia> filter(row -> row.x > 1, df)
    1 │     3  b
    2 │     2  a
 
-julia> filter(row -> row[:x] > 1, df)
+julia> filter(row -> row["x"] > 1, df)
 2×2 DataFrame
  Row │ x      y      
      │ Int64  String
@@ -1164,7 +1164,7 @@ julia> filter!(row -> row.x > 1, df)
    1 │     3  b
    2 │     2  a
                                                                                         
-julia> filter!(row -> row[:x] > 1, df)
+julia> filter!(row -> row["x"] > 1, df)
 2×2 DataFrame
  Row │ x      y      
      │ Int64  String

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1036,6 +1036,14 @@ julia> filter(row -> row.x > 1, df)
    1 │     3  b
    2 │     2  a
 
+julia> filter(row -> row[Not(:y)]... > 1, df)
+2×2 DataFrame
+ Row │ x      y      
+     │ Int64  String
+─────┼───────────────
+   1 │     3  b
+   2 │     2  a                                                                    
+
 julia> filter(:x => x -> x > 1, df)
 2×2 DataFrame
  Row │ x      y

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -992,7 +992,7 @@ Return a data frame containing only rows from `df` for which `fun` returns
 `true`.
 
 If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
-Column selectors may be used to index `DataFrameRow`s inside `fun`.
+(Column selectors may be used to index `DataFrameRow`s inside `fun`.)
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an
@@ -1121,6 +1121,7 @@ _filter_helper_astable(f, nti::Tables.NamedTupleIterator)::BitVector = (x -> f(x
 Remove rows from data frame `df` for which `fun` returns `false`.
 
 If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
+(Column selectors may be used to index `DataFrameRow`s inside `fun`.)
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an
@@ -1160,6 +1161,14 @@ julia> filter!(row -> row.x > 1, df)
 ─────┼───────────────
    1 │     3  b
    2 │     2  a
+                                                                                        
+julia> filter!(row -> row[Not(:y)]... > 1, df)
+2×2 DataFrame
+ Row │ x      y      
+     │ Int64  String
+─────┼───────────────
+   1 │     3  b
+   2 │     2  a                                                                                          
 
 julia> filter!(:x => x -> x == 3, df)
 1×2 DataFrame

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1036,7 +1036,7 @@ julia> filter(row -> row.x > 1, df)
    1 │     3  b
    2 │     2  a
 
-julia> filter(row -> row[Not(:y)]... > 1, df)
+julia> filter(row -> row[:x] > 1, df)
 2×2 DataFrame
  Row │ x      y      
      │ Int64  String
@@ -1162,7 +1162,7 @@ julia> filter!(row -> row.x > 1, df)
    1 │     3  b
    2 │     2  a
                                                                                         
-julia> filter!(row -> row[Not(:y)]... > 1, df)
+julia> filter!(row -> row[:x] > 1, df)
 2×2 DataFrame
  Row │ x      y      
      │ Int64  String

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1120,8 +1120,8 @@ _filter_helper_astable(f, nti::Tables.NamedTupleIterator)::BitVector = (x -> f(x
 
 Remove rows from data frame `df` for which `fun` returns `false`.
 
-    If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
-    Elements of a `DataFrameRow` may be accessed with dot syntax or column indexing inside `fun`.
+If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
+Elements of a `DataFrameRow` may be accessed with dot syntax or column indexing inside `fun`.
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -993,7 +993,7 @@ Return a data frame containing only rows from `df` for which `fun` returns
 
 If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
 (Individual elements may be accessed by indexing the passed `DataFrameRow`s
-with column selectors inside the definition of `fun.)
+with column selectors inside the definition of `fun`.)
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an
@@ -1123,7 +1123,7 @@ Remove rows from data frame `df` for which `fun` returns `false`.
 
 If `cols` is not specified then the predicate `fun` is passed `DataFrameRow`s.
 (Individual elements may be accessed by indexing the passed `DataFrameRow`s
-with column selectors inside the definition of `fun.)
+with column selectors inside the definition of `fun`.)
 
 If `cols` is specified then the predicate `fun` is passed elements of the
 corresponding columns as separate positional arguments, unless `cols` is an


### PR DESCRIPTION
It was shown to me recently that column selectors can be used inside filter function definitions, which is incredibly useful. I want to add a brief statement and example to the `filter` and `filter!` documentation to show that usage.