### PR TITLE
avoid categorical promotion

### DIFF
--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -972,10 +972,10 @@ end
 end
 
 @testset "test categorical values" begin
-    for v in [categorical([1, 2, 3]), categorical([1, 2, missing]),
-              categorical([missing, 1, 2]),
-              categorical(["1", "2", "3"]), categorical(["1", "2", missing]),
-              categorical([missing, "1", "2"])]
+    for v in Any[categorical([1, 2, 3]), categorical([1, 2, missing]),
+                 categorical([missing, 1, 2]),
+                 categorical(["1", "2", "3"]), categorical(["1", "2", missing]),
+                 categorical([missing, "1", "2"])]
         df = copy(refdf)
         df[!, :c1] .= v
         @test df.c1 ≅ v

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -1199,8 +1199,8 @@ end
         @test isa(df[!, 1], Vector{Int}) && isa(df[!, 2], Vector{Int})
     end
 
-    df = DataFrame([CategoricalArray(1:10),
-                    CategoricalArray(string.('a':'j'))], :auto)
+    df = DataFrame(Any[CategoricalArray(1:10),
+                       CategoricalArray(string.('a':'j'))], :auto)
     @test allowmissing!(df) === df
     @test all(x->x <: CategoricalVector, typeof.(eachcol(df)))
     @test eltype(df[!, 1]) <: Union{CategoricalValue{Int}, Missing}

--- a/test/join.jl
+++ b/test/join.jl
@@ -967,16 +967,16 @@ end
     @test_throws AssertionError OnCol(c1, [1])
     @test_throws MethodError OnCol(c1, 1)
 
-    oncols = [OnCol(c1, c2), OnCol(c3, c4), OnCol(c5, c6), OnCol(c1, c2, c3),
-              OnCol(c2, c3, c4), OnCol(c4, c5, c6), OnCol(c1, c2, c3, c4),
-              OnCol(c2, c3, c4, c5), OnCol(c3, c4, c5, c6), OnCol(c1, c2, c3, c4, c5),
-              OnCol(c2, c3, c4, c5, c6), OnCol(c1, c2, c3, c4, c5, c6),
-              OnCol(c4, c7), OnCol(c4, c5, c7), OnCol(c4, c5, c6, c7)]
-    tupcols = [tuple.(c1, c2), tuple.(c3, c4), tuple.(c5, c6), tuple.(c1, c2, c3),
-               tuple.(c2, c3, c4), tuple.(c4, c5, c6), tuple.(c1, c2, c3, c4),
-               tuple.(c2, c3, c4, c5), tuple.(c3, c4, c5, c6), tuple.(c1, c2, c3, c4, c5),
-               tuple.(c2, c3, c4, c5, c6), tuple.(c1, c2, c3, c4, c5, c6),
-               tuple.(c4, c7), tuple.(c4, c5, c7), tuple.(c4, c5, c6, c7)]
+    oncols = Any[OnCol(c1, c2), OnCol(c3, c4), OnCol(c5, c6), OnCol(c1, c2, c3),
+                 OnCol(c2, c3, c4), OnCol(c4, c5, c6), OnCol(c1, c2, c3, c4),
+                 OnCol(c2, c3, c4, c5), OnCol(c3, c4, c5, c6), OnCol(c1, c2, c3, c4, c5),
+                 OnCol(c2, c3, c4, c5, c6), OnCol(c1, c2, c3, c4, c5, c6),
+                 OnCol(c4, c7), OnCol(c4, c5, c7), OnCol(c4, c5, c6, c7)]
+    tupcols = Any[tuple.(c1, c2), tuple.(c3, c4), tuple.(c5, c6), tuple.(c1, c2, c3),
+                  tuple.(c2, c3, c4), tuple.(c4, c5, c6), tuple.(c1, c2, c3, c4),
+                  tuple.(c2, c3, c4, c5), tuple.(c3, c4, c5, c6), tuple.(c1, c2, c3, c4, c5),
+                  tuple.(c2, c3, c4, c5, c6), tuple.(c1, c2, c3, c4, c5, c6),
+                  tuple.(c4, c7), tuple.(c4, c5, c7), tuple.(c4, c5, c6, c7)]
 
     for (oncol, tupcol) in zip(oncols, tupcols)
         @test issorted(oncol) == issorted(tupcol)

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -126,7 +126,7 @@ end
                             Union{Int, Missing}[4, 8]], [:id, :a, :b, :c, :d])
     @test isa(udf[!, 1], Vector{Int})
     @test all(i -> isa(eachcol(udf)[i], Vector{Union{Int, Missing}}), 2:5)
-    df = DataFrame([categorical(repeat(1:2, inner=4)),
+    df = DataFrame(Any[categorical(repeat(1:2, inner=4)),
                        categorical(repeat('a':'d', outer=2)), categorical(1:8)],
                    [:id, :variable, :value])
     udf = unstack(df, :variable, :value)


### PR DESCRIPTION
Avoids issues in tests caused by `CategoricalVector` promotion rules.