### PR TITLE
Update working_with_dataframes.md

### DIFF
--- a/docs/src/man/working_with_dataframes.md
+++ b/docs/src/man/working_with_dataframes.md
@@ -497,7 +497,7 @@ for collections, but it is generally recommended to use the [`subset`](@ref)
 and [`subset!`](@ref) functions instead, as they are consistent with other
 DataFrames.jl functions (as opposed to [`filter`](@ref) and [`filter!`](@ref)).
 
-### Selecting and transforming columns
+## Selecting and transforming columns
 
 You can also use the [`select`](@ref)/[`select!`](@ref) and
 [`transform`](@ref)/[`transform!`](@ref) functions to select, rename and


### PR DESCRIPTION
[discoverability / quality of life for readers]
Hi, in that doc file, an important sub chapter is not visible from the outline on the sidebar, because its title is (in my opinion) hierarchised too low, with  `###`. My proposed change is to move it up one level, to a `##`.

https://dataframes.juliadata.org/stable/man/working_with_dataframes/#Selecting-and-transforming-columns , 
arguably a high priority for a learner. I personnally have looked for it a lot.