### PR TITLE
Correctly handle Tables.AbstractRow in operation specficiation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,9 @@
 
 ## Breaking changes
 
-* `Tables.AbstractRow` is now treated in the same way as
+* Objects inheriting from `Tables.AbstractRow` are now treated in the same way as
   `DataFrameRow` by `select`/`transform`/`combine` functions.
-  `Tables.AbstractRow` was treated as a scalar, but this was
+  In previous versions they were treated as a scalar, but this was
   inconsistent with the intention of `Tables.AbstractRow` definition
   ([#3348](https://github.com/JuliaData/DataFrames.jl/pull/3348))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # DataFrames.jl v1.6 Release Notes
 
+## Breaking changes
+
+* `Tables.AbstractRow` is now treated in the same way as
+  `DataFrameRow` by `select`/`transform`/`combine` functions.
+  `Tables.AbstractRow` was treated as a scalar, but this was
+  inconsistent with the intention of `Tables.AbstractRow` definition
+  ([#3348](https://github.com/JuliaData/DataFrames.jl/pull/3348))
+
 ## New functionalities
 
 * Add `Iterators.partition` support for `DataFrameRows`

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -110,16 +110,17 @@ object then a `NamedTuple` containing columns selected by `cols` is passed to
 
 What is allowed for `function` to return is determined by the `target_cols` value:
 1. If both `cols` and `target_cols` are omitted (so only a `function` is passed),
-   then returning a data frame, a matrix, a `NamedTuple`, or a `DataFrameRow` will
+   then returning a data frame, a matrix, a `NamedTuple`, `Tables.AbstractRow`
+   or a `DataFrameRow` will
    produce multiple columns in the result. Returning any other value produces
    a single column.
 2. If `target_cols` is a `Symbol` or a string then the function is assumed to return
    a single column. In this case returning a data frame, a matrix, a `NamedTuple`,
-   or a `DataFrameRow` raises an error.
+   `Tables.AbstractRow`, or a `DataFrameRow` raises an error.
 3. If `target_cols` is a vector of `Symbol`s or strings or `AsTable` it is assumed
    that `function` returns multiple columns.
    If `function` returns one of `AbstractDataFrame`, `NamedTuple`, `DataFrameRow`,
-   `AbstractMatrix` then rules described in point 1 above apply.
+   `Tables.AbstractRow`, `AbstractMatrix` then rules described in point 1 above apply.
    If `function` returns an `AbstractVector` then each element of this vector must
    support the `keys` function, which must return a collection of `Symbol`s, strings
    or integers; the return value of `keys` must be identical for all elements.

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -110,13 +110,13 @@ object then a `NamedTuple` containing columns selected by `cols` is passed to
 
 What is allowed for `function` to return is determined by the `target_cols` value:
 1. If both `cols` and `target_cols` are omitted (so only a `function` is passed),
-   then returning a data frame, a matrix, a `NamedTuple`, `Tables.AbstractRow`
+   then returning a data frame, a matrix, a `NamedTuple`, a `Tables.AbstractRow`
    or a `DataFrameRow` will
    produce multiple columns in the result. Returning any other value produces
    a single column.
 2. If `target_cols` is a `Symbol` or a string then the function is assumed to return
    a single column. In this case returning a data frame, a matrix, a `NamedTuple`,
-   `Tables.AbstractRow`, or a `DataFrameRow` raises an error.
+   a `Tables.AbstractRow`, or a `DataFrameRow` raises an error.
 3. If `target_cols` is a vector of `Symbol`s or strings or `AsTable` it is assumed
    that `function` returns multiple columns.
    If `function` returns one of `AbstractDataFrame`, `NamedTuple`, `DataFrameRow`,

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -177,6 +177,6 @@ include("other/metadata.jl")
 
 include("deprecated.jl")
 
-# include("other/precompile.jl")
+include("other/precompile.jl")
 
 end # module DataFrames

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -177,6 +177,6 @@ include("other/metadata.jl")
 
 include("deprecated.jl")
 
-include("other/precompile.jl")
+# include("other/precompile.jl")
 
 end # module DataFrames

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -118,13 +118,13 @@ const TRANSFORMATION_COMMON_RULES =
 
     What is allowed for `function` to return is determined by the `target_cols` value:
     1. If both `cols` and `target_cols` are omitted (so only a `function` is passed),
-       then returning a data frame, a matrix, a `NamedTuple`, `Tables.AbstractRow`
+       then returning a data frame, a matrix, a `NamedTuple`, a `Tables.AbstractRow`
        or a `DataFrameRow` will
        produce multiple columns in the result. Returning any other value produces
        a single column.
     2. If `target_cols` is a `Symbol` or a string then the function is assumed to return
        a single column. In this case returning a data frame, a matrix, a `NamedTuple`,
-       `Tables.AbstractRow`, or a `DataFrameRow` raises an error.
+       a `Tables.AbstractRow`, or a `DataFrameRow` raises an error.
     3. If `target_cols` is a vector of `Symbol`s or strings or `AsTable` it is assumed
        that `function` returns multiple columns.
        If `function` returns one of `AbstractDataFrame`, `NamedTuple`, `DataFrameRow`,
@@ -774,11 +774,11 @@ function _add_multicol_res(res::DataFrameRow, newdf::DataFrame, df::AbstractData
 end
 
 function _add_multicol_res(res::Tables.AbstractRow, newdf::DataFrame, df::AbstractDataFrame,
-    colnames::AbstractVector{Symbol},
-    allow_resizing_newdf::Ref{Bool}, wfun::Ref{Any},
-    col_idx::Union{Nothing, Int, AbstractVector{Int}, AsTable},
-    copycols::Bool, newname::Union{Nothing, Type{AsTable}, AbstractVector{Symbol}},
-    column_to_copy::BitVector)
+                           colnames::AbstractVector{Symbol},
+                           allow_resizing_newdf::Ref{Bool}, wfun::Ref{Any},
+                           col_idx::Union{Nothing, Int, AbstractVector{Int}, AsTable},
+                           copycols::Bool, newname::Union{Nothing, Type{AsTable}, AbstractVector{Symbol}},
+                           column_to_copy::BitVector)
     _insert_row_multicolumn(newdf, df, allow_resizing_newdf, colnames, res)
 end
 

--- a/src/groupeddataframe/callprocessing.jl
+++ b/src/groupeddataframe/callprocessing.jl
@@ -8,7 +8,9 @@ firstcoltype(firstmulticol::Bool) =
 
 # Wrapping automatically adds column names when the value returned
 # by the user-provided function lacks them
-wrap(x::Union{AbstractDataFrame, DataFrameRow}) = x
+wrap(x::AbstractDataFrame) = x
+wrap(x::DataFrameRow) = x
+wrap(x::Tables.AbstractRow) = x
 wrap(x::NamedTuple) = x
 function wrap(x::NamedTuple{<:Any, <:Tuple{Vararg{AbstractVector}}})
     if !isempty(x)
@@ -45,6 +47,10 @@ wrap_table(x::AbstractVector, ::FirstMultiCol) = throw(ArgumentError(ERROR_COL_C
 
 wrap_row(x::DataFrameRow, ::FirstSingleCol) = throw(ArgumentError(ERROR_COL_COUNT))
 wrap_row(x::DataFrameRow, ::FirstMultiCol) = wrap(x)
+
+wrap_row(x::Tables.AbstractRow, ::FirstSingleCol) = throw(ArgumentError(ERROR_COL_COUNT))
+wrap_row(x::Tables.AbstractRow, ::FirstMultiCol) = wrap(x)
+
 wrap_row(x::Any, ::FirstSingleCol) = wrap(x)
 # NamedTuple is not possible in this branch
 wrap_row(x::Any, ::FirstMultiCol) = throw(ArgumentError(ERROR_COL_COUNT))

--- a/src/groupeddataframe/complextransforms.jl
+++ b/src/groupeddataframe/complextransforms.jl
@@ -44,7 +44,7 @@ function _combine_with_first((first,)::Ref{Any},
         eltys = [eltype(parent(first)[!, i]) for i in parentcols(index(first))]
     elseif first isa Tables.AbstractRow
         n = lgd
-        eltys = [typeof Tables.getcolumn(first, name) for name in Tables.columnames(first)]
+        eltys = [typeof(Tables.getcolumn(first, name)) for name in Tables.columnnames(first)]
     elseif !firstmulticol && first[1] isa Union{AbstractArray{<:Any, 0}, Ref}
         extrude = true
         first = wrap_row(first[1], firstcoltype(firstmulticol))
@@ -69,7 +69,7 @@ function _combine_with_first((first,)::Ref{Any},
         initialcols = ntuple(i -> Tables.allocatecolumn(eltys[i], n), _ncol(first))
     end
     targetcolnames = first isa Tables.AbstractRow ?
-                     tuple(Tables.columnnames(first)...):
+                     tuple(Tables.columnnames(first)...) :
                      tuple(propertynames(first)...)
     if !extrude && first isa Union{AbstractDataFrame,
                                    NamedTuple{<:Any, <:Tuple{Vararg{AbstractVector}}}}

--- a/src/groupeddataframe/splitapplycombine.jl
+++ b/src/groupeddataframe/splitapplycombine.jl
@@ -2,7 +2,8 @@
 
 # this constant defines which types of values returned by aggregation function
 # in combine are considered to produce multiple columns in the resulting data frame
-const MULTI_COLS_TYPE = Union{AbstractDataFrame, NamedTuple, DataFrameRow, AbstractMatrix}
+const MULTI_COLS_TYPE = Union{AbstractDataFrame, NamedTuple, DataFrameRow,
+                              Tables.AbstractRow, AbstractMatrix}
 
 # use a constant Vector{Int} as a sentinel to signal that idx_agg has not been computed yet
 # we do not use nothing to avoid excessive specialization

--- a/src/other/names.jl
+++ b/src/other/names.jl
@@ -3,6 +3,7 @@
 _getnames(x::NamedTuple) = propertynames(x)
 _getnames(x::AbstractDataFrame) = _names(x)
 _getnames(x::DataFrameRow) = _names(x)
+_getnames(x::Tables.AbstractRow) = Tables.columnnames(x)
 _getnames(x::GroupKey) = parent(x).cols
 
 # this function is needed as == does not allow for comparison between tuples and vectors

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2439,7 +2439,7 @@ end
     @test combine(gdf, AsTable([:x, :y]) => ByRow(x -> df[1, :])) ==
           DataFrame(g=[1, 1, 1, 2, 2], x_y_function=fill(df[1, :], 5))
     @test combine(gdf, AsTable([:x, :y]) => ByRow(x -> Tables.Row(df[1, :]))) ==
-          DataFrame(g=[1, 1, 1, 2, 2], x_y_function=fill(Tables.Row(df[1, :], 5)))
+          DataFrame(g=[1, 1, 1, 2, 2], x_y_function=fill(Tables.Row(df[1, :]), 5))
 end
 
 @testset "test correctness of ungrouping" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -181,6 +181,8 @@ end
         @test sort(df_comb, colssym) == shcatdf
         @test sort(combine(df -> df[1, :], gd), colssym) ==
             shcatdf[.!nonunique(shcatdf, colssym), :]
+        @test sort(combine(df -> Tables.Row(df[1, :]), gd), colssym) ==
+            shcatdf[.!nonunique(shcatdf, colssym), :]
         df_ref = DataFrame(gd)
         @test sort(hcat(df_ref[!, cols], df_ref[!, Not(cols)]), colssym) == shcatdf
         @test df_ref.x == df_comb.x
@@ -206,7 +208,9 @@ end
         end
         @test combine(identity, gd) == shcatdf
         @test combine(df -> df[1, :], gd) ==
-            shcatdf[.!nonunique(shcatdf, colssym), :]
+              shcatdf[.!nonunique(shcatdf, colssym), :]
+        @test combine(df -> Tables.Row(df[1, :]), gd) ==
+              shcatdf[.!nonunique(shcatdf, colssym), :]
         df_ref = DataFrame(gd)
         @test hcat(df_ref[!, cols], df_ref[!, Not(cols)]) == shcatdf
         @test combine(f1, gd) == sres
@@ -388,8 +392,13 @@ end
 
     df = DataFrame(x=[1, 2, 3], y=[2, 3, 1])
     gdf = groupby_checked(df, :x)
+
     # Test function returning DataFrameRow
     res = combine(d -> DataFrameRow(d, 1, :), gdf)
+    @test res == DataFrame(x=df.x, y=df.y)
+
+    # Test function returning Tables.AbstractRow
+    res = combine(d -> Tables.Row(DataFrameRow(d, 1, :)), gdf)
     @test res == DataFrame(x=df.x, y=df.y)
 
     # Test function returning Tuple
@@ -456,6 +465,10 @@ end
     @test_throws ArgumentError combine(d -> d.x == [1] ? NamedTuple(d[1, :]) : d[1:1, :], gdf)
     @test_throws ArgumentError combine(d -> d.x == [1] ? Tables.columntable(d[1:1, :]) : NamedTuple(d[1, :]), gdf)
     @test_throws ArgumentError combine(d -> d.x == [1] ? NamedTuple(d[1, :]) : Tables.columntable(d[1:1, :]), gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? d[1:1, :] : Tables.Row(d[1, :]), gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? Tables.Row(d[1, :]) : d[1:1, :], gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? [1 2] : Tables.Row(d[1, :]), gdf)
+    @test_throws ArgumentError combine(d -> d.x == [1] ? Tables.Row(d[1, :]) : [1 2], gdf)
 
     # Test with NamedTuple with columns of incompatible lengths
     @test_throws DimensionMismatch combine(d -> (x1=[1], x2=[3, 4]), gdf)
@@ -930,6 +943,7 @@ end
         combine(gd, d -> DataFrame(c_sum=sum(d.c))) ==
         combine(gd, :c => (x -> [sum(x)]) => [:c_sum]) ==
         combine(gd, :c => (x -> [(c_sum=sum(x),)]) => AsTable) ==
+        combine(gd, :c => (x -> [Tables.Row((c_sum=sum(x),))]) => AsTable) ==
         combine(gd, :c => (x -> fill(sum(x), 1, 1)) => [:c_sum]) ==
         combine(gd, :c => (x -> [Dict(:c_sum => sum(x))]) => AsTable)
     @test_throws ArgumentError combine(:c => sum, gd)
@@ -993,6 +1007,7 @@ end
         @test combine(gd, col => sum) == combine(d -> (c_sum=sum(d.c),), gd)
         @test combine(gd, col => x -> sum(x)) == combine(d -> (c_function=sum(d.c),), gd)
         @test combine(gd, col => (x -> (z=sum(x),)) => AsTable) == combine(d -> (z=sum(d.c),), gd)
+        @test combine(gd, col => (x -> Tables.Row((z=sum(x),))) => AsTable) == combine(d -> (z=sum(d.c),), gd)
         @test combine(gd, col => (x -> DataFrame(z=sum(x),)) => AsTable) == combine(d -> (z=sum(d.c),), gd)
         @test combine(gd, col => identity) == combine(d -> (c_identity=d.c,), gd)
         @test combine(gd, col => (x -> (z=x,)) => AsTable) == combine(d -> (z=d.c,), gd)
@@ -2135,15 +2150,17 @@ end
     @test_throws ArgumentError haskey(gdf, (a=1, b=2, c=3))
 end
 
-@testset "Check aggregation of DataFrameRow" begin
+@testset "Check aggregation of DataFrameRow and Tables.AbstractRow" begin
     df = DataFrame(a=1)
     dfr = DataFrame(x=1, y="1")[1, 2:2]
     gdf = groupby_checked(df, :a)
     @test combine(sdf -> dfr, gdf) == DataFrame(a=1, y="1")
+    @test combine(sdf -> Tables.Row(dfr), gdf) == DataFrame(a=1, y="1")
 
     df = DataFrame(a=[1, 1, 2, 2, 3, 3], b='a':'f', c=string.(1:6))
     gdf = groupby_checked(df, :a)
     @test isequal_typed(combine(sdf -> sdf[1, [3, 2, 1]], gdf), df[1:2:5, [1, 3, 2]])
+    @test isequal_typed(combine(sdf -> Tables.Row(sdf[1, [3, 2, 1]]), gdf), df[1:2:5, [1, 3, 2]])
 end
 
 @testset "Allow returning DataFrame() or NamedTuple() to drop group" begin
@@ -2254,6 +2271,7 @@ end
     @test_throws ArgumentError combine(gdf, :x1 => x -> (x=[1], y=2))
     @test_throws ArgumentError combine(gdf, :x1 => x -> ones(2, 2))
     @test_throws ArgumentError combine(gdf, :x1 => x -> df[1, Not(:g)])
+    @test_throws ArgumentError combine(gdf, :x1 => x -> Tables.Row(df[1, Not(:g)]))
 end
 
 @testset "keepkeys" begin
@@ -2420,6 +2438,8 @@ end
           DataFrame(g=[1, 1, 1, 2, 2], x_y_identity=ByRow(identity)((x=1:5, y=6:10)))
     @test combine(gdf, AsTable([:x, :y]) => ByRow(x -> df[1, :])) ==
           DataFrame(g=[1, 1, 1, 2, 2], x_y_function=fill(df[1, :], 5))
+    @test combine(gdf, AsTable([:x, :y]) => ByRow(x -> Tables.Row(df[1, :]))) ==
+          DataFrame(g=[1, 1, 1, 2, 2], x_y_function=fill(Tables.Row(df[1, :], 5)))
 end
 
 @testset "test correctness of ungrouping" begin
@@ -3395,6 +3415,8 @@ end
           DataFrame(id=[1, 1, 2, 2, 3, 3], a=[1, 2, 1, 2, 1, 2], b=[3, 4, 3, 4, 3, 4])
     @test combine(gdf, x -> DataFrame(a=1:2, b=3:4)[1, :]) ==
           DataFrame(id=[1, 2, 3], a=[1, 1, 1], b=[3, 3, 3])
+    @test combine(gdf, x -> Tables.Row(DataFrame(a=1:2, b=3:4)[1, :])) ==
+          DataFrame(id=[1, 2, 3], a=[1, 1, 1], b=[3, 3, 3])
     @test combine(gdf, x -> (a=1, b=3)) ==
           DataFrame(id=[1, 2, 3], a=[1, 1, 1], b=[3, 3, 3])
     @test combine(gdf, x -> (a=1:2, b=3:4)) ==
@@ -3421,6 +3443,8 @@ end
     @test select(gdf, x -> DataFrame(a=1:2, b=3:4)) ==
           DataFrame(id=[1, 2, 3, 1, 3, 2], a=[1, 1, 1, 2, 2, 2], b=[3, 3, 3, 4, 4, 4])
     @test select(gdf, x -> DataFrame(a=1:2, b=3:4)[1, :]) ==
+          DataFrame(id=[1, 2, 3, 1, 3, 2], a=[1, 1, 1, 1, 1, 1], b=[3, 3, 3, 3, 3, 3])
+    @test select(gdf, x -> Tables.Row(DataFrame(a=1:2, b=3:4)[1, :])) ==
           DataFrame(id=[1, 2, 3, 1, 3, 2], a=[1, 1, 1, 1, 1, 1], b=[3, 3, 3, 3, 3, 3])
     @test select(gdf, x -> (a=1, b=3)) ==
           DataFrame(id=[1, 2, 3, 1, 3, 2], a=[1, 1, 1, 1, 1, 1], b=[3, 3, 3, 3, 3, 3])
@@ -3764,6 +3788,7 @@ end
     df = DataFrame(a=1:2)
     gdf = groupby_checked(df, :a)
     @test_throws ArgumentError combine(gdf, x -> x.a[1] == 1 ? 1 : x[1, :])
+    @test_throws ArgumentError combine(gdf, x -> x.a[1] == 1 ? 1 : Tables.Row(x[1, :]))
     @test_throws ArgumentError combine(gdf, x -> x.a[1] == 1 ? (a=1, b=2) : Ref(1))
 end
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -180,9 +180,9 @@ end
         df_comb = combine(identity, gd)
         @test sort(df_comb, colssym) == shcatdf
         @test sort(combine(df -> df[1, :], gd), colssym) ==
-            shcatdf[.!nonunique(shcatdf, colssym), :]
+              shcatdf[.!nonunique(shcatdf, colssym), :]
         @test sort(combine(df -> Tables.Row(df[1, :]), gd), colssym) ==
-            shcatdf[.!nonunique(shcatdf, colssym), :]
+              shcatdf[.!nonunique(shcatdf, colssym), :]
         df_ref = DataFrame(gd)
         @test sort(hcat(df_ref[!, cols], df_ref[!, Not(cols)]), colssym) == shcatdf
         @test df_ref.x == df_comb.x

--- a/test/select.jl
+++ b/test/select.jl
@@ -1187,7 +1187,7 @@ end
     @test select(df, AsTable(:) => ByRow(x -> df[1, :]) => AsTable) ==
           DataFrame(a=[1, 1, 1], b=4, c=7)
     @test select(df, AsTable(:) => ByRow(x -> Tables.Row(df[1, :]))) ==
-          DataFrame(a_b_c_function=fill(Tables.Row(df[1, :], 3)))
+          DataFrame(a_b_c_function=fill(Tables.Row(df[1, :]), 3))
     @test select(df, AsTable(:) => ByRow(x -> Tables.Row(df[1, :])) => AsTable) ==
           DataFrame(a=[1, 1, 1], b=4, c=7)
     @test transform(df, AsTable(Not(:)) =>

--- a/test/select.jl
+++ b/test/select.jl
@@ -2996,8 +2996,8 @@ end
 
     # note the grouping of Tables.AbstractRow types
     # they have a matching type of return value of keys (tuple vs vector)
-    for df in (DataFrame(id=[1, 1, 2], x = Any[cr, ir1, ir2]),
-               DataFrame(id=[1, 1, 2], x = Any[dr, dfr, mr]))
+    for df in (DataFrame(id=[1, 1, 2], x=Any[cr, ir1, ir2]),
+               DataFrame(id=[1, 1, 2], x=Any[dr, dfr, mr]))
         @test combine(df, :x => AsTable) ==
             DataFrame(a=[1, 1, 1], b=[3, 3, 3])
         @test combine(groupby(df, :id), :x => AsTable) ==
@@ -3005,10 +3005,10 @@ end
     end
 
     # example from issue https://github.com/JuliaData/DataFrames.jl/issues/3335
-    @test combine(groupby(DataFrame(:group=>[1,1,2,2]), :group),
+    @test combine(groupby(DataFrame(:group=>[1, 1, 2, 2]), :group),
                   sdf -> Tables.Row((; foo="foo", boo=[1, 2]))) ==
           DataFrame(group=1:2, foo=["foo", "foo"], boo=[[1, 2], [1, 2]])
-    @test combine(DataFrame(:group=>[1,1,2,2]),
+    @test combine(DataFrame(:group=>[1, 1, 2, 2]),
                   sdf -> Tables.Row((; foo="foo", boo=[1, 2]))) ==
           DataFrame(foo=["foo"], boo=[[1, 2]])
 

--- a/test/select.jl
+++ b/test/select.jl
@@ -2952,7 +2952,11 @@ end
         df = DataFrame(x=[1, 1, 2])
         @test combine(df, :x => (x -> row) => AsTable) ==
             DataFrame(a=1, b=3)
+        @test combine(df, x -> row) ==
+            DataFrame(a=1, b=3)
         @test select(df, :x => (x -> row) => AsTable) ==
+            DataFrame(a=[1, 1, 1], b=[3, 3, 3])
+        @test select(df, x -> row) ==
             DataFrame(a=[1, 1, 1], b=[3, 3, 3])
         @test combine(df, :x => ByRow(x -> row) => AsTable) ==
             DataFrame(a=[1, 1, 1], b=[3, 3, 3])
@@ -2966,7 +2970,11 @@ end
             DataFrame(p=[1, 1, 1], q=[3, 3, 3])
         @test combine(groupby(df, :x), :x => (x -> row) => AsTable) ==
             DataFrame(x=[1, 2], a=[1, 1], b=[3, 3])
+        @test combine(groupby(df, :x), x -> row) ==
+            DataFrame(x=[1, 2], a=[1, 1], b=[3, 3])
         @test select(groupby(df, :x), :x => (x -> row) => AsTable) ==
+            DataFrame(x=[1, 1, 2], a=[1, 1, 1], b=[3, 3, 3])
+        @test select(groupby(df, :x), x -> row) ==
             DataFrame(x=[1, 1, 2], a=[1, 1, 1], b=[3, 3, 3])
         @test combine(groupby(df, :x), :x => ByRow(x -> row) => AsTable) ==
             DataFrame(x=[1, 1, 2], a=[1, 1, 1], b=[3, 3, 3])
@@ -2995,6 +3003,14 @@ end
         @test combine(groupby(df, :id), :x => AsTable) ==
             DataFrame(id=[1, 1, 2], a=[1, 1, 1], b=[3, 3, 3])
     end
+
+    # example from issue https://github.com/JuliaData/DataFrames.jl/issues/3335
+    @test combine(groupby(DataFrame(:group=>[1,1,2,2]), :group),
+                  sdf -> Tables.Row((; foo="foo", boo=[1, 2]))) ==
+          DataFrame(group=1:2, foo=["foo", "foo"], boo=[[1, 2], [1, 2]])
+    @test combine(DataFrame(:group=>[1,1,2,2]),
+                  sdf -> Tables.Row((; foo="foo", boo=[1, 2]))) ==
+          DataFrame(foo=["foo"], boo=[[1, 2]])
 end
 
 end # module

--- a/test/select.jl
+++ b/test/select.jl
@@ -3011,6 +3011,10 @@ end
     @test combine(DataFrame(:group=>[1,1,2,2]),
                   sdf -> Tables.Row((; foo="foo", boo=[1, 2]))) ==
           DataFrame(foo=["foo"], boo=[[1, 2]])
+
+    gdf = groupby(DataFrame(x=1:2), :x)
+    @test_throws ArgumentError combine(gdf, :x => (x -> x[1] == 1 ? "x" : cr))
+    @test_throws ArgumentError combine(gdf, :x => (x -> x[1] == 2 ? "x" : cr) => AsTable)
 end
 
 end # module

--- a/test/select.jl
+++ b/test/select.jl
@@ -751,7 +751,7 @@ end
 @testset "select and select! reserved return values" begin
     df = DataFrame(x=1)
     df2 = copy(df)
-    for retval in [df2, (a=1, b=2), df2[1, :], ones(2, 2)]
+    for retval in [df2, (a=1, b=2), df2[1, :], ones(2, 2), Tables.Row(df2[1, :])]
         @test_throws ArgumentError select(df, :x => x -> retval)
         @test_throws ArgumentError select(df, :x => x -> retval, copycols=false)
         @test_throws ArgumentError select!(df, :x => x -> retval)
@@ -761,7 +761,7 @@ end
         select!(cdf, :x => ByRow(x -> retval))
         @test cdf == DataFrame(x_function=[retval])
 
-        if retval isa Union{NamedTuple, DataFrameRow}
+        if retval isa Union{NamedTuple, DataFrameRow, Tables.AbstractRow}
             @test select(df, :x => ByRow(x -> retval) => AsTable) == DataFrame(;retval...)
         elseif retval isa DataFrame
             @test_throws MethodError select(df, :x => ByRow(x -> retval) => AsTable)
@@ -1183,6 +1183,10 @@ end
           DataFrame(a_b_c_function=fill(df[1, :], 3))
     @test select(df, AsTable(:) => ByRow(x -> df[1, :]) => AsTable) ==
           DataFrame(a=[1, 1, 1], b=4, c=7)
+    @test select(df, AsTable(:) => ByRow(x -> Tables.Row(df[1, :]))) ==
+          DataFrame(a_b_c_function=fill(Tables.Row(df[1, :], 3)))
+    @test select(df, AsTable(:) => ByRow(x -> Tables.Row(df[1, :])) => AsTable) ==
+          DataFrame(a=[1, 1, 1], b=4, c=7)
     @test transform(df, AsTable(Not(:)) =>
           ByRow(identity)) == [df DataFrame(:identity => fill(NamedTuple(), nrow(df)))]
 
@@ -1381,7 +1385,7 @@ end
         @test select(sdf -> Ref([1]), df) == DataFrame(x1=[[1], [1]])
         @test select(sdf -> "x", df) == DataFrame(x1=["x", "x"])
         @test select(sdf -> [[1, 2], [3, 4]], df) == DataFrame(x1=[[1, 2], [3, 4]])
-        for ret in (DataFrame(), NamedTuple(), zeros(0, 0), DataFrame(t=1)[1, 1:0])
+        for ret in (DataFrame(), NamedTuple(), zeros(0, 0), DataFrame(t=1)[1, 1:0], Tables.Row(DataFrame(t=1)[1, 1:0]))
             @test select(sdf -> ret, df) == DataFrame()
         end
         @test_throws ArgumentError select(sdf -> DataFrame(a=10), df)


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/3335

After this PR `Tables.AbstractRow` is treated in the same way as `DataFrames.DataFrameRow` in all `combine`/`select`/`transform` operations.