### PR TITLE
better disallowmissing error message

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2060,30 +2060,22 @@ function Missings.disallowmissing(df::AbstractDataFrame,
     for i in axes(df, 2)
         x = df[!, i]
         if i in idxcols
-            local y
+            y = x
             if Missing <: eltype(x)
-                if error
-                    try
-                        y = disallowmissing(x)
-                    catch e
-                        row = findfirst(ismissing, x)
-                        if row !== nothing
+                try
+                    y = disallowmissing(x)
+                catch e
+                    row = findfirst(ismissing, x)
+                    if row !== nothing
+                        if error
                             col = _names(df)[i]
                             throw(ArgumentError("Missing value found in column " *
                                                 ":$col in row $row"))
-                        else
-                            rethrow(e)
                         end
-                    end
-                else
-                    if any(ismissing, x)
-                        y = x
                     else
-                        y = disallowmissing(x)
+                        rethrow(e)
                     end
                 end
-            else
-                y = x
             end
             push!(newcols, y === x ? copy(y) : y)
         else

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2061,11 +2061,14 @@ function Missings.disallowmissing(df::AbstractDataFrame,
         x = df[!, i]
         if i in idxcols
             if Missing <: eltype(x)
-                # any(ismissing, x) is cheap so we accept paying it
+                # finding missing is cheap so we accept paying it
                 # to get a better error message
-                if any(ismissing, x)
+                row = findfirst(ismissing, x)
+                if row !== nothing
                     if error
-                        throw(ArgumentError("Missing value found in column number $i"))
+                        col = _names(df)[i]
+                        throw(ArgumentError("Missing value found in column :$col " *
+                                            "in row $row"))
                     else
                         y = x
                     end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1190,8 +1190,16 @@ function disallowmissing! end
 
 function disallowmissing!(df::DataFrame, col::ColumnIndex; error::Bool=true)
     x = df[!, col]
-    if !(!error && Missing <: eltype(x) && any(ismissing, x))
-        df[!, col] = disallowmissing(x)
+    if Missing <: eltype(x)
+        # any(ismissing, x) is cheap so we accept paying it
+        # to get a better error message
+        if any(ismissing, x)
+            if error
+                throw(ArgumentError("Missing value found in column number $col"))
+            end
+        else
+            df[!, col] = disallowmissing(x)
+        end
     end
     return df
 end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1191,22 +1191,18 @@ function disallowmissing! end
 function disallowmissing!(df::DataFrame, col::ColumnIndex; error::Bool=true)
     x = df[!, col]
     if Missing <: eltype(x)
-        if error
-            try
-                df[!, col] = disallowmissing(x)
-            catch e
-                row = findfirst(ismissing, x)
-                if row !== nothing
+        try
+            df[!, col] = disallowmissing(x)
+        catch e
+            row = findfirst(ismissing, x)
+            if row !== nothing
+                if error
                     col_name = only(names(df, col))
                     throw(ArgumentError("Missing value found in column " *
                                         ":$col_name in row $row"))
-                else
-                    rethrow(e)
                 end
-            end
-        else
-            if !any(ismissing, x)
-                df[!, col] = disallowmissing(x)
+            else
+                rethrow(e)
             end
         end
     end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1191,11 +1191,14 @@ function disallowmissing! end
 function disallowmissing!(df::DataFrame, col::ColumnIndex; error::Bool=true)
     x = df[!, col]
     if Missing <: eltype(x)
-        # any(ismissing, x) is cheap so we accept paying it
+        # finding missing is cheap so we accept paying it
         # to get a better error message
-        if any(ismissing, x)
+        row = findfirst(ismissing, x)
+        if row !== nothing
             if error
-                throw(ArgumentError("Missing value found in column number $col"))
+                col_name = only(names(df, col))
+                throw(ArgumentError("Missing value found in column :$col_name " *
+                                    "in row $row"))
             end
         else
             df[!, col] = disallowmissing(x)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1131,7 +1131,7 @@ end
     @test isa(df[!, 1], Vector{Union{Int, Missing}})
     @test !isa(df[!, 2], Vector{Union{Int, Missing}})
     df[1, 1] = missing
-    @test_throws MethodError disallowmissing!(df, 1)
+    @test_throws ArgumentError disallowmissing!(df, 1)
     tmpcol = df[!, 1]
     disallowmissing!(df, 1, error=false)
     @test df[!, 1] === tmpcol
@@ -1145,7 +1145,7 @@ end
     @test isa(df[!, 1], Vector{Union{Int, Missing}})
     @test !isa(df[!, 2], Vector{Union{Int, Missing}})
     df[1, 1] = missing
-    @test_throws MethodError disallowmissing!(df, Not(Not(1)))
+    @test_throws ArgumentError disallowmissing!(df, Not(Not(1)))
     tmpcol = df[!, 1]
     disallowmissing!(df, Not(Not(1)), error=false)
     @test df[!, 1] === tmpcol
@@ -1206,7 +1206,7 @@ end
     @test eltype(df[!, 1]) <: Union{CategoricalValue{Int}, Missing}
     @test eltype(df[!, 2]) <: Union{CategoricalValue{String}, Missing}
     df[1, 2] = missing
-    @test_throws MissingException disallowmissing!(df)
+    @test_throws ArgumentError disallowmissing!(df)
     tmpcol =df[!, 2]
     disallowmissing!(df, error=false)
     @test df[!, 2] === tmpcol
@@ -1331,9 +1331,9 @@ end
         end
     end
 
-    @test_throws MethodError disallowmissing(DataFrame(x=[missing]))
+    @test_throws ArgumentError disallowmissing(DataFrame(x=[missing]))
     @test disallowmissing(DataFrame(x=[missing]), error=false) ≅ DataFrame(x=[missing])
-    @test_throws MethodError disallowmissing(DataFrame(x=[1, missing]))
+    @test_throws ArgumentError disallowmissing(DataFrame(x=[1, missing]))
     @test disallowmissing(DataFrame(x=[1, missing]), error=false) ≅ DataFrame(x=[1, missing])
 
     df = DataFrame(x=[1], y=Union{Int, Missing}[1], z=[missing])


### PR DESCRIPTION
Improve the error message in case column conversion fails, e.g.:
```
julia> df = DataFrame(x=1:3, y=[1,2,missing])
3×2 DataFrame
 Row │ x      y       
     │ Int64  Int64?  
─────┼────────────────
   1 │     1        1 
   2 │     2        2 
   3 │     3  missing 

julia> disallowmissing(df)
ERROR: ArgumentError: Missing value found in column number 2 

julia> disallowmissing!(df)
ERROR: ArgumentError: Missing value found in column number 2
```