### PR TITLE
Explain column-independent operations

### DIFF
--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -538,11 +538,20 @@ julia> iris_gdf[(Species="Iris-virginica",)]  # a NamedTuple
    1 │         6.3         3.3          6.0         2.5  Iris-virginica
    2 │         5.8         2.7          5.1         1.9  Iris-virginica
    3 │         7.1         3.0          5.9         2.1  Iris-virginica
+   4 │         6.3         2.9          5.6         1.8  Iris-virginica
+   5 │         6.5         3.0          5.8         2.2  Iris-virginica
+   6 │         7.6         3.0          6.6         2.1  Iris-virginica
+   7 │         4.9         2.5          4.5         1.7  Iris-virginica
+   8 │         7.3         2.9          6.3         1.8  Iris-virginica
   ⋮  │      ⋮           ⋮            ⋮           ⋮             ⋮
+  44 │         6.8         3.2          5.9         2.3  Iris-virginica
+  45 │         6.7         3.3          5.7         2.5  Iris-virginica
+  46 │         6.7         3.0          5.2         2.3  Iris-virginica
+  47 │         6.3         2.5          5.0         1.9  Iris-virginica
   48 │         6.5         3.0          5.2         2.0  Iris-virginica
   49 │         6.2         3.4          5.4         2.3  Iris-virginica
   50 │         5.9         3.0          5.1         1.8  Iris-virginica
-                                                         44 rows omitted
+                                                         35 rows omitted
 
 julia> iris_gdf[[("Iris-virginica",), ("Iris-setosa",)]] # a vector of Tuples
 GroupedDataFrame with 2 groups based on key: Species
@@ -551,18 +560,21 @@ First Group (50 rows): Species = "Iris-virginica"
      │ Float64      Float64     Float64      Float64     String15
 ─────┼──────────────────────────────────────────────────────────────────
    1 │         6.3         3.3          6.0         2.5  Iris-virginica
+   2 │         5.8         2.7          5.1         1.9  Iris-virginica
   ⋮  │      ⋮           ⋮            ⋮           ⋮             ⋮
+  49 │         6.2         3.4          5.4         2.3  Iris-virginica
   50 │         5.9         3.0          5.1         1.8  Iris-virginica
-                                                         48 rows omitted
+                                                         46 rows omitted
 ⋮
 Last Group (50 rows): Species = "Iris-setosa"
  Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
      │ Float64      Float64     Float64      Float64     String15
 ─────┼───────────────────────────────────────────────────────────────
    1 │         5.1         3.5          1.4         0.2  Iris-setosa
+   2 │         4.9         3.0          1.4         0.2  Iris-setosa
   ⋮  │      ⋮           ⋮            ⋮           ⋮            ⋮
   50 │         5.0         3.3          1.4         0.2  Iris-setosa
-                                                      48 rows omitted
+                                                      47 rows omitted
 
 julia> key = keys(iris_gdf) |> last # last key in iris_gdf
 GroupKey: (Species = String15("Iris-virginica"),)
@@ -578,14 +590,18 @@ julia> iris_gdf[key]
    4 │         6.3         2.9          5.6         1.8  Iris-virginica
    5 │         6.5         3.0          5.8         2.2  Iris-virginica
    6 │         7.6         3.0          6.6         2.1  Iris-virginica
+   7 │         4.9         2.5          4.5         1.7  Iris-virginica
+   8 │         7.3         2.9          6.3         1.8  Iris-virginica
   ⋮  │      ⋮           ⋮            ⋮           ⋮             ⋮
+  44 │         6.8         3.2          5.9         2.3  Iris-virginica
   45 │         6.7         3.3          5.7         2.5  Iris-virginica
   46 │         6.7         3.0          5.2         2.3  Iris-virginica
   47 │         6.3         2.5          5.0         1.9  Iris-virginica
   48 │         6.5         3.0          5.2         2.0  Iris-virginica
   49 │         6.2         3.4          5.4         2.3  Iris-virginica
   50 │         5.9         3.0          5.1         1.8  Iris-virginica
-                                                         38 rows omitted
+                                                         35 rows omitted
+
 julia> iris_gdf[Dict("Species" => "Iris-setosa")] # a dictionary
 50×5 SubDataFrame
  Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
@@ -597,14 +613,17 @@ julia> iris_gdf[Dict("Species" => "Iris-setosa")] # a dictionary
    4 │         4.6         3.1          1.5         0.2  Iris-setosa
    5 │         5.0         3.6          1.4         0.2  Iris-setosa
    6 │         5.4         3.9          1.7         0.4  Iris-setosa
+   7 │         4.6         3.4          1.4         0.3  Iris-setosa
+   8 │         5.0         3.4          1.5         0.2  Iris-setosa
   ⋮  │      ⋮           ⋮            ⋮           ⋮            ⋮
+  44 │         5.0         3.5          1.6         0.6  Iris-setosa
   45 │         5.1         3.8          1.9         0.4  Iris-setosa
   46 │         4.8         3.0          1.4         0.3  Iris-setosa
   47 │         5.1         3.8          1.6         0.2  Iris-setosa
   48 │         4.6         3.2          1.4         0.2  Iris-setosa
   49 │         5.3         3.7          1.5         0.2  Iris-setosa
   50 │         5.0         3.3          1.4         0.2  Iris-setosa
-                                                      38 rows omitted
+                                                      35 rows omitted
 ```
 
 Note that although `GroupedDataFrame` is iterable and indexable it is not an

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -1210,24 +1210,24 @@ julia> combine(gdf, eachindex, sdf -> axes(sdf, 1))
    6 │ c                    2      2
 ```
 
-Notice that column independent operation `eachindex` produces the same result
-as using anonymous function `sdf -> axes(sdf, 1)` that takes a `SubDataFrame`
+Notice that the column independent operation `eachindex` produces the same result
+as using the anonymous function `sdf -> axes(sdf, 1)` that takes a `SubDataFrame`
 as its first argument and returns indices along its first axes.
-Importantly without special definition of column-independent operation
+Importantly if it wasn't defined as a column-independent operation
 the `eachindex` function would fail when being passed as you can see here:
 
 ```jldoctest sac
-julia> combine(gdf, eachindex, sdf -> eachindex(sdf))
+julia> combine(gdf, sdf -> eachindex(sdf))
 ERROR: MethodError: no method matching keys(::SubDataFrame{DataFrame, DataFrames.Index, Vector{Int64}})
 ```
 
-The reason for this error is that `eachindex` function does not allow passing a
+The reason for this error is that the `eachindex` function does not allow passing a
 `SubDataFrame` as its argument.
 
-The same situation is with `proprow` and `groupindices`. They would not work
+The same applies to `proprow` and `groupindices`: they would not work
 with a `SubDataFrame` as stand-alone functions.
 
-A bit different case is with `nrow` column-independent operation. In this case
+The `nrow` column-independent operation is a different case, as
 the `nrow` function accepts `SubDataFrame` as an argument:
 
 ```jldoctest sac
@@ -1246,7 +1246,7 @@ difference is that they do not have the same names. `nrow` is a
 column-independent operation generating the `:nrow` column name by default with
 number of rows per group. On the other hand, the `sdf -> nrow(sdf)` anonymous
 function does gets a `SubDataFrame` as its argument and returns its number of
-rows. The `:x1` column name is a default auto-generated column name when
+rows. The `:x1` column name is the default auto-generated column name when
 processing anonymous functions.
 
 Passing a function taking a `SubDataFrame` is a flexible functionality allowing
@@ -1254,14 +1254,15 @@ you to perform complex operations on your data. However, you should bear in mind
 two aspects:
 
 * Using the full operation specification syntax (where source and target column
-  names are passed) will lead to faster execution of your code (as the Julia
-  compiler is able to better optimize execution of such operations) in
-  comparison to just passing a function taking a `SubDataFrame`.
+  names are passed) or column-independent operations will lead to faster
+  execution of your code (as the Julia compiler is able to better optimize
+  execution of such operations) in comparison to passing a function
+  taking a `SubDataFrame`.
 * Although writing `nrow`, `proprow`, `groupindices`, and `eachindex` looks
   like just passing a function they internally **do not** take a `SubDataFrame`
   as their argument. As we explained in this section, `proprow`,
   `groupindices`, and `eachindex` would not work with `SubDataFrame` as their
-  argument, and `nrow` would work, but would prouce a different column name.
+  argument, and `nrow` would work, but would produce a different column name.
   Instead, these four operations are special column-independent operations that
   are exceptions to the standard operation specification syntax rules. They
   were added for user convenience.

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -633,6 +633,8 @@ data frame and get a vector of results either use a comprehension or `collect`
 `GroupedDataFrame` into a vector first. Here are examples of both approaches:
 
 ```jldoctest sac
+julia> gd = groupby(iris, :Species);
+
 julia> [nrow(sdf) for sdf in gd]
 3-element Vector{Int64}:
  50

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -626,7 +626,7 @@ Last Group (5 rows): g = 501
 ```
 
 Note that although `GroupedDataFrame` is iterable and indexable it is not an
-`AbstractVector`. For this reason currently it was designed that it does not
+`AbstractVector`. For this reason currently it was decided that it does not
 support `map` nor broadcasting (to allow for making a decision in the future
 what result type they should produce). To apply a function to all groups of a
 data frame and get a vector of results either use a comprehension or `collect`

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -724,11 +724,10 @@ julia> [nrow(sdf) for sdf in iris_gdf]
  50
 ```
 
-Note that using the split-apply-combine strategy with operation specification
+Note that using the split-apply-combine strategy with the operation specification
 syntax in `combine`, `select` or `transform` will usually be faster for large
-`GroupedDataFrame` object than iterating it, with the difference that they
-produce a data frame. For the above examples an operation corresponding
-to the examples above is:
+`GroupedDataFrame` objects than iterating them, with the difference that they
+produce a data frame. An operation corresponding to the example above is:
 
 ```
 julia> combine(iris_gdf, nrow)
@@ -1220,7 +1219,7 @@ julia> combine(gdf, eachindex, sdf -> axes(sdf, 1))
    6 │ c                    2      2
 ```
 
-Notice that the column independent operation `eachindex` produces the same result
+Notice that the column-independent operation `eachindex` produces the same result
 as using the anonymous function `sdf -> axes(sdf, 1)` that takes a `SubDataFrame`
 as its first argument and returns indices along its first axes.
 Importantly if it wasn't defined as a column-independent operation

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -69,7 +69,7 @@ each subset of the `DataFrame`. This specification can be of the following forms
    except `AsTable` are allowed).
 4. a `col => target_cols` pair, which renames the column `col` to `target_cols`, which
    must be single name (as a `Symbol` or a string), a vector of names or `AsTable`.
-5. context-dependent expressions `function => target_cols` or just `function`
+5. column-independent operations `function => target_cols` or just `function`
    for specific `function`s where the input columns are omitted;
    without `target_cols` the new column has the same name as `function`, otherwise
    it must be single name (as a `Symbol` or a string). Supported `function`s are:
@@ -894,17 +894,17 @@ julia> df
    6 │     3  missing      6
 ```
 
-## Context-dependent expressions
+## Column-independent operations
 
 The operation specification language used with `combine`, `select` and `transform`
-supports the following context-dependent operations:
+supports the following column-independent operations:
 
 * getting the number of rows in a group (`nrow`);
 * getting the proportion of rows in a group (`proprow`);
 * getting the group number (`groupindices`);
 * getting a vector of indices within groups (`eachindex`).
 
-These operations are context-dependent, because they do not require specifying the input column
+These operations are column-independent, because they do not require specifying the input column
 name in the operation specification syntax.
 
 These four exceptions to the standard operation specification syntax were
@@ -985,8 +985,8 @@ julia> combine(gdf, nrow => "transaction_count")
 ```
 
 Note that in both cases we did not pass source column name as it is not needed
-to determine the number of rows per group. This is the reason why context-dependent
-expressions are exceptions to standard operation specification syntax.
+to determine the number of rows per group. This is the reason why column-independent
+operations are exceptions to standard operation specification syntax.
 
 The `nrow` expression also works in the operation specification syntax
 applied to a data frame. Here is an example:
@@ -1015,8 +1015,8 @@ easier to remember this exception.
 ### Getting the proportion of rows
 
 If you want to get a proportion of rows per group in a `GroupedDataFrame`
-you can use the `proprow` and `proprow => [target column name]` context-dependent
-expressions. Here are some examples:
+you can use the `proprow` and `proprow => [target column name]` column-independent
+operations. Here are some examples:
 
 ```jldoctest sac
 julia> combine(gdf, proprow)
@@ -1044,7 +1044,7 @@ specification syntax and is only allowed when processing a `GroupedDataFrame`.
 ### Getting the group number
 
 Another common operation is getting group number. Use the `groupindices` and
-`groupindices => [target column name]` context-dependent expressions to get it:
+`groupindices => [target column name]` column-independent operations to get it:
 
 
 ```jldoctest sac
@@ -1096,7 +1096,7 @@ julia> groupindices(gdf)
 
 ### Getting a vector of indices within groups
 
-The last context-dependent expression supported by the operation
+The last column-independent operation supported by the operation
 specification syntax is getting the index of each row within each group:
 
 
@@ -1188,13 +1188,13 @@ julia> combine(gdf, eachindex, :customer_id => eachindex)
 ```
 
 
-## Context-dependent expressions versus functions
+## Column-independent operations versus functions
 
-When discussing context dependent expressions it is important to remember
+When discussing column-independent operations it is important to remember
 that operation specification syntax allows you to pass a function (without
 source and target column names), in which case such a function gets passed a
 `SubDataFrame` that represents a group in a `GroupedDataFrame`. Here is an
-example:
+example comparing column-independent operation and a function:
 
 ```jldoctest sac
 julia> combine(gdf, nrow, x -> nrow(x))
@@ -1208,7 +1208,7 @@ julia> combine(gdf, nrow, x -> nrow(x))
 ```
 
 Notice that columns `:nrow` and `:x1` have an identical contents. This is
-expected. We already know that `nrow` is a context dependent expression
+expected. We already know that `nrow` is a column-independent operation
 generating the `:nrow` column with number of rows per group. However, the
 `x -> nrow(x)` anonymous function does exactly the same as it gets a
 `SubDataFrame` as its argument and returns its number of rows (the `:x1` column
@@ -1224,8 +1224,8 @@ two aspects:
   comparison to just passing a function taking a `SubDataFrame`.
 * Although writing `row`, `proprow`, `groupindices`, and `eachindex` looks like
   just passing a function they **do not** take a `SubDataFrame` as their
-  argument. As we explained in this section, they are special context-dependent
-  expressions that are exceptions to the standard operation specification syntax
+  argument. As we explained in this section, they are special column-independent
+  operations that are exceptions to the standard operation specification syntax
   rules. They were added for user convenience (and at the same time they are
   optimized to be fast).
 

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -1194,7 +1194,7 @@ When discussing column-independent operations it is important to remember
 that operation specification syntax allows you to pass a function (without
 source and target column names), in which case such a function gets passed a
 `SubDataFrame` that represents a group in a `GroupedDataFrame`. Here is an
-example comparing column-independent operation and a function:
+example comparing a column-independent operation and a function:
 
 ```jldoctest sac
 julia> combine(gdf, nrow, x -> nrow(x))
@@ -1207,7 +1207,7 @@ julia> combine(gdf, nrow, x -> nrow(x))
    3 │ c                2      2
 ```
 
-Notice that columns `:nrow` and `:x1` have an identical contents. This is
+Notice that columns `:nrow` and `:x1` have identical contents. This is
 expected. We already know that `nrow` is a column-independent operation
 generating the `:nrow` column with number of rows per group. However, the
 `x -> nrow(x)` anonymous function does exactly the same as it gets a

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -75,7 +75,7 @@ const TRANSFORMATION_COMMON_RULES =
        except `AsTable` are allowed).
     4. a `col => target_cols` pair, which renames the column `col` to `target_cols`, which
        must be single name (as a `Symbol` or a string), a vector of names or `AsTable`.
-    5. context dependent expressions `function => target_cols` or just `function`
+    5. context-dependent expressions `function => target_cols` or just `function`
        for specific `function`s where the input columns are omitted;
        without `target_cols` the new column has the same name as `function`, otherwise
        it must be single name (as a `Symbol` or a string). Supported `function`s are:
@@ -1267,7 +1267,7 @@ julia> select(gd, :, AsTable(Not(:a)) => sum, renamecols=false)
    8 │     2      1      8      9
 ```
 
-# context dependent expressions
+# context-dependent expressions
 ```jldoctest
 julia> df = DataFrame(a=[1, 1, 1, 2, 2, 1, 1, 2],
                       b=repeat([2, 1], outer=[4]),

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -75,7 +75,7 @@ const TRANSFORMATION_COMMON_RULES =
        except `AsTable` are allowed).
     4. a `col => target_cols` pair, which renames the column `col` to `target_cols`, which
        must be single name (as a `Symbol` or a string), a vector of names or `AsTable`.
-    5. context-dependent expressions `function => target_cols` or just `function`
+    5. column-independent operations `function => target_cols` or just `function`
        for specific `function`s where the input columns are omitted;
        without `target_cols` the new column has the same name as `function`, otherwise
        it must be single name (as a `Symbol` or a string). Supported `function`s are:
@@ -1267,7 +1267,7 @@ julia> select(gd, :, AsTable(Not(:a)) => sum, renamecols=false)
    8 │     2      1      8      9
 ```
 
-# context-dependent expressions
+# column-independent operations
 ```jldoctest
 julia> df = DataFrame(a=[1, 1, 1, 2, 2, 1, 1, 2],
                       b=repeat([2, 1], outer=[4]),

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -75,7 +75,7 @@ const TRANSFORMATION_COMMON_RULES =
        except `AsTable` are allowed).
     4. a `col => target_cols` pair, which renames the column `col` to `target_cols`, which
        must be single name (as a `Symbol` or a string), a vector of names or `AsTable`.
-    5. special convenience forms `function => target_cols` or just `function`
+    5. context dependent expressions `function => target_cols` or just `function`
        for specific `function`s where the input columns are omitted;
        without `target_cols` the new column has the same name as `function`, otherwise
        it must be single name (as a `Symbol` or a string). Supported `function`s are:
@@ -1267,7 +1267,7 @@ julia> select(gd, :, AsTable(Not(:a)) => sum, renamecols=false)
    8 │     2      1      8      9
 ```
 
-# special convenience transformations
+# context dependent expressions
 ```jldoctest
 julia> df = DataFrame(a=[1, 1, 1, 2, 2, 1, 1, 2],
                       b=repeat([2, 1], outer=[4]),


### PR DESCRIPTION
This PR adds additional explanation of context dependent expressions in operation specification syntax to make sure users know exactly how they work.

CC @yjunechoe @pdeffebach 