### PR TITLE
Improved REPL printing for GroupedDataFrames

### DIFF
--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -215,22 +215,10 @@ First Group (50 rows): Species = "Iris-setosa"
 ─────┼───────────────────────────────────────────────────────────────
    1 │         5.1         3.5          1.4         0.2  Iris-setosa
    2 │         4.9         3.0          1.4         0.2  Iris-setosa
-   3 │         4.7         3.2          1.3         0.2  Iris-setosa
-   4 │         4.6         3.1          1.5         0.2  Iris-setosa
-   5 │         5.0         3.6          1.4         0.2  Iris-setosa
-   6 │         5.4         3.9          1.7         0.4  Iris-setosa
-   7 │         4.6         3.4          1.4         0.3  Iris-setosa
-   8 │         5.0         3.4          1.5         0.2  Iris-setosa
   ⋮  │      ⋮           ⋮            ⋮           ⋮            ⋮
-  43 │         4.4         3.2          1.3         0.2  Iris-setosa
-  44 │         5.0         3.5          1.6         0.6  Iris-setosa
-  45 │         5.1         3.8          1.9         0.4  Iris-setosa
-  46 │         4.8         3.0          1.4         0.3  Iris-setosa
-  47 │         5.1         3.8          1.6         0.2  Iris-setosa
-  48 │         4.6         3.2          1.4         0.2  Iris-setosa
   49 │         5.3         3.7          1.5         0.2  Iris-setosa
   50 │         5.0         3.3          1.4         0.2  Iris-setosa
-                                                      34 rows omitted
+                                                      46 rows omitted
 ⋮
 Last Group (50 rows): Species = "Iris-virginica"
  Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
@@ -238,22 +226,9 @@ Last Group (50 rows): Species = "Iris-virginica"
 ─────┼──────────────────────────────────────────────────────────────────
    1 │         6.3         3.3          6.0         2.5  Iris-virginica
    2 │         5.8         2.7          5.1         1.9  Iris-virginica
-   3 │         7.1         3.0          5.9         2.1  Iris-virginica
-   4 │         6.3         2.9          5.6         1.8  Iris-virginica
-   5 │         6.5         3.0          5.8         2.2  Iris-virginica
-   6 │         7.6         3.0          6.6         2.1  Iris-virginica
-   7 │         4.9         2.5          4.5         1.7  Iris-virginica
-   8 │         7.3         2.9          6.3         1.8  Iris-virginica
   ⋮  │      ⋮           ⋮            ⋮           ⋮             ⋮
-  43 │         5.8         2.7          5.1         1.9  Iris-virginica
-  44 │         6.8         3.2          5.9         2.3  Iris-virginica
-  45 │         6.7         3.3          5.7         2.5  Iris-virginica
-  46 │         6.7         3.0          5.2         2.3  Iris-virginica
-  47 │         6.3         2.5          5.0         1.9  Iris-virginica
-  48 │         6.5         3.0          5.2         2.0  Iris-virginica
-  49 │         6.2         3.4          5.4         2.3  Iris-virginica
   50 │         5.9         3.0          5.1         1.8  Iris-virginica
-                                                         34 rows omitted
+                                                         47 rows omitted
 
 julia> combine(gdf, :PetalLength => mean)
 3×2 DataFrame
@@ -520,22 +495,10 @@ First Group (50 rows): Species = "Iris-setosa"
 ─────┼───────────────────────────────────────────────────────────────
    1 │         5.1         3.5          1.4         0.2  Iris-setosa
    2 │         4.9         3.0          1.4         0.2  Iris-setosa
-   3 │         4.7         3.2          1.3         0.2  Iris-setosa
-   4 │         4.6         3.1          1.5         0.2  Iris-setosa
-   5 │         5.0         3.6          1.4         0.2  Iris-setosa
-   6 │         5.4         3.9          1.7         0.4  Iris-setosa
-   7 │         4.6         3.4          1.4         0.3  Iris-setosa
-   8 │         5.0         3.4          1.5         0.2  Iris-setosa
   ⋮  │      ⋮           ⋮            ⋮           ⋮            ⋮
-  43 │         4.4         3.2          1.3         0.2  Iris-setosa
-  44 │         5.0         3.5          1.6         0.6  Iris-setosa
-  45 │         5.1         3.8          1.9         0.4  Iris-setosa
-  46 │         4.8         3.0          1.4         0.3  Iris-setosa
-  47 │         5.1         3.8          1.6         0.2  Iris-setosa
-  48 │         4.6         3.2          1.4         0.2  Iris-setosa
   49 │         5.3         3.7          1.5         0.2  Iris-setosa
   50 │         5.0         3.3          1.4         0.2  Iris-setosa
-                                                      34 rows omitted
+                                                      46 rows omitted
 ⋮
 Last Group (50 rows): Species = "Iris-virginica"
  Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
@@ -543,22 +506,9 @@ Last Group (50 rows): Species = "Iris-virginica"
 ─────┼──────────────────────────────────────────────────────────────────
    1 │         6.3         3.3          6.0         2.5  Iris-virginica
    2 │         5.8         2.7          5.1         1.9  Iris-virginica
-   3 │         7.1         3.0          5.9         2.1  Iris-virginica
-   4 │         6.3         2.9          5.6         1.8  Iris-virginica
-   5 │         6.5         3.0          5.8         2.2  Iris-virginica
-   6 │         7.6         3.0          6.6         2.1  Iris-virginica
-   7 │         4.9         2.5          4.5         1.7  Iris-virginica
-   8 │         7.3         2.9          6.3         1.8  Iris-virginica
   ⋮  │      ⋮           ⋮            ⋮           ⋮             ⋮
-  43 │         5.8         2.7          5.1         1.9  Iris-virginica
-  44 │         6.8         3.2          5.9         2.3  Iris-virginica
-  45 │         6.7         3.3          5.7         2.5  Iris-virginica
-  46 │         6.7         3.0          5.2         2.3  Iris-virginica
-  47 │         6.3         2.5          5.0         1.9  Iris-virginica
-  48 │         6.5         3.0          5.2         2.0  Iris-virginica
-  49 │         6.2         3.4          5.4         2.3  Iris-virginica
   50 │         5.9         3.0          5.1         1.8  Iris-virginica
-                                                         34 rows omitted
+                                                         47 rows omitted
 
 julia> combine(gd, valuecols(gd) .=> mean)
 3×5 DataFrame

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -101,7 +101,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
 
         show(io, gd[N]; summary=false,
              allrows=allrows, allcols=allcols, rowlabel=rowlabel,
-             truncate=truncate, kwargs..., display_size=(h2, w))
+             truncate=truncate, display_size=(h2, w), kwargs...)
     end
 end
 

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -38,36 +38,64 @@ function Base.show(io::IO, gd::GroupedDataFrame;
                  truncate=truncate, kwargs...)
         end
     else
-        if N > 0
-            nrows = size(gd[1], 1)
-            rows = nrows > 1 ? "rows" : "row"
+        N > 0 || return
 
-            identified_groups = [string(col, " = ", repr(gd[1][1, col]))
-                                 for col in gd.cols]
 
-            print(io, "\nFirst Group ($nrows $rows): ")
-            join(io, identified_groups, ", ")
-            println(io)
+        (h, w) = get(io, :displaysize, displaysize(io))
+        h -= 2 # two lines are already used for header
 
-            show(io, gd[1]; summary=false,
-                 allrows=allrows, allcols=allcols, rowlabel=rowlabel,
-                 truncate=truncate, kwargs...)
-        end
+        h1 = h2 = h # display heights available for first and last groups
         if N > 1
-            nrows = size(gd[N], 1)
-            rows = nrows > 1 ? "rows" : "row"
+            # line height of groups if printed in full (nrows + 3 extra for header)
+            g1 = size(gd[1], 1) + 3
+            g2 = size(gd[N], 1) + 3
 
-            identified_groups = [string(col, " = ", repr(gd[N][1, col]))
-                                 for col in gd.cols]
-            print(io, "\n⋮")
-            print(io, "\nLast Group ($nrows $rows): ")
-            join(io, identified_groups, ", ")
-            println(io)
-
-            show(io, gd[N]; summary=false,
-                 allrows=allrows, allcols=allcols, rowlabel=rowlabel,
-                 truncate=truncate, kwargs...)
+            if g1 + g2 > h # won't fit on screen
+                if g1 < h ÷ 2
+                    h2 = h - g1 - 2 # show first group fully, squash last
+                elseif g2 < h ÷ 2
+                    h1 = h - g2 - 2 # show last group fully, squash first
+                else
+                    # squash both groups
+                    h += 1
+                    h1 = h ÷ 2
+                    h2 = h - h1
+                end
+            end
         end
+
+
+        nrows = size(gd[1], 1)
+        rows = nrows > 1 ? "rows" : "row"
+
+        identified_groups = [string(col, " = ", repr(gd[1][1, col]))
+                             for col in gd.cols]
+
+        print(io, "\nFirst Group ($nrows $rows): ")
+        join(io, identified_groups, ", ")
+        println(io)
+
+        show(io, gd[1]; summary=false,
+             allrows=allrows, allcols=allcols, rowlabel=rowlabel,
+             truncate=truncate, kwargs..., display_size=(h1, w))
+
+
+        N > 1 || return
+
+
+        nrows = size(gd[N], 1)
+        rows = nrows > 1 ? "rows" : "row"
+
+        identified_groups = [string(col, " = ", repr(gd[N][1, col]))
+                             for col in gd.cols]
+        print(io, "\n⋮")
+        print(io, "\nLast Group ($nrows $rows): ")
+        join(io, identified_groups, ", ")
+        println(io)
+
+        show(io, gd[N]; summary=false,
+             allrows=allrows, allcols=allcols, rowlabel=rowlabel,
+             truncate=truncate, kwargs..., display_size=(h2, w))
     end
 end
 

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -47,7 +47,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
         h -= 2 # two lines are already used for header and gap between groups
 
         h1 = h2 = h # display heights available for first and last groups
-        if !allrows && N > 1
+        if N > 1
             # line height of groups if printed in full (nrows + 3 extra for header)
             g1 = size(gd[1], 1) + 3
             g2 = size(gd[N], 1) + 3

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -47,7 +47,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
         h -= 2 # two lines are already used for header and gap between groups
 
         h1 = h2 = h # display heights available for first and last groups
-        if N > 1
+        if !allrows && N > 1
             # line height of groups if printed in full (nrows + 3 extra for header)
             g1 = size(gd[1], 1) + 3
             g2 = size(gd[N], 1) + 3

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -85,7 +85,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
 
         show(io, gd[1]; summary=false,
              allrows=allrows, allcols=allcols, rowlabel=rowlabel,
-             truncate=truncate, kwargs..., display_size=(h1, w))
+             truncate=truncate, display_size=(h1, w), kwargs...)
 
         N > 1 || return
 

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -42,33 +42,28 @@ function Base.show(io::IO, gd::GroupedDataFrame;
 
         (h, w) = displaysize(io)
 
-        if h <= 10 # if too small, then show groups in minimum possible size
-            h1 = h2 = 1
-        elseif h <= 16
-            # when given a height of less than 16/2 = 8 lines, pretty_table displays single tables using
-            # extra lines - but here, we want to control the total height exactly. Empirical workaround:
-            h1 = 2((h - 10)÷2) + 1
-            h2 = 2((h - 11)÷2) + 1
-        else
+        if h > 0
             h -= 2 # two lines are already used for header and gap between groups
+            h <= 5 && (h = 5) # if too small to fit, print fully compact
+        end
 
-            h1 = h2 = h # display heights available for first and last groups
-            if N > 1
-                # line height of groups if printed in full (nrows + 3 extra for header)
-                g1 = size(gd[1], 1) + 3
-                g2 = size(gd[N], 1) + 3
+        h1 = h2 = h # display heights available for first and last groups
+        if N > 1 && h > 0
 
-                if g1 + g2 > h # won't fit on screen
-                    if g1 < h ÷ 2
-                        h2 = h - g1 - 2 # show first group fully, squash last
-                    elseif g2 < h ÷ 2
-                        h1 = h - g2 - 2 # show last group fully, squash first
-                    else
-                        # squash both groups
-                        h += 1
-                        h2 = h ÷ 2
-                        h1 = h - h2
-                    end
+            # line height of groups if printed in full (nrows + 3 extra for header)
+            g1 = size(gd[1], 1) + 3
+            g2 = size(gd[N], 1) + 3
+
+            if g1 + g2 > h # won't fit on screen
+                if g1 < h ÷ 2
+                    h2 = h - g1 - 2 # show first group fully, squash last
+                elseif g2 < h ÷ 2
+                    h1 = h - g2 - 2 # show last group fully, squash first
+                else
+                    # squash both groups
+                    h += 1
+                    h2 = h ÷ 2
+                    h1 = h - h2
                 end
             end
         end

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -42,7 +42,9 @@ function Base.show(io::IO, gd::GroupedDataFrame;
 
 
         (h, w) = get(io, :displaysize, displaysize(io))
-        h -= 2 # two lines are already used for header
+        0 < h <= 3 && (h = 3) # show in full if h=0; show only headers and columns for small h>0
+
+        h -= 2 # two lines are already used for header and gap between groups
 
         h1 = h2 = h # display heights available for first and last groups
         if N > 1

--- a/test/show.jl
+++ b/test/show.jl
@@ -335,24 +335,8 @@ end
         @test str_hrows == str_allrows
     end
 
-    # height is small but positive -> print fully compact
-    for h in 1:10
-        io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
-        show(io, groupby(df, :x), allcols=true)
-        str = String(take!(io.io))
-        @test str == """
-            GroupedDataFrame with 2 groups based on key: x
-            First Group (5 rows): x = false
-             Row │ x  y  z
-             5 rows omitted
-            ⋮
-            Last Group (45 rows): x = true
-             Row │ x  y  z
-            45 rows omitted"""
-    end
-
-    # printed height always matches desired height
-    for h in 11:40
+    # printed height always matches desired height, above a reasonable minimum
+    for h in 15:40
         io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
         show(io, groupby(df, :x), allcols=true)
         str = String(take!(io.io))

--- a/test/show.jl
+++ b/test/show.jl
@@ -261,6 +261,70 @@ end
            4 │ true  true  true
            5 │ true  true  true"""
 
+    show(io, groupby(df, :x), allcols=true, allrows=true) 
+    str = String(take!(io.io))
+    @test str == """
+        GroupedDataFrame with 2 groups based on key: x
+        First Group (5 rows): x = false
+         Row │ x      y      z
+             │ Bool   Bool   Bool
+        ─────┼─────────────────────
+           1 │ false  false  false
+           2 │ false  false  false
+           3 │ false  false  false
+           4 │ false  false  false
+           5 │ false  false  false
+        ⋮
+        Last Group (45 rows): x = true
+         Row │ x     y      z
+             │ Bool  Bool   Bool
+        ─────┼────────────────────
+           1 │ true  false  false
+           2 │ true  false  false
+           3 │ true  false  false
+           4 │ true  false  false
+           5 │ true  false  false
+           6 │ true  false  false
+           7 │ true  false  false
+           8 │ true  false  false
+           9 │ true  false  false
+          10 │ true  false  false
+          11 │ true  false  false
+          12 │ true  false  false
+          13 │ true  false  false
+          14 │ true  false  false
+          15 │ true  false  false
+          16 │ true  false  false
+          17 │ true  false  false
+          18 │ true  false  false
+          19 │ true  false  false
+          20 │ true  false  false
+          21 │ true   true  false
+          22 │ true   true  false
+          23 │ true   true  false
+          24 │ true   true  false
+          25 │ true   true  false
+          26 │ true   true  false
+          27 │ true   true  false
+          28 │ true   true  false
+          29 │ true   true  false
+          30 │ true   true  false
+          31 │ true   true  false
+          32 │ true   true  false
+          33 │ true   true  false
+          34 │ true   true  false
+          35 │ true   true  false
+          36 │ true   true  false
+          37 │ true   true  false
+          38 │ true   true  false
+          39 │ true   true  false
+          40 │ true   true  false
+          41 │ true   true   true
+          42 │ true   true   true
+          43 │ true   true   true
+          44 │ true   true   true
+          45 │ true   true   true"""
+
     # height is small but positive -> print squashed
     for h in 1:5
         io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
@@ -292,6 +356,35 @@ end
         str_allrows = String(take!(io.io))
         @test str_hrows == str_allrows
     end
+
+    # one group
+    io = IOContext(IOBuffer(), :displaysize=>(15, 40), :limit=>true)
+    df = DataFrame(x = 1:15, y = 1)
+    show(io, groupby(df, :y))
+    str = String(take!(io.io))
+    print(str)
+    @test str == """
+        GroupedDataFrame with 1 group based on key: y
+        First Group (15 rows): y = 1
+         Row │ x      y
+             │ Int64  Int64
+        ─────┼──────────────
+           1 │     1      1
+           2 │     2      1
+           3 │     3      1
+          ⋮  │   ⋮      ⋮
+          14 │    14      1
+          15 │    15      1
+             10 rows omitted"""
+
+    # zero groups
+    io = IOContext(IOBuffer())
+    df = DataFrame(x=[], y=Int[])
+    show(io, groupby(df, :x))
+    str = String(take!(io.io))
+    @test str == "GroupedDataFrame with 0 groups based on key: x"
+
+
 end
 
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -164,6 +164,105 @@ end
                                2 columns omitted"""
 end
 
+@testset "GroupedDataFrame displaysize test" begin
+    df = DataFrame(x = (1:50) .> 5, y = (1:50) .> 25, z = (1:50) .> 45)
+    io = IOContext(IOBuffer(), :displaysize=>(30, 40), :limit=>true)
+
+    show(io, groupby(df, :x), allcols=true)
+    str = String(take!(io.io))
+    @test str == """
+        GroupedDataFrame with 2 groups based on key: x
+        First Group (5 rows): x = false
+         Row │ x      y      z
+             │ Bool   Bool   Bool
+        ─────┼─────────────────────
+           1 │ false  false  false
+           2 │ false  false  false
+           3 │ false  false  false
+           4 │ false  false  false
+           5 │ false  false  false
+        ⋮
+        Last Group (45 rows): x = true
+         Row │ x     y      z
+             │ Bool  Bool   Bool
+        ─────┼────────────────────
+           1 │ true  false  false
+           2 │ true  false  false
+           3 │ true  false  false
+           4 │ true  false  false
+           5 │ true  false  false
+          ⋮  │  ⋮      ⋮      ⋮
+          41 │ true   true   true
+          42 │ true   true   true
+          43 │ true   true   true
+          44 │ true   true   true
+          45 │ true   true   true
+                   35 rows omitted"""
+
+    show(io, groupby(df, :y), allcols=true)
+    str = String(take!(io.io))
+    @test str == """
+        GroupedDataFrame with 2 groups based on key: y
+        First Group (25 rows): y = false
+         Row │ x      y      z
+             │ Bool   Bool   Bool
+        ─────┼─────────────────────
+           1 │ false  false  false
+           2 │ false  false  false
+           3 │ false  false  false
+          ⋮  │   ⋮      ⋮      ⋮
+          23 │  true  false  false
+          24 │  true  false  false
+          25 │  true  false  false
+                    19 rows omitted
+        ⋮
+        Last Group (25 rows): y = true
+         Row │ x     y     z
+             │ Bool  Bool  Bool
+        ─────┼───────────────────
+           1 │ true  true  false
+           2 │ true  true  false
+           3 │ true  true  false
+           4 │ true  true  false
+          ⋮  │  ⋮     ⋮      ⋮
+          23 │ true  true   true
+          24 │ true  true   true
+          25 │ true  true   true
+                  18 rows omitted"""
+
+    show(io, groupby(df, :z), allcols=true)
+    str = String(take!(io.io))
+    @test str == """
+        GroupedDataFrame with 2 groups based on key: z
+        First Group (45 rows): z = false
+         Row │ x      y      z
+             │ Bool   Bool   Bool
+        ─────┼─────────────────────
+           1 │ false  false  false
+           2 │ false  false  false
+           3 │ false  false  false
+           4 │ false  false  false
+           5 │ false  false  false
+          ⋮  │   ⋮      ⋮      ⋮
+          41 │  true   true  false
+          42 │  true   true  false
+          43 │  true   true  false
+          44 │  true   true  false
+          45 │  true   true  false
+                    35 rows omitted
+        ⋮
+        Last Group (5 rows): z = true
+         Row │ x     y     z
+             │ Bool  Bool  Bool
+        ─────┼──────────────────
+           1 │ true  true  true
+           2 │ true  true  true
+           3 │ true  true  true
+           4 │ true  true  true
+           5 │ true  true  true"""
+end
+
+
 @testset "IOContext parameters test" begin
     df = DataFrame(A=Int64[1:4;], B=["x\"", "∀ε>0: x+ε>x", "z\$", "A\nC"],
                    C=Float32[1.0, 2.0, 3.0, 4.0])

--- a/test/show.jl
+++ b/test/show.jl
@@ -260,6 +260,38 @@ end
            3 │ true  true  true
            4 │ true  true  true
            5 │ true  true  true"""
+
+    # height is small but positive -> print squashed
+    for h in 1:5
+        io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
+        show(io, groupby(df, :x), allcols=true)
+        str = String(take!(io.io))
+        @test str == """
+            GroupedDataFrame with 2 groups based on key: x
+            First Group (5 rows): x = false
+             Row │ x      y      z
+                 │ Bool   Bool   Bool
+            ─────┼─────────────────────
+              ⋮  │   ⋮      ⋮      ⋮
+                         5 rows omitted
+            ⋮
+            Last Group (45 rows): x = true
+             Row │ x     y      z
+                 │ Bool  Bool   Bool
+            ─────┼────────────────────
+              ⋮  │  ⋮      ⋮      ⋮
+                       45 rows omitted"""
+    end
+
+    # height is zero or invalid -> print all rows
+    for h in -1:0
+        io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
+        show(io, groupby(df, :x), allcols=true)
+        str_hrows = String(take!(io.io))
+        show(io, groupby(df, :x), allcols=true, allrows=true)
+        str_allrows = String(take!(io.io))
+        @test str_hrows == str_allrows
+    end
 end
 
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -388,8 +388,6 @@ end
     show(io, groupby(df, :x))
     str = String(take!(io.io))
     @test str == "GroupedDataFrame with 0 groups based on key: x"
-
-
 end
 
 @testset "IOContext parameters test" begin


### PR DESCRIPTION
This is a small enhancement to make `GroupedDataFrame`s display so that they fit in one screen, like regular `DataFrame`s with many rows.

Before, the first and last groups of a `GroupedDataFrame` would be displayed at full size; now, the two groups are made smaller (using the `:displaysize` parameter in `IOContext`) so that together they fill the required line height.

If the first group is smaller than half the available REPL height, and the last group is larger, or vice versa, then the smaller group is shown in full and the larger one is squashed (displayed with missing rows). This means that the group with the most rows takes up the most room visually, even after some of its rows are skipped.

See the `"GroupedDataFrame displaysize test"` test set for example output.