### PR TITLE
improve error message in operation specification syntax

### DIFF
--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -436,9 +436,9 @@ function _combine_process_pair_symbol(optional_i::Bool,
 
     if firstmulticol
         throw(ArgumentError("a single value or vector result is required " *
-                            "(got $(typeof(firstres))). Maybe it was " *
-                            "forgotten to wrap the return value of " *
-                            "the operation with `Ref`."))
+                            "(got $(typeof(firstres))). Maybe you " *
+                            "forgot to wrap the return value of " *
+                            "the operation with `Ref`?"))
     end
     # if idx_agg was not computed yet it is NOTHING_IDX_AGG
     # in this case if we are not passed a vector compute it.

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -435,7 +435,10 @@ function _combine_process_pair_symbol(optional_i::Bool,
     @assert only(wincols) isa Union{Tuple, NamedTuple}
 
     if firstmulticol
-        throw(ArgumentError("a single value or vector result is required (got $(typeof(firstres)))"))
+        throw(ArgumentError("a single value or vector result is required " *
+                            "(got $(typeof(firstres))). Maybe it was " *
+                            "forgotten to wrap the return value of " *
+                            "the operation with `Ref`."))
     end
     # if idx_agg was not computed yet it is NOTHING_IDX_AGG
     # in this case if we are not passed a vector compute it.


### PR DESCRIPTION
@nalimilan - also I think the issue is that our current stack trace is super long (essentially the same information is printed several times):
```
julia> df = DataFrame(a=[1, 1, 2, 2], b=11:14, c=21:24)
4×3 DataFrame
 Row │ a      b      c     
     │ Int64  Int64  Int64 
─────┼─────────────────────
   1 │     1     11     21
   2 │     1     12     22
   3 │     2     13     23
   4 │     2     14     24

julia> combine(groupby(df, :a), AsTable([:b, :c]) => DataFrame => :bc)
ERROR: ArgumentError: a single value or vector result is required (got DataFrame). Maybe it 
was forgotten to wrap the return value of the operation with `Ref`.
Stacktrace:
 [1] _combine(gd::GroupedDataFrame{DataFrame}, cs_norm::Vector{Any}, optional_transform::Vec
tor{Bool}, copycols::Bool, keeprows::Bool, renamecols::Bool, threads::Bool)
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:754
 [2] _combine_prepare_norm(gd::GroupedDataFrame{DataFrame}, cs_vec::Vector{Any}, keepkeys::B
ool, ungroup::Bool, copycols::Bool, keeprows::Bool, renamecols::Bool, threads::Bool)
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:86
 [3] _combine_prepare(gd::GroupedDataFrame{DataFrame}, ::Base.RefValue{Any}; keepkeys::Bool,
 ungroup::Bool, copycols::Bool, keeprows::Bool, renamecols::Bool, threads::Bool)
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:51
 [4] combine(::GroupedDataFrame{DataFrame}, ::Union{Regex, AbstractString, Function, Signed,
 Symbol, Unsigned, Pair, Type, All, Between, Cols, InvertedIndex, AbstractVecOrMat}, ::Varar
g{Union{Regex, AbstractString, Function, Signed, Symbol, Unsigned, Pair, Type, All, Between,
 Cols, InvertedIndex, AbstractVecOrMat}}; keepkeys::Bool, ungroup::Bool, renamecols::Bool, t
hreads::Bool)
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:860
 [5] combine(gd::GroupedDataFrame{DataFrame}, args::Union{Regex, AbstractString, Function, S
igned, Symbol, Unsigned, Pair, Type, All, Between, Cols, InvertedIndex, AbstractVecOrMat})  
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:860
 [6] top-level scope
   @ REPL[3]:1

caused by: TaskFailedException
Stacktrace:
 [1] wait
   @ .\task.jl:345 [inlined]
 [2] _combine(gd::GroupedDataFrame{DataFrame}, cs_norm::Vector{Any}, optional_transform::Vec
tor{Bool}, copycols::Bool, keeprows::Bool, renamecols::Bool, threads::Bool)
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:751
 [3] _combine_prepare_norm(gd::GroupedDataFrame{DataFrame}, cs_vec::Vector{Any}, keepkeys::B
ool, ungroup::Bool, copycols::Bool, keeprows::Bool, renamecols::Bool, threads::Bool)        
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:86
 [4] _combine_prepare(gd::GroupedDataFrame{DataFrame}, ::Base.RefValue{Any}; keepkeys::Bool,
 ungroup::Bool, copycols::Bool, keeprows::Bool, renamecols::Bool, threads::Bool)
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:51
 [5] combine(::GroupedDataFrame{DataFrame}, ::Union{Regex, AbstractString, Function, Signed,
 Symbol, Unsigned, Pair, Type, All, Between, Cols, InvertedIndex, AbstractVecOrMat}, ::Varar
g{Union{Regex, AbstractString, Function, Signed, Symbol, Unsigned, Pair, Type, All, Between,
 Cols, InvertedIndex, AbstractVecOrMat}}; keepkeys::Bool, ungroup::Bool, renamecols::Bool, t
hreads::Bool)
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:860
 [6] combine(gd::GroupedDataFrame{DataFrame}, args::Union{Regex, AbstractString, Function, S
igned, Symbol, Unsigned, Pair, Type, All, Between, Cols, InvertedIndex, AbstractVecOrMat})  
   @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.
jl:860
 [7] top-level scope
   @ REPL[3]:1

    nested task error: ArgumentError: a single value or vector result is required (got DataF
rame). Maybe it was forgotten to wrap the return value of the operation with `Ref`.
    Stacktrace:
     [1] _combine_process_pair_symbol(optional_i::Bool, gd::GroupedDataFrame{DataFrame}, see
n_cols::Dict{Symbol, Tuple{Bool, Int64}}, trans_res::Vector{DataFrames.TransformationResult}
, idx_agg::Base.RefValue{Vector{Int64}}, out_col_name::Symbol, firstmulticol::Bool, ::Base.R
efValue{Any}, wfun::Base.RefValue{Any}, wincols::Base.RefValue{Any}, threads::Bool, ::Base.R
efValue{Any})
       @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycomb
ine.jl:438
     [2] _combine_process_pair(::Base.RefValue{Any}, optional_i::Bool, parentdf::DataFrame, 
gd::GroupedDataFrame{DataFrame}, seen_cols::Dict{Symbol, Tuple{Bool, Int64}}, trans_res::Vec
tor{DataFrames.TransformationResult}, idx_agg::Base.RefValue{Vector{Int64}}, threads::Bool) 
       @ DataFrames ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycomb
ine.jl:635
     [3] macro expansion
       @ ~\.julia\dev\DataFrames\src\groupeddataframe\splitapplycombine.jl:741 
[inlined]
     [4] (::DataFrames.var"#741#750"{GroupedDataFrame{DataFrame}, Bool, Bool, Bool, DataFram
e, Dict{Symbol, Tuple{Bool, Int64}}, Vector{DataFrames.TransformationResult}, Base.RefValue{
Vector{Int64}}, Bool, Pair{AsTable, Pair{DataType, Symbol}}})()
       @ DataFrames ~\.julia\dev\DataFrames\src\other\utils.jl:227

```
Do you think it is fixable?

CC @jariji 