### PR TITLE
Make indexing of eachrow return the object of the same type on a view of the parent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,9 +38,12 @@
 
 ## Performance
 
-* Speed up `permute!` and `invpermute!` (and therefore sorting) 2x-8x 
+* Speed up `permute!` and `invpermute!` (and therefore sorting) 2x-8x
   for large tables by using cycle notation
   ([#3035](https://github.com/JuliaData/DataFrames.jl/pull/3035))
+* Make one-dimensional multi-element indexing of `DataFrameRows` return
+  `DataFrameRows`
+  ([#3037](https://github.com/JuliaData/DataFrames.jl/pull/3037))
 
 # DataFrames.jl v1.3.2 Patch Release Notes
 

--- a/src/abstractdataframe/iteration.jl
+++ b/src/abstractdataframe/iteration.jl
@@ -78,6 +78,8 @@ Base.IndexStyle(::Type{<:DataFrameRows}) = Base.IndexLinear()
 Base.size(itr::DataFrameRows) = (size(parent(itr), 1), )
 
 Base.@propagate_inbounds Base.getindex(itr::DataFrameRows, i::Int) = parent(itr)[i, :]
+Base.@propagate_inbounds Base.getindex(itr::DataFrameRows, idx) =
+    eachrow(@view parent(itr)[idx, :])
 
 # separate methods are needed due to dispatch ambiguity
 Base.getproperty(itr::DataFrameRows, col_ind::Symbol) =

--- a/test/iteration.jl
+++ b/test/iteration.jl
@@ -200,4 +200,27 @@ end
     @test findall(col -> eltype(col) <: Int, cols) == [1, 3]
 end
 
+@testset "multirow indexing of DataFrameRows" begin
+    df = DataFrame(a=1:4, b=11:14)
+    er = eachrow(df)
+    for sel in (1:2, Not(3:4), [true, true, false, false])
+        er2 = er[sel]
+        @test er2 isa DataFrames.DataFrameRows
+        @test parent(er2) isa SubDataFrame
+        @test parent(parent(er2)) === df
+        @test collect(er2) == [er[1], er[2]]
+    end
+    er2 = er[:]
+    @test er2 == er
+    @test er2 isa DataFrames.DataFrameRows
+    er2 = er[2:1]
+    @test length(er2) == 0
+    @test isempty(parent(er2))
+
+    # this is still allowed
+    er2 = er[1:2, 1]
+    @test er2 isa Vector{DataFrameRow}
+    @test er2 == er[1:2]
+end
+
 end # module


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/3023

Difference in performance:
```
julia> df = DataFrame(x=1:10^7);

julia> er = eachrow(df);

julia> @benchmark er[1:2:end]
BenchmarkTools.Trial: 10000 samples with 930 evaluations.
 Range (min … max):  101.398 ns …   4.602 μs  ┊ GC (min … max): 0.00% … 97.35%
 Time  (median):     114.194 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   125.150 ns ± 188.553 ns  ┊ GC (mean ± σ):  6.88% ±  4.44%

         ▂▇██▄▂
  ▄▄▄▃▄▅▆██████▆▄▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  101 ns           Histogram: frequency by time          179 ns <

 Memory estimate: 160 bytes, allocs estimate: 5.

julia> @benchmark er[1:2:end, 1]
BenchmarkTools.Trial: 24 samples with 1 evaluation.
 Range (min … max):  106.814 ms … 376.798 ms  ┊ GC (min … max):  0.00% … 71.58%
 Time  (median):     222.870 ms               ┊ GC (median):    53.74%
 Time  (mean ± σ):   217.177 ms ±  84.670 ms  ┊ GC (mean ± σ):  50.89% ± 25.07%

  █▃         ▃▃                 █
  ██▁▁▁▁▁▁▁▁▁██▁▁▁▇▁▁▁▁▁▁▇▁▇▁▇▁▇█▁▁▇▇▇▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▇▁▇▁▇▁▇ ▁
  107 ms           Histogram: frequency by time          377 ms <

 Memory estimate: 343.32 MiB, allocs estimate: 5000007.

julia> s = trues(10^7);

julia> @benchmark er[s]
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  30.100 μs … 136.300 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     33.600 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   34.640 μs ±   6.310 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃▅▇▇██▇▇▆▅▄▃▂ ▁ ▂▁ ▁  ▁                                      ▃
  ████████████████████▇▇█▇▇▇▇▇█▇▇█▇▅▆▆▆▆▆▄▅▅▅▅▄▄▁▅▅▄▄▃▅▄▃▁▄▁▃▅ █
  30.1 μs       Histogram: log(frequency) by time      66.8 μs <

 Memory estimate: 160 bytes, allocs estimate: 4.

julia> @benchmark er[s, 1]
BenchmarkTools.Trial: 10 samples with 1 evaluation.
 Range (min … max):  241.458 ms … 859.491 ms  ┊ GC (min … max):  0.00% … 75.40%
 Time  (median):     485.684 ms               ┊ GC (median):    55.90%
 Time  (mean ± σ):   538.071 ms ± 208.937 ms  ┊ GC (mean ± σ):  59.62% ± 22.31%

  ▁         ▁ ▁    ▁▁          ▁         ▁           █        ▁  
  █▁▁▁▁▁▁▁▁▁█▁█▁▁▁▁██▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁▁▁▁█▁▁▁▁▁▁▁▁█ ▁
  241 ms           Histogram: frequency by time          859 ms <

 Memory estimate: 686.65 MiB, allocs estimate: 10000004.
```

For `eachcol` I have not changed anything as now we have:
```
Base.@propagate_inbounds Base.getindex(itr::DataFrameColumns, idx::MultiColumnIndex) =
    eachcol(parent(itr)[!, idx])
```
and the only difference would be that we could change it to:
```
Base.@propagate_inbounds Base.getindex(itr::DataFrameColumns, idx::MultiColumnIndex) =
    eachcol(@view parent(itr)[!, idx])
```
but I am not sure it is worth it (I think not).