### PR TITLE
Allow CI failure on Julia nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
             version: 'nightly'
             arch: x64
             allow_failure: true
-
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
         version:
           - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
-          - 'nightly'
         os:
           - ubuntu-latest
         arch:
@@ -23,6 +22,11 @@ jobs:
           - os: windows-latest
             version: '1'
             arch: x86
+          - os: ubuntu-latest
+            version: 'nightly'
+            arch: x64
+            allow_failure: true
+
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Recently I have noticed that much more often than it happened in the past I get DataFrames.jl tests fail on Julia nightly, but then the issue goes away, but some new almost immediately pops out.

I propose to disable tests passing on Julia nightly in total test result evaluation (but still run them to see if they pass or fail).

CC @DilumAluthge 