### PR TITLE
add resize!, keepat!, pop!, popfist!, popat!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@
 * Add `allcombinations` function that returns a data frame created
   from all combinations of the passed vectors
   ([#3031](https://github.com/JuliaData/DataFrames.jl/pull/3031))
-* Add `keepat!` and `pop!`, `popfirst!`, `popat!`
+* Add `resize!`, `keepat!`, `pop!`, `popfirst!`, and `popat!`
    ([#3047](https://github.com/JuliaData/DataFrames.jl/pull/3047))
 
 ## Previously announced breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,8 +38,6 @@
   ([#3031](https://github.com/JuliaData/DataFrames.jl/pull/3031))
 * Add `keepat!` and `pop!`, `popfirst!`, `popat!`
    ([#3047](https://github.com/JuliaData/DataFrames.jl/pull/3047))
-* In `deleteat!` allow unsorted or duplicate indices passed
-   ([#3047](https://github.com/JuliaData/DataFrames.jl/pull/3047))
 
 ## Previously announced breaking changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,10 @@
 * Add `allcombinations` function that returns a data frame created
   from all combinations of the passed vectors
   ([#3031](https://github.com/JuliaData/DataFrames.jl/pull/3031))
+* Add `keepat!` and `pop!`, `popfirst!`, `popat!`
+   ([#3047](https://github.com/JuliaData/DataFrames.jl/pull/3047))
+* In `deleteat!` allow unsorted or duplicate indices passed
+   ([#3047](https://github.com/JuliaData/DataFrames.jl/pull/3047))
 
 ## Previously announced breaking changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,8 @@
 * Add `allcombinations` function that returns a data frame created
   from all combinations of the passed vectors
   ([#3031](https://github.com/JuliaData/DataFrames.jl/pull/3031))
-* Add `resize!`, `keepat!`, `pop!`, `popfirst!`, and `popat!`
+* Add `resize!`, `keepat!`, `pop!`, `popfirst!`, and `popat!`,
+  make `deleteat!` signature more precise
    ([#3047](https://github.com/JuliaData/DataFrames.jl/pull/3047))
 
 ## Previously announced breaking changes

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CategoricalArrays = "0.10.0"
-Compat = "3.44, 4.1"
+Compat = "3.45, 4.1"
 DataAPI = "1.10"
 InvertedIndices = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CategoricalArrays = "0.10.0"
-Compat = "3.17"
+Compat = "3.44, 4.1"
 DataAPI = "1.10"
 InvertedIndices = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -144,9 +144,13 @@ empty
 empty!
 filter
 filter!
+keepat!
 first
 last
 only
+pop!
+popat!
+popfirst!
 nonunique
 subset
 subset!

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -147,11 +147,12 @@ filter!
 keepat!
 first
 last
+nonunique
 only
 pop!
 popat!
 popfirst!
-nonunique
+resize!
 subset
 subset!
 unique

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -105,6 +105,14 @@ else
     export only
 end
 
+if isdefined(Base, :keepat!)  # Introduced in 1.7.0
+    import Base.keepat!
+else
+    # TODO: uncomment when keepat! is added to Compat.jl
+    # import Compat.keepat!
+    export keepat!
+end
+
 if VERSION >= v"1.3"
     using Base.Threads: @spawn
 else

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -112,6 +112,13 @@ else
     export keepat!
 end
 
+if isdefined(Base, :popat!)  # Introduced in 1.5.0
+    import Base.popat!
+else
+    import Compat.popat!
+    export popat!
+end
+
 if VERSION >= v"1.3"
     using Base.Threads: @spawn
 else

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -108,8 +108,7 @@ end
 if isdefined(Base, :keepat!)  # Introduced in 1.7.0
     import Base.keepat!
 else
-    # TODO: uncomment when keepat! is added to Compat.jl
-    # import Compat.keepat!
+    import Compat.keepat!
     export keepat!
 end
 

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1050,7 +1050,7 @@ julia> df
    2 │     3      6
 ```
 """
-function Base.popat!(df::DataFrame, i::Integer)
+function popat!(df::DataFrame, i::Integer)
     i isa Bool && throw(ArgumentError("Invalid index of type Bool"))
     nt = NamedTuple(df[i, :])
     deleteat!(df, i)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -814,6 +814,7 @@ function Base.deleteat!(df::DataFrame, inds::AbstractVector{<:Integer})
     return _deleteat!_helper(df, inds)
 end
 
+# Bool is accepted here because it is accepted in Base Julia
 function Base.deleteat!(df::DataFrame, inds::Integer)
     size(df, 2) == 0 && throw(BoundsError(df, (inds, :)))
     return _deleteat!_helper(df, Int[inds])

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -769,6 +769,10 @@ end
 
 Delete rows specified by `inds` from a `DataFrame` `df` in place and return it.
 
+Internally `deleteat!` is called for all columns so `inds` must be:
+a vector of sorted and unique integers, a boolean vector, an integer,
+or `Not` wrapping any valid selector.
+
 # Examples
 ```jldoctest
 julia> df = DataFrame(a=1:3, b=4:6)
@@ -852,6 +856,10 @@ end
 
 Delete rows at all indices not specified by `inds` from a `DataFrame` `df`
 in place and return it.
+
+Internally `deleteat!` is called for all columns so `inds` must be:
+a vector of sorted and unique integers, a boolean vector, an integer,
+or `Not` wrapping any valid selector.
 
 # Examples
 ```jldoctest

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -892,6 +892,25 @@ keepat!(df::DataFrame, inds::Not) = keepat!(df, axes(df, 1)[inds])
     empty!(df::DataFrame)
 
 Remove all rows from `df`, making each of its columns empty.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(a=1:3, b=4:6)
+3×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      4
+   2 │     2      5
+   3 │     3      6
+
+julia> empty!(df)
+0×2 DataFrame
+
+julia> Tables.columntable(df)
+(a = Int64[], b = Int64[])
+```
+
 """
 function Base.empty!(df::DataFrame)
     foreach(empty!, eachcol(df))
@@ -902,6 +921,26 @@ end
     resize!(df::DataFrame, n::Integer)
 
 Resize `df` to have `n` rows by calling `resize!` on all columns of `df`.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(a=1:3, b=4:6)
+3×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      4
+   2 │     2      5
+   3 │     3      6
+
+julia> resize!(df, 2)
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      4
+   2 │     2      5
+```
 """
 function Base.resize!(df::DataFrame, n::Integer)
     if ncol(df) == 0 && n != 0
@@ -916,6 +955,34 @@ end
     pop!(df::DataFrame)
 
 Remove the last row from `df` and return a `NamedTuple` created from this row.
+
+!!! note
+
+    Using this method for very wide data frames may lead to expensive compilation.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(a=1:3, b=4:6)
+3×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      4
+   2 │     2      5
+   3 │     3      6
+
+julia> pop!(df)
+(a = 3, b = 6)
+
+julia> df
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      4
+   2 │     2      5
+```
+
 """
 Base.pop!(df::DataFrame) = popat!(df, nrow(df))
 
@@ -923,6 +990,32 @@ Base.pop!(df::DataFrame) = popat!(df, nrow(df))
     popfirst!(df::DataFrame)
 
 Remove the first row from `df` and return a `NamedTuple` created from this row.
+!!! note
+
+    Using this method for very wide data frames may lead to expensive compilation.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(a=1:3, b=4:6)
+3×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      4
+   2 │     2      5
+   3 │     3      6
+
+julia> popfirst!(df)
+(a = 1, b = 4)
+
+julia> df
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     2      5
+   2 │     3      6
+```
 """
 Base.popfirst!(df::DataFrame) = popat!(df, 1)
 
@@ -930,8 +1023,35 @@ Base.popfirst!(df::DataFrame) = popat!(df, 1)
     popat!(df::DataFrame, i::Integer)
 
 Remove the `i`-th row from `df` and return a `NamedTuple` created from this row.
+!!! note
+
+    Using this method for very wide data frames may lead to expensive compilation.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(a=1:3, b=4:6)
+3×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      4
+   2 │     2      5
+   3 │     3      6
+
+julia> popat!(df, 2)
+(a = 2, b = 5)
+
+julia> df
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      4
+   2 │     3      6
+```
 """
 function Base.popat!(df::DataFrame, i::Integer)
+    i isa Bool && throw(ArgumentError("Invalid index of type Bool"))
     nt = NamedTuple(df[i, :])
     deleteat!(df, i)
     return nt

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -793,6 +793,8 @@ julia> deleteat!(df, 2)
    2 │     3      6
 ```
 """
+Base.deleteat!(df::DataFrame, inds)
+
 Base.deleteat!(df::DataFrame, ::Colon) = empty!(df)
 
 # Bool is accepted here because it is accepted in Base Julia
@@ -902,6 +904,8 @@ julia> keepat!(df, [1, 3])
    2 │     3      6
 ```
 """
+keepat!(df::DataFrame, inds)
+
 keepat!(df::DataFrame, ::Colon) = df
 
 function keepat!(df::DataFrame, inds::AbstractVector)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -807,7 +807,7 @@ function Base.deleteat!(df::DataFrame, inds::AbstractVector)
     return _deleteat!_helper(df, inds)
 end
 
-function Base.deleteat!(df::DataFrame, inds::Integer) = deleteat!(df, Int[inds])
+Base.deleteat!(df::DataFrame, inds::Integer) = deleteat!(df, Int[inds])
 
 function Base.deleteat!(df::DataFrame, inds::AbstractVector{Bool})
     if length(inds) != size(df, 1)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -769,9 +769,6 @@ end
 
 Delete rows specified by `inds` from a `DataFrame` `df` in place and return it.
 
-`inds` do not have to be sorted nor unique. Non-unique elements of `inds`
-are de-duplicated before deleting rows.
-
 # Examples
 ```jldoctest
 julia> df = DataFrame(a=1:3, b=4:6)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -819,10 +819,8 @@ function Base.deleteat!(df::DataFrame, inds::AbstractVector)
     end
 
     # workaround https://github.com/JuliaLang/julia/pull/41646
-    @static if VERSION <= v"1.6.2"
-        if inds isa UnitRange{<:Integer}
-            inds = collect(inds)
-        end
+    if VERSION <= v"1.6.2" && inds isa UnitRange{<:Integer}
+        inds = collect(inds)
     end
 
     if !issorted(inds, lt=<=)
@@ -838,10 +836,8 @@ function Base.deleteat!(df::DataFrame, inds::AbstractVector{Bool})
     end
     drop = _findall(inds)
     # workaround https://github.com/JuliaLang/julia/pull/41646
-    @static if VERSION <= v"1.6.2"
-        if drop isa UnitRange{<:Integer}
-            drop = collect(drop)
-        end
+    if VERSION <= v"1.6.2" && drop isa UnitRange{<:Integer}
+        drop = collect(drop)
     end
     return _deleteat!_helper(df, drop)
 end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -899,7 +899,7 @@ function keepat!(df::DataFrame, inds::AbstractVector{<:Integer})
     return deleteat!(df, Not(inds))
 end
 
-Base.keepat!(df::DataFrame, inds::AbstractVector) =
+keepat!(df::DataFrame, inds::AbstractVector) =
     isempty(inds) ? empty!(df) : throw(ArgumentError("unsupported index $inds"))
 
 function keepat!(df::DataFrame, inds::Integer)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -916,7 +916,7 @@ julia> empty!(df)
 0×2 DataFrame
 
 julia> df.a, df.b
-Int64[], Int64[]
+(Int64[], Int64[])
 ```
 
 """

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -671,6 +671,17 @@ end
     df = DataFrame(a=[1, 2], b=[3, 4])
     @test deleteat!(df, true) == DataFrame(a=2, b=4)
     @test_throws BoundsError deleteat!(df, false)
+
+    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test isempty(deleteat!(df, :))
+
+    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test_throws MethodError deleteat!(df, "a")
+    @test_throws MethodError deleteat!(df, zeros(Int, 0, 0))
+    @test_throws ArgumentError deleteat!(df, [1.5])
+    @test_throws ArgumentError deleteat!(df, Integer[1, true])
+    @test deleteat!(df, []) == DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test_throws BoundsError keepat!(DataFrame(), Not(1))
 end
 
 @testset "describe" begin
@@ -2324,6 +2335,17 @@ end
     df = DataFrame(a=[1, 2], b=[3, 4])
     @test_throws ArgumentError keepat!(df, true)
     @test_throws ArgumentError keepat!(df, false)
+
+    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test keepat!(df, :) == DataFrame(a=[1, 2], b=[3.0, 4.0])
+
+    df = DataFrame(a=[1, 2], b=[3.0, 4.0])
+    @test_throws MethodError keepat!(df, "a")
+    @test_throws MethodError keepat!(df, zeros(Int, 0, 0))
+    @test_throws ArgumentError keepat!(df, [1.5])
+    @test_throws ArgumentError keepat!(df, Integer[1, true])
+    @test isempty(keepat!(df, []))
+    @test_throws BoundsError keepat!(DataFrame(), Not(1))
 end
 
 @testset "resize!" begin

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -629,11 +629,11 @@ end
     @test_throws BoundsError deleteat!(df, [10])
 
     df = DataFrame(a=[])
-    @test_throws BoundsError deleteat!(df, 10)
-
     if VERSION >= v"1.1"
+        @test_throws BoundsError deleteat!(df, 10)
         @test_throws BoundsError deleteat!(df, [10])
     else
+        @test_throws InexactError deleteat!(df, 10)
         @test_throws InexactError deleteat!(df, [10])
     end
 

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -680,8 +680,17 @@ end
     @test_throws MethodError deleteat!(df, zeros(Int, 0, 0))
     @test_throws ArgumentError deleteat!(df, [1.5])
     @test_throws ArgumentError deleteat!(df, Integer[1, true])
+    @test_throws ArgumentError deleteat!(df, Integer[true, 2])
     @test deleteat!(df, []) == DataFrame(a=[1, 2], b=[3.0, 4.0])
-    @test_throws BoundsError keepat!(DataFrame(), Not(1))
+    @test_throws BoundsError deleteat!(DataFrame(), Not(1))
+
+    df = DataFrame(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
+    @test deleteat!(df, UnitRange{Integer}(1,2)) == DataFrame(a=3, b=5.0)
+    df = DataFrame(a=[1, 2, 3], b=[3.0, 4.0, 5.0])
+    @test_throws ArgumentError deleteat!(df, UnitRange{Integer}(true,true))
+    @test_throws BoundsError deleteat!(df, true:true)
+    df = DataFrame(a=1, b=3.0)
+    @test isempty(deleteat!(df, true:true))
 end
 
 @testset "describe" begin
@@ -2344,6 +2353,7 @@ end
     @test_throws MethodError keepat!(df, zeros(Int, 0, 0))
     @test_throws ArgumentError keepat!(df, [1.5])
     @test_throws ArgumentError keepat!(df, Integer[1, true])
+    @test_throws ArgumentError keepat!(df, Integer[true, 2])
     @test isempty(keepat!(df, []))
     @test_throws BoundsError keepat!(DataFrame(), Not(1))
 end


### PR DESCRIPTION
Partially implement changes requested in https://github.com/JuliaData/DataFrames.jl/issues/2936.

@nalimilan - if you agree with the proposed changes (especially `deleteat!` - I think, given that the operation is expensive anyway, we can afford sorting and de-duplicating incorrect input instead of having an undefined behavior in this case) I will add tests.