### PR TITLE
allow function in allowduplicates in unstack

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# DataFrames.jl v1.3 Release Notes
+# DataFrames.jl v1.4 Release Notes
 
 ## New functionalities
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# DataFrames.jl v1.3 Release Notes
+
+## New functionalities
+
+* `unstack` now allows passing a function in `allowduplicates` keyword argument;
+  this allows for a convenient creation of two dimensional pivot tables
+  ([#2998](https://github.com/JuliaData/DataFrames.jl/issues/2998))
+
 # DataFrames.jl v1.3.2 Patch Release Notes
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## New functionalities
 
-* `unstack` now allows passing a function in `allowduplicates` keyword argument;
+* `unstack` now allows passing a function in `valuestransform` keyword argument;
   this allows for a convenient creation of two dimensional pivot tables
   ([#2998](https://github.com/JuliaData/DataFrames.jl/issues/2998))
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.3.2"
+version = "1.4.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -296,9 +296,8 @@ This is provides a view of the original columns stacked together.
 Id columns -- `RepeatedVector`
 This repeats the original columns N times where N is the number of columns stacked.
 
-None of these reshaping functions perform any aggregation. To do aggregation,
-use the split-apply-combine functions in combination with reshaping. Here is an
-example:
+To do aggregation, use the split-apply-combine functions in combination with
+`unstack` or use the `valuestransform` keyword argument in `unstack`. Here is an example:
 
 ```jldoctest reshape
 julia> using Statistics
@@ -326,9 +325,9 @@ julia> d = stack(iris, Not(:Species))
  750 │ Iris-virginica  id             150.0
                             735 rows omitted
 
-julia> x = combine(groupby(d, [:variable, :Species]), :value => mean => :vsum)
+julia> agg = combine(groupby(d, [:variable, :Species]), :value => mean => :vmean)
 15×3 DataFrame
- Row │ variable     Species          vsum
+ Row │ variable     Species          vmean
      │ String       String15         Float64
 ─────┼───────────────────────────────────────
    1 │ SepalLength  Iris-setosa        5.006
@@ -347,7 +346,18 @@ julia> x = combine(groupby(d, [:variable, :Species]), :value => mean => :vsum)
   14 │ id           Iris-versicolor   75.5
   15 │ id           Iris-virginica   125.5
 
-julia> first(unstack(x, :Species, :vsum), 6)
+julia> unstack(agg, :variable, :Species, :vmean)
+5×4 DataFrame
+ Row │ variable     Iris-setosa  Iris-versicolor  Iris-virginica
+     │ String       Float64?     Float64?         Float64?
+─────┼───────────────────────────────────────────────────────────
+   1 │ SepalLength        5.006            5.936           6.588
+   2 │ SepalWidth         3.418            2.77            2.974
+   3 │ PetalLength        1.464            4.26            5.552
+   4 │ PetalWidth         0.244            1.326           2.026
+   5 │ id                25.5             75.5           125.5
+
+julia> unstack(d, :variable, :Species, :value, valuestransform=mean)
 5×4 DataFrame
  Row │ variable     Iris-setosa  Iris-versicolor  Iris-virginica
      │ String       Float64?     Float64?         Float64?

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -238,8 +238,8 @@ Row and column keys will be ordered in the order of their first appearance.
   `true` then the last encountered `value` will be retained;
   this keyword argument is ignored if `valuestransform` keyword argument is passed.
 - `valuestransform`: if passed then `allowduplicates` is ignored and instead
-   the passed function will be called on a view vector containing all elements
-   for each non-missing combination of `rowkeys` and `colkey`.
+   the passed function will be called on a vector view containing all elements
+   for each combination of `rowkeys` and `colkey` present in the data.
 - `fill`: missing row/column combinations are filled with this value. The
   default is `missing`. If the `value` column is a `CategoricalVector` and
   `fill` is not `missing` then in order to keep unstacked value columns also

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -408,7 +408,7 @@ function unstack(df::AbstractDataFrame, rowkeys, colkey::ColumnIndex,
             df_agg = df_agg[sortperm(group_rows), :]
         end
         return unstack(df_agg, rowkeys, colkey, value, renamecols=renamecols,
-                    allowmissing=allowmissing, allowduplicates=false, fill=fill)
+                       allowmissing=allowmissing, allowduplicates=false, fill=fill)
     end
     rowkey_ints = vcat(index(df)[rowkeys])
     @assert rowkey_ints isa AbstractVector{Int}

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -747,7 +747,7 @@ end
           DataFrame(one=2, two=1)
 end
 
-@testset "allowduplicates as function" begin
+@testset "valuestransform" begin
     df = DataFrame(rowid=[1, 1, 1, 1, 2, 2], colid=[1, 1, 2, 2, 3, 3], values=1:6)
     @test_throws ArgumentError unstack(df, :rowid, :colid, :values)
     @test unstack(df, :rowid, :colid, :values, allowduplicates=true) ≅

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -737,13 +737,13 @@ end
     df = DataFrame(x=[:one, :two, :one], y=[1, 2, 3])
     @test_throws ArgumentError unstack(df, :x, :y)
     @test unstack(df, :x, :y, allowduplicates=true) == DataFrame(one=3, two=2)
-    @test unstack(df, :x, :y, operation=identity) ==
+    @test unstack(df, :x, :y, valuestransform=identity) ==
           DataFrame(one=[[1, 3]], two=[[2]])
-    @test unstack(df, :x, :y, operation=last) ==
+    @test unstack(df, :x, :y, valuestransform=last) ==
           DataFrame(one=3, two=2)
-    @test unstack(df, :x, :y, operation=first) ==
+    @test unstack(df, :x, :y, valuestransform=first) ==
           DataFrame(one=1, two=2)
-    @test unstack(df, :x, :y, operation=length) ==
+    @test unstack(df, :x, :y, valuestransform=length) ==
           DataFrame(one=2, two=1)
 end
 
@@ -756,36 +756,36 @@ end
     @test unstack(df, :rowid, :colid, :values, allowduplicates=true, fill=0) ==
           DataFrame("rowid" => 1:2, "1" => [2, 0],
                     "2" => [4, 0], "3" => [0, 6])
-    @test unstack(df, :rowid, :colid, :values, operation=identity) ≅
+    @test unstack(df, :rowid, :colid, :values, valuestransform=identity) ≅
           DataFrame("rowid" => 1:2, "1" => [1:2, missing],
                     "2" => [3:4, missing], "3" => [missing, 5:6])
     @test unstack(df, :rowid, :colid, :values,
-                  operation=identity, fill=Int[]) ==
+                  valuestransform=identity, fill=Int[]) ==
           DataFrame("rowid" => 1:2, "1" => [1:2, []],
                     "2" => [3:4, []], "3" => [[], 5:6])
-    @test unstack(df, :rowid, :colid, :values, operation=sum) ≅
+    @test unstack(df, :rowid, :colid, :values, valuestransform=sum) ≅
           DataFrame("rowid" => 1:2, "1" => [3, missing],
                     "2" => [7, missing], "3" => [missing, 11])
-    @test unstack(df, :rowid, :colid, :values, operation=sum, fill=0) ==
+    @test unstack(df, :rowid, :colid, :values, valuestransform=sum, fill=0) ==
           DataFrame("rowid" => 1:2, "1" => [3, 0],
                     "2" => [7, 0], "3" => [0, 11])
-    @test unstack(df, :rowid, :colid, :values, operation=length) ≅
+    @test unstack(df, :rowid, :colid, :values, valuestransform=length) ≅
           DataFrame("rowid" => 1:2, "1" => [2, missing],
                     "2" => [2, missing], "3" => [missing, 2])
-    @test unstack(df, :rowid, :colid, :values, operation=length, fill=0) ==
+    @test unstack(df, :rowid, :colid, :values, valuestransform=length, fill=0) ==
           DataFrame("rowid" => 1:2, "1" => [2, 0],
                     "2" => [2, 0], "3" => [0, 2])
     @test unstack(df, :rowid, :colid, :values,
-                  operation=x -> isempty(x) ? missing : length(x)) ≅
+                  valuestransform=x -> isempty(x) ? missing : length(x)) ≅
           DataFrame("rowid" => 1:2, "1" => [2, missing],
                     "2" => [2, missing], "3" => [missing, 2])
     @test unstack(df, :rowid, :colid, :values,
-                  operation=x -> isempty(x) ? missing : x) ≅
+                  valuestransform=x -> isempty(x) ? missing : x) ≅
           DataFrame("rowid" => 1:2, "1" => [1:2, missing],
                     "2" => [3:4, missing], "3" => [missing, 5:6])
 
     df = DataFrame(rowid=[2, 2, 2, 2, 1, 1], colid=[2, 2, 1, 1, 3, 3], values=1:6)
-    @test unstack(df, :rowid, :colid, :values, operation=identity) ≅
+    @test unstack(df, :rowid, :colid, :values, valuestransform=identity) ≅
           DataFrame("rowid" => [2,1], "2" => [1:2, missing],
                     "1" => [3:4, missing], "3" => [missing, 5:6])
 
@@ -793,22 +793,22 @@ end
     # check correctness of row and column ordering
     for _ in 1:10
         df = DataFrame(rowid=rand(1:10, 50), colid=rand(1:10, 50), values=1:50)
-        res = unstack(df, :rowid, :colid, :values, operation=last)
+        res = unstack(df, :rowid, :colid, :values, valuestransform=last)
         @test res ≅ unstack(df, :rowid, :colid, :values, allowduplicates=true)
         @test res.rowid == unique(df.rowid)
         @test names(res, Not(1)) == string.(unique(df.colid))
-        res = unstack(df, :rowid, :colid, :values, operation=last, fill=0)
+        res = unstack(df, :rowid, :colid, :values, valuestransform=last, fill=0)
         @test res ≅ unstack(df, :rowid, :colid, :values, allowduplicates=true, fill=0)
         @test res.rowid == unique(df.rowid)
         @test names(res, Not(1)) == string.(unique(df.colid))
 
         df.rowid=categorical(df.rowid, levels=shuffle(unique(df.rowid)))
         df.colid=categorical(df.colid, levels=shuffle(unique(df.colid)))
-        res = unstack(df, :rowid, :colid, :values, operation=last)
+        res = unstack(df, :rowid, :colid, :values, valuestransform=last)
         @test res ≅ unstack(df, :rowid, :colid, :values, allowduplicates=true)
         @test unwrap.(res.rowid) == unique(df.rowid)
         @test names(res, Not(1)) == string.(unique(df.colid))
-        res = unstack(df, :rowid, :colid, :values, operation=last, fill=0)
+        res = unstack(df, :rowid, :colid, :values, valuestransform=last, fill=0)
         @test res ≅
             unstack(df, :rowid, :colid, :values, allowduplicates=true, fill=0)
         @test unwrap.(res.rowid) == unique(df.rowid)

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -737,13 +737,13 @@ end
     df = DataFrame(x=[:one, :two, :one], y=[1, 2, 3])
     @test_throws ArgumentError unstack(df, :x, :y)
     @test unstack(df, :x, :y, allowduplicates=true) == DataFrame(one=3, two=2)
-    @test unstack(df, :x, :y, allowduplicates=identity) ==
+    @test unstack(df, :x, :y, operation=identity) ==
           DataFrame(one=[[1, 3]], two=[[2]])
-    @test unstack(df, :x, :y, allowduplicates=last) ==
+    @test unstack(df, :x, :y, operation=last) ==
           DataFrame(one=3, two=2)
-    @test unstack(df, :x, :y, allowduplicates=first) ==
+    @test unstack(df, :x, :y, operation=first) ==
           DataFrame(one=1, two=2)
-    @test unstack(df, :x, :y, allowduplicates=length) ==
+    @test unstack(df, :x, :y, operation=length) ==
           DataFrame(one=2, two=1)
 end
 
@@ -756,36 +756,36 @@ end
     @test unstack(df, :rowid, :colid, :values, allowduplicates=true, fill=0) ==
           DataFrame("rowid" => 1:2, "1" => [2, 0],
                     "2" => [4, 0], "3" => [0, 6])
-    @test unstack(df, :rowid, :colid, :values, allowduplicates=identity) ≅
+    @test unstack(df, :rowid, :colid, :values, operation=identity) ≅
           DataFrame("rowid" => 1:2, "1" => [1:2, missing],
                     "2" => [3:4, missing], "3" => [missing, 5:6])
     @test unstack(df, :rowid, :colid, :values,
-                  allowduplicates=identity, fill=Int[]) ==
+                  operation=identity, fill=Int[]) ==
           DataFrame("rowid" => 1:2, "1" => [1:2, []],
                     "2" => [3:4, []], "3" => [[], 5:6])
-    @test unstack(df, :rowid, :colid, :values, allowduplicates=sum) ≅
+    @test unstack(df, :rowid, :colid, :values, operation=sum) ≅
           DataFrame("rowid" => 1:2, "1" => [3, missing],
                     "2" => [7, missing], "3" => [missing, 11])
-    @test unstack(df, :rowid, :colid, :values, allowduplicates=sum, fill=0) ==
+    @test unstack(df, :rowid, :colid, :values, operation=sum, fill=0) ==
           DataFrame("rowid" => 1:2, "1" => [3, 0],
                     "2" => [7, 0], "3" => [0, 11])
-    @test unstack(df, :rowid, :colid, :values, allowduplicates=length) ≅
+    @test unstack(df, :rowid, :colid, :values, operation=length) ≅
           DataFrame("rowid" => 1:2, "1" => [2, missing],
                     "2" => [2, missing], "3" => [missing, 2])
-    @test unstack(df, :rowid, :colid, :values, allowduplicates=length, fill=0) ==
+    @test unstack(df, :rowid, :colid, :values, operation=length, fill=0) ==
           DataFrame("rowid" => 1:2, "1" => [2, 0],
                     "2" => [2, 0], "3" => [0, 2])
     @test unstack(df, :rowid, :colid, :values,
-                  allowduplicates=x -> isempty(x) ? missing : length(x)) ≅
+                  operation=x -> isempty(x) ? missing : length(x)) ≅
           DataFrame("rowid" => 1:2, "1" => [2, missing],
                     "2" => [2, missing], "3" => [missing, 2])
     @test unstack(df, :rowid, :colid, :values,
-                  allowduplicates=x -> isempty(x) ? missing : x) ≅
+                  operation=x -> isempty(x) ? missing : x) ≅
           DataFrame("rowid" => 1:2, "1" => [1:2, missing],
                     "2" => [3:4, missing], "3" => [missing, 5:6])
 
     df = DataFrame(rowid=[2, 2, 2, 2, 1, 1], colid=[2, 2, 1, 1, 3, 3], values=1:6)
-    @test unstack(df, :rowid, :colid, :values, allowduplicates=identity) ≅
+    @test unstack(df, :rowid, :colid, :values, operation=identity) ≅
           DataFrame("rowid" => [2,1], "2" => [1:2, missing],
                     "1" => [3:4, missing], "3" => [missing, 5:6])
 
@@ -793,22 +793,22 @@ end
     # check correctness of row and column ordering
     for _ in 1:10
         df = DataFrame(rowid=rand(1:10, 50), colid=rand(1:10, 50), values=1:50)
-        res = unstack(df, :rowid, :colid, :values, allowduplicates=last)
+        res = unstack(df, :rowid, :colid, :values, operation=last)
         @test res ≅ unstack(df, :rowid, :colid, :values, allowduplicates=true)
         @test res.rowid == unique(df.rowid)
         @test names(res, Not(1)) == string.(unique(df.colid))
-        res = unstack(df, :rowid, :colid, :values, allowduplicates=last, fill=0)
+        res = unstack(df, :rowid, :colid, :values, operation=last, fill=0)
         @test res ≅ unstack(df, :rowid, :colid, :values, allowduplicates=true, fill=0)
         @test res.rowid == unique(df.rowid)
         @test names(res, Not(1)) == string.(unique(df.colid))
 
         df.rowid=categorical(df.rowid, levels=shuffle(unique(df.rowid)))
         df.colid=categorical(df.colid, levels=shuffle(unique(df.colid)))
-        res = unstack(df, :rowid, :colid, :values, allowduplicates=last)
+        res = unstack(df, :rowid, :colid, :values, operation=last)
         @test res ≅ unstack(df, :rowid, :colid, :values, allowduplicates=true)
         @test unwrap.(res.rowid) == unique(df.rowid)
         @test names(res, Not(1)) == string.(unique(df.colid))
-        res = unstack(df, :rowid, :colid, :values, allowduplicates=last, fill=0)
+        res = unstack(df, :rowid, :colid, :values, operation=last, fill=0)
         @test res ≅
             unstack(df, :rowid, :colid, :values, allowduplicates=true, fill=0)
         @test unwrap.(res.rowid) == unique(df.rowid)

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -769,6 +769,9 @@ end
     @test unstack(df, :rowid, :colid, :values, valuestransform=sum, fill=0) ==
           DataFrame("rowid" => 1:2, "1" => [3, 0],
                     "2" => [7, 0], "3" => [0, 11])
+    @test unstack(df, :rowid, :colid, :values, valuestransform=sum, fill="X") ==
+          DataFrame("rowid" => 1:2, "1" => [3, "X"],
+                    "2" => [7, "X"], "3" => ["X", 11])
     @test unstack(df, :rowid, :colid, :values, valuestransform=length) ≅
           DataFrame("rowid" => 1:2, "1" => [2, missing],
                     "2" => [2, missing], "3" => [missing, 2])
@@ -788,6 +791,9 @@ end
     @test unstack(df, :rowid, :colid, :values, valuestransform=identity) ≅
           DataFrame("rowid" => [2,1], "2" => [1:2, missing],
                     "1" => [3:4, missing], "3" => [missing, 5:6])
+    @test unstack(df, :rowid, :colid, :values, valuestransform=identity, fill="X") ==
+          DataFrame("rowid" => [2,1], "2" => [1:2, "X"],
+                    "1" => [3:4, "X"], "3" => ["X", 5:6])
 
     Random.seed!(1234)
     # check correctness of row and column ordering


### PR DESCRIPTION
Follow up to https://github.com/JuliaData/DataFrames.jl/pull/2995
Replaces https://github.com/JuliaData/DataFrames.jl/pull/1181

What I would discuss if `allowduplicates` is a good name for this keyword argument now. Maybe we should introduce a new keyword argument (a single one) and deprecate `allowduplicates` (in a long term deprecation fashion i.e. we do need to remove it any time soon)