### PR TITLE
Make sure we use MIME when calling repr in GroupedDataFrame printing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# DataFrames.jl v1.4.3 Patch Release Notes
+
+## Display improvements
+
+* Improve printing of grouping keys when displaying `GroupedDataFrame`
+  ([#3213](https://github.com/JuliaData/DataFrames.jl/pull/3213))
+
 # DataFrames.jl v1.4.2 Patch Release Notes
 
 ## Bug fixes

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataFrames"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.4.2"
+version = "1.4.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -28,6 +28,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 CategoricalArrays = "0.10.0"
 Compat = "4.2"
 DataAPI = "1.12.0"
+InlineStrings = "1.3.0"
 InvertedIndices = "1"
 IteratorInterfaceExtensions = "0.1.1, 1"
 Missings = "0.4.2, 1"
@@ -48,6 +49,7 @@ Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DataValues = "e7dc6d0d-1eca-5fa6-8ad6-5aecde8b7ea5"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -57,5 +59,5 @@ ShiftedArrays = "1277b4bf-5013-50f5-be3d-901d8477a67a"
 
 [targets]
 test = ["CategoricalArrays", "Combinatorics", "DataStructures", "DataValues",
-        "Dates", "Logging", "OffsetArrays", "Test", "Unitful",
+        "Dates", "InlineStrings", "Logging", "OffsetArrays", "Test", "Unitful",
         "ShiftedArrays", "SparseArrays"]

--- a/src/dataframerow/show.jl
+++ b/src/dataframerow/show.jl
@@ -30,3 +30,25 @@ Base.show(dfr::DataFrameRow;
           kwargs...) =
     show(stdout, dfr; allcols=allcols, rowlabel=rowlabel, eltypes=eltypes,
          truncate=truncate, kwargs...)
+
+function Base.show(io::IO, mime::MIME"text/html", dfr::DataFrameRow; kwargs...)
+    _verify_kwargs_for_html(; kwargs...)
+    r, c = parentindices(dfr)
+    title = "DataFrameRow ($(length(dfr)) columns)"
+    _show(io, mime, view(parent(dfr), [r], c); rowid=r, title=title, kwargs...)
+end
+
+function Base.show(io::IO, mime::MIME"text/latex", dfr::DataFrameRow; eltypes::Bool=true)
+    r, c = parentindices(dfr)
+    _show(io, mime, view(parent(dfr), [r], c), eltypes=eltypes, rowid=r)
+end
+
+function Base.show(io::IO, mime::MIME"text/csv", dfr::DataFrameRow)
+    r, c = parentindices(dfr)
+    show(io, mime, view(parent(dfr), [r], c))
+end
+
+function Base.show(io::IO, mime::MIME"text/tab-separated-values", dfr::DataFrameRow)
+    r, c = parentindices(dfr)
+    show(io, mime, view(parent(dfr), [r], c))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ fatalerrors = length(ARGS) > 0 && ARGS[1] == "-f"
 quiet = length(ARGS) > 0 && ARGS[1] == "-q"
 anyerrors = false
 
-using DataFrames, Dates, Test, Random
+using DataFrames, Dates, Test, Random, InlineStrings
 
 if Threads.nthreads() < 2
     @warn("Running with only one thread: correctness of parallel operations is not tested")

--- a/test/show.jl
+++ b/test/show.jl
@@ -12,7 +12,7 @@ Base.show(io::IO, f::F) = show(io, f.i)
 
 module TestShow
 
-using DataFrames, Dates, Random, Test, CategoricalArrays
+using DataFrames, Dates, Random, Test, CategoricalArrays, InlineStrings
 
 import Main: ⛵⛵⛵⛵⛵, F
 
@@ -1012,6 +1012,110 @@ end
              │ CategoricalValue…
         ─────┼───────────────────
            1 │ 1"""
+end
+
+@testset "InlineStrings with GroupedDataFrame" begin
+    df = DataFrame(id=inlinestrings(["a", "b", "c"]), value=1:3)
+
+    io = IOContext(IOBuffer(), :limit=>true)
+    show(io, groupby(df, :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n" *
+        "First Group (1 row): id = \"a\"\n Row │ id       value\n" *
+        "     │ String1  Int64\n─────┼────────────────\n" *
+        "   1 │ a            1\n⋮\nLast Group (1 row): id = \"c\"\n" *
+        " Row │ id       value\n     │ String1  Int64\n─────┼────────────────\n" *
+        "   1 │ c            3"
+
+    io = IOContext(IOBuffer(), :limit=>true)
+    show(io, MIME("text/plain"), groupby(df, :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n" *
+        "First Group (1 row): id = \"a\"\n Row │ id       value\n" *
+        "     │ String1  Int64\n─────┼────────────────\n" *
+        "   1 │ a            1\n⋮\nLast Group (1 row): id = \"c\"\n" *
+        " Row │ id       value\n     │ String1  Int64\n─────┼────────────────\n" *
+        "   1 │ c            3"
+
+    io = IOContext(IOBuffer(), :limit=>false)
+    show(io, groupby(df, :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n" *
+        "Group 1 (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
+        "─────┼────────────────\n   1 │ a            1\nGroup 2 (1 row): id = \"b\"\n" *
+        " Row │ id       value\n     │ String1  Int64\n─────┼────────────────\n" *
+        "   1 │ b            2\nGroup 3 (1 row): id = \"c\"\n Row │ id       value\n" *
+        "     │ String1  Int64\n─────┼────────────────\n   1 │ c            3"
+
+    io = IOContext(IOBuffer(), :limit=>false)
+    show(io, MIME("text/plain"), groupby(df, :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n" *
+        "Group 1 (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
+        "─────┼────────────────\n   1 │ a            1\nGroup 2 (1 row): id = \"b\"\n" *
+        " Row │ id       value\n     │ String1  Int64\n─────┼────────────────\n" *
+        "   1 │ b            2\nGroup 3 (1 row): id = \"c\"\n Row │ id       value\n" *
+        "     │ String1  Int64\n─────┼────────────────\n   1 │ c            3"
+
+    io = IOContext(IOBuffer(), :limit=>true)
+    show(io, groupby(df[1:1, :], :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n" *
+        "First Group (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
+        "─────┼────────────────\n   1 │ a            1"
+
+    io = IOContext(IOBuffer(), :limit=>false)
+    show(io, groupby(df[1:1, :], :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n" *
+        "Group 1 (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
+        "─────┼────────────────\n   1 │ a            1"
+
+    io = IOContext(IOBuffer(), :limit=>true)
+    show(io, MIME("text/plain"), groupby(df[1:1, :], :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n" *
+        "First Group (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
+        "─────┼────────────────\n   1 │ a            1"
+
+    io = IOContext(IOBuffer(), :limit=>false)
+    show(io, MIME("text/plain"), groupby(df[1:1, :], :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n" *
+        "Group 1 (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
+        "─────┼────────────────\n   1 │ a            1"
+
+    io = IOContext(IOBuffer())
+    show(io, MIME("text/html"), groupby(df, :id))
+    @test String(take!(io.io)) === "<p><b>GroupedDataFrame with 3 groups based on key: id</b></p>" *
+        "<div><div style = \"float: left;\"><span>First Group (1 row): id = &quot;a&quot;</span></div>" *
+        "<div style = \"clear: both;\"></div></div>" *
+        "<div class = \"data-frame\" style = \"overflow-x: scroll;\">" *
+        "<table class = \"data-frame\" style = \"margin-bottom: 6px;\">" *
+        "<thead><tr class = \"header\"><th class = \"rowNumber\" " *
+        "style = \"font-weight: bold; text-align: right;\">Row</th>" *
+        "<th style = \"text-align: left;\">id</th><th style = \"text-align: left;\">value</th></tr>" *
+        "<tr class = \"subheader headerLastRow\"><th class = \"rowNumber\" " *
+        "style = \"font-weight: bold; text-align: right;\"></th>" *
+        "<th title = \"String1\" style = \"text-align: left;\">String1</th>" *
+        "<th title = \"Int64\" style = \"text-align: left;\">Int64</th></tr></thead>" *
+        "<tbody><tr><td class = \"rowNumber\" style = \"font-weight: bold; text-align: right;\">1</td>" *
+        "<td style = \"text-align: left;\">a</td><td style = \"text-align: right;\">1</td></tr></tbody>" *
+        "</table></div><p>&vellip;</p><div><div style = \"float: left;\">" *
+        "<span>Last Group (1 row): id = &quot;c&quot;</span></div>" *
+        "<div style = \"clear: both;\"></div></div><div class = \"data-frame\" " *
+        "style = \"overflow-x: scroll;\"><table class = \"data-frame\" " *
+        "style = \"margin-bottom: 6px;\"><thead><tr class = \"header\">" *
+        "<th class = \"rowNumber\" style = \"font-weight: bold; text-align: right;\">Row</th>" *
+        "<th style = \"text-align: left;\">id</th><th style = \"text-align: left;\">value</th></tr>" *
+        "<tr class = \"subheader headerLastRow\"><th class = \"rowNumber\" " *
+        "style = \"font-weight: bold; text-align: right;\"></th>" *
+        "<th title = \"String1\" style = \"text-align: left;\">String1</th>" *
+        "<th title = \"Int64\" style = \"text-align: left;\">Int64</th></tr></thead>" *
+        "<tbody><tr><td class = \"rowNumber\" style = \"font-weight: bold; text-align: right;\">1</td>" *
+        "<td style = \"text-align: left;\">c</td><td style = \"text-align: right;\">3</td></tr></tbody></table></div>"
+
+    io = IOContext(IOBuffer())
+    show(io, MIME("text/latex"), groupby(df, :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n\n" *
+        "First Group (1 row): id = \"a\"\n\n\\begin{tabular}{r|cc}\n" *
+        "\t& id & value\\\\\n\t\\hline\n\t& String1 & Int64\\\\\n" *
+        "\t\\hline\n\t1 & a & 1 \\\\\n\\end{tabular}\n\n\$\\dots\$\n\n" *
+        "Last Group (1 row): id = \"c\"\n\n\\begin{tabular}{r|cc}\n" *
+        "\t& id & value\\\\\n\t\\hline\n\t& String1 & Int64\\\\\n\t\\hline\n" *
+        "\t1 & c & 3 \\\\\n\\end{tabular}\n"
 end
 
 end # module

--- a/test/show.jl
+++ b/test/show.jl
@@ -1015,7 +1015,7 @@ end
 end
 
 @testset "InlineStrings with GroupedDataFrame" begin
-    df = DataFrame(id=inlinestrings(["a", "b", "c"]), value=1:3)
+    df = DataFrame(id=inlinestrings(["a", "b", "c"]), value=collect(Int64, 1:3))
 
     io = IOContext(IOBuffer(), :limit=>true)
     show(io, groupby(df, :id))

--- a/test/show.jl
+++ b/test/show.jl
@@ -1019,63 +1019,116 @@ end
 
     io = IOContext(IOBuffer(), :limit=>true)
     show(io, groupby(df, :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n" *
-        "First Group (1 row): id = \"a\"\n Row │ id       value\n" *
-        "     │ String1  Int64\n─────┼────────────────\n" *
-        "   1 │ a            1\n⋮\nLast Group (1 row): id = \"c\"\n" *
-        " Row │ id       value\n     │ String1  Int64\n─────┼────────────────\n" *
-        "   1 │ c            3"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 3 groups based on key: id
+        First Group (1 row): id = "a"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ a            1
+        ⋮
+        Last Group (1 row): id = "c"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ c            3"""
 
     io = IOContext(IOBuffer(), :limit=>true)
     show(io, MIME("text/plain"), groupby(df, :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n" *
-        "First Group (1 row): id = \"a\"\n Row │ id       value\n" *
-        "     │ String1  Int64\n─────┼────────────────\n" *
-        "   1 │ a            1\n⋮\nLast Group (1 row): id = \"c\"\n" *
-        " Row │ id       value\n     │ String1  Int64\n─────┼────────────────\n" *
-        "   1 │ c            3"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 3 groups based on key: id
+        First Group (1 row): id = "a"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ a            1
+        ⋮
+        Last Group (1 row): id = "c"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ c            3"""
 
     io = IOContext(IOBuffer(), :limit=>false)
     show(io, groupby(df, :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n" *
-        "Group 1 (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
-        "─────┼────────────────\n   1 │ a            1\nGroup 2 (1 row): id = \"b\"\n" *
-        " Row │ id       value\n     │ String1  Int64\n─────┼────────────────\n" *
-        "   1 │ b            2\nGroup 3 (1 row): id = \"c\"\n Row │ id       value\n" *
-        "     │ String1  Int64\n─────┼────────────────\n   1 │ c            3"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 3 groups based on key: id
+        Group 1 (1 row): id = "a"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ a            1
+        Group 2 (1 row): id = "b"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ b            2
+        Group 3 (1 row): id = "c"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ c            3"""
+
 
     io = IOContext(IOBuffer(), :limit=>false)
     show(io, MIME("text/plain"), groupby(df, :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n" *
-        "Group 1 (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
-        "─────┼────────────────\n   1 │ a            1\nGroup 2 (1 row): id = \"b\"\n" *
-        " Row │ id       value\n     │ String1  Int64\n─────┼────────────────\n" *
-        "   1 │ b            2\nGroup 3 (1 row): id = \"c\"\n Row │ id       value\n" *
-        "     │ String1  Int64\n─────┼────────────────\n   1 │ c            3"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 3 groups based on key: id
+        Group 1 (1 row): id = "a"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ a            1
+        Group 2 (1 row): id = "b"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ b            2
+        Group 3 (1 row): id = "c"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ c            3"""
 
     io = IOContext(IOBuffer(), :limit=>true)
     show(io, groupby(df[1:1, :], :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n" *
-        "First Group (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
-        "─────┼────────────────\n   1 │ a            1"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 1 group based on key: id
+        First Group (1 row): id = "a"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ a            1"""
 
     io = IOContext(IOBuffer(), :limit=>false)
     show(io, groupby(df[1:1, :], :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n" *
-        "Group 1 (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
-        "─────┼────────────────\n   1 │ a            1"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 1 group based on key: id
+        Group 1 (1 row): id = "a"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ a            1"""
 
     io = IOContext(IOBuffer(), :limit=>true)
     show(io, MIME("text/plain"), groupby(df[1:1, :], :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n" *
-        "First Group (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
-        "─────┼────────────────\n   1 │ a            1"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 1 group based on key: id
+        First Group (1 row): id = "a"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ a            1"""
 
     io = IOContext(IOBuffer(), :limit=>false)
     show(io, MIME("text/plain"), groupby(df[1:1, :], :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n" *
-        "Group 1 (1 row): id = \"a\"\n Row │ id       value\n     │ String1  Int64\n" *
-        "─────┼────────────────\n   1 │ a            1"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 1 group based on key: id
+        Group 1 (1 row): id = "a"
+         Row │ id       value
+             │ String1  Int64
+        ─────┼────────────────
+           1 │ a            1"""
 
     io = IOContext(IOBuffer())
     show(io, MIME("text/html"), groupby(df, :id))
@@ -1126,20 +1179,47 @@ end
 
     io = IOContext(IOBuffer())
     show(io, MIME("text/latex"), groupby(df, :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n\n" *
-        "First Group (1 row): id = \"a\"\n\n\\begin{tabular}{r|cc}\n" *
-        "\t& id & value\\\\\n\t\\hline\n\t& String1 & Int64\\\\\n" *
-        "\t\\hline\n\t1 & a & 1 \\\\\n\\end{tabular}\n\n\$\\dots\$\n\n" *
-        "Last Group (1 row): id = \"c\"\n\n\\begin{tabular}{r|cc}\n" *
-        "\t& id & value\\\\\n\t\\hline\n\t& String1 & Int64\\\\\n\t\\hline\n" *
-        "\t1 & c & 3 \\\\\n\\end{tabular}\n"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 3 groups based on key: id
+
+        First Group (1 row): id = "a"
+
+        \\begin{tabular}{r|cc}
+        \t& id & value\\\\
+        \t\\hline
+        \t& String1 & Int64\\\\
+        \t\\hline
+        \t1 & a & 1 \\\\
+        \\end{tabular}
+
+        \$\\dots\$
+
+        Last Group (1 row): id = "c"
+
+        \\begin{tabular}{r|cc}
+        \t& id & value\\\\
+        \t\\hline
+        \t& String1 & Int64\\\\
+        \t\\hline
+        \t1 & c & 3 \\\\
+        \\end{tabular}
+        """
 
     io = IOContext(IOBuffer())
     show(io, MIME("text/latex"), groupby(df[1:1, :], :id))
-    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n\n" *
-        "First Group (1 row): id = \"a\"\n\n\\begin{tabular}{r|cc}\n" *
-        "\t& id & value\\\\\n\t\\hline\n\t& String1 & Int64\\\\\n" *
-        "\t\\hline\n\t1 & a & 1 \\\\\n\\end{tabular}\n"
+    @test String(take!(io.io)) === """
+        GroupedDataFrame with 1 group based on key: id
+
+        First Group (1 row): id = "a"
+
+        \\begin{tabular}{r|cc}
+        \t& id & value\\\\
+        \t\\hline
+        \t& String1 & Int64\\\\
+        \t\\hline
+        \t1 & a & 1 \\\\
+        \\end{tabular}
+        """
 end
 
 end # module

--- a/test/show.jl
+++ b/test/show.jl
@@ -1108,6 +1108,23 @@ end
         "<td style = \"text-align: left;\">c</td><td style = \"text-align: right;\">3</td></tr></tbody></table></div>"
 
     io = IOContext(IOBuffer())
+    show(io, MIME("text/html"), groupby(df[1:1, :], :id))
+    @test String(take!(io.io)) === "<p><b>GroupedDataFrame with 1 group based on key: id</b></p><div>" *
+        "<div style = \"float: left;\"><span>First Group (1 row): id = &quot;a&quot;</span></div>" *
+        "<div style = \"clear: both;\"></div></div><div class = \"data-frame\" " *
+        "style = \"overflow-x: scroll;\"><table class = \"data-frame\" " *
+        "style = \"margin-bottom: 6px;\"><thead><tr class = \"header\">" *
+        "<th class = \"rowNumber\" style = \"font-weight: bold; text-align: right;\">Row</th>" *
+        "<th style = \"text-align: left;\">id</th><th style = \"text-align: left;\">value</th></tr>" *
+        "<tr class = \"subheader headerLastRow\"><th class = \"rowNumber\" " *
+        "style = \"font-weight: bold; text-align: right;\"></th>" *
+        "<th title = \"String1\" style = \"text-align: left;\">String1</th>" *
+        "<th title = \"Int64\" style = \"text-align: left;\">Int64</th></tr></thead>" *
+        "<tbody><tr><td class = \"rowNumber\" style = \"font-weight: bold; " *
+        "text-align: right;\">1</td><td style = \"text-align: left;\">a</td>" *
+        "<td style = \"text-align: right;\">1</td></tr></tbody></table></div>"
+
+    io = IOContext(IOBuffer())
     show(io, MIME("text/latex"), groupby(df, :id))
     @test String(take!(io.io)) === "GroupedDataFrame with 3 groups based on key: id\n\n" *
         "First Group (1 row): id = \"a\"\n\n\\begin{tabular}{r|cc}\n" *
@@ -1116,6 +1133,13 @@ end
         "Last Group (1 row): id = \"c\"\n\n\\begin{tabular}{r|cc}\n" *
         "\t& id & value\\\\\n\t\\hline\n\t& String1 & Int64\\\\\n\t\\hline\n" *
         "\t1 & c & 3 \\\\\n\\end{tabular}\n"
+
+    io = IOContext(IOBuffer())
+    show(io, MIME("text/latex"), groupby(df[1:1, :], :id))
+    @test String(take!(io.io)) === "GroupedDataFrame with 1 group based on key: id\n\n" *
+        "First Group (1 row): id = \"a\"\n\n\\begin{tabular}{r|cc}\n" *
+        "\t& id & value\\\\\n\t\\hline\n\t& String1 & Int64\\\\\n" *
+        "\t\\hline\n\t1 & a & 1 \\\\\n\\end{tabular}\n"
 end
 
 end # module


### PR DESCRIPTION
What this PR changes:
1. better code organization (so that later changes to `DataFrameRow` and `GroupedDataFrame` printing are needed to be made in one file).
2. key of the PR: use `MIME("text/plain)` when calling `repr` to show group label key. This is needed to avoid printing type name in some cases (which is not useful).

This resolves the issue that before this change docs building was not passing due to the changes in InlineStrings.jl printing rules.