### PR TITLE
Improve documentation and speedup isempty

### DIFF
--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -54,6 +54,7 @@ similar
 ## Summary information
 ```@docs
 describe
+isempty
 length
 ncol
 ndims

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -358,6 +358,24 @@ function Base.size(df::AbstractDataFrame, i::Integer)
 end
 
 """
+    ncol(df::AbstractDataFrame)
+
+Return the number of columns in an `AbstractDataFrame` `df`.
+
+See also [`nrow`](@ref), [`size`](@ref).
+
+# Examples
+
+```jldoctest
+julia> df = DataFrame(i=1:10, x=rand(10), y=rand(["a", "b", "c"], 10));
+
+julia> ncol(df)
+3
+```
+"""
+ncol(df::AbstractDataFrame) = length(index(df))
+
+"""
     isempty(df::AbstractDataFrame)
 
 Return `true` if data frame `df` has zero rows, and `false` otherwise.
@@ -1358,23 +1376,6 @@ end
 
 nonunique(df::AbstractDataFrame, cols) = nonunique(select(df, cols, copycols=false))
 
-Base.unique!(df::AbstractDataFrame) = deleteat!(df, _findall(nonunique(df)))
-Base.unique!(df::AbstractDataFrame, cols::AbstractVector) =
-    deleteat!(df, _findall(nonunique(df, cols)))
-Base.unique!(df::AbstractDataFrame, cols) =
-    deleteat!(df, _findall(nonunique(df, cols)))
-
-# Unique rows of an AbstractDataFrame.
-@inline function Base.unique(df::AbstractDataFrame; view::Bool=false)
-    rowidxs = (!).(nonunique(df))
-    return view ? Base.view(df, rowidxs, :) : df[rowidxs, :]
-end
-
-@inline function Base.unique(df::AbstractDataFrame, cols; view::Bool=false)
-    rowidxs = (!).(nonunique(df, cols))
-    return view ? Base.view(df, rowidxs, :) : df[rowidxs, :]
-end
-
 """
     unique(df::AbstractDataFrame; view::Bool=false)
     unique(df::AbstractDataFrame, cols; view::Bool=false)
@@ -1392,7 +1393,7 @@ See also: [`unique!`](@ref) [`nonunique`](@ref).
 
 # Arguments
 - `df` : the AbstractDataFrame
-- `cols` :  column indicator (Symbol, Int, Vector{Symbol}, Regex, etc.)
+- `cols` :  column indicator (`Symbol`, `Int`, `Vector{Symbol}`, `Regex`, etc.)
 specifying the column(s) to compare.
 
 # Examples
@@ -1440,7 +1441,15 @@ julia> unique(df, 2)
    2 │     2      2
 ```
 """
-unique
+@inline function Base.unique(df::AbstractDataFrame; view::Bool=false)
+    rowidxs = (!).(nonunique(df))
+    return view ? Base.view(df, rowidxs, :) : df[rowidxs, :]
+end
+
+@inline function Base.unique(df::AbstractDataFrame, cols; view::Bool=false)
+    rowidxs = (!).(nonunique(df, cols))
+    return view ? Base.view(df, rowidxs, :) : df[rowidxs, :]
+end
 
 """
     unique!(df::AbstractDataFrame)
@@ -1456,7 +1465,7 @@ See also: [`unique`](@ref) [`nonunique`](@ref).
 
 # Arguments
 - `df` : the AbstractDataFrame
-- `cols` :  column indicator (Symbol, Int, Vector{Symbol}, Regex, etc.)
+- `cols` :  column indicator (`Symbol`, `Int`, `Vector{Symbol}`, `Regex`, etc.)
 specifying the column(s) to compare.
 
 # Examples
@@ -1496,7 +1505,9 @@ julia> unique!(df)  # modifies df
    4 │     4      2
 ```
 """
-unique!
+Base.unique!(df::AbstractDataFrame) = deleteat!(df, _findall(nonunique(df)))
+Base.unique!(df::AbstractDataFrame, cols) =
+    deleteat!(df, _findall(nonunique(df, cols)))
 
 """
     fillcombinations(df::AbstractDataFrame, indexcols;
@@ -2163,46 +2174,6 @@ end
 
 Base.parent(adf::AbstractDataFrame) = adf
 Base.parentindices(adf::AbstractDataFrame) = axes(adf)
-
-## Documentation for methods defined elsewhere
-
-"""
-    nrow(df::AbstractDataFrame)
-
-Return the number of rows in an `AbstractDataFrame` `df`.
-
-See also: [`ncol`](@ref), [`size`](@ref).
-
-# Examples
-
-```jldoctest
-julia> df = DataFrame(i=1:10, x=rand(10), y=rand(["a", "b", "c"], 10));
-
-julia> nrow(df)
-10
-```
-
-"""
-function nrow end
-
-"""
-    ncol(df::AbstractDataFrame)
-
-Return the number of columns in an `AbstractDataFrame` `df`.
-
-See also [`nrow`](@ref), [`size`](@ref).
-
-# Examples
-
-```jldoctest
-julia> df = DataFrame(i=1:10, x=rand(10), y=rand(["a", "b", "c"], 10));
-
-julia> ncol(df)
-3
-```
-
-"""
-function ncol end
 
 """
     disallowmissing(df::AbstractDataFrame, cols=:; error::Bool=true)

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -358,9 +358,9 @@ function Base.size(df::AbstractDataFrame, i::Integer)
 end
 
 """
-    isempty(::AbstractDataFrame)
+    isempty(df::AbstractDataFrame)
 
-Return `true` if data frame has zero rows.
+Return `true` if data frame `df` has zero rows, and `false` otherwise.
 """
 Base.isempty(df::AbstractDataFrame) = nrow(df) == 0
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -1506,6 +1506,8 @@ julia> unique!(df)  # modifies df
 ```
 """
 Base.unique!(df::AbstractDataFrame) = deleteat!(df, _findall(nonunique(df)))
+Base.unique!(df::AbstractDataFrame, cols::AbstractVector) =
+    deleteat!(df, _findall(nonunique(df, cols)))
 Base.unique!(df::AbstractDataFrame, cols) =
     deleteat!(df, _findall(nonunique(df, cols)))
 

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -362,7 +362,7 @@ end
 
 Return `true` if data frame has zero rows.
 """
-Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0
+Base.isempty(df::AbstractDataFrame) = nrow(df) == 0
 
 if VERSION < v"1.6"
     Base.firstindex(df::AbstractDataFrame, i::Integer) = first(axes(df, i))

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -357,7 +357,12 @@ function Base.size(df::AbstractDataFrame, i::Integer)
     end
 end
 
-Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0 || size(df, 2) == 0
+"""
+    isempty(::AbstractDataFrame)
+
+Return `true` if data frame has zero rows.
+"""
+Base.isempty(df::AbstractDataFrame) = size(df, 1) == 0
 
 if VERSION < v"1.6"
     Base.firstindex(df::AbstractDataFrame, i::Integer) = first(axes(df, i))
@@ -1373,8 +1378,6 @@ end
 """
     unique(df::AbstractDataFrame; view::Bool=false)
     unique(df::AbstractDataFrame, cols; view::Bool=false)
-    unique!(df::AbstractDataFrame)
-    unique!(df::AbstractDataFrame, cols)
 
 Return a data frame containing only the first occurrence of unique rows in `df`.
 When `cols` is specified, the returned `DataFrame` contains complete rows,
@@ -1382,13 +1385,10 @@ retaining in each case the first occurrence of a given combination of values
 in selected columns or their transformations. `cols` can be any column
 selector or transformation accepted by [`select`](@ref).
 
-
-For `unique`, if `view=false` a freshly allocated `DataFrame` is returned,
+If `view=false` a freshly allocated `DataFrame` is returned,
 and if `view=true` then a `SubDataFrame` view into `df` is returned.
 
-`unique!` updates `df` in-place and does not support the `view` keyword argument.
-
-See also [`nonunique`](@ref).
+See also: [`unique!`](@ref) [`nonunique`](@ref).
 
 # Arguments
 - `df` : the AbstractDataFrame
@@ -1438,6 +1438,52 @@ julia> unique(df, 2)
 ─────┼──────────────
    1 │     1      1
    2 │     2      2
+```
+"""
+unique
+
+"""
+    unique!(df::AbstractDataFrame)
+    unique!(df::AbstractDataFrame, cols)
+
+Update `df` in-place to contain only the first occurrence of unique rows in `df`.
+When `cols` is specified, the returned `DataFrame` contains complete rows,
+retaining in each case the first occurrence of a given combination of values
+in selected columns or their transformations. `cols` can be any column
+selector or transformation accepted by [`select`](@ref).
+
+See also: [`unique`](@ref) [`nonunique`](@ref).
+
+# Arguments
+- `df` : the AbstractDataFrame
+- `cols` :  column indicator (Symbol, Int, Vector{Symbol}, Regex, etc.)
+specifying the column(s) to compare.
+
+# Examples
+```jldoctest
+julia> df = DataFrame(i=1:4, x=[1, 2, 1, 2])
+4×2 DataFrame
+ Row │ i      x
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      1
+   2 │     2      2
+   3 │     3      1
+   4 │     4      2
+
+julia> df = vcat(df, df)
+8×2 DataFrame
+ Row │ i      x
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      1
+   2 │     2      2
+   3 │     3      1
+   4 │     4      2
+   5 │     1      1
+   6 │     2      2
+   7 │     3      1
+   8 │     4      2
 
 julia> unique!(df)  # modifies df
 4×2 DataFrame
@@ -1450,7 +1496,7 @@ julia> unique!(df)  # modifies df
    4 │     4      2
 ```
 """
-(unique, unique!)
+unique!
 
 """
     fillcombinations(df::AbstractDataFrame, indexcols;
@@ -2120,34 +2166,43 @@ Base.parentindices(adf::AbstractDataFrame) = axes(adf)
 
 ## Documentation for methods defined elsewhere
 
-function nrow end
-function ncol end
-
 """
     nrow(df::AbstractDataFrame)
-    ncol(df::AbstractDataFrame)
 
-Return the number of rows or columns in an `AbstractDataFrame` `df`.
+Return the number of rows in an `AbstractDataFrame` `df`.
 
-See also [`size`](@ref).
+See also: [`ncol`](@ref), [`size`](@ref).
 
-**Examples**
+# Examples
 
 ```jldoctest
 julia> df = DataFrame(i=1:10, x=rand(10), y=rand(["a", "b", "c"], 10));
 
-julia> size(df)
-(10, 3)
-
 julia> nrow(df)
 10
+```
+
+"""
+function nrow end
+
+"""
+    ncol(df::AbstractDataFrame)
+
+Return the number of columns in an `AbstractDataFrame` `df`.
+
+See also [`nrow`](@ref), [`size`](@ref).
+
+# Examples
+
+```jldoctest
+julia> df = DataFrame(i=1:10, x=rand(10), y=rand(["a", "b", "c"], 10));
 
 julia> ncol(df)
 3
 ```
 
 """
-(nrow, ncol)
+function ncol end
 
 """
     disallowmissing(df::AbstractDataFrame, cols=:; error::Bool=true)
@@ -2162,7 +2217,7 @@ If `cols` is omitted all columns in the data frame are converted.
 If `error=false` then columns containing a `missing` value will be skipped instead
 of throwing an error.
 
-**Examples**
+# Examples
 
 ```jldoctest
 julia> df = DataFrame(a=Union{Int, Missing}[1, 2])
@@ -2241,7 +2296,7 @@ to element type `Union{T, Missing}` from `T` to allow support for missing values
 
 If `cols` is omitted all columns in the data frame are converted.
 
-**Examples**
+# Examples
 
 ```jldoctest
 julia> df = DataFrame(a=[1, 2])

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -427,9 +427,24 @@ _onebased_check_error(i, col) =
                         "columns that use 1-based indexing, but " *
                         "column $i has starting index equal to $(firstindex(col))"))
 
+"""
+    nrow(df::AbstractDataFrame)
+
+Return the number of rows in an `AbstractDataFrame` `df`.
+
+See also: [`ncol`](@ref), [`size`](@ref).
+
+# Examples
+
+```jldoctest
+julia> df = DataFrame(i=1:10, x=rand(10), y=rand(["a", "b", "c"], 10));
+
+julia> nrow(df)
+10
+```
+"""
 # note: these type assertions are required to pass tests
 nrow(df::DataFrame) = ncol(df) > 0 ? length(_columns(df)[1])::Int : 0
-ncol(df::DataFrame) = length(index(df))
 
 ##############################################################################
 ##

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -442,8 +442,7 @@ julia> df = DataFrame(i=1:10, x=rand(10), y=rand(["a", "b", "c"], 10));
 julia> nrow(df)
 10
 ```
-"""
-# note: these type assertions are required to pass tests
+""" # note: these type assertions are required to pass tests
 nrow(df::DataFrame) = ncol(df) > 0 ? length(_columns(df)[1])::Int : 0
 
 ##############################################################################

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -151,7 +151,6 @@ Base.@propagate_inbounds Base.view(adf::AbstractDataFrame, rowinds::Not,
 index(sdf::SubDataFrame) = getfield(sdf, :colindex)
 
 nrow(sdf::SubDataFrame) = ncol(sdf) > 0 ? length(rows(sdf))::Int : 0
-ncol(sdf::SubDataFrame) = length(index(sdf))
 
 Base.@propagate_inbounds Base.getindex(sdf::SubDataFrame, rowind::Integer, colind::ColumnIndex) =
     parent(sdf)[rows(sdf)[rowind], parentcols(index(sdf), colind)]

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2642,4 +2642,10 @@ end
     end
 end
 
+@testset "isempty" begin
+    @test isempty(DataFrame())
+    @test isempty(DataFrame(a=[]))
+    @test !isempty(DataFrame(a=1))
+end
+
 end # module


### PR DESCRIPTION
@nalimilan :

1. Your recent comment prompted me to add `isempty` documentation as in DataFrames.jl when we say that data frame is empty it means that it has 0 rows (but can have some columns). I have also simplified `isempty` implementation as currently data frame that has positive number of rows must have some columns.
2. I have also split duplicate definitions in documentation that we discussed we should do.