### PR TITLE
Add hints to use macro packages for new users

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,8 +34,13 @@ tool for working with tabular data in Julia -- as noted below, there are some
 other great libraries for certain use-cases -- but it provides great data
 wrangling functionality through a familiar interface.
 
-To understand the toolchain in more detail, have a look at the tutorials in this manual. New
-users can start with the [First Steps with DataFrames.jl](@ref) section.
+To understand the toolchain in more detail, have a look at the tutorials in this manual.
+New users can start with the [First Steps with DataFrames.jl](@ref) section.
+
+If you do not have a significant programming experience you might find 
+[DataFramesMeta.jl](https://juliadata.github.io/DataFramesMeta.jl/stable/) package
+helpful when writing more advanced data transformations since it provides
+convenience syntax similar to [dplyr](https://dplyr.tidyverse.org/) in R.
 
 ## DataFrames.jl and the Julia Data Ecosystem
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,12 +37,12 @@ wrangling functionality through a familiar interface.
 To understand the toolchain in more detail, have a look at the tutorials in this manual.
 New users can start with the [First Steps with DataFrames.jl](@ref) section.
 
-If you do not have a significant programming experience you might find 
-[DataFramesMeta.jl](https://juliadata.github.io/DataFramesMeta.jl/stable/) package
-or one of the other convenience packages discussed in
-[Data manipulation frameworks](@ref) section of this manual
-helpful when writing more advanced data transformations. These packages provide
-convenience syntax similar to [dplyr](https://dplyr.tidyverse.org/) in R.
+You may find the [DataFramesMeta.jl](https://juliadata.github.io/DataFramesMeta.jl/stable/)
+package or one of the other convenience packages discussed in
+the [Data manipulation frameworks](@ref) section of this manual
+helpful when writing more advanced data transformations,
+especially if you do not have a significant programming experience.
+These packages provide convenience syntax similar to [dplyr](https://dplyr.tidyverse.org/) in R.
 
 ## DataFrames.jl and the Julia Data Ecosystem
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,7 +39,9 @@ New users can start with the [First Steps with DataFrames.jl](@ref) section.
 
 If you do not have a significant programming experience you might find 
 [DataFramesMeta.jl](https://juliadata.github.io/DataFramesMeta.jl/stable/) package
-helpful when writing more advanced data transformations since it provides
+or one of the other convenience packages discussed in
+[Data manipulation frameworks](@ref) section of this manual
+helpful when writing more advanced data transformations. These packages provide
 convenience syntax similar to [dplyr](https://dplyr.tidyverse.org/) in R.
 
 ## DataFrames.jl and the Julia Data Ecosystem


### PR DESCRIPTION
Users asked to give a hint that macro-packages can be easier to use for newcomers in the opening page of DataFrames.jl manual near its top (so that it is easily discoverable).

@nalimilan, @pdeffebach, @jkrumbiegel - I have proposed something, but I am not sure if the wording is best. Can you please comment? (I think that good wording here is important) Thank you!

Also I mention only DataFramesMeta.jl as I did not want to introduce additional user confusion (i.e. that they need to make choices between DataFramesMeta.jl and DataFrameMacros.jl). But maybe it is better to mention both. I am open for suggestions.
(they are both mentioned below in data wrangling section)