### PR TITLE
1-arg permutedims(df)

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -683,7 +683,7 @@ with name specified by `dest_namescol`.
 # Arguments
 - `df` : the `AbstractDataFrame`
 - `src_namescol` : the column that will become the new header.
-   If omitted then column names `x1`, `x2`, ... are generated automatically.
+   If omitted then column names `:x1`, `:x2`, ... are generated automatically.
 - `dest_namescol` : the name of the first column in the returned `DataFrame`.
   Defaults to the same name as `src_namescol`.
   Not supported when `src_namescol` is a vector or is omitted.

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -670,7 +670,8 @@ Base.transpose(::AbstractDataFrame, args...; kwargs...) =
     throw(ArgumentError("`transpose` not defined for `AbstractDataFrame`s. Try `permutedims` instead"))
 
 """
-    permutedims(df::AbstractDataFrame, src_namescol::Union{Int, Symbol, AbstractString},
+    permutedims(df::AbstractDataFrame,
+                [src_namescol::Union{Int, Symbol, AbstractString}],
                 [dest_namescol::Union{Symbol, AbstractString}];
                 makeunique::Bool=false, strict::Bool=true)
 
@@ -681,7 +682,9 @@ with name specified by `dest_namescol`.
 
 # Arguments
 - `df` : the `AbstractDataFrame`
-- `src_namescol` : the column that will become the new header.
+- `src_namescol` : the column that will become the new header. If this argument
+  is not passed then auto-generated header is used with column names
+  `x1`, `x2`, ... and in this case column names from the `df` are dropped.
 - `dest_namescol` : the name of the first column in the returned `DataFrame`.
   Defaults to the same name as `src_namescol`.
 - `makeunique` : if `false` (the default), an error will be raised

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -712,7 +712,7 @@ resulting columns will have element type `Float64`. If the source has
 # Examples
 
 ```jldoctest
-julia> df
+julia> df = DataFrame(a=1:2, b=3:4)
 2×2 DataFrame
  Row │ a      b
      │ Int64  Int64

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -825,5 +825,5 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
 end
 
 Base.permutedims(df::AbstractDataFrame) = DataFrame(permutedims(Matrix(df)), :auto)
-Base.permutedims(df::AbstractDataFrame, cnames::AbstractVector, makeunique::Bool=false) =
+Base.permutedims(df::AbstractDataFrame, cnames::AbstractVector; makeunique::Bool=false) =
     DataFrame(permutedims(Matrix(df)), cnames, makeunique=makeunique)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -791,3 +791,5 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
     return permutedims(df, src_namescol, dest_namescol;
                        makeunique=makeunique, strict=strict)
 end
+
+Base.permutedims(df::AbstractDataFrame) = DataFrame(permutedims(Matrix(df)), :auto)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -682,9 +682,14 @@ with name specified by `dest_namescol`.
 
 # Arguments
 - `df` : the `AbstractDataFrame`
-- `src_namescol` : the column that will become the new header. If this argument
-  is not passed then auto-generated header is used with column names
-  `x1`, `x2`, ... and in this case column names from the `df` are dropped.
+- `src_namescol` : the column that will become the new header.
+   Alternatively a vector of strings or `Symbol`s can be passed
+   which will be used as column names in returned data frame.
+   If this argument is not passed then auto-generated header is used with
+   column names `x1`, `x2`, ... and passing `makeunique` keyword argument is
+   not allowed.
+   If this argument is a vector or is skipped then then passing `dest_namescol`
+   and `strict` arguments is not allowed and column names from the `df` are dropped.
 - `dest_namescol` : the name of the first column in the returned `DataFrame`.
   Defaults to the same name as `src_namescol`.
 - `makeunique` : if `false` (the default), an error will be raised
@@ -697,9 +702,9 @@ with name specified by `dest_namescol`.
   the `string` function.
 
 Note: The element types of columns in resulting `DataFrame`
-(other than the first column, which always has element type `String`)
-will depend on the element types of _all_ input columns
-based on the result of `promote_type`.
+(other than the first column if it is created from `df` column names,
+which always has element type `String`) will depend on the element types of
+_all_ input columns based on the result of `promote_type`.
 That is, if the source data frame contains `Int` and `Float64` columns,
 resulting columns will have element type `Float64`. If the source has
 `Int` and `String` columns, resulting columns will have element type `Any`.
@@ -707,6 +712,30 @@ resulting columns will have element type `Float64`. If the source has
 # Examples
 
 ```jldoctest
+julia> df
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      3
+   2 │     2      4
+
+julia> permutedims(df)
+2×2 DataFrame
+ Row │ x1     x2
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      2
+   2 │     3      4
+
+julia> permutedims(df, [:p, :q])
+2×2 DataFrame
+ Row │ p      q
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      2
+   2 │     3      4
+
 julia> df1 = DataFrame(a=["x", "y"], b=[1.0, 2.0], c=[3, 4], d=[true, false])
 2×4 DataFrame
  Row │ a       b        c      d
@@ -796,3 +825,5 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
 end
 
 Base.permutedims(df::AbstractDataFrame) = DataFrame(permutedims(Matrix(df)), :auto)
+Base.permutedims(df::AbstractDataFrame, cnames::AbstractVector, makeunique::Bool=false) =
+    DataFrame(permutedims(Matrix(df)), cnames, makeunique=makeunique)

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -683,13 +683,7 @@ with name specified by `dest_namescol`.
 # Arguments
 - `df` : the `AbstractDataFrame`
 - `src_namescol` : the column that will become the new header.
-   Alternatively a vector of strings or `Symbol`s can be passed
-   which will be used as column names in returned data frame.
-   If this argument is not passed then auto-generated header is used with
-   column names `x1`, `x2`, ... and passing `makeunique` keyword argument is
-   not allowed.
-   If this argument is a vector or is skipped then then passing `dest_namescol`
-   and `strict` arguments is not allowed and column names from the `df` are dropped.
+   If omitted then column names `x1`, `x2`, ... are generated automatically.
 - `dest_namescol` : the name of the first column in the returned `DataFrame`.
   Defaults to the same name as `src_namescol`.
 - `makeunique` : if `false` (the default), an error will be raised

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -686,14 +686,17 @@ with name specified by `dest_namescol`.
    If omitted then column names `x1`, `x2`, ... are generated automatically.
 - `dest_namescol` : the name of the first column in the returned `DataFrame`.
   Defaults to the same name as `src_namescol`.
+  Not supported when `src_namescol` is a vector or is omitted.
 - `makeunique` : if `false` (the default), an error will be raised
   if duplicate names are found; if `true`, duplicate names will be suffixed
   with `_i` (`i` starting at 1 for the first duplicate).
+  Not supported when `src_namescol` is omitted.
 - `strict` : if `true` (the default), an error will be raised if the values
   contained in the `src_namescol` are not all `Symbol` or all `AbstractString`,
   or can all be converted to `String` using `convert`. If `false`
   then any values are accepted and the will be changed to strings using
   the `string` function.
+  Not supported when `src_namescol` is a vector or is omitted.
 
 Note: The element types of columns in resulting `DataFrame`
 (other than the first column if it is created from `df` column names,

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -668,6 +668,9 @@ end
     @test_throws ArgumentError permutedims(df, 1)
     # but allowed with strict=false
     @test permutedims(df, 1, strict=false) == ref
+
+    df = DataFrame(a=1:2, b=3:4)
+    @test permutedims(df) = DataFrame(a=[1, 3], b=[2, 4])
 end
 
 @testset "stack view=true additional tests" begin

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -670,7 +670,7 @@ end
     @test permutedims(df, 1, strict=false) == ref
 
     df = DataFrame(a=1:2, b=3:4)
-    @test permutedims(df) == DataFrame(a=[1, 3], b=[2, 4])
+    @test permutedims(df) == DataFrame(x1=[1, 3], x2=[2, 4])
     @test permutedims(df, [:p, :q]) == DataFrame(p=[1, 3], q=[2, 4])
     @test permutedims(df, ["p", "q"]) == DataFrame(p=[1, 3], q=[2, 4])
     @test_throws ArgumentError permutedims(df, ["p", "p"]) == DataFrame(p=[1, 3], q=[2, 4])

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -671,6 +671,10 @@ end
 
     df = DataFrame(a=1:2, b=3:4)
     @test permutedims(df) = DataFrame(a=[1, 3], b=[2, 4])
+    @test permutedims(df, [:p, :q]) = DataFrame(p=[1, 3], q=[2, 4])
+    @test permutedims(df, ["p", "q"]) = DataFrame(p=[1, 3], q=[2, 4])
+    @test_throws ArgumentError permutedims(df, ["p", "p"]) = DataFrame(p=[1, 3], q=[2, 4])
+    @test permutedims(df, ["p", "p"], makeunique=true) = DataFrame(p=[1, 3], p_1=[2, 4])
 end
 
 @testset "stack view=true additional tests" begin

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -675,6 +675,8 @@ end
     @test permutedims(df, ["p", "q"]) == DataFrame(p=[1, 3], q=[2, 4])
     @test_throws ArgumentError permutedims(df, ["p", "p"]) == DataFrame(p=[1, 3], q=[2, 4])
     @test permutedims(df, ["p", "p"], makeunique=true) == DataFrame(p=[1, 3], p_1=[2, 4])
+    @test permutedims(DataFrame()) == permutedims(DataFrame(a=[], b=[])) ==
+          permutedims(DataFrame(), []) == permutedims(DataFrame(a=[], b=[]), []) == DataFrame()
 end
 
 @testset "stack view=true additional tests" begin

--- a/test/reshape.jl
+++ b/test/reshape.jl
@@ -670,11 +670,11 @@ end
     @test permutedims(df, 1, strict=false) == ref
 
     df = DataFrame(a=1:2, b=3:4)
-    @test permutedims(df) = DataFrame(a=[1, 3], b=[2, 4])
-    @test permutedims(df, [:p, :q]) = DataFrame(p=[1, 3], q=[2, 4])
-    @test permutedims(df, ["p", "q"]) = DataFrame(p=[1, 3], q=[2, 4])
-    @test_throws ArgumentError permutedims(df, ["p", "p"]) = DataFrame(p=[1, 3], q=[2, 4])
-    @test permutedims(df, ["p", "p"], makeunique=true) = DataFrame(p=[1, 3], p_1=[2, 4])
+    @test permutedims(df) == DataFrame(a=[1, 3], b=[2, 4])
+    @test permutedims(df, [:p, :q]) == DataFrame(p=[1, 3], q=[2, 4])
+    @test permutedims(df, ["p", "q"]) == DataFrame(p=[1, 3], q=[2, 4])
+    @test_throws ArgumentError permutedims(df, ["p", "p"]) == DataFrame(p=[1, 3], q=[2, 4])
+    @test permutedims(df, ["p", "p"], makeunique=true) == DataFrame(p=[1, 3], p_1=[2, 4])
 end
 
 @testset "stack view=true additional tests" begin


### PR DESCRIPTION
Going along with the other PR #3114, I was thinking maybe it would be better to just make permutedims easier to use instead of try to change the DataFrame constructors. 

The current methods for permutedims are honestly pretty confusing to me and I was surprised there wasn't a simple method that just permutes and doesn't add new columns or anything annoying like that.

I would love if someone could make it non-allocating or whatever, but I think regardless it makes sense to have this method defined. 

Would appreciate some comments :)