### PR TITLE
improve printing of GroupedDataFrame in corner cases

### DIFF
--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -43,10 +43,10 @@ function Base.show(io::IO, gd::GroupedDataFrame;
         (h, w) = displaysize(io)
 
         # in the code below we accept that output for desired height less
-        # than 15 does not have to always exactly math the passed value
+        # than 15 does not have to always exactly match the passed value
         if h > 0
             # 2 lines for header and gap between groups, 3 lines for prompts;
-            # correcting for this allow at least 8 lines (4 for each group)
+            # correcting for this allows at least 8 lines (4 for each group)
             h = max(h - 5, 8)
 
             if N == 1

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -50,7 +50,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
             h = max(h - 5, 8)
 
             if N == 1
-                h1 = h + 3 # add two lines for prompts and one line as there no gap between groups
+                h1 = h + 3 # add two lines for prompts and one line as there is no gap between groups
                 h2 = 0 # not used
             else
                 # line height of groups if printed in full; 4 lines for header

--- a/test/show.jl
+++ b/test/show.jl
@@ -342,8 +342,9 @@ end
         show(io, groupby(df, :x), allcols=true)
         str = String(take!(io.io))
         nlines = length(split(str, '\n'))
-        desired = min(a + b + 10, h - 3) # leave one line for last REPL prompt at top, two for new prompt
+        # leave one line for last REPL prompt at top, two for new prompt
         # (this is the same behavior as ungrouped data frames)
+        desired = min(a + b + 10, h - 3) 
         @test nlines == desired
     end
 
@@ -353,8 +354,9 @@ end
         show(io, groupby(df, :x), allcols=true)
         str = String(take!(io.io))
         nlines = length(split(str, '\n'))
-        desired = min(a + 5, h - 3) # leave one line for last REPL prompt at top, two for new prompt
+        # leave one line for last REPL prompt at top, two for new prompt
         # (this is the same behavior as ungrouped data frames)
+        desired = min(a + 5, h - 3)
         @test nlines == desired
     end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -261,7 +261,7 @@ end
            4 │ true  true  true
            5 │ true  true  true"""
 
-    show(io, groupby(df, :x), allcols=true, allrows=true) 
+    show(io, groupby(df, :x), allcols=true, allrows=true)
     str = String(take!(io.io))
     @test str == """
         GroupedDataFrame with 2 groups based on key: x
@@ -336,12 +336,24 @@ end
     end
 
     # printed height always matches desired height, above a reasonable minimum
-    for h in 15:40
+    for a in 1:50, b in 1:50, h in 15:40
+        df = DataFrame(x = [fill(1, a); fill(2, b)])
         io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
         show(io, groupby(df, :x), allcols=true)
         str = String(take!(io.io))
         nlines = length(split(str, '\n'))
-        desired = h - 3 # leave one line for last REPL prompt at top, two for new prompt
+        desired = min(a + b + 10, h - 3) # leave one line for last REPL prompt at top, two for new prompt
+        # (this is the same behavior as ungrouped data frames)
+        @test nlines == desired
+    end
+
+    for a in 1:50, h in 15:40
+        df = DataFrame(x = fill(1, a))
+        io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
+        show(io, groupby(df, :x), allcols=true)
+        str = String(take!(io.io))
+        nlines = length(split(str, '\n'))
+        desired = min(a + 5, h - 3) # leave one line for last REPL prompt at top, two for new prompt
         # (this is the same behavior as ungrouped data frames)
         @test nlines == desired
     end
@@ -351,7 +363,6 @@ end
     df = DataFrame(x = 1:15, y = 1)
     show(io, groupby(df, :y))
     str = String(take!(io.io))
-    print(str)
     @test str == """
         GroupedDataFrame with 1 group based on key: y
         First Group (15 rows): y = 1

--- a/test/show.jl
+++ b/test/show.jl
@@ -344,7 +344,7 @@ end
         nlines = length(split(str, '\n'))
         # leave one line for last REPL prompt at top, two for new prompt
         # (this is the same behavior as ungrouped data frames)
-        desired = min(a + b + 10, h - 3) 
+        desired = min(a + b + 10, h - 3)
         @test nlines == desired
     end
 
@@ -362,7 +362,7 @@ end
 
     # one group
     io = IOContext(IOBuffer(), :displaysize=>(15, 40), :limit=>true)
-    df = DataFrame(x = 1:15, y = 1)
+    df = DataFrame(x = Int64.(1:15), y = Int64(1))
     show(io, groupby(df, :y))
     str = String(take!(io.io))
     @test str == """


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/3186

Covers all corner cases of various relative sizes of groups and single group.