### PR TITLE
Update subset to handle large number of selectors better

### DIFF
--- a/src/abstractdataframe/subset.jl
+++ b/src/abstractdataframe/subset.jl
@@ -104,6 +104,7 @@ function _get_subset_conditions(df::Union{AbstractDataFrame, GroupedDataFrame},
     @assert ncol(df_conditions) == length(conditions)
 
     cols = eachcol(df_conditions)
+    # with many columns, process each column sequentially to avoid large compilation time
     if length(conditions) > 16
         if skipmissing
             cond = _and_long_missing.(cols[1], cols[2])

--- a/src/abstractdataframe/subset.jl
+++ b/src/abstractdataframe/subset.jl
@@ -107,6 +107,13 @@ described for [`select`](@ref) with the restriction that:
   `AbstractDataFrame`, `NamedTuple`, `DataFrameRow` or `AbstractMatrix`
   is not supported).
 
+The `subset` function is optimized for speed when low number of of conditions passed
+(up to several dozens). If you need to subset rows based on a larger number
+of columns prefer passing one condition using the syntax
+`AsTable(column_selector) => condition_function∘collect` when the condition function
+or for row-wise condition `AsTable(column_selector) => ByRow(condition_function∘collect)`,
+see [`DataFrames.table_transformation`](@ref) documentation for a detailed explanation.
+
 If `skipmissing=false` (the default) `args` are required to produce vectors
 containing only `Bool` values. If `skipmissing=true`, additionally `missing` is
 allowed and it is treated as `false` (i.e. rows for which one of the conditions


### PR DESCRIPTION
@nalimilan - could you please have a look. When we finalize the description I will add the same for `subset!`.

The reason for this note is that we are using recurrence to calculate row condition (so when there are many columns we get stack overflow due too deep recurrence and in general very slow compilation)