### PR TITLE
improve error message when column is not found

### DIFF
--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -386,13 +386,13 @@ end
         candidates = fuzzymatch(l, idx)
         if isempty(candidates)
             if isempty(l)
-                throw(ArgumentError("column name :$idx not found in the " *
+                throw(ArgumentError("column name \"$idx\" not found in the " *
                                     "data frame since it has no columns"))
             end
             throw(ArgumentError("column name :$idx not found in the data frame"))
         end
-        candidatesstr = join(string.(':', candidates), ", ", " and ")
-        throw(ArgumentError("column name :$idx not found in the data frame; " *
+        candidatesstr = join(string.('"', candidates, '"'), ", ", " and ")
+        throw(ArgumentError("column name \"$idx\" not found in the data frame; " *
                             "existing most similar names are: $candidatesstr"))
     end
     return i


### PR DESCRIPTION
Following discussion on Slack.

After the change:
```
julia> df = DataFrame()
0×0 DataFrame

julia> df.a
ERROR: ArgumentError: column name "a" not found in the data frame since it has no columns

julia> df = DataFrame(a=1, b=2, c=3)
1×3 DataFrame
 Row │ a      b      c     
     │ Int64  Int64  Int64 
─────┼─────────────────────
   1 │     1      2      3

julia> df.d
ERROR: ArgumentError: column name "d" not found in the data frame; existing most similar names are: "a", "b" and "c"
```

I use string quoting not `:` and backticks as suggested on Slack as we allow string as column name.