### PR TITLE
Fix bug in subset[!] when handling no conditions case

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,8 @@
 * passing very many data frames to `innerjoin` and `outerjoin`
   does not lead to stack overflow
   ([#3233](https://github.com/JuliaData/DataFrames.jl/pull/3233))
+* fixed incorrect handling of passing no conditions in `subset` and `subset!`
+  ([#3264](https://github.com/JuliaData/DataFrames.jl/pull/3264))
 
 # DataFrames.jl v1.4.4 Patch Release Notes
 

--- a/test/subset.jl
+++ b/test/subset.jl
@@ -592,6 +592,8 @@ end
     df = DataFrame(a=1:2)
     @test subset(df, Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
     @test subset(groupby(df, :a), Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
+    @test subset!(df, Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
+    @test subset!(groupby(df, :a), Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
 end
 
 end

--- a/test/subset.jl
+++ b/test/subset.jl
@@ -588,4 +588,10 @@ end
     @test gdf == groupby(DataFrame(a=1:3), :a)[[3, 1]]
 end
 
+@testset "empty conditions in subset" begin
+    df = DataFrame(a=1:2)
+    @test subset(df, Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
+    @test subset(groupby(df, :a), Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
+end
+
 end

--- a/test/subset.jl
+++ b/test/subset.jl
@@ -590,10 +590,10 @@ end
 
 @testset "empty conditions in subset" begin
     df = DataFrame(a=1:2)
-    @test subset(df, Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
-    @test subset(groupby(df, :a), Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
-    @test subset!(df, Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
-    @test subset!(groupby(df, :a), Not(:a) .=> ByRow(Returns(true))) == DataFrame(a=1:2)
+    @test subset(df, Not(:a) .=> ByRow(x -> true)) == DataFrame(a=1:2)
+    @test subset(groupby(df, :a), Not(:a) .=> ByRow(x -> true)) == DataFrame(a=1:2)
+    @test subset!(df, Not(:a) .=> ByRow(x -> true)) == DataFrame(a=1:2)
+    @test subset!(groupby(df, :a), Not(:a) .=> ByRow(x -> true)) == DataFrame(a=1:2)
 end
 
 end


### PR DESCRIPTION
This PR fixes a situation when we can only detect that no conditions are passed after processing them. Example of wrong behavior (fixed by this PR):

```
julia>     df = DataFrame(a=1:2)
2×1 DataFrame
 Row │ a
     │ Int64
─────┼───────
   1 │     1
   2 │     2

julia> subset(df, Not(:a) .=> ByRow(Returns(true)))
ERROR: AssertionError: !(isempty(conditions))
```