### PR TITLE
Extend `stack` from Base/Compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.4.1"
+version = "1.4.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CategoricalArrays = "0.10.0"
-Compat = "3.45, 4.2"
+Compat = "3.46, 4.2"
 DataAPI = "1.10"
 InvertedIndices = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -25,7 +25,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CategoricalArrays = "0.10.0"
-Compat = "3.45, 4.1"
+Compat = "3.45, 4.2"
 DataAPI = "1.10"
 InvertedIndices = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -78,7 +78,6 @@ export AbstractDataFrame,
        select!,
        select,
        semijoin,
-       stack,
        subset,
        subset!,
        transform,
@@ -140,6 +139,13 @@ if isdefined(Base, :ComposedFunction) # Julia >= 1.6.0-DEV.85
     using Base: ComposedFunction
 else
     using Compat: ComposedFunction
+end
+
+if VERSION >= v"1.9.0-DEV.1163"
+    import Base: stack
+else
+    import Compat: stack
+    export stack
 end
 
 include("other/utils.jl")


### PR DESCRIPTION
Added to Julia in https://github.com/JuliaLang/julia/pull/43334, added to Compat in https://github.com/JuliaLang/Compat.jl/pull/777 (v4.2). This PR requires the latter to be merged and tagged first.

Closes https://github.com/JuliaData/DataFrames.jl/issues/3119.