### PR TITLE
patch deleteat!

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -797,8 +797,8 @@ Base.deleteat!(df::DataFrame, inds)
 
 Base.deleteat!(df::DataFrame, ::Colon) = empty!(df)
 
-# Bool is accepted here because it is accepted in Base Julia
 function Base.deleteat!(df::DataFrame, inds::Integer)
+    inds isa Bool && throw(ArgumentError("Invalid index of type Bool"))
     size(df, 2) == 0 && throw(BoundsError(df, (inds, :)))
     return _deleteat!_helper(df, Int[inds])
 end

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -669,8 +669,7 @@ end
     @test_throws AssertionError deleteat!(df, 1)
 
     df = DataFrame(a=[1, 2], b=[3, 4])
-    @test deleteat!(df, true) == DataFrame(a=2, b=4)
-    @test_throws BoundsError deleteat!(df, false)
+    @test_throws ArgumentError deleteat!(df, true)
 
     df = DataFrame(a=[1, 2], b=[3.0, 4.0])
     @test isempty(deleteat!(df, :))


### PR DESCRIPTION
`deleteat!(df, true)` is deprecated in Base Julia, so it is better to throw error on this in DataFrames.jl (rather than to blindly be consistent with deprecated behavior)