### PR TITLE
Reduce memory use in threading correctness tests

### DIFF
--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -2023,7 +2023,8 @@ include("indexing_offset.jl")
 
 @testset "threading correctness tests" begin
     for x in (10, 1_100_000), y in 1:4
-        df = DataFrame([rand(Int8, x) for _ in 1:y], :auto, copycols=false)
+        vecvec = [rand(Int8, x) for _ in 1:y]
+        df = DataFrame(vecvec, :auto, copycols=false)
         for rowrange in [:, 1:nrow(df)-5, collect(1:nrow(df)-5), axes(df, 1) .< nrow(df)-5],
             colrange in [:, axes(df, 2), collect(axes(df, 2)), 1:ncol(df) - 1]
             # Equivalent but using less memory than:

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -2023,7 +2023,7 @@ include("indexing_offset.jl")
 
 @testset "threading correctness tests" begin
     for x in (10, 1_100_000), y in 1:4
-        mat = rand(Int8, x, y)
+        mat = fill(nothing, x, y)
         df = DataFrame(mat, :auto)
         for rowrange in [:, 1:nrow(df)-5, collect(1:nrow(df)-5), axes(df, 1) .< nrow(df)-5],
             colrange in [:, axes(df, 2), collect(axes(df, 2)), 1:ncol(df) - 1]

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -2027,11 +2027,9 @@ include("indexing_offset.jl")
         df = DataFrame(vecvec, :auto, copycols=false)
         for rowrange in [:, 1:nrow(df)-5, collect(1:nrow(df)-5), axes(df, 1) .< nrow(df)-5],
             colrange in [:, axes(df, 2), collect(axes(df, 2)), 1:ncol(df) - 1]
-            # Equivalent but using less memory than:
-            # @test DataFrame(mat[rowrange, colrange], :auto) == df[rowrange, colrange]
             df2 = df[rowrange, colrange]
             for j in axes(df2, 2)
-                @test df2[!, j] == view(mat, rowrange, j)
+                @test df2[!, j] == view(vecvec[j], rowrange)
             end
         end
     end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -2023,8 +2023,7 @@ include("indexing_offset.jl")
 
 @testset "threading correctness tests" begin
     for x in (10, 1_100_000), y in 1:4
-        mat = fill(nothing, x, y)
-        df = DataFrame(mat, :auto)
+        df = DataFrame([rand(Int8, x) for _ in 1:y], :auto, copycols=false)
         for rowrange in [:, 1:nrow(df)-5, collect(1:nrow(df)-5), axes(df, 1) .< nrow(df)-5],
             colrange in [:, axes(df, 2), collect(axes(df, 2)), 1:ncol(df) - 1]
             # Equivalent but using less memory than:


### PR DESCRIPTION
Work with a matrix filled with `nothing` instead of random `Int8`s, goes from 98 KB to 48 B. This is an attempt to perhaps elevate the failiure here: https://github.com/JuliaData/DataFrames.jl/actions/runs/3091782763/jobs/5002284179#step:6:1105