### PR TITLE
Improved error when column numbers do not match in transformations

### DIFF
--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -592,8 +592,9 @@ function _gen_colnames(@nospecialize(res), newname::Union{AbstractVector{Symbol}
 
     if newname !== AsTable && newname !== nothing
         if length(colnames) != length(newname)
-            throw(ArgumentError("Number of returned columns does not match the " *
-                                "length of requested output"))
+            throw(ArgumentError("Number of returned columns is $(length(colnames)) " *
+                                "and it does not match the length of requested " *
+                                "output which is $(length(newname))"))
         end
         colnames = newname
     end

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -593,8 +593,8 @@ function _gen_colnames(@nospecialize(res), newname::Union{AbstractVector{Symbol}
     if newname !== AsTable && newname !== nothing
         if length(colnames) != length(newname)
             throw(ArgumentError("Number of returned columns is $(length(colnames)) " *
-                                "and it does not match the length of requested " *
-                                "output which is $(length(newname))"))
+                                "and it does not match the number of provided output " *
+                                "names which is $(length(newname))"))
         end
         colnames = newname
     end

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -438,8 +438,9 @@ function _combine_process_pair_astable(optional_i::Bool,
     end
     if out_col_name isa AbstractVector{Symbol}
         if length(out_col_name) != length(nms)
-            throw(ArgumentError("Number of returned columns does not " *
-                                "match the length of requested output"))
+            throw(ArgumentError("Number of returned columns is $(length(nms)) " *
+                    "and it does not match the length of requested " *
+                    "output which is $(length(out_col_name))"))
         else
             nms = out_col_name
         end

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -439,8 +439,8 @@ function _combine_process_pair_astable(optional_i::Bool,
     if out_col_name isa AbstractVector{Symbol}
         if length(out_col_name) != length(nms)
             throw(ArgumentError("Number of returned columns is $(length(nms)) " *
-                    "and it does not match the length of requested " *
-                    "output which is $(length(out_col_name))"))
+                                "and it does not match the number of provided output " *
+                                "names which is $(length(out_col_name))"))
         else
             nms = out_col_name
         end

--- a/test/select.jl
+++ b/test/select.jl
@@ -2696,4 +2696,15 @@ end
     @test allunique(df2.y)
 end
 
+@testset "improved error message when numbers requested and returned columns does not match" begin
+    df = DataFrame(id=1:2, a=[(a=1,b=2),(a=3,b=4)])
+    gdf = groupby(df, :id)
+    @test_throws ArgumentError select(df, :a => [:x])
+    @test_throws ArgumentError select(gdf, :a => [:x])
+    @test select(df, :id, :a => [:x, :y]) == DataFrame(id=1:2, x=[1, 3], y=[2, 4])
+    @test select(gdf, :a => [:x, :y]) == DataFrame(id=1:2, x=[1, 3], y=[2, 4])
+    @test_throws ArgumentError select(df, :a => [:x, :y, :z])
+    @test_throws ArgumentError select(gdf, :a => [:x, :y, :z])
+end
+
 end # module


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2959

Example:
```
julia> df = DataFrame(id=1:2, a=[(a=1,b=2),(a=3,b=4)])
2×2 DataFrame
 Row │ id     a
     │ Int64  NamedTup…      
─────┼───────────────────────
   1 │     1  (a = 1, b = 2)
   2 │     2  (a = 3, b = 4)

julia> gdf = groupby(df, :id)
GroupedDataFrame with 2 groups based on key: id
First Group (1 row): id = 1
 Row │ id     a
     │ Int64  NamedTup…      
─────┼───────────────────────
   1 │     1  (a = 1, b = 2)
⋮
Last Group (1 row): id = 2
 Row │ id     a
     │ Int64  NamedTup…      
─────┼───────────────────────
   1 │     2  (a = 3, b = 4)

julia> select(df, :a => [:x])
ERROR: ArgumentError: Number of returned columns is 2 and it does not match the length of requested output which is 1

julia> select(gdf, :a => [:x])
ERROR: ArgumentError: Number of returned columns is 2 and it does not match the length of requested output which is 1

julia> select(df, :id, :a => [:x, :y])
2×3 DataFrame
 Row │ id     x      y     
     │ Int64  Int64  Int64
─────┼─────────────────────
   1 │     1      1      2
   2 │     2      3      4

julia> select(gdf, :a => [:x, :y])
2×3 DataFrame
 Row │ id     x      y     
     │ Int64  Int64  Int64
─────┼─────────────────────
   1 │     1      1      2
   2 │     2      3      4

julia> select(df, :a => [:x, :y, :z])
ERROR: ArgumentError: Number of returned columns is 2 and it does not match the length of requested output which is 3

julia> select(gdf, :a => [:x, :y, :z])
ERROR: ArgumentError: Number of returned columns is 2 and it does not match the length of requested output which is 3
```