### PR TITLE
fix dispatch errors in tests on Julia 1.10

### DIFF
--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2925,7 +2925,7 @@ end
     gdf = groupby_checked(df, :g)
     @test combine(gdf, :x => sum)[1, 2] isa Missing
     @test eltype(combine(gdf, :x => sum)[!, 2]) === Missing
-    @test_throws MethodError combine(gdf, :x => sum∘skipmissing)
+    @test_throws Exception combine(gdf, :x => sum∘skipmissing)
     df = DataFrame(g=[1, 1, 1, 1, 1, 1], x=convert(Vector{Union{Real, Missing}}, fill(missing, 6)))
     gdf = groupby_checked(df, :g)
     @test combine(gdf, :x => sum)[1, 2] isa Missing

--- a/test/select.jl
+++ b/test/select.jl
@@ -2900,8 +2900,8 @@ end
                 @test combine(table, AsTable([p, q]) => ByRow(var) => :x) ≅
                       DataFrame(x=[missing, missing, missing])
                 if p == :c1 && q == :c2
-                    @test_throws MethodError combine(table, AsTable([p, q]) =>
-                                                            ByRow(var∘skipmissing) => :x)
+                    @test_throws Exception combine(table, AsTable([p, q]) =>
+                                                   ByRow(var∘skipmissing) => :x)
                 else
                     @test combine(table, AsTable([p, q]) => ByRow(var∘skipmissing) => :x) ≅
                           DataFrame(x=[NaN, NaN, NaN])
@@ -2909,8 +2909,8 @@ end
                 @test combine(table, AsTable([p, q]) => ByRow(std) => :x) ≅
                       DataFrame(x=[missing, missing, missing])
                 if p == :c1 && q == :c2
-                    @test_throws MethodError combine(table, AsTable([p, q]) =>
-                                                            ByRow(std∘skipmissing) => :x)
+                    @test_throws Exception combine(table, AsTable([p, q]) =>
+                                                   ByRow(std∘skipmissing) => :x)
                 else
                     @test combine(table, AsTable([p, q]) => ByRow(std∘skipmissing) => :x) ≅
                           DataFrame(x=[NaN, NaN, NaN])


### PR DESCRIPTION
This is a minor test fix.

@LilithHafner - there are currently a lot of failing tests on Julia nightly due to sorting changes following #3340.
I understand that soon they would be gone, right? (when your PR to Julia is merged).
I will wait to merge this PR until then.