### PR TITLE
Add better error message on error when pushing rows to a data frame

### DIFF
--- a/src/dataframe/insertion.jl
+++ b/src/dataframe/insertion.jl
@@ -298,7 +298,7 @@ function _append_or_prepend!(df1::DataFrame, df2::AbstractDataFrame; cols::Symbo
             end
         end
         @error "Error adding value to column :$(_names(df1)[current_col]). " *
-               "Maybe you have forgotten to ask for column " *
+               "Maybe it was forgotten to require column " *
                "element type promotion, which can be done " *
                "by passing the promote=true keyword argument."
         rethrow(err)
@@ -686,7 +686,7 @@ function _row_inserter!(df::DataFrame, loc::Integer, row::Any,
             @assert length(col2) == nrows
         end
         @error "Error adding value to column :$(_names(df)[current_col]). " *
-               "Maybe you have forgotten to ask for column element type promotion, " *
+               "Maybe it was forgotten to ask for column element type promotion, " *
                "which can be done by passing the promote=true keyword argument."
         rethrow(err)
     end
@@ -749,7 +749,7 @@ function _dfr_row_inserter!(df::DataFrame, loc::Integer, dfr::DataFrameRow,
                 end
                 colname = _names(df)[col_num]
                 throw(AssertionError("Error adding value to column :$colname. " *
-                                     "Maybe you have forgotten to ask for column " *
+                                     "Maybe it was forgotten to ask for column " *
                                      "element type promotion, which can be done " *
                                      "by passing the promote=true keyword argument."))
             end
@@ -865,7 +865,7 @@ function _row_inserter!(df::DataFrame, loc::Integer,
                         @assert length(col2) == nrows
                     end
                     @error "Error adding value to column :$colname. " *
-                           "Maybe you have forgotten to ask for column " *
+                           "Maybe it was forgotten to ask for column " *
                            "element type promotion, which can be done " *
                            "by passing the promote=true keyword argument."
                     rethrow(err)
@@ -972,7 +972,7 @@ function _row_inserter!(df::DataFrame, loc::Integer,
             @assert length(col2) == nrows
         end
         @error "Error adding value to column :$(_names(df)[current_col]). " *
-               "Maybe you have forgotten to ask for column " *
+               "Maybe it was forgotten to ask for column " *
                "element type promotion, which can be done " *
                "by passing the promote=true keyword argument."
         rethrow(err)

--- a/src/dataframe/insertion.jl
+++ b/src/dataframe/insertion.jl
@@ -300,7 +300,7 @@ function _append_or_prepend!(df1::DataFrame, df2::AbstractDataFrame; cols::Symbo
         @error "Error adding value to column :$(_names(df1)[current_col]). " *
                "Maybe you have forgotten to ask for column " *
                "element type promotion, which can be done " *
-               "by passing `promote=true` keyword argument."
+               "by passing the promote=true keyword argument."
         rethrow(err)
     end
 
@@ -687,7 +687,7 @@ function _row_inserter!(df::DataFrame, loc::Integer, row::Any,
         end
         @error "Error adding value to column :$(_names(df)[current_col]). " *
                "Maybe you have forgotten to ask for column element type promotion, " *
-               "which can be done by passing `promote=true` keyword argument."
+               "which can be done by passing the promote=true keyword argument."
         rethrow(err)
     end
     _drop_all_nonnote_metadata!(df)
@@ -751,7 +751,7 @@ function _dfr_row_inserter!(df::DataFrame, loc::Integer, dfr::DataFrameRow,
                 throw(AssertionError("Error adding value to column :$colname. " *
                                      "Maybe you have forgotten to ask for column " *
                                      "element type promotion, which can be done " *
-                                     "by passing `promote=true` keyword argument."))
+                                     "by passing the promote=true keyword argument."))
             end
             # use a function barrier to improve performance
             mode isa Val{:push} && pushhelper!(col, r)
@@ -867,7 +867,7 @@ function _row_inserter!(df::DataFrame, loc::Integer,
                     @error "Error adding value to column :$colname. " *
                            "Maybe you have forgotten to ask for column " *
                            "element type promotion, which can be done " *
-                           "by passing `promote=true` keyword argument."
+                           "by passing the promote=true keyword argument."
                     rethrow(err)
                 end
             else
@@ -974,7 +974,7 @@ function _row_inserter!(df::DataFrame, loc::Integer,
         @error "Error adding value to column :$(_names(df)[current_col]). " *
                "Maybe you have forgotten to ask for column " *
                "element type promotion, which can be done " *
-               "by passing `promote=true` keyword argument."
+               "by passing the promote=true keyword argument."
         rethrow(err)
     end
     _drop_all_nonnote_metadata!(df)

--- a/src/dataframe/insertion.jl
+++ b/src/dataframe/insertion.jl
@@ -748,10 +748,7 @@ function _dfr_row_inserter!(df::DataFrame, loc::Integer, dfr::DataFrameRow,
                     @assert length(col2) == nrows
                 end
                 colname = _names(df)[col_num]
-                throw(AssertionError("Error adding value to column :$colname. " *
-                                     "Maybe it was forgotten to ask for column " *
-                                     "element type promotion, which can be done " *
-                                     "by passing the promote=true keyword argument."))
+                throw(AssertionError("Error adding value to column :$colname."))
             end
             # use a function barrier to improve performance
             mode isa Val{:push} && pushhelper!(col, r)

--- a/src/dataframe/insertion.jl
+++ b/src/dataframe/insertion.jl
@@ -297,7 +297,10 @@ function _append_or_prepend!(df1::DataFrame, df2::AbstractDataFrame; cols::Symbo
                 deleteat!(col, 1:length(col) - nrow1)
             end
         end
-        @error "Error adding value to column :$(_names(df1)[current_col])."
+        @error "Error adding value to column :$(_names(df1)[current_col]). " *
+               "Maybe you have forgotten to ask for column " *
+               "element type promotion, which can be done " *
+               "by passing `promote=true` keyword argument."
         rethrow(err)
     end
 
@@ -682,7 +685,9 @@ function _row_inserter!(df::DataFrame, loc::Integer, row::Any,
             end
             @assert length(col2) == nrows
         end
-        @error "Error adding value to column :$(_names(df)[current_col])."
+        @error "Error adding value to column :$(_names(df)[current_col]). " *
+               "Maybe you have forgotten to ask for column element type promotion, " *
+               "which can be done by passing `promote=true` keyword argument."
         rethrow(err)
     end
     _drop_all_nonnote_metadata!(df)
@@ -743,7 +748,10 @@ function _dfr_row_inserter!(df::DataFrame, loc::Integer, dfr::DataFrameRow,
                     @assert length(col2) == nrows
                 end
                 colname = _names(df)[col_num]
-                throw(AssertionError("Error adding value to column :$colname"))
+                throw(AssertionError("Error adding value to column :$colname. " *
+                                     "Maybe you have forgotten to ask for column " *
+                                     "element type promotion, which can be done " *
+                                     "by passing `promote=true` keyword argument."))
             end
             # use a function barrier to improve performance
             mode isa Val{:push} && pushhelper!(col, r)
@@ -828,7 +836,7 @@ function _row_inserter!(df::DataFrame, loc::Integer,
                     end
                     @assert length(col2) == nrows
                 end
-                throw(AssertionError("Error adding value to column :$colname"))
+                throw(AssertionError("Error adding value to column :$colname."))
             end
             if haskey(row, colname)
                 val = row[colname]
@@ -856,7 +864,10 @@ function _row_inserter!(df::DataFrame, loc::Integer,
                         end
                         @assert length(col2) == nrows
                     end
-                    @error "Error adding value to column :$colname."
+                    @error "Error adding value to column :$colname. " *
+                           "Maybe you have forgotten to ask for column " *
+                           "element type promotion, which can be done " *
+                           "by passing `promote=true` keyword argument."
                     rethrow(err)
                 end
             else
@@ -960,7 +971,10 @@ function _row_inserter!(df::DataFrame, loc::Integer,
             end
             @assert length(col2) == nrows
         end
-        @error "Error adding value to column :$(_names(df)[current_col])."
+        @error "Error adding value to column :$(_names(df)[current_col]). " *
+               "Maybe you have forgotten to ask for column " *
+               "element type promotion, which can be done " *
+               "by passing `promote=true` keyword argument."
         rethrow(err)
     end
     _drop_all_nonnote_metadata!(df)


### PR DESCRIPTION
Typically an error in `push!` etc. is because `promote=false` is set. This PR improves error message to give a proper hint to the user.

CC @nickrobinson251