### PR TITLE
Improve error message when pushing/appending with promote=true

### DIFF
--- a/src/dataframe/insertion.jl
+++ b/src/dataframe/insertion.jl
@@ -301,9 +301,7 @@ function _append_or_prepend!(df1::DataFrame, df2::AbstractDataFrame; cols::Symbo
             @error "Error adding value to column :$(_names(df1)[current_col])."
         else
             @error "Error adding value to column :$(_names(df1)[current_col]). " *
-                "Maybe it was forgotten to require column " *
-                "element type promotion, which can be done " *
-                "by passing the promote=true keyword argument."
+                   "Maybe you forgot passing `promote=true`?"
         end
         rethrow(err)
     end
@@ -697,8 +695,7 @@ function _row_inserter!(df::DataFrame, loc::Integer, row::Any,
             @error "Error adding value to column :$(_names(df)[current_col])."
         else
             @error "Error adding value to column :$(_names(df)[current_col]). " *
-                   "Maybe it was forgotten to ask for column element type promotion, " *
-                   "which can be done by passing the promote=true keyword argument."
+                   "Maybe you forgot passing `promote=true`?"
         end
         rethrow(err)
     end
@@ -874,9 +871,7 @@ function _row_inserter!(df::DataFrame, loc::Integer,
                         @assert length(col2) == nrows
                     end
                     @error "Error adding value to column :$colname. " *
-                           "Maybe it was forgotten to ask for column " *
-                           "element type promotion, which can be done " *
-                           "by passing the promote=true keyword argument."
+                           "Maybe you forgot passing `promote=true`?"
                     rethrow(err)
                 end
             else
@@ -984,9 +979,7 @@ function _row_inserter!(df::DataFrame, loc::Integer,
             @error "Error adding value to column :$(_names(df)[current_col])."
         else
             @error "Error adding value to column :$(_names(df)[current_col]). " *
-                   "Maybe it was forgotten to ask for column " *
-                   "element type promotion, which can be done " *
-                   "by passing the promote=true keyword argument."
+                   "Maybe you forgot passing `promote=true`?"
         end
         rethrow(err)
     end

--- a/src/dataframe/insertion.jl
+++ b/src/dataframe/insertion.jl
@@ -297,10 +297,14 @@ function _append_or_prepend!(df1::DataFrame, df2::AbstractDataFrame; cols::Symbo
                 deleteat!(col, 1:length(col) - nrow1)
             end
         end
-        @error "Error adding value to column :$(_names(df1)[current_col]). " *
-               "Maybe it was forgotten to require column " *
-               "element type promotion, which can be done " *
-               "by passing the promote=true keyword argument."
+        if promote
+            @error "Error adding value to column :$(_names(df1)[current_col])."
+        else
+            @error "Error adding value to column :$(_names(df1)[current_col]). " *
+                "Maybe it was forgotten to require column " *
+                "element type promotion, which can be done " *
+                "by passing the promote=true keyword argument."
+        end
         rethrow(err)
     end
 
@@ -689,9 +693,13 @@ function _row_inserter!(df::DataFrame, loc::Integer, row::Any,
             end
             @assert length(col2) == nrows
         end
-        @error "Error adding value to column :$(_names(df)[current_col]). " *
-               "Maybe it was forgotten to ask for column element type promotion, " *
-               "which can be done by passing the promote=true keyword argument."
+        if promote
+            @error "Error adding value to column :$(_names(df)[current_col])."
+        else
+            @error "Error adding value to column :$(_names(df)[current_col]). " *
+                   "Maybe it was forgotten to ask for column element type promotion, " *
+                   "which can be done by passing the promote=true keyword argument."
+        end
         rethrow(err)
     end
     _drop_all_nonnote_metadata!(df)
@@ -972,13 +980,16 @@ function _row_inserter!(df::DataFrame, loc::Integer,
             end
             @assert length(col2) == nrows
         end
-        @error "Error adding value to column :$(_names(df)[current_col]). " *
-               "Maybe it was forgotten to ask for column " *
-               "element type promotion, which can be done " *
-               "by passing the promote=true keyword argument."
+        if promote
+            @error "Error adding value to column :$(_names(df)[current_col])."
+        else
+            @error "Error adding value to column :$(_names(df)[current_col]). " *
+                   "Maybe it was forgotten to ask for column " *
+                   "element type promotion, which can be done " *
+                   "by passing the promote=true keyword argument."
+        end
         rethrow(err)
     end
     _drop_all_nonnote_metadata!(df)
     return df
 end
-

--- a/test/insertion.jl
+++ b/test/insertion.jl
@@ -1355,18 +1355,18 @@ end
                                             promote=true)
         @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), [1000])
         @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), [1000],
-                                        promote=true)
+                                          promote=true)
         @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x=1000,))
         @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x=1000,),
-                                        promote=true)
+                                          promote=true)
         @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x=1000,),
-                                        cols=:union, promote=true)
+                                          cols=:union, promote=true)
         @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x=1000,),
-                                        cols=:union, promote=false)
+                                          cols=:union, promote=false)
         @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x="x",),
-                                        cols=:union, promote=true)
+                                          cols=:union, promote=true)
         @test_throws MethodError push!(DataFrame(x=PooledArray(1:255, UInt8)), (x="x",),
-                                    cols=:union, promote=false)
+                                       cols=:union, promote=false)
     end
 end
 

--- a/test/insertion.jl
+++ b/test/insertion.jl
@@ -1343,4 +1343,31 @@ end
     end
 end
 
+@testset "PooledArray error #3356" begin
+    buf = IOBuffer()
+    sl = SimpleLogger(buf)
+
+    with_logger(sl) do
+        @test_throws ErrorException append!(DataFrame(x=PooledArray(1:255, UInt8)),
+                                            DataFrame(x=PooledArray(256:500, UInt8)))
+        @test_throws ErrorException append!(DataFrame(x=PooledArray(1:255, UInt8)),
+                                            DataFrame(x=PooledArray(256:500, UInt8)),
+                                            promote=true)
+        @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), [1000])
+        @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), [1000],
+                                        promote=true)
+        @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x=1000,))
+        @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x=1000,),
+                                        promote=true)
+        @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x=1000,),
+                                        cols=:union, promote=true)
+        @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x=1000,),
+                                        cols=:union, promote=false)
+        @test_throws ErrorException push!(DataFrame(x=PooledArray(1:255, UInt8)), (x="x",),
+                                        cols=:union, promote=true)
+        @test_throws MethodError push!(DataFrame(x=PooledArray(1:255, UInt8)), (x="x",),
+                                    cols=:union, promote=false)
+    end
+end
+
 end # module

--- a/test/insertion.jl
+++ b/test/insertion.jl
@@ -1,6 +1,6 @@
 module TestInsertion
 
-using DataFrames, Test, Logging, DataStructures
+using DataFrames, Test, Logging, DataStructures, PooledArrays
 const ≅ = isequal
 
 @testset "push!(df, row)" begin


### PR DESCRIPTION
Improve error in cases like:

```
append!(DataFrame(x=PooledArray(1:255, UInt8)), DataFrame(x=PooledArray(256:500, UInt8)); promote=true)
```

as reported by @jariji 