### PR TITLE
Vector{Vector} constructor fallback when passing in rows, not columns

### DIFF
--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -175,8 +175,12 @@ struct DataFrame <: AbstractDataFrame
         if length(columns) == length(colindex) == 0
             return new(AbstractVector[], Index())
         elseif length(columns) != length(colindex)
-            throw(DimensionMismatch("Number of columns ($(length(columns))) and number of " *
-                                    "column names ($(length(colindex))) are not equal"))
+            if all(length(x) == length(colindex) for x in columns)
+                columns = convert(Vector{Vector}, collect(eachrow(reduce(hcat, columns))))
+            else
+                throw(DimensionMismatch("Number of columns ($(length(columns))) and number of " *
+                                        "column names ($(length(colindex))) are not equal"))
+            end
         end
 
         len = -1


### PR DESCRIPTION
I don't intend to have this merged and I'm sure the code is wrong for many reasons.

I just want to hear what the reasons are for requiring the Vector{Vector} constructor be columns. It seems not too crazy to at least check if the "columns" are actually rows, and have the same length as the Index. If they are, what would be problematic about permuting the data so that the columns are actually columns? 

Another possibility is just doing the check for `all(length(x) == length(colindex) for x in columns)` and returning a helpful (copy-pastable) error for "Are you trying to make a DataFrame from rows? Try doing `DataFrame(collect(eachrow(reduce(hcat, rows))), cnames)`". I realize that this snippet is not efficient and probably wrong. 

I know that the current row-by-row construction is loop + `push!` or just make the rows NamedTuples to begin with. 