### PR TITLE
Performance of transform! on SubDataFrame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,9 @@
 
 * Make sure that `AsTable` accepts only valid argument
   ([#3064](https://github.com/JuliaData/DataFrames.jl/pull/3064))
+* Make sure we avoid aliasing when repeating the same column
+  in `select[!]` and `transform[!]` on `GroupedDataFrame`
+  ([#3070](https://github.com/JuliaData/DataFrames.jl/pull/3070))
 
 ## Performance
 
@@ -60,6 +63,8 @@
 * Make one-dimensional multi-element indexing of `DataFrameRows` return
   `DataFrameRows`
   ([#3037](https://github.com/JuliaData/DataFrames.jl/pull/3037))
+* Make `transform!` on `SubDataFrame` faster
+  ([#3070](https://github.com/JuliaData/DataFrames.jl/pull/3070))
 
 # DataFrames.jl v1.3.4 Patch Release Notes
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2534,7 +2534,7 @@ function _permutation_helper!(fun::Union{typeof(Base.permute!!), typeof(Base.inv
     end
 
     seen_cols = IdDict{Any, Nothing}()
-    for (i, col) in enumerate(eachcol(df))
+    for col in eachcol(df)
         if !haskey(seen_cols, col)
             seen_cols[col] = nothing
             _cycle_permute!(col, cp)

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -913,7 +913,7 @@ select!(df::DataFrame, @nospecialize(args...); renamecols::Bool=true) =
     _replace_columns!(df, select(df, args..., copycols=false, renamecols=renamecols))
 
 select!(df::SubDataFrame, @nospecialize(args...); renamecols::Bool=true) =
-    _replace_columns!(df, select(df, args..., copycols=true, renamecols=renamecols))
+    _replace_columns!(df, select(df, args..., copycols=true, renamecols=renamecols), false)
 
 function select!(@nospecialize(arg::Base.Callable), df::AbstractDataFrame; renamecols::Bool=true)
     if arg isa Colon
@@ -943,8 +943,11 @@ $TRANSFORMATION_COMMON_RULES
 
 See [`select`](@ref) for examples.
 """
-transform!(df::AbstractDataFrame, @nospecialize(args...); renamecols::Bool=true) =
-    select!(df, :, args..., renamecols=renamecols)
+transform!(df::DataFrame, @nospecialize(args...); renamecols::Bool=true) =
+    _replace_columns!(df, select(df, :, args..., copycols=false, renamecols=renamecols))
+
+transform!(df::SubDataFrame, @nospecialize(args...); renamecols::Bool=true) =
+    _replace_columns!(df, select(df, args..., copycols=true, renamecols=renamecols), true)
 
 function transform!(@nospecialize(arg::Base.Callable), df::AbstractDataFrame; renamecols::Bool=true)
     if arg isa Colon

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -705,6 +705,7 @@ function _add_col_check_copy(newdf::DataFrame, df::AbstractDataFrame,
                 if v === cdf[i]
                     if column_to_copy[i]
                         must_copy = true
+                        break
                     else
                         column_to_copy[i] = true
                     end

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -971,7 +971,7 @@ See [`select`](@ref) for examples.
 """
 transform!(df::DataFrame, @nospecialize(args...);
            renamecols::Bool=true, threads::Bool=true) =
-    _replace_columns!(df, select(df, :, args..., copycols=false, renamecols=renamecols, threads=threads))
+    select!(df, :, args..., renamecols=renamecols, threads=threads)
 
 transform!(df::SubDataFrame, @nospecialize(args...); renamecols::Bool=true, threads::Bool=true) =
     _replace_columns!(df, select(df, args..., copycols=true, renamecols=renamecols, threads=threads),

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -26,13 +26,16 @@ const TRANSFORMATION_COMMON_RULES =
     Operations can then be applied on each group using one of the following functions:
     * `combine`: does not put restrictions on number of rows returned, the order of rows
       is specified by the order of groups in `GroupedDataFrame`; it is typically used
-      to compute summary statistics by group;
+      to compute summary statistics by group; for `GroupedDataFrame` if grouping columns
+      are kept they are put as first columns in the result;
     * `select`: return a data frame with the number and order of rows exactly the same
       as the source data frame, including only new calculated columns;
-      `select!` is an in-place version of `select`;
+      `select!` is an in-place version of `select`; for `GroupedDataFrame` if grouping columns
+      are kept they are put as first columns in the result;
     * `transform`: return a data frame with the number and order of rows exactly the same
       as the source data frame, including all columns from the source and new calculated columns;
-      `transform!` is an in-place version of `transform`.
+      `transform!` is an in-place version of `transform`. For `GroupedDataFrame`
+      existing columns in the source data frame are put as first columns in the result;
 
     All these functions take a specification of one or more functions to apply to
     each subset of the `DataFrame`. This specification can be of the following forms:
@@ -914,7 +917,7 @@ select!(df::DataFrame, @nospecialize(args...); renamecols::Bool=true) =
     _replace_columns!(df, select(df, args..., copycols=false, renamecols=renamecols))
 
 select!(df::SubDataFrame, @nospecialize(args...); renamecols::Bool=true) =
-    _replace_columns!(df, select(df, args..., copycols=true, renamecols=renamecols), false)
+    _replace_columns!(df, select(df, args..., copycols=true, renamecols=renamecols), keep_present=false)
 
 function select!(@nospecialize(arg::Base.Callable), df::AbstractDataFrame; renamecols::Bool=true)
     if arg isa Colon
@@ -948,7 +951,7 @@ transform!(df::DataFrame, @nospecialize(args...); renamecols::Bool=true) =
     _replace_columns!(df, select(df, :, args..., copycols=false, renamecols=renamecols))
 
 transform!(df::SubDataFrame, @nospecialize(args...); renamecols::Bool=true) =
-    _replace_columns!(df, select(df, args..., copycols=true, renamecols=renamecols), true)
+    _replace_columns!(df, select(df, args..., copycols=true, renamecols=renamecols), keep_present=true)
 
 function transform!(@nospecialize(arg::Base.Callable), df::AbstractDataFrame; renamecols::Bool=true)
     if arg isa Colon

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -34,7 +34,7 @@ const TRANSFORMATION_COMMON_RULES =
       are kept they are put as first columns in the result;
     * `transform`: return a data frame with the number and order of rows exactly the same
       as the source data frame, including all columns from the source and new calculated columns;
-      `transform!` is an in-place version of `transform`. For `GroupedDataFrame`
+      `transform!` is an in-place version of `transform`; for `GroupedDataFrame`
       existing columns in the source data frame are put as first columns in the result;
 
     All these functions take a specification of one or more functions to apply to

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -969,7 +969,8 @@ $TRANSFORMATION_COMMON_RULES
 
 See [`select`](@ref) for examples.
 """
-transform!(df::DataFrame, @nospecialize(args...); renamecols::Bool=true, threads::Bool=true) =
+transform!(df::DataFrame, @nospecialize(args...);
+           renamecols::Bool=true, threads::Bool=true) =
     _replace_columns!(df, select(df, :, args..., copycols=false, renamecols=renamecols, threads=threads))
 
 transform!(df::SubDataFrame, @nospecialize(args...); renamecols::Bool=true, threads::Bool=true) =

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1812,6 +1812,9 @@ end
 
 # This is not exactly copy! as in general we allow axes to be different
 function _replace_columns!(df::DataFrame, newdf::DataFrame)
+    # here we do not support wastransform argument like for SubDataFrame
+    # because by default in DataFrame case columns are not copied
+    # so we need to pass `:` to select! to handle this case correctly
     @assert ncol(newdf) == 0 || nrow(df) == nrow(newdf)
     copy!(_columns(df), _columns(newdf))
     copy!(_names(index(df)), _names(newdf))

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -1812,9 +1812,8 @@ end
 
 # This is not exactly copy! as in general we allow axes to be different
 function _replace_columns!(df::DataFrame, newdf::DataFrame)
-    # here we do not support wastransform argument like for SubDataFrame
-    # because by default in DataFrame case columns are not copied
-    # so we need to pass `:` to select! to handle this case correctly
+    # for DataFrame object here we do not support keep_present keyword argument
+    # like for SubDataFrame because here transform! always falls back to select!
     @assert ncol(newdf) == 0 || nrow(df) == nrow(newdf)
     copy!(_columns(df), _columns(newdf))
     copy!(_names(index(df)), _names(newdf))

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -863,11 +863,12 @@ function select!(gd::GroupedDataFrame,
     df = parent(gd)
     if df isa DataFrame
         newdf = select(gd, args..., copycols=false, renamecols=renamecols)
+        _replace_columns!(df, newdf)
     else
         @assert df isa SubDataFrame
         newdf = select(gd, args..., copycols=true, renamecols=renamecols)
+        _replace_columns!(df, newdf, false)
     end
-    _replace_columns!(df, newdf)
     return ungroup ? df : gd
 end
 
@@ -885,11 +886,14 @@ function transform!(gd::GroupedDataFrame,
     df = parent(gd)
     if df isa DataFrame
         newdf = select(gd, :, args..., copycols=false, renamecols=renamecols)
+        # net to recover column order of df in newdf and add new columns at the end
+        select!(newdf, propertynames(df), :)
+        _replace_columns!(df, newdf)
     else
         @assert df isa SubDataFrame
-        newdf = select(gd, :, args..., copycols=true, renamecols=renamecols)
+        newdf = select(gd, args..., copycols=true, renamecols=renamecols)
+        # here column order of df is retained due to wastransform=true
+        _replace_columns!(df, newdf, true)
     end
-    select!(newdf, propertynames(df), :)
-    _replace_columns!(df, newdf)
     return ungroup ? df : gd
 end

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -937,7 +937,7 @@ function transform!(gd::GroupedDataFrame,
         @assert df isa SubDataFrame
         newdf = select(gd, args..., copycols=true, renamecols=renamecols,
                        threads=threads)
-        # here column order of df is retained due to wastransform=true
+        # here column order of df is retained due to keep_present=true
         _replace_columns!(df, newdf, keep_present=true)
     end
     return ungroup ? df : gd

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -883,7 +883,7 @@ function select!(gd::GroupedDataFrame,
     else
         @assert df isa SubDataFrame
         newdf = select(gd, args..., copycols=true, renamecols=renamecols)
-        _replace_columns!(df, newdf, false)
+        _replace_columns!(df, newdf, keep_present=false)
     end
     return ungroup ? df : gd
 end
@@ -909,7 +909,7 @@ function transform!(gd::GroupedDataFrame,
         @assert df isa SubDataFrame
         newdf = select(gd, args..., copycols=true, renamecols=renamecols)
         # here column order of df is retained due to wastransform=true
-        _replace_columns!(df, newdf, true)
+        _replace_columns!(df, newdf, keep_present=true)
     end
     return ungroup ? df : gd
 end

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -332,7 +332,7 @@ function _replace_columns!(sdf::SubDataFrame, newdf::DataFrame, wastransform::Bo
         sdf[!, colname] = newdf[!, colname]
     end
 
-    # if ww called _replace_columns! from transform we are done as we want to
+    # if _replace_columns! was called from transform we are done as we want to
     # keep all columns that were previously present.
     # In this case column order will be correct.
     # Otherwise If columns did not match this means that we have either:

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -316,8 +316,8 @@ function is_column_insertion_allowed(df::AbstractDataFrame)
     throw(ArgumentError("Unsupported data frame type"))
 end
 
-function _replace_columns!(sdf::SubDataFrame, newdf::DataFrame, wastransform::Bool)
-    if wastransform
+function _replace_columns!(sdf::SubDataFrame, newdf::DataFrame; keep_present::Bool)
+    if keep_present
         colsmatch = issubset(_names(newdf), _names(sdf))
     else
         colsmatch = _names(newdf) == _names(sdf)
@@ -344,7 +344,7 @@ function _replace_columns!(sdf::SubDataFrame, newdf::DataFrame, wastransform::Bo
     # and that operation was allowed.
     # Therefore we need to update the parent of sdf in place to make sure
     # it holds only the required target columns in a correct order.
-    if !wastransform && !colsmatch
+    if !keep_present && !colsmatch
         pdf = parent(sdf)
         @assert pdf isa DataFrame
         select!(pdf, _names(newdf))

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -335,7 +335,7 @@ function _replace_columns!(sdf::SubDataFrame, newdf::DataFrame, wastransform::Bo
     # if _replace_columns! was called from transform we are done as we want to
     # keep all columns that were previously present.
     # In this case column order will be correct.
-    # Otherwise If columns did not match this means that we have either:
+    # Otherwise if columns did not match this means that we have either:
     # 1. inserted some columns into newdf
     # or
     # 2. requested to reorder the existing columns

--- a/test/select.jl
+++ b/test/select.jl
@@ -2707,4 +2707,55 @@ end
     @test_throws ArgumentError select(gdf, :a => [:x, :y, :z])
 end
 
+@testset "additional test of handling of operation specfication in select!/transform!" begin
+    df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
+    select!(df, :b, :c => :d, :a => (x -> 2 * x) => :e)
+    @test df == DataFrame(b='a':'d', d=["p", "q", "r", "s"], e=[2, 4, 6, 8])
+
+    df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
+    transform!(df, :b, :c => :d, :a => (x -> 2 * x) => :e)
+    @test df == DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"],
+                          d=["p", "q", "r", "s"], e=[2, 4, 6, 8])
+    @test df.c !== df.d
+
+    df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
+    select!(groupby(df, :c), :b, :c => :d, :a => (x -> 2 * x) => :e)
+    @test df == DataFrame(c=["p", "q", "r", "s"], b='a':'d',
+                          d=["p", "q", "r", "s"], e=[2, 4, 6, 8])
+    @test df.c !== df.d
+
+    df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
+    transform!(groupby(df, :c), :b, :c => :d, :a => (x -> 2 * x) => :e)
+    @test df == DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"],
+                          d=["p", "q", "r", "s"], e=[2, 4, 6, 8])
+    @test df.c !== df.d
+
+    df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
+    sdf = @view df[[2, 4], :]
+    select!(sdf, :b, :c => :d, :a => (x -> 2 * x) => :e)
+    @test df ≅ DataFrame(b='a':'d', d=[missing, "q", missing, "s"],
+                         e=[missing, 4, missing, 8])
+
+    df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
+    sdf = @view df[[2, 4], :]
+    transform!(sdf, :b, :c => :d, :a => (x -> 2 * x) => :e)
+    @test df ≅ DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"],
+                         d=[missing, "q", missing, "s"],
+                         e=[missing, 4, missing, 8])
+
+    df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
+    sdf = @view df[[2, 4], :]
+    select!(groupby(sdf, :c), :b, :c => :d, :a => (x -> 2 * x) => :e)
+    @test df ≅ DataFrame(c=["p", "q", "r", "s"], b='a':'d',
+                         d=[missing, "q", missing, "s"],
+                         e=[missing, 4, missing, 8])
+
+    df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
+    sdf = @view df[[2, 4], :]
+    transform!(groupby(sdf, :c), :b, :c => :d, :a => (x -> 2 * x) => :e)
+    @test df ≅ DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"],
+                         d=[missing, "q", missing, "s"],
+                         e=[missing, 4, missing, 8])
+end
+
 end # module

--- a/test/select.jl
+++ b/test/select.jl
@@ -2732,6 +2732,7 @@ end
 
     df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
     sdf = @view df[[2, 4], :]
+    # note that in this test a column from parent of sdf is dropped
     select!(sdf, :b, :c => :d, :a => (x -> 2 * x) => :e)
     @test df ≅ DataFrame(b='a':'d', d=[missing, "q", missing, "s"],
                          e=[missing, 4, missing, 8])
@@ -2745,6 +2746,7 @@ end
 
     df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
     sdf = @view df[[2, 4], :]
+    # note that in this test a column from parent of sdf is dropped
     select!(groupby(sdf, :c), :b, :c => :d, :a => (x -> 2 * x) => :e)
     @test df ≅ DataFrame(c=["p", "q", "r", "s"], b='a':'d',
                          d=[missing, "q", missing, "s"],

--- a/test/select.jl
+++ b/test/select.jl
@@ -2707,7 +2707,7 @@ end
     @test_throws ArgumentError select(gdf, :a => [:x, :y, :z])
 end
 
-@testset "additional test of handling of operation specfication in select!/transform!" begin
+@testset "handling of operation specification in select!/transform!" begin
     df = DataFrame(a=1:4, b='a':'d', c=["p", "q", "r", "s"])
     select!(df, :b, :c => :d, :a => (x -> 2 * x) => :e)
     @test df == DataFrame(b='a':'d', d=["p", "q", "r", "s"], e=[2, 4, 6, 8])


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/3069.

What this PR addresses.

1. The initially reported performance issue. After the PR:
```
julia> using DataFrames, BenchmarkTools

julia> df = DataFrame(rand(100000, 100), :auto);

julia> subdf = view(df, df.x1 .>= 0.5, :);

julia> @btime transform!($subdf, :x1 => maximum => :x1);
  289.800 μs (128 allocations: 1.15 MiB)

julia> gdf = groupby(subdf, :x2);

julia> @btime transform!($gdf, :x1 => maximum => :x1);
  1.090 ms (300 allocations: 4.21 MiB)
```
and before the PR:
```
julia> using DataFrames, BenchmarkTools

julia> df = DataFrame(rand(100000, 100), :auto);

julia> subdf = view(df, df.x1 .>= 0.5, :);

julia> @btime transform!($subdf, :x1 => maximum => :x1);
  37.446 ms (1642 allocations: 114.68 MiB)

julia> gdf = groupby(subdf, :x2);

julia> @btime transform!($gdf, :x1 => maximum => :x1);
  35.303 ms (4853 allocations: 117.23 MiB)
```

2. Aliasing issue in `select[!]` and `transform[!]` on `GroupedDataFrame`

After the PR:
```
julia> df = DataFrame(a=1:2, b=3:4);

julia> gdf = groupby(df, :a);

julia> res = select(gdf, :b, :a => :c, :b => :d, copycols=false);

julia> res.a === res.c
false

julia> res.b === res.d
false
```
and before the PR:
```
julia> df = DataFrame(a=1:2, b=3:4);

julia> gdf = groupby(df, :a);

julia> res = select(gdf, :b, :a => :c, :b => :d, copycols=false);

julia> res.a === res.c
true

julia> res.b === res.d
true
```