### PR TITLE
Add an option in joins to specify row order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,13 +3,19 @@
 ## New functionalities
 
 * Add `Iterators.partition` support
-   ([#3212](https://github.com/JuliaData/DataFrames.jl/pull/3212))
+  ([#3212](https://github.com/JuliaData/DataFrames.jl/pull/3212))
 * Add `allunique` and allow transformations in `cols` argument of `describe`
   and `nonunique` when working with `SubDataFrame`
   ([3232](https://github.com/JuliaData/DataFrames.jl/pull/3232))
 * Joining functions now support `order` keyword argument allowing the user
   to specify the order of the rows in the produced table
-   ([#3233](https://github.com/JuliaData/DataFrames.jl/pull/3233))
+  ([#3233](https://github.com/JuliaData/DataFrames.jl/pull/3233))
+
+## Bug fixes
+
+* passing very many data frames to `innerjoin` and `outerjoin`
+  does not lead to stack overflow
+  ([#3233](https://github.com/JuliaData/DataFrames.jl/pull/3233))
 
 # DataFrames.jl v1.4.4 Patch Release Notes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@
 * Add `allunique` and allow transformations in `cols` argument of `describe`
   and `nonunique` when working with `SubDataFrame`
   ([3232](https://github.com/JuliaData/DataFrames.jl/pull/3232))
+* Joining functions now support `order` keyword argument allowing the user
+  to specify the order of the rows in the produced table
+   ([#3233](https://github.com/JuliaData/DataFrames.jl/pull/3233))
 
 # DataFrames.jl v1.4.4 Patch Release Notes
 

--- a/docs/src/man/joins.md
+++ b/docs/src/man/joins.md
@@ -1,6 +1,10 @@
 # Database-Style Joins
 
-We often need to combine two or more data sets together to provide a complete picture of the topic we are studying. For example, suppose that we have the following two data sets:
+## Intoduction to joins
+
+We often need to combine two or more data sets together to provide a complete
+picture of the topic we are studying. For example, suppose that we have the
+following two data sets:
 
 ```jldoctest joins
 julia> using DataFrames
@@ -22,7 +26,8 @@ julia> jobs = DataFrame(ID=[20, 40], Job=["Lawyer", "Doctor"])
    2 │    40  Doctor
 ```
 
-We might want to work with a larger data set that contains both the names and jobs for each ID. We can do this using the `innerjoin` function:
+We might want to work with a larger data set that contains both the names and
+jobs for each ID. We can do this using the `innerjoin` function:
 
 ```jldoctest joins
 julia> innerjoin(people, jobs, on = :ID)
@@ -34,21 +39,29 @@ julia> innerjoin(people, jobs, on = :ID)
    2 │    40  Jane Doe  Doctor
 ```
 
-In relational database theory, this operation is generally referred to as a join.
-The columns used to determine which rows should be combined during a join are called keys.
+In relational database theory, this operation is generally referred to as a
+join. The columns used to determine which rows should be combined during a join
+are called keys.
 
 The following functions are provided to perform seven kinds of joins:
 
--   `innerjoin`: the output contains rows for values of the key that exist in all passed data frames.
--   `leftjoin`: the output contains rows for values of the key that exist in the first (left) argument,
-    whether or not that value exists in the second (right) argument.
--   `rightjoin`: the output contains rows for values of the key that exist in the second (right) argument,
-    whether or not that value exists in the first (left) argument.
--   `outerjoin`: the output contains rows for values of the key that exist in any of the passed data frames.
--   `semijoin`: Like an inner join, but output is restricted to columns from the first (left) argument.
--   `antijoin`: The output contains rows for values of the key that exist in the first (left) but not the second (right) argument.
-    As with `semijoin`, output is restricted to columns from the first (left) argument.
--   `crossjoin`: The output is the cartesian product of rows from all passed data frames.
+- `innerjoin`: the output contains rows for values of the key that exist in all
+  passed data frames.
+- `leftjoin`: the output contains rows for values of the key that exist in the
+  first (left) argument, whether or not that value exists in the second (right)
+  argument.
+- `rightjoin`: the output contains rows for values of the key that exist in the
+  second (right) argument, whether or not that value exists in the first (left)
+  argument.
+- `outerjoin`: the output contains rows for values of the key that exist in any
+  of the passed data frames.
+- `semijoin`: Like an inner join, but output is restricted to columns from the
+  first (left) argument.
+- `antijoin`: The output contains rows for values of the key that exist in the
+  first (left) but not the second (right) argument. As with `semijoin`, output
+  is restricted to columns from the first (left) argument.
+- `crossjoin`: The output is the cartesian product of rows from all passed data
+  frames.
 
 See [the Wikipedia page on SQL joins](https://en.wikipedia.org/wiki/Join_(SQL)) for more information.
 
@@ -124,8 +137,10 @@ julia> crossjoin(people, jobs, makeunique = true)
    4 │    40  Jane Doe     60  Astronaut
 ```
 
-In order to join data frames on keys which have different names in the left and right tables,
-you may pass `left => right` pairs as `on` argument:
+## Joining on key columns with different names
+
+In order to join data frames on keys which have different names in the left and
+right tables, you may pass `left => right` pairs as `on` argument:
 
 ```jldoctest joins
 julia> a = DataFrame(ID=[20, 40], Name=["John Doe", "Jane Doe"])
@@ -198,6 +213,8 @@ julia> innerjoin(a, b, on = [:City => :Location, :Job => :Work])
    9 │ New York   Doctor         5  e
 ```
 
+## Handling of duplicate keys and tracking source data frame
+
 Additionally, notice that in the last join rows 2 and 3 had the same values on
 `on` variables in both joined `DataFrame`s. In such a situation `innerjoin`,
 `outerjoin`, `leftjoin` and `rightjoin` will produce all combinations of
@@ -248,3 +265,204 @@ julia> outerjoin(a, b, on=:ID, validate=(true, true), source=:source)
 
 Note that this time we also used the `validate` keyword argument and it did not
 produce errors as the keys defined in both source data frames were unique.
+
+## Renaming joined columns
+
+Often you want to keep track of the source data frame of a given column.
+This feature is supported with the `ranamecols` keyword argument:
+
+```jldoctest joins
+julia> innerjoin(a, b, on=:ID, renamecols = "_left" => "_right")
+1×3 DataFrame
+ Row │ ID     Name_left  Job_right 
+     │ Int64  String     String
+─────┼─────────────────────────────
+   1 │    20  John       Lawyer
+```
+
+In the above example we added `"_left"` suffix to the non-key columns from
+the left table and `"_right"` suffix to the non-key columns from the right
+table.
+
+Alternatively it is allowed to pass a function transforming column names:
+```jldoctest joins
+julia> innerjoin(a, b, on=:ID, renamecols = lowercase => uppercase)
+1×3 DataFrame
+ Row │ ID     name    JOB    
+     │ Int64  String  String
+─────┼───────────────────────
+   1 │    20  John    Lawyer
+
+```
+
+## Matching missing values in joins
+
+By default when you try to to perform a join on a key that has `missing` values
+you get an error:
+
+```jldoctest joins
+julia> df1 = DataFrame(id=[1, missing, 3], a=1:3)
+3×2 DataFrame
+ Row │ id       a     
+     │ Int64?   Int64 
+─────┼────────────────
+   1 │       1      1
+   2 │ missing      2
+   3 │       3      3
+
+julia> df2 = DataFrame(id=[1, 2, missing], b=1:3)
+3×2 DataFrame
+ Row │ id       b     
+     │ Int64?   Int64 
+─────┼────────────────
+   1 │       1      1
+   2 │       2      2
+   3 │ missing      3
+
+julia> innerjoin(df1, df2, on=:id)
+ERROR: ArgumentError: missing values in key columns are not allowed when matchmissing == :error
+```
+
+If you would prefer for `missing` values to be matched as equal pass
+`matchimssing=:equal` keyword argument:
+
+```jldoctest join
+julia> innerjoin(df1, df2, on=:id, matchmissing=:equal)
+2×3 DataFrame
+ Row │ id       a      b     
+     │ Int64?   Int64  Int64 
+─────┼───────────────────────
+   1 │       1      1      1
+   2 │ missing      2      3
+```
+
+Alternatively you might want to drop all rows with `missing` values. In this
+case pass `matchmissing=:notequal`:
+
+```jldoctest join
+julia> innerjoin(df1, df2, on=:id, matchmissing=:notequal)
+1×3 DataFrame
+ Row │ id      a      b     
+     │ Int64?  Int64  Int64
+─────┼──────────────────────
+   1 │      1      1      1
+```
+
+## Specifying row order in the join result
+
+By default the order of rows produced by the join operation is undefined:
+
+```jldoctest join
+julia> df_left = DataFrame(id=[1, 2, 4, 5], left=1:4)
+4×2 DataFrame
+ Row │ id     left  
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      1
+   2 │     2      2
+   3 │     4      3
+   4 │     5      4
+
+julia> df_right = DataFrame(id=[2, 1, 3, 6, 7], right=1:5)
+4×2 DataFrame
+ Row │ id     right 
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      1
+   2 │     2      2
+   3 │     3      3
+   4 │     6      4
+
+julia> outerjoin(df_left, df_right, on=:id)
+7×3 DataFrame
+ Row │ id     left     right   
+     │ Int64  Int64?   Int64?
+─────┼─────────────────────────
+   1 │     2        2        1
+   2 │     1        1        2
+   3 │     4        3  missing
+   4 │     5        4  missing
+   5 │     3  missing        3
+   6 │     6  missing        4
+   7 │     7  missing        5
+```
+
+If you would like the result to keep row order of the left table pass
+`order=:left` keyword argument:
+
+```jldoctest join
+julia> outerjoin(df_left, df_right, on=:id, order=:left)
+7×3 DataFrame
+ Row │ id     left     right   
+     │ Int64  Int64?   Int64?
+─────┼─────────────────────────
+   1 │     1        1        2
+   2 │     2        2        1
+   3 │     4        3  missing
+   4 │     5        4  missing
+   5 │     3  missing        3
+   6 │     6  missing        4
+   7 │     7  missing        5
+```
+
+Note that in this case keys missing from left table arre put after the keys
+present in the left table.
+
+Similarly `order=:right` keeps the order of the right table (and puts keys
+not present in it at the end):
+
+```jldoctest join
+julia> outerjoin(df_left, df_right, on=:id, order=:right)
+7×3 DataFrame
+ Row │ id     left     right   
+     │ Int64  Int64?   Int64?
+─────┼─────────────────────────
+   1 │     2        2        1
+   2 │     1        1        2
+   3 │     3  missing        3
+   4 │     6  missing        4
+   5 │     7  missing        5
+   6 │     4        3  missing
+   7 │     5        4  missing
+```
+
+## In-place left join
+
+A common operation is adding data from a reference table to some main table.
+It is possible to perform such an in-place update using the `leftjoin!`
+function. In this case left table is updated in place with matching rows from
+the right table.
+
+```jldoctest join
+julia> main = DataFrame(id=1:4, main=1:4)
+4×2 DataFrame
+ Row │ id     main  
+     │ Int64  Int64 
+─────┼──────────────
+   1 │     1      1
+   2 │     2      2
+   3 │     3      3
+   4 │     4      4
+
+julia> leftjoin!(main, DataFrame(id=[2, 4], info=["a", "b"]), on=:id);
+
+julia> main
+4×3 DataFrame
+ Row │ id     main   info    
+     │ Int64  Int64  String? 
+─────┼───────────────────────
+   1 │     1      1  missing 
+   2 │     2      2  a
+   3 │     3      3  missing 
+   4 │     4      4  b
+```
+
+Note that in this case the order and number of rows in the left table is not
+changed. Therefore, in particular, it is not allowed to have duplicate keys
+in the right table:
+
+```
+julia> leftjoin!(main, DataFrame(id=[2, 2], info_bad=["a", "b"]), on=:id)
+ERROR: ArgumentError: duplicate rows found in right table
+```
+

--- a/docs/src/man/joins.md
+++ b/docs/src/man/joins.md
@@ -1,6 +1,6 @@
 # Database-Style Joins
 
-## Intoduction to joins
+## Introduction to joins
 
 We often need to combine two or more data sets together to provide a complete
 picture of the topic we are studying. For example, suppose that we have the
@@ -280,8 +280,8 @@ julia> innerjoin(a, b, on=:ID, renamecols = "_left" => "_right")
    1 │    20  John       Lawyer
 ```
 
-In the above example we added `"_left"` suffix to the non-key columns from
-the left table and `"_right"` suffix to the non-key columns from the right
+In the above example we added the `"_left"` suffix to the non-key columns from
+the left table and the `"_right"` suffix to the non-key columns from the right
 table.
 
 Alternatively it is allowed to pass a function transforming column names:
@@ -323,8 +323,8 @@ julia> innerjoin(df1, df2, on=:id)
 ERROR: ArgumentError: missing values in key columns are not allowed when matchmissing == :error
 ```
 
-If you would prefer for `missing` values to be matched as equal pass
-`matchimssing=:equal` keyword argument:
+If you would prefer `missing` values to be treated as equal pass
+the `matchmissing=:equal` keyword argument:
 
 ```jldoctest joins
 julia> innerjoin(df1, df2, on=:id, matchmissing=:equal)
@@ -388,8 +388,8 @@ julia> outerjoin(df_left, df_right, on=:id)
    7 │     7  missing        5
 ```
 
-If you would like the result to keep row order of the left table pass
-`order=:left` keyword argument:
+If you would like the result to keep the row order of the left table pass
+the `order=:left` keyword argument:
 
 ```jldoctest joins
 julia> outerjoin(df_left, df_right, on=:id, order=:left)
@@ -406,8 +406,8 @@ julia> outerjoin(df_left, df_right, on=:id, order=:left)
    7 │     7  missing        5
 ```
 
-Note that in this case keys missing from left table arre put after the keys
-present in the left table.
+Note that in this case keys missing from the left table are put after the keys
+present in it.
 
 Similarly `order=:right` keeps the order of the right table (and puts keys
 not present in it at the end):
@@ -431,7 +431,7 @@ julia> outerjoin(df_left, df_right, on=:id, order=:right)
 
 A common operation is adding data from a reference table to some main table.
 It is possible to perform such an in-place update using the `leftjoin!`
-function. In this case left table is updated in place with matching rows from
+function. In this case the left table is updated in place with matching rows from
 the right table.
 
 ```jldoctest joins

--- a/docs/src/man/joins.md
+++ b/docs/src/man/joins.md
@@ -326,7 +326,7 @@ ERROR: ArgumentError: missing values in key columns are not allowed when matchmi
 If you would prefer for `missing` values to be matched as equal pass
 `matchimssing=:equal` keyword argument:
 
-```jldoctest join
+```jldoctest joins
 julia> innerjoin(df1, df2, on=:id, matchmissing=:equal)
 2×3 DataFrame
  Row │ id       a      b     
@@ -339,7 +339,7 @@ julia> innerjoin(df1, df2, on=:id, matchmissing=:equal)
 Alternatively you might want to drop all rows with `missing` values. In this
 case pass `matchmissing=:notequal`:
 
-```jldoctest join
+```jldoctest joins
 julia> innerjoin(df1, df2, on=:id, matchmissing=:notequal)
 1×3 DataFrame
  Row │ id      a      b     
@@ -352,7 +352,7 @@ julia> innerjoin(df1, df2, on=:id, matchmissing=:notequal)
 
 By default the order of rows produced by the join operation is undefined:
 
-```jldoctest join
+```jldoctest joins
 julia> df_left = DataFrame(id=[1, 2, 4, 5], left=1:4)
 4×2 DataFrame
  Row │ id     left  
@@ -390,7 +390,7 @@ julia> outerjoin(df_left, df_right, on=:id)
 If you would like the result to keep row order of the left table pass
 `order=:left` keyword argument:
 
-```jldoctest join
+```jldoctest joins
 julia> outerjoin(df_left, df_right, on=:id, order=:left)
 7×3 DataFrame
  Row │ id     left     right   
@@ -411,7 +411,7 @@ present in the left table.
 Similarly `order=:right` keeps the order of the right table (and puts keys
 not present in it at the end):
 
-```jldoctest join
+```jldoctest joins
 julia> outerjoin(df_left, df_right, on=:id, order=:right)
 7×3 DataFrame
  Row │ id     left     right   
@@ -433,7 +433,7 @@ It is possible to perform such an in-place update using the `leftjoin!`
 function. In this case left table is updated in place with matching rows from
 the right table.
 
-```jldoctest join
+```jldoctest joins
 julia> main = DataFrame(id=1:4, main=1:4)
 4×2 DataFrame
  Row │ id     main  

--- a/docs/src/man/joins.md
+++ b/docs/src/man/joins.md
@@ -364,14 +364,15 @@ julia> df_left = DataFrame(id=[1, 2, 4, 5], left=1:4)
    4 │     5      4
 
 julia> df_right = DataFrame(id=[2, 1, 3, 6, 7], right=1:5)
-4×2 DataFrame
+5×2 DataFrame
  Row │ id     right 
      │ Int64  Int64 
 ─────┼──────────────
-   1 │     1      1
-   2 │     2      2
+   1 │     2      1
+   2 │     1      2
    3 │     3      3
    4 │     6      4
+   5 │     7      5
 
 julia> outerjoin(df_left, df_right, on=:id)
 7×3 DataFrame

--- a/src/join/composer.jl
+++ b/src/join/composer.jl
@@ -778,7 +778,7 @@ function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::Abstract
         res = innerjoin(res, dfn, on=on, makeunique=makeunique, validate=validate,
                         matchmissing=matchmissing,
                         order= order === :right ?
-                               (i == length(dfn) ? :right : :undefined) :
+                               (i == length(dfs) ? :right : :undefined) :
                                order)
     end
     return res
@@ -1268,7 +1268,7 @@ function outerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::Abstract
                    validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
                    matchmissing::Symbol=:error, order::Symbol=:undefined)
     res = outerjoin(df1, df2, on=on, makeunique=makeunique, validate=validate,
-                        matchmissing=matchmissing)
+                        matchmissing=matchmissing, order=order)
     for dfn in dfs
         res = outerjoin(res, dfn, on=on, makeunique=makeunique, validate=validate,
                         matchmissing=matchmissing, order=order)

--- a/src/join/composer.jl
+++ b/src/join/composer.jl
@@ -757,7 +757,7 @@ function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::Abstract
                    matchmissing::Symbol=:error,
                    order::Union{Nothing, Symbol}=nothing)
     res = innerjoin(df1, df2, on=on, makeunique=makeunique, validate=validate,
-                        matchmissing=matchmissing)
+                    matchmissing=matchmissing, order=order)
     for dfn in dfs
         res = innerjoin(res, dfn, on=on, makeunique=makeunique, validate=validate,
                         matchmissing=matchmissing, order=order)
@@ -1264,7 +1264,7 @@ Perform a semi join of two data frame objects and return a `DataFrame`
 containing the result. A semi join returns the subset of rows of `df1` that
 match with the keys in `df2`.
 
-The order of rows in the result is is kept from `df1`.
+The order of rows in the result is kept from `df1`.
 
 # Arguments
 - `df1`, `df2`: the `AbstractDataFrames` to be joined
@@ -1375,7 +1375,7 @@ Perform an anti join of two data frame objects and return a `DataFrame`
 containing the result. An anti join returns the subset of rows of `df1` that do
 not match with the keys in `df2`.
 
-The order of rows in the result is is kept from `df1`.
+The order of rows in the result is kept from `df1`.
 
 # Arguments
 - `df1`, `df2`: the `AbstractDataFrames` to be joined

--- a/src/join/composer.jl
+++ b/src/join/composer.jl
@@ -200,7 +200,7 @@ end
 # `delta` is by how much integers in `input` need to be shifted so that
 # smallest of them has index 1
 #
-# After the first loop `count` vector holds in location `i-delta` number of
+# After the first loop `count` vector holds in location `i-delta` the number of
 # times an integer `i` is present in `input`.
 # After the second loop a cumulative sum of these values is stored.
 # Third loop updates `count` to determine the locations where data should go.

--- a/src/join/composer.jl
+++ b/src/join/composer.jl
@@ -750,16 +750,20 @@ function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
                  matchmissing=matchmissing, order=order)
 end
 
-innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame...;
-          on::Union{<:OnType, AbstractVector} = Symbol[],
-          makeunique::Bool=false,
-          validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
-          matchmissing::Symbol=:error,
-          order::Union{Nothing, Symbol}=nothing) =
-    innerjoin(innerjoin(df1, df2, on=on, makeunique=makeunique, validate=validate,
-                        matchmissing=matchmissing),
-              dfs..., on=on, makeunique=makeunique, validate=validate,
-              matchmissing=matchmissing, order=order)
+function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame...;
+                   on::Union{<:OnType, AbstractVector} = Symbol[],
+                   makeunique::Bool=false,
+                   validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
+                   matchmissing::Symbol=:error,
+                   order::Union{Nothing, Symbol}=nothing)
+    res = innerjoin(df1, df2, on=on, makeunique=makeunique, validate=validate,
+                        matchmissing=matchmissing)
+    for dfn in dfs
+        res = innerjoin(res, dfn, on=on, makeunique=makeunique, validate=validate,
+                        matchmissing=matchmissing, order=order)
+    end
+    return res
+end
 
 """
     leftjoin(df1, df2; on, makeunique=false, source=nothing, validate=(false, false),
@@ -1240,14 +1244,18 @@ function outerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
                  matchmissing=matchmissing, order=order)
 end
 
-outerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame...;
-          on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false,
-          validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
-          matchmissing::Symbol=:error, order::Union{Nothing, Symbol}=nothing) =
-    outerjoin(outerjoin(df1, df2, on=on, makeunique=makeunique, validate=validate,
-                        matchmissing=matchmissing),
-              dfs..., on=on, makeunique=makeunique, validate=validate,
-              matchmissing=matchmissing, order=order)
+function outerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame...;
+                   on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false,
+                   validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
+                   matchmissing::Symbol=:error, order::Union{Nothing, Symbol}=nothing)
+    res = outerjoin(df1, df2, on=on, makeunique=makeunique, validate=validate,
+                        matchmissing=matchmissing)
+    for dfn in dfs
+        res = outerjoin(res, dfn, on=on, makeunique=makeunique, validate=validate,
+                        matchmissing=matchmissing, order=order)
+    end
+    return res
+end
 
 """
     semijoin(df1, df2; on, makeunique=false, validate=(false, false), matchmissing=:error)

--- a/test/join.jl
+++ b/test/join.jl
@@ -2208,4 +2208,12 @@ end
     end
 end
 
+@testset "wide joins" begin
+    dfs = [DataFrame("id" => 0, "x$i" => i) for i in 1:10000]
+    res = innerjoin(dfs..., on="id")
+    @test res == DataFrame(["id" => 0; ["x$i" => i for i in 1:10000]]) 
+    res = outerjoin(dfs..., on="id")
+    @test res == DataFrame(["id" => 0; ["x$i" => i for i in 1:10000]]) 
+end
+
 end # module

--- a/test/join.jl
+++ b/test/join.jl
@@ -2044,7 +2044,7 @@ end
     end
     for i in 1:20
         @test DataFrames._count_sortperm(ones(Int, i)) == 1:i
-        @test_throws AssertionError DataFrames._count_sortperm(zeros(Int, i))
+        @test DataFrames._count_sortperm(zeros(Int, i)) == 1:i
         @test DataFrames._count_sortperm([fill(1, i); fill(2, i)]) == 1:2*i
         @test DataFrames._count_sortperm([fill(2, i); fill(1, i)]) == [i+1:2i; 1:i]
     end
@@ -2061,10 +2061,6 @@ end
         res = fun(df1, df2, on=:x, sort=:right)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
-        @test issorted(semijoin(df1, df2, on=:x).id1)
-        @test issorted(semijoin(df2, df1, on=:x).id2)
-        @test issorted(antijoin(df1, df2, on=:x).id1)
-        @test issorted(antijoin(df2, df1, on=:x).id2)
         df1.x = string.(df1.x)
         df2.x = string.(df2.x)
         ref = fun(df1, df2, on=:x)
@@ -2074,11 +2070,8 @@ end
         res = fun(df1, df2, on=:x, sort=:right)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
-        @test issorted(semijoin(df1, df2, on=:x).id1)
-        @test issorted(semijoin(df2, df1, on=:x).id2)
-        @test issorted(antijoin(df1, df2, on=:x).id1)
-        @test issorted(antijoin(df2, df1, on=:x).id2)
     end
+
     for fun in (innerjoin, leftjoin, rightjoin, outerjoin)
         df1 = DataFrame(x=[0, 1, 2, 3, 4], id1=1:5)
         df2 = DataFrame(x=[1, 2, 3, 5, 6, 7], id2=1:6)
@@ -2089,10 +2082,6 @@ end
         res = fun(df1, df2, on=:x, sort=:right)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
-        @test issorted(semijoin(df1, df2, on=:x).id1)
-        @test issorted(semijoin(df2, df1, on=:x).id2)
-        @test issorted(antijoin(df1, df2, on=:x).id1)
-        @test issorted(antijoin(df2, df1, on=:x).id2)
         df1.x = string.(df1.x)
         df2.x = string.(df2.x)
         ref = fun(df1, df2, on=:x)
@@ -2102,10 +2091,115 @@ end
         res = fun(df1, df2, on=:x, sort=:right)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
-        @test issorted(semijoin(df1, df2, on=:x).id1)
-        @test issorted(semijoin(df2, df1, on=:x).id2)
-        @test issorted(antijoin(df1, df2, on=:x).id1)
-        @test issorted(antijoin(df2, df1, on=:x).id2)
+    end
+
+    for fun in (leftjoin, rightjoin, outerjoin)
+        df1 = DataFrame(x=[0, 3, 1, 2, 4], id1=1:5)
+        df2 = DataFrame(x=[2, 5, 1, 3, 7, 6], id2=1:6)
+        ref = fun(df1, df2, on=:x, source=:src)
+        res = fun(df1, df2, on=:x, sort=:left, source=:src)
+        @test issorted(res.id1)
+        @test sort(ref, :id1) ≅ res
+        res = fun(df1, df2, on=:x, sort=:right, source=:src)
+        @test issorted(res.id2)
+        @test sort(ref, :id2) ≅ res
+        df1.x = string.(df1.x)
+        df2.x = string.(df2.x)
+        ref = fun(df1, df2, on=:x, source=:src)
+        res = fun(df1, df2, on=:x, sort=:left, source=:src)
+        @test issorted(res.id1)
+        @test sort(ref, :id1) ≅ res
+        res = fun(df1, df2, on=:x, sort=:right, source=:src)
+        @test issorted(res.id2)
+        @test sort(ref, :id2) ≅ res
+    end
+
+    for fun in (leftjoin, rightjoin, outerjoin)
+        df1 = DataFrame(x=[0, 1, 2, 3, 4], id1=1:5)
+        df2 = DataFrame(x=[1, 2, 3, 5, 6, 7], id2=1:6)
+        ref = fun(df1, df2, on=:x, source=:src)
+        res = fun(df1, df2, on=:x, sort=:left, source=:src)
+        @test issorted(res.id1)
+        @test sort(ref, :id1) ≅ res
+        res = fun(df1, df2, on=:x, sort=:right, source=:src)
+        @test issorted(res.id2)
+        @test sort(ref, :id2) ≅ res
+        df1.x = string.(df1.x)
+        df2.x = string.(df2.x)
+        ref = fun(df1, df2, on=:x, source=:src)
+        res = fun(df1, df2, on=:x, sort=:left, source=:src)
+        @test issorted(res.id1)
+        @test sort(ref, :id1) ≅ res
+        res = fun(df1, df2, on=:x, sort=:right, source=:src)
+        @test issorted(res.id2)
+        @test sort(ref, :id2) ≅ res
+    end
+
+    df1 = DataFrame(x=[0, 3, 1, 2, 4], id1=1:5)
+    df2 = DataFrame(x=[2, 5, 1, 3, 7, 6], id2=1:6)
+    @test issorted(semijoin(df1, df2, on=:x).id1)
+    @test issorted(semijoin(df2, df1, on=:x).id2)
+    @test issorted(antijoin(df1, df2, on=:x).id1)
+    @test issorted(antijoin(df2, df1, on=:x).id2)
+    df1.x = string.(df1.x)
+    df2.x = string.(df2.x)
+    @test issorted(semijoin(df1, df2, on=:x).id1)
+    @test issorted(semijoin(df2, df1, on=:x).id2)
+    @test issorted(antijoin(df1, df2, on=:x).id1)
+    @test issorted(antijoin(df2, df1, on=:x).id2)
+    df1 = DataFrame(x=[0, 1, 2, 3, 4], id1=1:5)
+    df2 = DataFrame(x=[1, 2, 3, 5, 6, 7], id2=1:6)
+    @test issorted(semijoin(df1, df2, on=:x).id1)
+    @test issorted(semijoin(df2, df1, on=:x).id2)
+    @test issorted(antijoin(df1, df2, on=:x).id1)
+    @test issorted(antijoin(df2, df1, on=:x).id2)
+    df1.x = string.(df1.x)
+    df2.x = string.(df2.x)
+    @test issorted(semijoin(df1, df2, on=:x).id1)
+    @test issorted(semijoin(df2, df1, on=:x).id2)
+    @test issorted(antijoin(df1, df2, on=:x).id1)
+    @test issorted(antijoin(df2, df1, on=:x).id2)
+end
+
+@time @testset "randomized join tests with sort" begin
+    Random.seed!(1234)
+    for lenl in 0:20, lenr in 0:20, rep in 1:10
+        df1 = DataFrame(x=rand(0:lenl, lenl), id1=1:lenl)
+        df2 = DataFrame(x=rand(0:lenr, lenr), id2=1:lenr)
+        ref = innerjoin(df1, df2, on=:x)
+        res = innerjoin(df1, df2, on=:x, sort=:left)
+        @test issorted(res, [:id1, :id2])
+        @test sort(ref, :id1) ≅ res
+        res = innerjoin(df1, df2, on=:x, sort=:right)
+        @test issorted(res, [:id2, :id1])
+        @test sort(ref, :id2) ≅ res
+        for fun in (leftjoin, rightjoin, outerjoin)
+            ref = fun(df1, df2, on=:x, source=:src)
+            res = fun(df1, df2, on=:x, sort=:left, source=:src)
+            @test issorted(res, [:id1, :id2])
+            @test sort(ref, :id1) ≅ res
+            res = fun(df1, df2, on=:x, sort=:right, source=:src)
+            @test issorted(res, [:id2, :id1])
+            @test sort(ref, :id2) ≅ res
+        end
+        df1.x = string.(df1.x)
+        df2.x = string.(df2.x)
+        ref = innerjoin(df1, df2, on=:x)
+        res = innerjoin(df1, df2, on=:x, sort=:left)
+        @test issorted(res, [:id1, :id2])
+        @test sort(ref, :id1) ≅ res
+        res = innerjoin(df1, df2, on=:x, sort=:right)
+        @test issorted(res, [:id2, :id1])
+        @test sort(ref, :id2) ≅ res
+        for fun in (leftjoin, rightjoin, outerjoin)
+            ref = fun(df1, df2, on=:x, source=:src)
+            res = fun(df1, df2, on=:x, sort=:left, source=:src)
+            @test issorted(res, [:id1, :id2])
+            @test sort(ref, :id1) ≅ res
+            res = fun(df1, df2, on=:x, sort=:right, source=:src)
+            @test issorted(res, [:id2, :id1])
+            @test sort(ref, :id2) ≅ res
+        end
     end
 end
 

--- a/test/join.jl
+++ b/test/join.jl
@@ -2050,24 +2050,24 @@ end
     end
 end
 
-@testset "basic join tests with sort" begin
+@testset "basic join tests with order" begin
     for fun in (innerjoin, leftjoin, rightjoin, outerjoin)
         df1 = DataFrame(x=[0, 3, 1, 2, 4], id1=1:5)
         df2 = DataFrame(x=[2, 5, 1, 3, 7, 6], id2=1:6)
         ref = fun(df1, df2, on=:x)
-        res = fun(df1, df2, on=:x, sort=:left)
+        res = fun(df1, df2, on=:x, order=:left)
         @test issorted(res.id1)
         @test sort(ref, :id1) ≅ res
-        res = fun(df1, df2, on=:x, sort=:right)
+        res = fun(df1, df2, on=:x, order=:right)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
         df1.x = string.(df1.x)
         df2.x = string.(df2.x)
         ref = fun(df1, df2, on=:x)
-        res = fun(df1, df2, on=:x, sort=:left)
+        res = fun(df1, df2, on=:x, order=:left)
         @test issorted(res.id1)
         @test sort(ref, :id1) ≅ res
-        res = fun(df1, df2, on=:x, sort=:right)
+        res = fun(df1, df2, on=:x, order=:right)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
     end
@@ -2076,19 +2076,19 @@ end
         df1 = DataFrame(x=[0, 1, 2, 3, 4], id1=1:5)
         df2 = DataFrame(x=[1, 2, 3, 5, 6, 7], id2=1:6)
         ref = fun(df1, df2, on=:x)
-        res = fun(df1, df2, on=:x, sort=:left)
+        res = fun(df1, df2, on=:x, order=:left)
         @test issorted(res.id1)
         @test sort(ref, :id1) ≅ res
-        res = fun(df1, df2, on=:x, sort=:right)
+        res = fun(df1, df2, on=:x, order=:right)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
         df1.x = string.(df1.x)
         df2.x = string.(df2.x)
         ref = fun(df1, df2, on=:x)
-        res = fun(df1, df2, on=:x, sort=:left)
+        res = fun(df1, df2, on=:x, order=:left)
         @test issorted(res.id1)
         @test sort(ref, :id1) ≅ res
-        res = fun(df1, df2, on=:x, sort=:right)
+        res = fun(df1, df2, on=:x, order=:right)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
     end
@@ -2097,19 +2097,19 @@ end
         df1 = DataFrame(x=[0, 3, 1, 2, 4], id1=1:5)
         df2 = DataFrame(x=[2, 5, 1, 3, 7, 6], id2=1:6)
         ref = fun(df1, df2, on=:x, source=:src)
-        res = fun(df1, df2, on=:x, sort=:left, source=:src)
+        res = fun(df1, df2, on=:x, order=:left, source=:src)
         @test issorted(res.id1)
         @test sort(ref, :id1) ≅ res
-        res = fun(df1, df2, on=:x, sort=:right, source=:src)
+        res = fun(df1, df2, on=:x, order=:right, source=:src)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
         df1.x = string.(df1.x)
         df2.x = string.(df2.x)
         ref = fun(df1, df2, on=:x, source=:src)
-        res = fun(df1, df2, on=:x, sort=:left, source=:src)
+        res = fun(df1, df2, on=:x, order=:left, source=:src)
         @test issorted(res.id1)
         @test sort(ref, :id1) ≅ res
-        res = fun(df1, df2, on=:x, sort=:right, source=:src)
+        res = fun(df1, df2, on=:x, order=:right, source=:src)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
     end
@@ -2118,19 +2118,19 @@ end
         df1 = DataFrame(x=[0, 1, 2, 3, 4], id1=1:5)
         df2 = DataFrame(x=[1, 2, 3, 5, 6, 7], id2=1:6)
         ref = fun(df1, df2, on=:x, source=:src)
-        res = fun(df1, df2, on=:x, sort=:left, source=:src)
+        res = fun(df1, df2, on=:x, order=:left, source=:src)
         @test issorted(res.id1)
         @test sort(ref, :id1) ≅ res
-        res = fun(df1, df2, on=:x, sort=:right, source=:src)
+        res = fun(df1, df2, on=:x, order=:right, source=:src)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
         df1.x = string.(df1.x)
         df2.x = string.(df2.x)
         ref = fun(df1, df2, on=:x, source=:src)
-        res = fun(df1, df2, on=:x, sort=:left, source=:src)
+        res = fun(df1, df2, on=:x, order=:left, source=:src)
         @test issorted(res.id1)
         @test sort(ref, :id1) ≅ res
-        res = fun(df1, df2, on=:x, sort=:right, source=:src)
+        res = fun(df1, df2, on=:x, order=:right, source=:src)
         @test issorted(res.id2)
         @test sort(ref, :id2) ≅ res
     end
@@ -2160,10 +2160,10 @@ end
     @test issorted(antijoin(df1, df2, on=:x).id1)
     @test issorted(antijoin(df2, df1, on=:x).id2)
 
-    @test_throws ArgumentError innerjoin(df1, df2, on=:x, sort=:x)
-    @test_throws ArgumentError leftjoin(df1, df2, on=:x, sort=:x)
-    @test_throws ArgumentError rightjoin(df1, df2, on=:x, sort=:x)
-    @test_throws ArgumentError outerjoin(df1, df2, on=:x, sort=:x)
+    @test_throws ArgumentError innerjoin(df1, df2, on=:x, order=:x)
+    @test_throws ArgumentError leftjoin(df1, df2, on=:x, order=:x)
+    @test_throws ArgumentError rightjoin(df1, df2, on=:x, order=:x)
+    @test_throws ArgumentError outerjoin(df1, df2, on=:x, order=:x)
 end
 
 @time @testset "randomized join tests with sort" begin
@@ -2172,36 +2172,36 @@ end
         df1 = DataFrame(x=rand(0:lenl, lenl), id1=1:lenl)
         df2 = DataFrame(x=rand(0:lenr, lenr), id2=1:lenr)
         ref = innerjoin(df1, df2, on=:x)
-        res = innerjoin(df1, df2, on=:x, sort=:left)
+        res = innerjoin(df1, df2, on=:x, order=:left)
         @test issorted(res, [:id1, :id2])
         @test sort(ref, :id1) ≅ res
-        res = innerjoin(df1, df2, on=:x, sort=:right)
+        res = innerjoin(df1, df2, on=:x, order=:right)
         @test issorted(res, [:id2, :id1])
         @test sort(ref, :id2) ≅ res
         for fun in (leftjoin, rightjoin, outerjoin)
             ref = fun(df1, df2, on=:x, source=:src)
-            res = fun(df1, df2, on=:x, sort=:left, source=:src)
+            res = fun(df1, df2, on=:x, order=:left, source=:src)
             @test issorted(res, [:id1, :id2])
             @test sort(ref, :id1) ≅ res
-            res = fun(df1, df2, on=:x, sort=:right, source=:src)
+            res = fun(df1, df2, on=:x, order=:right, source=:src)
             @test issorted(res, [:id2, :id1])
             @test sort(ref, :id2) ≅ res
         end
         df1.x = string.(df1.x)
         df2.x = string.(df2.x)
         ref = innerjoin(df1, df2, on=:x)
-        res = innerjoin(df1, df2, on=:x, sort=:left)
+        res = innerjoin(df1, df2, on=:x, order=:left)
         @test issorted(res, [:id1, :id2])
         @test sort(ref, :id1) ≅ res
-        res = innerjoin(df1, df2, on=:x, sort=:right)
+        res = innerjoin(df1, df2, on=:x, order=:right)
         @test issorted(res, [:id2, :id1])
         @test sort(ref, :id2) ≅ res
         for fun in (leftjoin, rightjoin, outerjoin)
             ref = fun(df1, df2, on=:x, source=:src)
-            res = fun(df1, df2, on=:x, sort=:left, source=:src)
+            res = fun(df1, df2, on=:x, order=:left, source=:src)
             @test issorted(res, [:id1, :id2])
             @test sort(ref, :id1) ≅ res
-            res = fun(df1, df2, on=:x, sort=:right, source=:src)
+            res = fun(df1, df2, on=:x, order=:right, source=:src)
             @test issorted(res, [:id2, :id1])
             @test sort(ref, :id2) ≅ res
         end

--- a/test/join.jl
+++ b/test/join.jl
@@ -2209,6 +2209,17 @@ end
 end
 
 @testset "wide joins" begin
+    Random.seed!(1234)
+    # we need many repetitions to make sure we cover all cases
+    @time for _ in 1:1000, k in 2:4
+        dfs = [(n=rand(10:20);
+                DataFrame("id" => randperm(n), "x$i" => 1:n)) for i in 1:4]
+        @test issorted(innerjoin(dfs..., on="id", order=:left)[:, 2])
+        @test issorted(outerjoin(dfs..., on="id", order=:left)[:, 2])
+        @test issorted(innerjoin(dfs..., on="id", order=:right)[:, end])
+        @test issorted(outerjoin(dfs..., on="id", order=:right)[:, end])
+    end
+
     dfs = [DataFrame("id" => 0, "x$i" => i) for i in 1:10000]
     res = innerjoin(dfs..., on="id")
     @test res == DataFrame(["id" => 0; ["x$i" => i for i in 1:10000]]) 

--- a/test/join.jl
+++ b/test/join.jl
@@ -2159,6 +2159,11 @@ end
     @test issorted(semijoin(df2, df1, on=:x).id2)
     @test issorted(antijoin(df1, df2, on=:x).id1)
     @test issorted(antijoin(df2, df1, on=:x).id2)
+
+    @test_throws ArgumentError innerjoin(df1, df2, on=:x, sort=:x)
+    @test_throws ArgumentError leftjoin(df1, df2, on=:x, sort=:x)
+    @test_throws ArgumentError rightjoin(df1, df2, on=:x, sort=:x)
+    @test_throws ArgumentError outerjoin(df1, df2, on=:x, sort=:x)
 end
 
 @time @testset "randomized join tests with sort" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/2753

The performance probably can be improved in some cases, but I wanted to start with something simple that works (and already has performance that is not horrible).

I proposed the `sort` kwarg to specify sorting order, but maybe some other name would be better (earlier we discussed `order`).