### PR TITLE
Use cycle notation to speed up `permute!`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@
 * Add `fillcombinations` function that generates all combinations of
   levels of selected columns of a data frame
   ([#3012](https://github.com/JuliaData/DataFrames.jl/issues/3012))
-* Guarantee that permute! and invpermute! throw on invalid input
+* Guarantee that `permute!` and `invpermute!` throw on invalid input
   ([#3035](https://github.com/JuliaData/DataFrames.jl/pull/3035))
 
 ## Previously announced breaking changes
@@ -38,7 +38,7 @@
 
 ## Performance
 
-* Speed up permute! and invpermute! (and therefore sort!) 2x-8x 
+* Speed up `permute!` and `invpermute!` (and therefore sort!) 2x-8x 
   for large tables by using cycle notation
   ([#3035](https://github.com/JuliaData/DataFrames.jl/pull/3035))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
 
 ## Performance
 
-* Speed up `permute!` and `invpermute!` (and therefore sort!) 2x-8x 
+* Speed up `permute!` and `invpermute!` (and therefore sorting) 2x-8x 
   for large tables by using cycle notation
   ([#3035](https://github.com/JuliaData/DataFrames.jl/pull/3035))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,8 @@
 * Add `fillcombinations` function that generates all combinations of
   levels of selected columns of a data frame
   ([#3012](https://github.com/JuliaData/DataFrames.jl/issues/3012))
+* Guarantee that permute! and invpermute! throw on invalid input
+  ([#3035](https://github.com/JuliaData/DataFrames.jl/pull/3035))
 
 ## Previously announced breaking changes
 
@@ -33,6 +35,12 @@
   into an existing column of a data frame replaces it. Under Julia 1.6
   or older it is an in place operation.
   ([#3022](https://github.com/JuliaData/DataFrames.jl/pull/3022)
+
+## Performance
+
+* Speed up permute! and invpermute! (and therefore sort!) 2x-8x 
+  for large tables by using cycle notation
+  ([#3035](https://github.com/JuliaData/DataFrames.jl/pull/3035))
 
 # DataFrames.jl v1.3.2 Patch Release Notes
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2654,7 +2654,7 @@ Like [`permute!`](@ref), but the inverse of the given permutation is applied.
 `invpermute!` will produce a correct result even if some columns of passed data
 frame or permutation `p` are identical (checked with `===`). Otherwise, if two
 columns share some part of memory but are not identical (e.g. are different views
-of the same parent vector) then `permute!` result might be incorrect.
+of the same parent vector) then `invpermute!` result might be incorrect.
 
 # Examples
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2525,7 +2525,9 @@ end
 
 function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.invpermute!!)},
                               df::AbstractDataFrame, p::AbstractVector{<:Integer})
-    nrow(df) != length(p) && throw(DimensionMismatch("Permutation does not have a correct length ($(nrow(df)) != $(length(p)))"))
+    nrow(df) != length(p) &&
+        throw(DimensionMismatch("Permutation does not have a correct length " *
+                                "(expected $(nrow(df)) but got $(length(p)))"))
     
     cp = _compile_permutation!(Base.copymutable(p))
 
@@ -2587,7 +2589,7 @@ end
 
 # Permute a vector `v` based on a permutation `p` listed in zero terminated
 # cycle notation. For example, the permutation 1 -> 2, 2 -> 3, 3 -> 1, 4 -> 6,
-# 5 -> 5, 6 -> 4 is traditionaly expressed as [2, 3, 1, 6, 5, 4] but in cycle
+# 5 -> 5, 6 -> 4 is traditionally expressed as [2, 3, 1, 6, 5, 4] but in cycle
 # notation is expressed as [1, 2, 3, 0, 4, 6, 0]
 function _cycle_permute!(v::AbstractVector, p::AbstractVector{<:Integer})
     i = firstindex(p)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2563,26 +2563,26 @@ function _compile_permutation!(p::AbstractVector{<:Integer})
     count = length(p)
     @inbounds while count > 0
         start = findnext(!iszero, p, start + 1)
-        start isa Int || throw(ArgumentError("Not a permutation"))
+        start isa Int || throw(ArgumentError("Passed vector p is not a valid permutation"))
         last_k = p[start]
         count -= 1
         last_k == start && continue
         out_len += 1
         out[out_len] = last_k
         p[start] = 0
-        start <= last_k <= length(p) || throw(ArgumentError("Not a permutation"))
+        start <= last_k <= length(p) || throw(ArgumentError("Passed vector p is not a valid permutation"))
         out_len += 1
         k = out[out_len] = p[last_k]
         while true
             count -= 1
             p[last_k] = 0
             last_k = k
-            start <= k <= length(p) || throw(ArgumentError("Not a permutation"))
+            start <= k <= length(p) || throw(ArgumentError("Passed vector p is not a valid permutation"))
             out_len += 1
             k = out[out_len] = p[k]
             k == 0 && break
         end
-        last_k == start  || throw(ArgumentError("Not a permutation"))
+        last_k == start  || throw(ArgumentError("Passed vector p is not a valid permutation"))
     end
     return resize!(out, out_len)
 end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2555,12 +2555,12 @@ end
 # destroying the original permutation in the process.
 function _compile_permutation!(p::AbstractVector{<:Integer})
     Base.require_one_based_indexing(p)
-    out = similar(p, 3length(p)÷2)
+    out = similar(p, 3 * length(p) ÷ 2)
     out_len = 0
     start = 0
     count = length(p)
     @inbounds while count > 0
-        start = findnext(!iszero, p, start+1)
+        start = findnext(!iszero, p, start + 1)
         start isa Int || throw(ArgumentError("Not a permutation"))
         k = p[start]
         count -= 1
@@ -2579,7 +2579,7 @@ function _compile_permutation!(p::AbstractVector{<:Integer})
             k == 0 && break # or k < start+1
         end
     end
-    resize!(out, out_len)
+    return resize!(out, out_len)
 end
 
 # permute a vector `v` based on a permutation `p` listed in cycle notation
@@ -2598,7 +2598,7 @@ function _cycle_permute!(v::AbstractVector, p::AbstractVector{<:Integer})
         v[last_p_i] = start
         i += 1
     end
-    v
+    return v
 end
 
 """

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2532,9 +2532,7 @@ function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.inv
     isempty(cp) && return df
 
     if fun === Base.invpermute!! 
-        pop!(cp)
-        reverse!(cp)
-        push!(cp, 0)
+        reverse!(@view cp[1:end-1])
     end
 
     seen_cols = IdDict{Any, Nothing}()

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2531,11 +2531,14 @@ function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.inv
         if haskey(seen_cols, col)
             push!(toskip, i)
         else
+            checkbounds(col, eachindex(p))
             seen_cols[col] = nothing
         end
     end
 
     cp = _compile_permutation!(Base.copymutable(p))
+
+    isempty(cp) && return df
 
     if fun === Base.invpermute!! 
         pop!(cp)
@@ -2545,7 +2548,6 @@ function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.inv
 
     for (i, col) in enumerate(eachcol(df))
         if !(i in toskip)
-            checkbounds(col, eachindex(p))
             _cycle_permute!(col, cp)
         end
     end

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2552,8 +2552,10 @@ function _compile_permutation!(p::AbstractVector{<:Integer})
     firstindex(p) == 1 || 
         throw(ArgumentError("Permutation vectors must have 1-based indexing"))
     # this length is sufficient because we do not record 1-cycles,
-    # so the worst case is all 2-cycles.
-    out = similar(p, 3 * length(p) ÷ 2) 
+    # so the worst case is all 2-cycles. One extra element gives the
+    # algorithm leeway to defer error detection without unsafe reads.
+    # trace _compile_permutation!([3,3,1]) for example.
+    out = similar(p, 3 * length(p) ÷ 2 + 1)
     out_len = 0
     start = 0
     count = length(p)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2592,7 +2592,7 @@ end
 # Permute a vector `v` based on a permutation `p` listed in zero terminated
 # cycle notation. For example, the permutation 1 -> 2, 2 -> 3, 3 -> 1, 4 -> 6,
 # 5 -> 5, 6 -> 4 is traditionaly expressed as [2, 3, 1, 6, 5, 4] but in cycle
-# notation is expressed as [1, 2, 3, 0, 4, 6, 0] (or [1, 2, 3, 0, 4, 6, 0, 5, 0])
+# notation is expressed as [1, 2, 3, 0, 4, 6, 0]
 function _cycle_permute!(v::AbstractVector, p::AbstractVector{<:Integer})
     i = firstindex(p)
     @inbounds while i < lastindex(p)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2551,8 +2551,8 @@ function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.inv
     return df
 end
 
-# convert a classical permutation to cycle notation, 
-# zeroing the original permutation in the process.
+# convert a classical permutation to zero terminated cycle 
+# notation, zeroing the original permutation in the process.
 function _compile_permutation!(p::AbstractVector{<:Integer})
     firstindex(p) == 1 || 
         throw(ArgumentError("Permutation vectors must have 1-based indexing"))
@@ -2588,7 +2588,10 @@ function _compile_permutation!(p::AbstractVector{<:Integer})
     return resize!(out, out_len)
 end
 
-# permute a vector `v` based on a permutation `p` listed in cycle notation
+# Permute a vector `v` based on a permutation `p` listed in zero terminated
+# cycle notation. For example, the permutation 1 -> 2, 2 -> 3, 3 -> 1, 4 -> 6,
+# 5 -> 5, 6 -> 4 is traditionaly expressed as [2, 3, 1, 6, 5, 4] but in cycle
+# notation is expressed as [1, 2, 3, 0, 4, 6, 0] (or [1, 2, 3, 0, 4, 6, 0, 5, 0])
 function _cycle_permute!(v::AbstractVector, p::AbstractVector{<:Integer})
     i = firstindex(p)
     @inbounds while i < lastindex(p)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2525,7 +2525,7 @@ end
 
 function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.invpermute!!)},
                               df::AbstractDataFrame, p::AbstractVector{<:Integer})
-    length(p) <= nrow(df) || throw(ArgumentError("Permutation is too long"))
+    length(p) == nrow(df) || throw(ArgumentError("Permutation is too long"))
     
     cp = _compile_permutation!(Base.copymutable(p))
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2617,8 +2617,7 @@ end
 Permute data frame `df` in-place, according to permutation `p`.
 Throws `ArgumentError` if `p` is not a permutation.
 
-To return a new data frame instead of permuting `df` in-place, use `df[p]`.
-Note that this is generally faster than `permute!(df, p)` for large data frames.
+To return a new data frame instead of permuting `df` in-place, use `df[p, :]`.
 
 `permute!` will produce a correct result even if some columns of passed data frame
 or permutation `p` are identical (checked with `===`). Otherwise, if two columns share

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2525,7 +2525,7 @@ end
 
 function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.invpermute!!)},
                               df::AbstractDataFrame, p::AbstractVector{<:Integer})
-    length(p) == nrow(df) || throw(ArgumentError("Permutation is too long"))
+    length(p) == nrow(df) || throw(ArgumentError("Permutation does not have a correct length"))
     
     cp = _compile_permutation!(Base.copymutable(p))
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2533,10 +2533,6 @@ function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.inv
         else
             seen_cols[col] = nothing
         end
-        # p might be a column of df so we make sure we unalias
-        if col === p
-            p = copy(p)
-        end
     end
 
     cp = _compile_permutation!(Base.copymutable(p))

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2525,7 +2525,7 @@ end
 
 function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.invpermute!!)},
                               df::AbstractDataFrame, p::AbstractVector{<:Integer})
-    length(p) == nrow(df) || throw(ArgumentError("Permutation does not have a correct length"))
+    nrow(df) != length(p) && throw(DimensionMismatch("Permutation does not have a correct length ($(nrow(df)) != $(length(p)))"))
     
     cp = _compile_permutation!(Base.copymutable(p))
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2570,7 +2570,7 @@ function _compile_permutation!(p::AbstractVector{<:Integer})
         out_len += 1
         out[out_len] = last_k
         p[start] = 0
-        start <= last_k <= length(p) || throw(ArgumentError("Passed vector p is not a valid permutation"))
+        start < last_k <= length(p) || throw(ArgumentError("Passed vector p is not a valid permutation"))
         out_len += 1
         k = out[out_len] = p[last_k]
         while true
@@ -2582,7 +2582,7 @@ function _compile_permutation!(p::AbstractVector{<:Integer})
             k = out[out_len] = p[k]
             k == 0 && break
         end
-        last_k == start  || throw(ArgumentError("Passed vector p is not a valid permutation"))
+        last_k == start || throw(ArgumentError("Passed vector p is not a valid permutation"))
     end
     return resize!(out, out_len)
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2166,10 +2166,11 @@ end
     @test df2 == dfc
 
     @test DataFrame(x=[17]) == invpermute!(DataFrame(x=[17]), [1])
-    
+
     @test_throws DimensionMismatch("Permutation does not have a correct length (5 != 6)") permute!(df, [1, 4, 3, 2, 5, 6])
     @test_throws DimensionMismatch("Permutation does not have a correct length (5 != 3)") permute!(df, [1, 3, 2])
     @test_throws ArgumentError("Not a permutation") permute!(df, [4, 4, 2, 5, 3])
+    @test_throws ArgumentError("Not a permutation") DataFrames._compile_permutation!([3, 3, 1])
     @test_throws ArgumentError("Permutation vectors must have 1-based indexing") invpermute!(df, OffsetArray([5,4,7,8,6], 4:8))
 end
 
@@ -2187,7 +2188,7 @@ end
                     @test_throws DimensionMismatch("Permutation does not have a correct length ($len != $perm_len)") permute!(df, p)
                     @test_throws DimensionMismatch("Permutation does not have a correct length ($len != $perm_len)") invpermute!(df, p)
                 elseif sort(p) != collect(1:perm_len)
-                    if perm_len <= 4 || rand() < .005
+                    if perm_len <= 5 || rand() < .01
                         @test_throws ArgumentError("Not a permutation") permute!(df, p)
                         @test_throws ArgumentError("Not a permutation") invpermute!(df, p)
                     end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2163,6 +2163,11 @@ end
     @test dfv == dfc[[3, 1, 2, 4], :]
     @test invpermute!(dfv, dfv.d) === dfv
     @test df2 == dfc
+
+    @test_throws BoundsError permute!(df, [1, 4, 3, 2, 5, 6])
+    @test_throws ArgumentError("Not a permutation") permute!(df, [1, 1])
+    @test_throws ArgumentError("Not a permutation") permute!(df, [2, 2])
+    @test_throws ArgumentError("Not a permutation") permute!(df, [4, 4, 2, 5, 3])
 end
 
 @testset "shuffle, shuffle!" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2167,11 +2167,11 @@ end
 
     @test DataFrame(x=[17]) == invpermute!(DataFrame(x=[17]), [1])
 
-    @test_throws DimensionMismatch("Permutation does not have a correct length (5 != 6)") permute!(df, [1, 4, 3, 2, 5, 6])
-    @test_throws DimensionMismatch("Permutation does not have a correct length (5 != 3)") permute!(df, [1, 3, 2])
-    @test_throws ArgumentError("Not a permutation") permute!(df, [4, 4, 2, 5, 3])
-    @test_throws ArgumentError("Not a permutation") DataFrames._compile_permutation!([3, 3, 1])
-    @test_throws ArgumentError("Permutation vectors must have 1-based indexing") invpermute!(df, OffsetArray([5,4,7,8,6], 4:8))
+    @test_throws DimensionMismatch permute!(df, [1, 4, 3, 2, 5, 6])
+    @test_throws DimensionMismatch permute!(df, [1, 3, 2])
+    @test_throws ArgumentError permute!(df, [4, 4, 2, 5, 3])
+    @test_throws ArgumentError DataFrames._compile_permutation!([3, 3, 1])
+    @test_throws ArgumentError invpermute!(df, OffsetArray([5,4,7,8,6], 4:8))
 end
 
 @testset "exhaustive permute!, invpermute!" begin
@@ -2185,12 +2185,12 @@ end
                 digits!(p, i, base=perm_len+3)
                 p .-= 2
                 if perm_len != len
-                    @test_throws DimensionMismatch("Permutation does not have a correct length ($len != $perm_len)") permute!(df, p)
-                    @test_throws DimensionMismatch("Permutation does not have a correct length ($len != $perm_len)") invpermute!(df, p)
+                    @test_throws DimensionMismatch permute!(df, p)
+                    @test_throws DimensionMismatch invpermute!(df, p)
                 elseif sort(p) != collect(1:perm_len)
                     if perm_len <= 5 || rand() < 0.01
-                        @test_throws ArgumentError("Not a permutation") permute!(df, p)
-                        @test_throws ArgumentError("Not a permutation") invpermute!(df, p)
+                        @test_throws ArgumentError permute!(df, p)
+                        @test_throws ArgumentError invpermute!(df, p)
                     end
                 else
                     @test df[p, :] == permute!(df, p)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2170,6 +2170,38 @@ end
     @test_throws ArgumentError("Not a permutation") permute!(df, [4, 4, 2, 5, 3])
 end
 
+@testset "exhaustive permute!, invpermute!" begin
+    for len in 0:6
+        df = DataFrame([rand(len) for _ in 1:3], :auto)
+        df0 = copy(df)
+        for perm_len in 0:min(6, len+1)
+            p = fill(0, perm_len)
+            for i in 0:(perm_len+3)^perm_len
+                digits!(p, i, base=perm_len+3)
+                p .-= 2
+                if perm_len > len
+                    if len < 4
+                        @test_throws BoundsError permute!(df, p)
+                        @test_throws BoundsError invpermute!(df, p)
+                    end
+                elseif sort(p) != collect(1:perm_len)
+                    if len < 5
+                        @test_throws ArgumentError("Not a permutation") permute!(df, p)
+                        @test_throws ArgumentError("Not a permutation") invpermute!(df, p)
+                    end
+                else
+                    p2 = copy(p)
+                    while length(p2) < len
+                        push!(p2, length(p2)+1)
+                    end
+                    @test df[p2, :] == permute!(df, p)
+                    @test df0 == invpermute!(df, p)
+                end
+            end
+        end
+    end
+end
+
 @testset "shuffle, shuffle!" begin
     refdf = DataFrame(a=1:5, b=11:15)
     refdf.c = refdf.a

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -3,6 +3,7 @@ module TestDataFrame
 using Dates, DataFrames, Statistics, Random, Test, Logging, DataStructures,
       CategoricalArrays
 using DataFrames: _columns, index
+using OffsetArrays: OffsetArray
 const ≅ = isequal
 const ≇ = !isequal
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2164,10 +2164,13 @@ end
     @test invpermute!(dfv, dfv.d) === dfv
     @test df2 == dfc
 
-    @test_throws BoundsError permute!(df, [1, 4, 3, 2, 5, 6])
+    @test df == invpermute!(copy(df), [1])
+    
+    @test_throws ArgumentError("Permutation is too long") permute!(df, [1, 4, 3, 2, 5, 6])
     @test_throws ArgumentError("Not a permutation") permute!(df, [1, 1])
     @test_throws ArgumentError("Not a permutation") permute!(df, [2, 2])
     @test_throws ArgumentError("Not a permutation") permute!(df, [4, 4, 2, 5, 3])
+    @test_throws ArgumentError("Permutation vectors must have 1-based indexing") invpermute!(df, OffsetArray([5,4], 4:5))
 end
 
 @testset "exhaustive permute!, invpermute!" begin
@@ -2181,8 +2184,8 @@ end
                 p .-= 2
                 if perm_len > len
                     if len < 4
-                        @test_throws BoundsError permute!(df, p)
-                        @test_throws BoundsError invpermute!(df, p)
+                        @test_throws ArgumentError("Permutation is too long") permute!(df, p)
+                        @test_throws ArgumentError("Permutation is too long") invpermute!(df, p)
                     end
                 elseif sort(p) != collect(1:perm_len)
                     if len < 5

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2174,6 +2174,7 @@ end
 end
 
 @testset "exhaustive permute!, invpermute!" begin
+    Random.seed!(1729)
     for perm_len in 0:6
         p = fill(0, perm_len)
         for len in (perm_len > 4 ? [perm_len] : (max(0, perm_len-1):perm_len+1))

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2208,6 +2208,10 @@ end
         dfc = copy(df)
         @test df[p, :] == permute!(df, p)
         @test dfc == invpermute!(df, p)
+        df = DataFrame([v, v, rand(len), v], :auto, copycols=false)
+        dfc = copy(df)
+        @test df[p, :] == permute!(df, p)
+        @test dfc == invpermute!(df, p)
     end
 end
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2188,7 +2188,7 @@ end
                     @test_throws DimensionMismatch("Permutation does not have a correct length ($len != $perm_len)") permute!(df, p)
                     @test_throws DimensionMismatch("Permutation does not have a correct length ($len != $perm_len)") invpermute!(df, p)
                 elseif sort(p) != collect(1:perm_len)
-                    if perm_len <= 5 || rand() < .01
+                    if perm_len <= 5 || rand() < 0.01
                         @test_throws ArgumentError("Not a permutation") permute!(df, p)
                         @test_throws ArgumentError("Not a permutation") invpermute!(df, p)
                     end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2166,6 +2166,7 @@ end
     @test df2 == dfc
 
     @test DataFrame(x=[17]) == invpermute!(DataFrame(x=[17]), [1])
+    @test DataFrame(x=[17, 29]) == invpermute!(DataFrame(x=[29, 17]), [2, 1])
 
     @test_throws DimensionMismatch permute!(df, [1, 4, 3, 2, 5, 6])
     @test_throws DimensionMismatch permute!(df, [1, 3, 2])


### PR DESCRIPTION
EDIT: nothing in this comment is still true. See the discussion below.

This is an improvement when there are 3+ columns, and should be an improvement for fewer columns once [upstream](https://github.com/scheinerman/Permutations.jl/pull/24) [changes](https://github.com/scheinerman/Permutations.jl/pull/25) merge.

```julia
using DataFrames, Random, BenchmarkTools
df = DataFrame([rand(500_000) for _ in 1:50], :auto);
@benchmark permute!(df, p) setup=(p=shuffle!(collect(1:500_000)))
```
Gives an 8x speedup on my computer: `2.207 s` to `276.050 ms`

(blocked until https://github.com/scheinerman/Permutations.jl/pull/24 merges due to pathological `O(rows^2)` runtime on identity permutation)