### PR TITLE
optimize reverse! for small data frames and factor out _foreach_unique_column

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2555,20 +2555,20 @@ julia> reverse!(df, 2, 3)
 ```
 """
 function Base.reverse!(df::AbstractDataFrame, start::Integer=1, stop::Integer=nrow(df))
-    _foreach_unique_column(col -> reverse!(col, start, stop), df)
+    _foreach_unique_column!(col -> reverse!(col, start, stop), df)
     _drop_all_nonnote_metadata!(parent(df))
     return df
 end
 
-function _foreach_unique_column(f::Function, df::AbstractDataFrame)
+function _foreach_unique_column!(f!::Function, df::AbstractDataFrame)
     seen_cols = IdDict{Any, Nothing}()
     for col in eachcol(df)
         if !haskey(seen_cols, col)
             seen_cols[col] = nothing
-            f(col)
+            f!(col)
         end
     end
-    nothing
+    return nothing
 end
 
 function _permutation_helper!(fun::Union{typeof(permute!), typeof(invpermute!)},
@@ -2588,7 +2588,7 @@ function _permutation_helper!(fun::Union{typeof(permute!), typeof(invpermute!)},
         reverse!(@view cp[1:end-1])
     end
 
-    _foreach_unique_column(col -> _cycle_permute!(col, cp), df)
+    _foreach_unique_column!(col -> _cycle_permute!(col, cp), df)
 
     _drop_all_nonnote_metadata!(parent(df))
     return df


### PR DESCRIPTION
use the same mechanism in `reverse!` as is already in use in `_permutation_helper!`. Because these are and should likely remain the same, I also factored out the common code into an internal helper function.

I did not make the helper function generic enough to also cover `_dealias_dataframe!`, but I still think this PR is an improvement in maintainability as well as performance.