### PR TITLE
Add rename() for Index, SubIndex, and SubDataFrame

### DIFF
--- a/src/other/index.jl
+++ b/src/other/index.jl
@@ -110,6 +110,8 @@ end
 
 rename!(f::Function, x::Index) = rename!(x, [(n=>Symbol(f(string(n)))) for n in x.names])
 
+rename(x::Index, nms) = rename!(copy(x), nms)
+
 # we do not define keys on purpose;
 # use names to get keys as strings with copying
 # or _names to get keys as Symbols without copying
@@ -589,3 +591,10 @@ rename!(x::SubIndex, nms::AbstractVector{Pair{Symbol, Symbol}}) =
 rename!(f::Function, x::SubIndex) =
     throw(ArgumentError("rename! is not supported for views other than created " *
                         "with Colon as a column selector"))
+
+function rename(x::SubIndex, nms)
+    index = getfield(x, :parent)
+    newindex = myrename(index, nms)
+    cols = parentcols(x)
+    SubIndex(newindex, cols, getfield(x, :remap))
+end

--- a/src/subdataframe/subdataframe.jl
+++ b/src/subdataframe/subdataframe.jl
@@ -397,3 +397,8 @@ function _try_select_no_copy(sdf::SubDataFrame, cols)
     return isnothing(colsidx) ? select(sdf, cols) : select(sdf, colsidx, copycols=false)
 end
 
+function rename(x::SubDataFrame, p::Pair{Symbol,Symbol})
+    idx = index(x)
+    newidx = rename(idx, [p])
+    SubDataFrame(parent(x), newidx, rows(x))
+end


### PR DESCRIPTION
Addresses https://github.com/JuliaData/DataFrames.jl/issues/3317

```
import DataFrames
N = 1_000_000
df = DataFrames.DataFrame(
    :x => [rand(('a','b')) for _ in 1:N],
    :y => 1:N,
    :z => 1:N,
)
gdf = DataFrames.groupby(df, :x);
sdf = gdf |> first;

@time x = DataFrames.rename(sdf, :x => :x2)
x |> typeof
```

The last two lines return:
Current main:
```
0.005457 seconds (36 allocations: 9.550 MiB)
DataFrame
```

This commit:
```
0.000013 seconds (24 allocations: 2.578 KiB)
SubDataFrame
```