### PR TITLE
fix aliasing detection in sort!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# DataFrames.jl v1.3.2 Patch Release Notes
+
+## Bug fixes
+
+* Fix aliasing detection in `sort!`
+  ([#2981](https://github.com/JuliaData/DataFrames.jl/issues/2981))
+
 # DataFrames.jl v1.3.1 Patch Release Notes
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 ## Bug fixes
 
-* Fix aliasing detection in `sort!`
+* Fix aliasing detection in `sort!` (now only identical columns passing `===`
+  test are considered aliases)
   ([#2981](https://github.com/JuliaData/DataFrames.jl/issues/2981))
 
 # DataFrames.jl v1.3.1 Patch Release Notes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.3.1"
+version = "1.3.2"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -677,9 +677,13 @@ function Base.sort!(df::AbstractDataFrame, cols=All();
     return sort!(df, _alg, ord)
 end
 
-function Base.sort!(df::AbstractDataFrame, a::Base.Sort.Algorithm, o::Base.Sort.Ordering)
-    c = collect(eachcol(df))
+strip_subdataframe(df::AbstractDataFrame) = df
+strip_subdataframe(df::SubDataFrame) = strip_subdataframe(parent(df))
 
+function Base.sort!(df::AbstractDataFrame, a::Base.Sort.Algorithm, o::Base.Sort.Ordering)
+
+    # aliasing detection should be made on source data frame level
+    c = eachcol(strip_subdataframe(df))
     toskip = Set{Int}()
     for (i, col) in enumerate(c)
         # Check if this column has been sorted already
@@ -693,7 +697,7 @@ function Base.sort!(df::AbstractDataFrame, a::Base.Sort.Algorithm, o::Base.Sort.
     p = _sortperm(df, a, o)
     pp = similar(p)
 
-    for (i, col) in enumerate(c)
+    for (i, col) in enumerate(eachcol(df))
         if !(i in toskip)
             copyto!(pp, p)
             Base.permute!!(col, pp)

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -685,23 +685,12 @@ end
 function Base.sort!(df::AbstractDataFrame, a::Base.Sort.Algorithm, o::Base.Sort.Ordering)
     c = eachcol(df)
     toskip = Set{Int}()
-    # in theory two different vectors might have the same objectid
-    # for SubDataFrame we take advantage of the fact that objectid
-    # for multiple views of the same vector with the same indices
-    # are the same as SubArray is immutable and the rule is
-    # objectid(x) == objectid(y) if x === y
-    seen_cols = Dict()
+    seen_cols = IdDict{Any, Nothing}()
     for (i, col) in enumerate(c)
-        col_id = objectid(col)
-        if haskey(seen_cols, col_id)
-            for old_col in seen_cols[col_id]
-                if col === old_col
-                    push!(toskip, i)
-                    break
-                end
-            end
+        if haskey(seen_cols, col)
+            push!(toskip, i)
         else
-            seen_cols[col_id] = Any[col]
+            seen_cols[col] = nothing
         end
     end
 

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -696,7 +696,7 @@ function Base.sort!(df::AbstractDataFrame, a::Base.Sort.Algorithm, o::Base.Sort.
     p = _sortperm(df, a, o)
     pp = similar(p)
 
-    for (i, col) in enumerate(c)
+    for (i, col) in enumerate(eachcol(df))
         if !(i in toskip)
             copyto!(pp, p)
             Base.permute!!(col, pp)

--- a/src/abstractdataframe/sort.jl
+++ b/src/abstractdataframe/sort.jl
@@ -683,10 +683,9 @@ function Base.sort!(df::AbstractDataFrame, cols=All();
 end
 
 function Base.sort!(df::AbstractDataFrame, a::Base.Sort.Algorithm, o::Base.Sort.Ordering)
-    c = eachcol(df)
     toskip = Set{Int}()
     seen_cols = IdDict{Any, Nothing}()
-    for (i, col) in enumerate(c)
+    for (i, col) in enumerate(eachcol(df))
         if haskey(seen_cols, col)
             push!(toskip, i)
         else

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -352,7 +352,7 @@ end
     dfv = view(df, 1:3, :)
     sort!(dfv, :b)
     @test df == DataFrame(a=[3, 2, 1, 6, 5], b=[4, 5, 6, 1, 2])
-    # this is a result if we had no aliasing
+    # this is the "correct" result if we had no aliasing
     x = [1:6;]
     df = DataFrame(a=view(x, 1:5), b=view(x, 6:-1:2))
     dfv = view(df, 1:3, :)

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -376,17 +376,6 @@ end
     sort!(dfv, :x4)
     @test issorted(dfv)
     @test issorted(df[1:5, :])
-
-    # performance test
-    df = DataFrame(x1=1)
-    for i in 2:10_000
-        df[!, "x$i"] = df.x1
-    end
-    sort!(df, :x1)
-    @test @elapsed(sort!(df, :x1)) < 0.1
-    df = copy(df)
-    sort!(df, :x1)
-    @test @elapsed(sort!(df, :x1)) < 0.1
 end
 
 end # module

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -355,6 +355,11 @@ end
         df.x2 = view(x, 2:101)
         @test_throws ArgumentError sort!(sdf)
     end
+
+    x = [1:6;]
+    df = DataFrame(a=view(x, 1:5), b=view(x, 6:-1:2), copycols=false)
+    dfv = view(df, 1:3, [2])
+    @test_throws ArgumentError sort!(dfv)
 end
 
 end # module

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -323,4 +323,38 @@ end
     end
 end
 
+@testset "correct aliasing detection" begin
+    for sel in ([1, 2, 3], 1:3)
+        df = DataFrame(a=1:5, b=11:15, c=21:25)
+        dfc = copy(df)
+        sdf = view(df, sel, :)
+        sort!(sdf)
+        @test df[:, 1:3] == dfc
+        df.d = df.a
+        sort!(sdf)
+        @test df[:, 1:3] == dfc
+        x = [1:6;]
+        df.x1 = view(x, 1:5)
+        df.x2 = view(x, 2:6)
+        @test_throws ArgumentError sort!(sdf)
+    end
+
+    Random.seed!(1234)
+    for sel in ([1:100;], 1:100)
+        df = DataFrame(a=rand(100), b=rand(100), c=rand(100), id=1:100)
+        dfc = sort(df)
+        sdf = view(df, sel, :)
+        sort!(sdf)
+        @test df[:, 1:4] == dfc
+        sort!(df, :id)
+        df.d = df.a
+        sort!(sdf)
+        @test df[:, 1:4] == dfc
+        x = [1:101;]
+        df.x1 = view(x, 1:100)
+        df.x2 = view(x, 2:101)
+        @test_throws ArgumentError sort!(sdf)
+    end
+end
+
 end # module

--- a/test/sort.jl
+++ b/test/sort.jl
@@ -210,6 +210,7 @@ end
 
 @testset "sort! tests" begin
     # safe aliasing test
+    # this works because 2:5 is immutable
     df = DataFrame()
     x = [10:-1:1;]
     df.x1 = view(x, 2:5)
@@ -222,6 +223,15 @@ end
     df = DataFrame()
     x = [10:-1:1;]
     df.x1 = view(x, 2:5)
+    df.x2 = view(x, [2:5;])
+    sort!(df)
+    @test_broken issorted(df)
+    @test_broken x == [10, 6, 7, 8, 9, 5, 4, 3, 2, 1]
+    @test_broken df == DataFrame(x1=6:9, x2=6:9)
+
+    df = DataFrame()
+    x = [10:-1:1;]
+    df.x1 = view(x, 2:5)
     df.x2 = view(x, 2:5)
     dfv = view(df, 2:4, :)
     sort!(dfv)
@@ -229,23 +239,33 @@ end
     @test x == [10, 9, 6, 7, 8, 5, 4, 3, 2, 1]
     @test df == DataFrame(x1=[9; 6:8], x2=[9; 6:8])
 
+    df = DataFrame()
+    x = [10:-1:1;]
+    df.x1 = view(x, [2:5;])
+    df.x2 = view(x, 2:5)
+    dfv = view(df, 2:4, :)
+    sort!(dfv)
+    @test_broken issorted(dfv)
+    @test_broken x == [10, 9, 6, 7, 8, 5, 4, 3, 2, 1]
+    @test_broken df == DataFrame(x1=[9; 6:8], x2=[9; 6:8])
+
     # unsafe aliasing test
     df = DataFrame()
     x = [10:-1:1;]
     df.x1 = view(x, 2:5)
     df.x2 = view(x, 3:6)
-    @test_throws ArgumentError sort!(df)
-    @test x == 10:-1:1
-    @test df == DataFrame(x1=9:-1:6, x2=8:-1:5)
+    sort!(df)
+    @test_broken x == 10:-1:1
+    @test_broken df == DataFrame(x1=9:-1:6, x2=8:-1:5)
 
     df = DataFrame()
     x = [10:-1:1;]
     df.x1 = view(x, 2:5)
     df.x2 = view(x, 3:6)
     dfv = view(df, 2:4, :)
-    @test_throws ArgumentError sort!(dfv)
-    @test x == 10:-1:1
-    @test df == DataFrame(x1=9:-1:6, x2=8:-1:5)
+    sort!(dfv)
+    @test_broken x == 10:-1:1
+    @test_broken df == DataFrame(x1=9:-1:6, x2=8:-1:5)
 
     # complex view sort test
     Random.seed!(1234)


### PR DESCRIPTION
The problem in DataFrames.jl 1.3.1 is:
```
julia> using DataFrames

julia> df = DataFrame(a=1:5, b=11:15, c=21:25)
5×3 DataFrame
 Row │ a      b      c     
     │ Int64  Int64  Int64 
─────┼─────────────────────
   1 │     1     11     21
   2 │     2     12     22
   3 │     3     13     23
   4 │     4     14     24
   5 │     5     15     25

julia> sdf = view(df, [1, 2, 3], :)
3×3 SubDataFrame
 Row │ a      b      c     
     │ Int64  Int64  Int64 
─────┼─────────────────────
   1 │     1     11     21
   2 │     2     12     22
   3 │     3     13     23

julia> sort!(sdf)
ERROR: ArgumentError: data frame contains non identical columns that share the same memory
```

This is caused by incorrect aliasing detection rule.

This PR fixes this.