### PR TITLE
add information about TableMetadaTools.jl to docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -37,12 +37,18 @@ wrangling functionality through a familiar interface.
 To understand the toolchain in more detail, have a look at the tutorials in this manual.
 New users can start with the [First Steps with DataFrames.jl](@ref) section.
 
-You may find the [DataFramesMeta.jl](https://juliadata.github.io/DataFramesMeta.jl/stable/)
-package or one of the other convenience packages discussed in
-the [Data manipulation frameworks](@ref) section of this manual
-helpful when writing more advanced data transformations,
-especially if you do not have a significant programming experience.
-These packages provide convenience syntax similar to [dplyr](https://dplyr.tidyverse.org/) in R.
+You may find the
+[DataFramesMeta.jl](https://juliadata.github.io/DataFramesMeta.jl/stable/)
+package or one of the other convenience packages discussed in the [Data
+manipulation frameworks](@ref) section of this manual helpful when writing more
+advanced data transformations, especially if you do not have a significant
+programming experience. These packages provide convenience syntax similar to
+[dplyr](https://dplyr.tidyverse.org/) in R.
+
+If you use metadata when working with DataFrames.jl you might find the
+[TableMetadataTools.jl](https://github.com/JuliaData/TableMetadataTools.jl)
+package useful. This package defines several convenience functions for
+performing typical metadata operations.
 
 ## DataFrames.jl and the Julia Data Ecosystem
 

--- a/docs/src/lib/metadata.md
+++ b/docs/src/lib/metadata.md
@@ -10,6 +10,11 @@ level. This is supported using the functions defined by the DataAPI.jl interface
 * for column-level metatadata: [`colmetadata`](@ref), [`colmetadatakeys`](@ref),
   [`colmetadata!`](@ref), [`deletecolmetadata!`](@ref), [`emptycolmetadata!`](@ref).
 
+Additionally you might find the
+[TableMetadataTools.jl](https://github.com/JuliaData/TableMetadataTools.jl)
+package useful. This package defines several convenience functions for
+performing typical metadata operations.
+
 Assume that we work with a data frame-like object `df` that has a column `col`
 (referred to either via a `Symbol`, a string or an integer index).
 


### PR DESCRIPTION
TableMetadataTools.jl is now a registered package after a first round of user feedback.
I think it is good to add a reference to it as these convenience functions are important for performing common operations on metadata.