### PR TITLE
Use `pkgdir` instead of `pathof`

### DIFF
--- a/docs/src/man/basics.md
+++ b/docs/src/man/basics.md
@@ -262,9 +262,9 @@ In order to read the file in we will use the `CSV.read` function.
 ```jldoctest dataframe
 julia> using CSV
 
-julia> german_ref = CSV.read(joinpath(dirname(pathof(DataFrames)),
-                                      "..", "docs", "src", "assets", "german.csv"),
-                             DataFrame)
+julia> path = joinpath(pkgdir(DataFrames), "docs", "src", "assets", "german.csv");
+
+julia> german_ref = CSV.read(path, DataFrame)
 1000×10 DataFrame
   Row │ id     Age    Sex      Job    Housing  Saving accounts  Checking accou ⋯
       │ Int64  Int64  String7  Int64  String7  String15         String15       ⋯
@@ -306,15 +306,14 @@ using these fixed-width types.
 
 Let us now explain in detail the following code block:
 ```julia
-german_ref = CSV.read(joinpath(dirname(pathof(DataFrames)),
-                               "..", "docs", "src", "assets", "german.csv"),
-                      DataFrame)
+path = joinpath(pkgdir(DataFrames), "docs", "src", "assets", "german.csv");
+
+german_ref = CSV.read(path, DataFrame)
 ```
 - we are storing the `german.csv` file in the DataFrames.jl repository to make
   user's life easier and avoid having to download it each time;
-- `pathof(DataFrames)` gives us the full path of the file that was used to
-  import the DataFrames.jl package;
-- first we split the directory part from it using `dirname`;
+- `pkgdir(DataFrames)` gives us the full path to the root of the DataFrames.jl
+  package.
 - then from this directory we need to move to the directory where the
   `german.csv` file is stored; we use `joinpath` as this is a recommended way to
   compose paths to resources stored on disk in an operating system independent

--- a/docs/src/man/importing_and_exporting.md
+++ b/docs/src/man/importing_and_exporting.md
@@ -39,9 +39,9 @@ post-processing:
 ```jldoctest readdlm
 julia> using DelimitedFiles, DataFrames
 
-julia> data, header = readdlm(joinpath(dirname(pathof(DataFrames)),
-                                       "..", "docs", "src", "assets", "iris.csv"),
-                              ',', header=true);
+julia> path = joinpath(pkgdir(DataFrames), "docs", "src", "assets", "iris.csv");
+
+julia> data, header = readdlm(path, ',', header=true);
 
 julia> iris_raw = DataFrame(data, vec(header))
 150×5 DataFrame

--- a/docs/src/man/reshaping_and_pivoting.md
+++ b/docs/src/man/reshaping_and_pivoting.md
@@ -5,9 +5,9 @@ Reshape data from wide to long format using the `stack` function:
 ```jldoctest reshape
 julia> using DataFrames, CSV
 
-julia> iris = CSV.read((joinpath(dirname(pathof(DataFrames)),
-                                 "..", "docs", "src", "assets", "iris.csv")),
-                       DataFrame)
+julia> path = joinpath(pkgdir(DataFrames), "docs", "src", "assets", "iris.csv");
+
+julia> iris = CSV.read(path, DataFrame)
 150×5 DataFrame
  Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
      │ Float64      Float64     Float64      Float64     String15

--- a/docs/src/man/sorting.md
+++ b/docs/src/man/sorting.md
@@ -6,9 +6,9 @@ just calling `sort!` will sort all columns, in place:
 ```jldoctest sort
 julia> using DataFrames, CSV
 
-julia> iris = CSV.read((joinpath(dirname(pathof(DataFrames)),
-                                 "..", "docs", "src", "assets", "iris.csv")),
-                       DataFrame)
+julia> path = joinpath(pkgdir(DataFrames), "docs", "src", "assets", "iris.csv");
+
+julia> iris = CSV.read(path, DataFrame)
 150×5 DataFrame
  Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
      │ Float64      Float64     Float64      Float64     String15

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -195,9 +195,9 @@ We show several examples of these functions applied to the `iris` dataset below:
 ```jldoctest sac
 julia> using DataFrames, CSV, Statistics
 
-julia> iris = CSV.read((joinpath(dirname(pathof(DataFrames)),
-                                 "..", "docs", "src", "assets", "iris.csv")),
-                       DataFrame)
+julia> path = joinpath(pkgdir(DataFrames), "docs", "src", "assets", "iris.csv");
+
+julia> iris = CSV.read(path, DataFrame)
 150×5 DataFrame
  Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
      │ Float64      Float64     Float64      Float64     String15
@@ -637,8 +637,8 @@ data frame and get a vector of results either use a comprehension or `collect`
 julia> sdf_vec = collect(iris_gdf)
 3-element Vector{Any}:
  50×5 SubDataFrame
- Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species     
-     │ Float64      Float64     Float64      Float64     String15    
+ Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
+     │ Float64      Float64     Float64      Float64     String15
 ─────┼───────────────────────────────────────────────────────────────
    1 │         5.1         3.5          1.4         0.2  Iris-setosa
    2 │         4.9         3.0          1.4         0.2  Iris-setosa
@@ -659,7 +659,7 @@ julia> sdf_vec = collect(iris_gdf)
                                                       35 rows omitted
  50×5 SubDataFrame
  Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
-     │ Float64      Float64     Float64      Float64     String15        
+     │ Float64      Float64     Float64      Float64     String15
 ─────┼───────────────────────────────────────────────────────────────────
    1 │         7.0         3.2          4.7         1.4  Iris-versicolor
    2 │         6.4         3.2          4.5         1.5  Iris-versicolor
@@ -679,8 +679,8 @@ julia> sdf_vec = collect(iris_gdf)
   50 │         5.7         2.8          4.1         1.3  Iris-versicolor
                                                           35 rows omitted
  50×5 SubDataFrame
- Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species        
-     │ Float64      Float64     Float64      Float64     String15       
+ Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
+     │ Float64      Float64     Float64      Float64     String15
 ─────┼──────────────────────────────────────────────────────────────────
    1 │         6.3         3.3          6.0         2.5  Iris-virginica
    2 │         5.8         2.7          5.1         1.9  Iris-virginica
@@ -732,7 +732,7 @@ produce a data frame. An operation corresponding to the example above is:
 ```
 julia> combine(iris_gdf, nrow)
 3×2 DataFrame
- Row │ Species          nrow  
+ Row │ Species          nrow
      │ String15         Int64
 ─────┼────────────────────────
    1 │ Iris-setosa         50
@@ -1068,7 +1068,7 @@ julia> combine(gdf, groupindices)
 
 julia> transform(gdf, groupindices)
 6×4 DataFrame
- Row │ customer_id  transaction_id  volume  groupindices 
+ Row │ customer_id  transaction_id  volume  groupindices
      │ String       Int64           Int64   Int64
 ─────┼───────────────────────────────────────────────────
    1 │ a                        12       2             1
@@ -1124,7 +1124,7 @@ julia> combine(gdf, eachindex)
 
 julia> select(gdf, eachindex, groupindices)
 6×3 DataFrame
- Row │ customer_id  eachindex  groupindices 
+ Row │ customer_id  eachindex  groupindices
      │ String       Int64      Int64
 ─────┼──────────────────────────────────────
    1 │ a                    1             1
@@ -1208,8 +1208,8 @@ example comparing a column-independent operation and a function:
 ```jldoctest sac
 julia> combine(gdf, eachindex, sdf -> axes(sdf, 1))
 6×3 DataFrame
- Row │ customer_id  eachindex  x1    
-     │ String       Int64      Int64 
+ Row │ customer_id  eachindex  x1
+     │ String       Int64      Int64
 ─────┼───────────────────────────────
    1 │ a                    1      1
    2 │ b                    1      1
@@ -1286,8 +1286,8 @@ to `groupby`:
 ```jldoctest sac
 julia> push!(df, ["a", 100, 100]) # push row with large integer values to disable default sorting
 7×3 DataFrame
- Row │ customer_id  transaction_id  volume 
-     │ String       Int64           Int64  
+ Row │ customer_id  transaction_id  volume
+     │ String       Int64           Int64
 ─────┼─────────────────────────────────────
    1 │ a                        12       2
    2 │ b                        15       3


### PR DESCRIPTION
This makes the examples easier to read since:

```julia
julia> joinpath(dirname(pathof(DataFrames)), "..", "docs") |> normpath
"/home/rik/.julia/packages/DataFrames/LteEl/docs"

julia> joinpath(pkgdir(DataFrames), "docs")
"/home/rik/.julia/packages/DataFrames/LteEl/docs"
```

Regarding availability, `pkgdir` is available since Julia 1.4 (https://github.com/JuliaLang/julia/blob/v1.4.0/NEWS.md) and this repo is lower bounded to Julia 1.6: 

https://github.com/JuliaData/DataFrames.jl/blob/0b3d620ef6acd287d5db74258972f470532029e3/Project.toml#L47

The trailing spaces behind the tables were removed automatically by my editor. Let me know if I should undo that.