### PR TITLE
copy more constructors from type doc to getting started

### DIFF
--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -136,7 +136,7 @@ returned by this syntax does not change `df`.
 
 julia> df = DataFrame(A=1:4, B=["M", "F", "F", "M"])
 4×2 DataFrame
- Row │ a      b
+ Row │ A      B
      │ Int64  String
 ─────┼───────────────
    1 │     1  M

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -54,7 +54,11 @@ julia> DataFrame(a=1:4, b=["M", "F", "F", "M"]) # keyword argument constructor
    2 │     2  F
    3 │     3  F
    4 │     4  M
+```
 
+Here are examples of other commonly used ways to construct a data frame:
+
+```jldoctest dataframe
 julia> DataFrame((a=[1, 2], b=[3, 4])) # Tables.jl table constructor from a named tuple of vectors
 2×2 DataFrame
  Row │ a      b

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -54,6 +54,70 @@ julia> df = DataFrame(A=1:4, B=["M", "F", "F", "M"])
    2 │     2  F
    3 │     3  F
    4 │     4  M
+
+julia> DataFrame((a=[1, 2], b=[3, 4])) # Tables.jl table constructor
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      3
+   2 │     2      4
+
+julia> DataFrame([(a=1, b=0), (a=2, b=0)]) # Tables.jl table constructor
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      0
+   2 │     2      0
+
+julia> DataFrame("a" => 1:2, "b" => 0) # Pair constructor
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      0
+   2 │     2      0
+
+julia> DataFrame([:a => 1:2, :b => 0]) # vector of Pairs constructor
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      0
+   2 │     2      0
+
+julia> DataFrame(Dict(:a => 1:2, :b => 0)) # dictionary constructor
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      0
+   2 │     2      0
+
+julia> DataFrame(a=1:2, b=0) # keyword argument constructor
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      0
+   2 │     2      0
+
+julia> DataFrame([[1, 2], [0, 0]], [:a, :b]) # vector of vectors constructor
+2×2 DataFrame
+ Row │ a      b
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      0
+   2 │     2      0
+
+julia> DataFrame([1 0; 2 0], :auto) # matrix constructor
+2×2 DataFrame
+ Row │ x1     x2
+     │ Int64  Int64
+─────┼──────────────
+   1 │     1      0
+   2 │     2      0
 ```
 
 Columns can be directly (i.e. without copying) extracted using `df.col`,

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -45,7 +45,7 @@ each corresponding to a column or variable. The simplest way of constructing a
 ```jldoctest dataframe
 julia> using DataFrames
 
-julia> df = DataFrame(a=1:4, b=["M", "F", "F", "M"]) # keyword argument constructor
+julia> DataFrame(a=1:4, b=["M", "F", "F", "M"]) # keyword argument constructor
 4×2 DataFrame
  Row │ a      b
      │ Int64  String
@@ -129,6 +129,17 @@ returned by this syntax does not change `df`.
 
 
 ```jldoctest dataframe
+
+julia> df = DataFrame(A=1:4, B=["M", "F", "F", "M"])
+4×2 DataFrame
+ Row │ a      b
+     │ Int64  String
+─────┼───────────────
+   1 │     1  M
+   2 │     2  F
+   3 │     3  F
+   4 │     4  M
+
 julia> df.A
 4-element Vector{Int64}:
  1

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -45,9 +45,9 @@ each corresponding to a column or variable. The simplest way of constructing a
 ```jldoctest dataframe
 julia> using DataFrames
 
-julia> df = DataFrame(A=1:4, B=["M", "F", "F", "M"])
+julia> df = DataFrame(a=1:4, b=["M", "F", "F", "M"]) # keyword argument constructor
 4×2 DataFrame
- Row │ A      B
+ Row │ a      b
      │ Int64  String
 ─────┼───────────────
    1 │     1  M
@@ -55,7 +55,7 @@ julia> df = DataFrame(A=1:4, B=["M", "F", "F", "M"])
    3 │     3  F
    4 │     4  M
 
-julia> DataFrame((a=[1, 2], b=[3, 4])) # Tables.jl table constructor
+julia> DataFrame((a=[1, 2], b=[3, 4])) # Tables.jl table constructor from a named tuple of vectors
 2×2 DataFrame
  Row │ a      b
      │ Int64  Int64
@@ -63,7 +63,7 @@ julia> DataFrame((a=[1, 2], b=[3, 4])) # Tables.jl table constructor
    1 │     1      3
    2 │     2      4
 
-julia> DataFrame([(a=1, b=0), (a=2, b=0)]) # Tables.jl table constructor
+julia> DataFrame([(a=1, b=0), (a=2, b=0)]) # Tables.jl table constructor from a vector of named tuples
 2×2 DataFrame
  Row │ a      b
      │ Int64  Int64
@@ -88,14 +88,6 @@ julia> DataFrame([:a => 1:2, :b => 0]) # vector of Pairs constructor
    2 │     2      0
 
 julia> DataFrame(Dict(:a => 1:2, :b => 0)) # dictionary constructor
-2×2 DataFrame
- Row │ a      b
-     │ Int64  Int64
-─────┼──────────────
-   1 │     1      0
-   2 │     2      0
-
-julia> DataFrame(a=1:2, b=0) # keyword argument constructor
 2×2 DataFrame
  Row │ a      b
      │ Int64  Int64

--- a/docs/src/man/getting_started.md
+++ b/docs/src/man/getting_started.md
@@ -133,7 +133,6 @@ returned by this syntax does not change `df`.
 
 
 ```jldoctest dataframe
-
 julia> df = DataFrame(A=1:4, B=["M", "F", "F", "M"])
 4×2 DataFrame
  Row │ A      B


### PR DESCRIPTION
I feel those constructors are used frequently and hard to find if not in getting started doc. Would it be better to copy them here? 

And I feel the `Note` section on top a bit long and useless in a getting started doc. I think the display is ommited is already obvious from the output. Might be better to move that out to another advanced topic page. 