### PR TITLE
Add support for `renamecols` keyword argument in `crossjoin`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Add `Iterators.partition` support for `DataFrameRows`
   ([#3299](https://github.com/JuliaData/DataFrames.jl/pull/3299))
+* Add support for `renamecols` keyword argument in `crossjoin`
+  ([#3314](https://github.com/JuliaData/DataFrames.jl/pull/3314))
 * `DataFrameRows` and `DataFrameColumns` now support
   `nrow`, `ncol`, and `Tables.subset`
   ([#3311](https://github.com/JuliaData/DataFrames.jl/pull/3311))

--- a/test/join.jl
+++ b/test/join.jl
@@ -72,7 +72,16 @@ anti = left[Bool[ismissing(x) for x in left.Job], [:ID, :Name]]
                       C=[3, 4, 5, 3, 4, 5])
 
     @test crossjoin(df1, df2) == cross
-
+    @test crossjoin(df1, df2, renamecols="_left" => "_right") ==
+          rename(cross, [:A_left, :B_left, :C_right])
+    @test crossjoin(df1, df2, renamecols=(x -> x * "_left") => x -> x * "_right") ==
+          rename(cross, [:A_left, :B_left, :C_right])
+    @test crossjoin(df1, df2, renamecols=(x -> Symbol(x * "_left")) => x -> Symbol(x * "_right")) ==
+          rename(cross, [:A_left, :B_left, :C_right])
+    @test_throws ArgumentError crossjoin(df1, df2, renamecols=(x -> "a") => x -> "a")
+    @test crossjoin(df1, df2, renamecols=(x -> "a") => x -> "a", makeunique=true) ==
+          rename(cross, [:a, :a_1, :a_2])
+          
     # Cross joins handle naming collisions
     @test size(crossjoin(df1, df1, makeunique=true)) == (4, 4)
 

--- a/test/join.jl
+++ b/test/join.jl
@@ -73,6 +73,9 @@ anti = left[Bool[ismissing(x) for x in left.Job], [:ID, :Name]]
 
     @test crossjoin(df1, df2) == cross
     @test crossjoin(df1, df2, renamecols="_left" => "_right") ==
+          crossjoin(df1, df2, renamecols=:_left => :_right) ==
+          crossjoin(df1, df2, renamecols="_left" => :_right) ==
+          crossjoin(df1, df2, renamecols=:_left => "_right") ==
           rename(cross, [:A_left, :B_left, :C_right])
     @test crossjoin(df1, df2, renamecols=(x -> x * "_left") => x -> x * "_right") ==
           rename(cross, [:A_left, :B_left, :C_right])


### PR DESCRIPTION
Following user's request on Discourse.