### PR TITLE
fix metadata handling in permutedims

### DIFF
--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -851,6 +851,15 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
                        makeunique=makeunique, strict=strict)
 end
 
-Base.permutedims(df::AbstractDataFrame) = DataFrame(permutedims(Matrix(df)), :auto)
-Base.permutedims(df::AbstractDataFrame, cnames::AbstractVector; makeunique::Bool=false) =
-    DataFrame(permutedims(Matrix(df)), cnames, makeunique=makeunique)
+function Base.permutedims(df::AbstractDataFrame)
+    out_df = DataFrame(permutedims(Matrix(df)), :auto)
+    _copy_table_note_metadata!(out_df, df)
+    return out_df
+end
+
+function Base.permutedims(df::AbstractDataFrame, cnames::AbstractVector;
+                          makeunique::Bool=false)
+    out_df = DataFrame(permutedims(Matrix(df)), cnames, makeunique=makeunique)
+    _copy_table_note_metadata!(out_df, df)
+    return out_df
+end

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -1373,27 +1373,29 @@ end
 end
 
 @testset "permutedims" begin
-    df = DataFrame(a=["x", "y"], b=[1.0, 2.0], c=[3, 4], d=[true, false])
-    res = permutedims(df, 1)
-    @test check_allnotemetadata(res)
-    @test getfield(res, :metadata) === nothing
-    @test getfield(res, :colmetadata) === nothing
+    for fun in (x -> permutedims(x, 1), permutedims, x -> permutedims(x, [:a, :b]))
+        df = DataFrame(a=["x", "y"], b=[1.0, 2.0], c=[3, 4], d=[true, false])
+        res = fun(df)
+        @test check_allnotemetadata(res)
+        @test getfield(res, :metadata) === nothing
+        @test getfield(res, :colmetadata) === nothing
 
-    metadata!(df, "name", "empty", style=:note)
-    metadata!(df, "name1", "empty1", style=:default)
-    colmetadata!(df, :a, "name", "a", style=:note)
-    colmetadata!(df, :a, "name1", "a1", style=:default)
-    colmetadata!(df, :b, "name", "b", style=:note)
-    colmetadata!(df, :b, "name1", "b1", style=:default)
-    colmetadata!(df, :c, "name", "c", style=:note)
-    colmetadata!(df, :c, "name1", "c1", style=:default)
-    colmetadata!(df, :d, "name", "d", style=:note)
-    colmetadata!(df, :d, "name1", "d1", style=:default)
-    res = permutedims(df, 1)
-    @test check_allnotemetadata(res)
-    @test collect(metadatakeys(res)) == ["name"]
-    @test metadata(res, "name") == "empty"
-    @test getfield(res, :colmetadata) === nothing
+        metadata!(df, "name", "empty", style=:note)
+        metadata!(df, "name1", "empty1", style=:default)
+        colmetadata!(df, :a, "name", "a", style=:note)
+        colmetadata!(df, :a, "name1", "a1", style=:default)
+        colmetadata!(df, :b, "name", "b", style=:note)
+        colmetadata!(df, :b, "name1", "b1", style=:default)
+        colmetadata!(df, :c, "name", "c", style=:note)
+        colmetadata!(df, :c, "name1", "c1", style=:default)
+        colmetadata!(df, :d, "name", "d", style=:note)
+        colmetadata!(df, :d, "name1", "d1", style=:default)
+        res = permutedims(df, 1)
+        @test check_allnotemetadata(res)
+        @test collect(metadatakeys(res)) == ["name"]
+        @test metadata(res, "name") == "empty"
+        @test getfield(res, :colmetadata) === nothing
+    end
 end
 
 @testset "broadcasting" begin


### PR DESCRIPTION
Fixes the missing part of `permutedims` implementation from #3115.