### PR TITLE
fix deleteat! and subset! performance

### DIFF
--- a/src/abstractdataframe/subset.jl
+++ b/src/abstractdataframe/subset.jl
@@ -468,7 +468,7 @@ function subset!(df::AbstractDataFrame, @nospecialize(args...);
                 skipmissing::Bool=false, threads::Bool=true)
     isempty(args) && return df
     row_selector = _get_subset_conditions(df, Ref{Any}(args), skipmissing, threads)
-    return deleteat!(df, findall(!, row_selector))
+    return deleteat!(df, .!row_selector)
 end
 
 function subset!(gdf::GroupedDataFrame, @nospecialize(args...); skipmissing::Bool=false,
@@ -486,7 +486,7 @@ function subset!(gdf::GroupedDataFrame, @nospecialize(args...); skipmissing::Boo
     groups = gdf.groups
     lazy_lock = gdf.lazy_lock
     row_selector = _get_subset_conditions(gdf, Ref{Any}(args), skipmissing, threads)
-    res = deleteat!(df, findall(!, row_selector))
+    res = deleteat!(df, .!row_selector)
     if nrow(res) == length(groups) # we have not removed any rows
         return ungroup ? res : gdf
     end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -889,7 +889,7 @@ function Base.deleteat!(df::DataFrame, inds::AbstractVector{Bool})
     end
     # workaround https://github.com/JuliaLang/julia/pull/41646
     if VERSION <= v"1.6.2" && drop isa UnitRange{<:Integer}
-        drop = collect(inds)
+        inds = collect(inds)
     end
     return _deleteat!_helper(df, inds)
 end
@@ -909,10 +909,10 @@ function _deleteat!_helper(df::DataFrame, drop)
     deleteat!(col1, drop)
     newn = length(col1)
     @assert newn <= n
-    # the 0.05 threshold is heuristic; based on tests
+    # the 0.06 threshold is heuristic; based on tests
     # the assignment makes the code type-unstable but it is a small union
     # so the overhead should be small
-    if drop isa AbstractVector{Bool} && newn < 0.05 * n
+    if drop isa AbstractVector{Bool} && newn < 0.06 * n
         drop = findall(drop)
     end
     for i in 2:length(cols)

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -909,7 +909,12 @@ function _deleteat!_helper(df::DataFrame, drop)
     deleteat!(col1, drop)
     newn = length(col1)
     @assert newn <= n
-
+    # the 0.05 threshold is heuristic; based on tests
+    # the assignment makes the code type-unstable but it is a small union
+    # so the overhead should be small
+    if drop isa AbstractVector{Bool} && newn < 0.05 * n
+        drop = findall(drop)
+    end
     for i in 2:length(cols)
         col = cols[i]
         # this check is done to handle column aliases

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -887,12 +887,11 @@ function Base.deleteat!(df::DataFrame, inds::AbstractVector{Bool})
     if length(inds) != size(df, 1)
         throw(BoundsError(df, (inds, :)))
     end
-    drop = _findall(inds)
     # workaround https://github.com/JuliaLang/julia/pull/41646
     if VERSION <= v"1.6.2" && drop isa UnitRange{<:Integer}
-        drop = collect(drop)
+        drop = collect(inds)
     end
-    return _deleteat!_helper(df, drop)
+    return _deleteat!_helper(df, inds)
 end
 
 Base.deleteat!(df::DataFrame, inds::Not) =

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -517,6 +517,16 @@ end
     @test_throws BoundsError deleteat!(df, true:true)
     df = DataFrame(a=1, b=3.0)
     @test isempty(deleteat!(df, true:true))
+
+    Random.seed!(1234)
+    for t in 0:0.005:1.0
+        # two columns are needed as the second column is affected
+        # by the adaptive algorithm
+        df = DataFrame(i=1:10^5, j=1:10^5)
+        idxs = rand(10^5) .< t
+        deleteat!(df, idxs)
+        df.i == df.j == findall(idxs)
+    end
 end
 
 @testset "describe" begin


### PR DESCRIPTION
Explanation in https://discourse.julialang.org/t/learning-to-benchmark-and-find-the-best-function-to-select-a-subset-of-a-dataframe/91704/12.

# Benchmarks

## This PR
```
julia> using Random

julia> Random.seed!(1234)
TaskLocalRNG()

julia> df = DataFrame(rand(10^6, 100), :auto);

julia> df.id = rand(1:100, 10^6);

julia> inds = rand(Bool, 10^6);

julia> x = copy(df); @time deleteat!(x, inds);
  0.084989 seconds (29.05 k allocations: 1.471 MiB, 11.83% compilation time)

julia> x = copy(df); @time deleteat!(x, inds);
  0.074356 seconds (305 allocations: 4.766 KiB)

julia> x = copy(df); @time subset!(x, :x1 => Returns(inds));
  0.091337 seconds (485 allocations: 262.422 KiB)

julia> x = copy(df); @time subset!(x, :x1 => Returns(inds));
  0.148983 seconds (485 allocations: 262.422 KiB)

julia> x = groupby(copy(df), :id); @time subset!(x, :x1 => x -> rand(Bool, length(x)));     
  0.207012 seconds (1.15 M allocations: 63.651 MiB, 31.11% compilation time)

julia> x = groupby(copy(df), :id); @time subset!(x, :x1 => x -> rand(Bool, length(x)));     
  0.216079 seconds (1.15 M allocations: 63.632 MiB, 30.41% compilation time)
```

## 1.4.4 release
```
julia> using Random

julia> Random.seed!(1234)
TaskLocalRNG()

julia> df = DataFrame(rand(10^6, 100), :auto);

julia> df.id = rand(1:100, 10^6);

julia> inds = rand(Bool, 10^6);

julia> x = copy(df); @time deleteat!(x, inds);
  0.300327 seconds (307 allocations: 3.817 MiB)

julia> x = copy(df); @time deleteat!(x, inds);
  0.303013 seconds (307 allocations: 3.817 MiB)

julia> x = copy(df); @time subset!(x, :x1 => Returns(inds));
  0.307057 seconds (483 allocations: 4.074 MiB)

julia> x = copy(df); @time subset!(x, :x1 => Returns(inds));
  0.300665 seconds (483 allocations: 4.074 MiB)

julia> x = groupby(copy(df), :id); @time subset!(x, :x1 => x -> rand(Bool, length(x)));
  0.437468 seconds (1.15 M allocations: 67.427 MiB, 15.85% compilation time)

julia> x = groupby(copy(df), :id); @time subset!(x, :x1 => x -> rand(Bool, length(x)));
  0.417350 seconds (1.15 M allocations: 67.425 MiB, 15.70% compilation time)
```