### PR TITLE
Use DataAPI.rownumber instead of DataFrames' `rownumber`

### DIFF
--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -39,6 +39,7 @@ import DataAPI,
        DataAPI.colmetadata!,
        DataAPI.deletecolmetadata!,
        DataAPI.emptycolmetadata!,
+       DataAPI.rownumber,
        Tables,
        Tables.columnindex,
        Future.copy!


### PR DESCRIPTION
Following this issue (https://github.com/JuliaData/DataAPI.jl/issues/60) in DataAPI.jl, proposing to use the new intefrace for `rownumber` from DataAPI.jl instead of the one defined in DataFrames. 

The implementation in DataFrames is not changed, the only change is to import `rownumber`from DataAPI.jl.