### PR TITLE
Reduce test memory usage

### DIFF
--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -2031,7 +2031,10 @@ end
         df = DataFrame(mat, :auto)
         for rowrange in [:, 1:nrow(df)-5, collect(1:nrow(df)-5), axes(df, 1) .< nrow(df)-5],
             colrange in [:, axes(df, 2), collect(axes(df, 2)), 1:ncol(df) - 1]
-            @test DataFrame(mat[rowrange, colrange], :auto) == df[rowrange, colrange]
+            df2 = df[rowrange, colrange]
+            for j in axes(df2, 2)
+                @test df2[!, j] == view(mat, rowrange, c)
+            end
         end
     end
 end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -2031,6 +2031,8 @@ end
         df = DataFrame(mat, :auto)
         for rowrange in [:, 1:nrow(df)-5, collect(1:nrow(df)-5), axes(df, 1) .< nrow(df)-5],
             colrange in [:, axes(df, 2), collect(axes(df, 2)), 1:ncol(df) - 1]
+            # Equivalent but using less memory than:
+            # @test DataFrame(mat[rowrange, colrange], :auto) == df[rowrange, colrange]
             df2 = df[rowrange, colrange]
             for j in axes(df2, 2)
                 @test df2[!, j] == view(mat, rowrange, j)

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -2033,7 +2033,7 @@ end
             colrange in [:, axes(df, 2), collect(axes(df, 2)), 1:ncol(df) - 1]
             df2 = df[rowrange, colrange]
             for j in axes(df2, 2)
-                @test df2[!, j] == view(mat, rowrange, c)
+                @test df2[!, j] == view(mat, rowrange, j)
             end
         end
     end


### PR DESCRIPTION
Another place where CI tests fail on 32-bit machine because out of memory. The change reduces memory consumption as we cannot make the data smaller since we test threading.