### PR TITLE
update docs for join on (left, right) tuple

### DIFF
--- a/docs/src/man/joins.md
+++ b/docs/src/man/joins.md
@@ -125,7 +125,7 @@ julia> crossjoin(people, jobs, makeunique = true)
 ```
 
 In order to join data frames on keys which have different names in the left and right tables,
-you may pass `(left, right)` tuples or `left => right` pairs as `on` argument:
+you may pass `left => right` pairs as `on` argument:
 
 ```jldoctest joins
 julia> a = DataFrame(ID=[20, 40], Name=["John Doe", "Jane Doe"])


### PR DESCRIPTION
I tried to use a tuple but in DataFrames 1.3 I got this error:

ERROR: ArgumentError: Using a `Tuple{Symbol, Symbol}` or a vector containing such tuples as a value of `on` keyword argument is not supported: use `Pair{Symbol, Symbol}` instead.

So I'm assuming this option is no longer supported.