### PR TITLE
Add vector of names method to `rename` docstring

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -309,7 +309,14 @@ julia> df = DataFrame(i=1, x=2, y=3)
 ─────┼─────────────────────
    1 │     1      2      3
 
-julia> rename(df, :i => :A, :x => :X)
+julia> rename(df, [:a, :b, :c])
+1×3 DataFrame
+ Row │ a      b      c
+     │ Int64  Int64  Int64
+─────┼─────────────────────
+   1 │     1      2      3
+
+julia> rename(df, :i => "A", :x => "X")
 1×3 DataFrame
  Row │ A      X      y
      │ Int64  Int64  Int64


### PR DESCRIPTION
This method was documented in `rename!` but not in `rename`, so I copied the example over. I also changed two Symbols to Strings in the second example so they also match.

This is a comparison of the two docstrings before my changes:
![image](https://github.com/JuliaData/DataFrames.jl/assets/65452054/451b61a7-e338-4149-86e2-5bbe363d0317)
