### PR TITLE
allow no rowkey in unstack

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -213,6 +213,7 @@ Row and column keys will be ordered in the order of their first appearance.
 - `rowkeys` : the columns with a unique key for each row, if not given,
   find a key by grouping on anything not a `colkey` or `value`.
   Can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
+  If `rowkeys` contains no columns data is assumed to have the same row key.
 - `colkey` : the column ($COLUMNINDEX_STR) holding the column names in wide format,
   defaults to `:variable`
 - `value` : the value column ($COLUMNINDEX_STR), defaults to `:value`
@@ -362,7 +363,6 @@ function unstack(df::AbstractDataFrame, rowkeys, colkey::ColumnIndex,
                  allowmissing::Bool=false, allowduplicates::Bool=false, fill=missing)
     rowkey_ints = vcat(index(df)[rowkeys])
     @assert rowkey_ints isa AbstractVector{Int}
-    length(rowkey_ints) == 0 && throw(ArgumentError("No key column found"))
     g_rowkey = groupby(df, rowkey_ints)
     g_colkey = groupby(df, colkey)
     valuecol = df[!, value]

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -213,7 +213,7 @@ Row and column keys will be ordered in the order of their first appearance.
 - `rowkeys` : the columns with a unique key for each row, if not given,
   find a key by grouping on anything not a `colkey` or `value`.
   Can be any column selector ($COLUMNINDEX_STR; $MULTICOLUMNINDEX_STR).
-  If `rowkeys` contains no columns data is assumed to have the same row key.
+  If `rowkeys` contains no columns all rows are assumed to have the same key.
 - `colkey` : the column ($COLUMNINDEX_STR) holding the column names in wide format,
   defaults to `:variable`
 - `value` : the value column ($COLUMNINDEX_STR), defaults to `:value`

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -730,4 +730,13 @@ end
     @test dfu.a isa Vector{Any}
 end
 
+@testset "no rowkey unstack" begin
+    df = DataFrame(x=[:one, :two], y = [1, 2])
+    @test unstack(df, :x, :y) == DataFrame(one=1, two=2)
+
+    df = DataFrame(x=[:one, :two, :one], y = [1, 2, 3])
+    @test_throws ArgumentError unstack(df, :x, :y)
+    @test unstack(df, :x, :y, allowduplicates=true) == DataFrame(one=3, two=2)
+end
+
 end # module

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -731,10 +731,10 @@ end
 end
 
 @testset "no rowkey unstack" begin
-    df = DataFrame(x=[:one, :two], y = [1, 2])
+    df = DataFrame(x=[:one, :two], y=[1, 2])
     @test unstack(df, :x, :y) == DataFrame(one=1, two=2)
 
-    df = DataFrame(x=[:one, :two, :one], y = [1, 2, 3])
+    df = DataFrame(x=[:one, :two, :one], y=[1, 2, 3])
     @test_throws ArgumentError unstack(df, :x, :y)
     @test unstack(df, :x, :y, allowduplicates=true) == DataFrame(one=3, two=2)
 end


### PR DESCRIPTION
Fixes #2994 

It turns out that when I have re-written the `unstack` implementation to improve its performance we get handling of no row-key for free. So I have added it.

The question is if we want to add another option for `allowduplicates` like `allowduplicates=:vector`, in which case we would store a list of duplicate values (a la `dplyr` in #2994 example). This would be a new feature (and probably go to 1.4 release as what I make here is a patch)