### PR TITLE
New dupcol keyword to replace makeunique

### DIFF
--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -117,9 +117,9 @@ Compat.hasproperty(df::AbstractDataFrame, s::AbstractString) = haskey(index(df),
 
 """
     rename!(df::AbstractDataFrame, vals::AbstractVector{Symbol};
-            makeunique::Bool=false)
+            makeunique::Bool=false, dupcol::Symbol=:error)
     rename!(df::AbstractDataFrame, vals::AbstractVector{<:AbstractString};
-            makeunique::Bool=false)
+            makeunique::Bool=false, dupcol::Symbol=:error)
     rename!(df::AbstractDataFrame, (from => to)::Pair...)
     rename!(df::AbstractDataFrame, d::AbstractDict)
     rename!(df::AbstractDataFrame, d::AbstractVector{<:Pair})
@@ -179,9 +179,9 @@ julia> rename!(df, [:a, :b, :c])
    1 │     1      2      3
 
 julia> rename!(df, [:a, :b, :a])
-ERROR: ArgumentError: Duplicate variable names: :a. Pass makeunique=true to make them unique using a suffix automatically.
+ERROR: ArgumentError: Duplicate variable names: :a. Pass dupcol=:makeunique to make them unique using a suffix automatically.
 
-julia> rename!(df, [:a, :b, :a], makeunique=true)
+julia> rename!(df, [:a, :b, :a], dupcol=:makeunique)
 1×3 DataFrame
  Row │ a      b      a_1
      │ Int64  Int64  Int64
@@ -197,16 +197,16 @@ julia> rename!(uppercase, df)
 ```
 """
 function rename!(df::AbstractDataFrame, vals::AbstractVector{Symbol};
-                 makeunique::Bool=false)
-    rename!(index(df), vals, makeunique=makeunique)
+                 makeunique::Bool=false, dupcol::Symbol=:error)
+    rename!(index(df), vals, makeunique=makeunique, dupcol=dupcol)
     # renaming columns of SubDataFrame has to clean non-note metadata in its parent
     _drop_all_nonnote_metadata!(parent(df))
     return df
 end
 
 function rename!(df::AbstractDataFrame, vals::AbstractVector{<:AbstractString};
-                 makeunique::Bool=false)
-    rename!(index(df), Symbol.(vals), makeunique=makeunique)
+                 makeunique::Bool=false, dupcol::Symbol=:error)
+    rename!(index(df), Symbol.(vals), makeunique=makeunique, dupcol=dupcol)
     # renaming columns of SubDataFrame has to clean non-note metadata in its parent
     _drop_all_nonnote_metadata!(parent(df))
     return df
@@ -353,9 +353,9 @@ julia> rename(uppercase, df)
 ```
 """
 rename(df::AbstractDataFrame, vals::AbstractVector{Symbol};
-       makeunique::Bool=false) = rename!(copy(df), vals, makeunique=makeunique)
+       makeunique::Bool=false, dupcol::Symbol=:error) = rename!(copy(df), vals, makeunique=makeunique, dupcol=dupcol)
 rename(df::AbstractDataFrame, vals::AbstractVector{<:AbstractString};
-       makeunique::Bool=false) = rename!(copy(df), vals, makeunique=makeunique)
+       makeunique::Bool=false, dupcol::Symbol=:error) = rename!(copy(df), vals, makeunique=makeunique, dupcol=dupcol)
 rename(df::AbstractDataFrame, args...) = rename!(copy(df), args...)
 rename(f::Function, df::AbstractDataFrame) = rename!(f, copy(df))
 
@@ -1536,13 +1536,20 @@ end
 
 """
     hcat(df::AbstractDataFrame...;
-         makeunique::Bool=false, copycols::Bool=true)
+         makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
 
 Horizontally concatenate data frames.
 
 If `makeunique=false` (the default) column names of passed objects must be unique.
 If `makeunique=true` then duplicate column names will be suffixed
 with `_i` (`i` starting at 1 for the first duplicate).
+Deprecated in favor of `dupcol`
+
+If `dupcol=:error` (the default) then columns names of passed objects must be unique.
+If `dupcol=:makeunique` then duplicate column names will be suffixed
+with `_i` (`i` starting at 1 for the first duplicate).
+If `dupcol=:update` then duplicate columns names will be combined with the left-hand
+column overwritten by non-missing values from the right hand column(s)
 
 If `copycols=true` (the default) then the `DataFrame` returned by `hcat` will
 contain copied columns from the source data frames.
@@ -1575,7 +1582,7 @@ julia> df2 = DataFrame(A=4:6, B=4:6)
    2 │     5      5
    3 │     6      6
 
-julia> df3 = hcat(df1, df2, makeunique=true)
+julia> df3 = hcat(df1, df2, dupcol=:makeunique)
 3×4 DataFrame
  Row │ A      B      A_1    B_1
      │ Int64  Int64  Int64  Int64
@@ -1587,32 +1594,32 @@ julia> df3 = hcat(df1, df2, makeunique=true)
 julia> df3.A === df1.A
 false
 
-julia> df3 = hcat(df1, df2, makeunique=true, copycols=false);
+julia> df3 = hcat(df1, df2, dupcol=:makeunique, copycols=false);
 
 julia> df3.A === df1.A
 true
 ```
 """
-function Base.hcat(df::AbstractDataFrame; makeunique::Bool=false, copycols::Bool=true)
+function Base.hcat(df::AbstractDataFrame; makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
     df = DataFrame(df, copycols=copycols)
     _drop_all_nonnote_metadata!(df)
     return df
 end
 
 # TODO: after deprecation remove AbstractVector methods
-Base.hcat(df::AbstractDataFrame, x::AbstractVector; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(DataFrame(df, copycols=copycols), x, makeunique=makeunique, copycols=copycols)
-Base.hcat(x::AbstractVector, df::AbstractDataFrame; makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(x, df, makeunique=makeunique, copycols=copycols)
+Base.hcat(df::AbstractDataFrame, x::AbstractVector; makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
+    hcat!(DataFrame(df, copycols=copycols), x, makeunique=makeunique, dupcol=dupcol, copycols=copycols)
+Base.hcat(x::AbstractVector, df::AbstractDataFrame; makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
+    hcat!(x, df, makeunique=makeunique, dupcol=dupcol, copycols=copycols)
 Base.hcat(df1::AbstractDataFrame, df2::AbstractDataFrame;
-          makeunique::Bool=false, copycols::Bool=true) =
+          makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
     hcat!(DataFrame(df1, copycols=copycols), df2,
-          makeunique=makeunique, copycols=copycols)
+          makeunique=makeunique, dupcol=dupcol, copycols=copycols)
 Base.hcat(df::AbstractDataFrame, x::Union{AbstractVector, AbstractDataFrame},
           y::Union{AbstractVector, AbstractDataFrame}...;
-          makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(hcat(df, x, makeunique=makeunique, copycols=copycols), y...,
-          makeunique=makeunique, copycols=copycols)
+          makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
+    hcat!(hcat(df, x, makeunique=makeunique, dupcol=dupcol, copycols=copycols), y...,
+          makeunique=makeunique, dupcol=dupcol, copycols=copycols)
 
 """
     vcat(dfs::AbstractDataFrame...;
@@ -2870,6 +2877,10 @@ const INSERTCOLS_ARGUMENTS =
     - `makeunique` : defines what to do if `name` already exists in `df`;
       if it is `false` an error will be thrown; if it is `true` a new unique name will
       be generated by adding a suffix
+    - `dupcol` : defines what to do if `name` already exists in `df`;
+      if it is :error an error will be thrown; if is :makeunique a new unique name will
+      be generated by adding a suffix; if it is :update then the existing column will be 
+      updated with the non-missing values
     - `copycols` : whether vectors passed as columns should be copied
 
     If `val` is an `AbstractRange` then the result of `collect(val)` is inserted.
@@ -2891,7 +2902,7 @@ const INSERTCOLS_ARGUMENTS =
 
 """
     insertcols(df::AbstractDataFrame[, col], (name=>val)::Pair...;
-               after::Bool=false, makeunique::Bool=false, copycols::Bool=true)
+               after::Bool=false, makeunique::Bool=false, dupcol=:error, copycols::Bool=true)
 
 Insert a column into a copy of `df` data frame using the [`insertcols!`](@ref)
 function and return the newly created data frame.
@@ -2922,7 +2933,7 @@ julia> insertcols(df, 1, :b => 'a':'c')
    2 │ b         2
    3 │ c         3
 
-julia> insertcols(df, :c => 2:4, :c => 3:5, makeunique=true)
+julia> insertcols(df, :c => 2:4, :c => 3:5, dupcol=:error)
 3×3 DataFrame
  Row │ a      c      c_1
      │ Int64  Int64  Int64
@@ -2942,13 +2953,13 @@ julia> insertcols(df, :a, :d => 7:9, after=true)
 ```
 """
 insertcols(df::AbstractDataFrame, args...;
-           after::Bool=false, makeunique::Bool=false, copycols::Bool=true) =
+           after::Bool=false, makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
     insertcols!(copy(df), args...;
-                after=after, makeunique=makeunique, copycols=copycols)
+                after=after, makeunique=makeunique, dupcol=dupcol, copycols=copycols)
 
 """
     insertcols!(df::AbstractDataFrame[, col], (name=>val)::Pair...;
-                after::Bool=false, makeunique::Bool=false, copycols::Bool=true)
+                after::Bool=false, makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
 
 Insert a column into a data frame in place. Return the updated data frame.
 
@@ -2979,7 +2990,7 @@ julia> insertcols!(df, 1, :b => 'a':'c')
    2 │ b         2
    3 │ c         3
 
-julia> insertcols!(df, 2, :c => 2:4, :c => 3:5, makeunique=true)
+julia> insertcols!(df, 2, :c => 2:4, :c => 3:5, dupcol=:error)
 3×4 DataFrame
  Row │ b     c      c_1    a
      │ Char  Int64  Int64  Int64
@@ -2999,7 +3010,10 @@ julia> insertcols!(df, :b, :d => 7:9, after=true)
 ```
 """
 function insertcols!(df::AbstractDataFrame, col::ColumnIndex, name_cols::Pair{Symbol}...;
-                     after::Bool=false, makeunique::Bool=false, copycols::Bool=true)
+                     after::Bool=false, makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
+    
+    dupcol = _dupcol(dupcol, makeunique)
+
     if !is_column_insertion_allowed(df)
         throw(ArgumentError("insertcols! is only supported for DataFrame, or for " *
                             "SubDataFrame created with `:` as column selector"))
@@ -3025,15 +3039,15 @@ function insertcols!(df::AbstractDataFrame, col::ColumnIndex, name_cols::Pair{Sy
                             "$(ncol(df)) columns at index $col_ind"))
     end
 
-    if !makeunique
+    if dupcol == :error
         if !allunique(first.(name_cols))
             throw(ArgumentError("Names of columns to be inserted into a data frame " *
-                                "must be unique when `makeunique=true`"))
+                                "must be unique when `dupcol=:error`"))
         end
         for (n, _) in name_cols
             if hasproperty(df, n)
                 throw(ArgumentError("Column $n is already present in the data frame " *
-                                    "which is not allowed when `makeunique=true`"))
+                                    "which is not allowed when `dupcol=:error`"))
             end
         end
     end
@@ -3103,19 +3117,28 @@ function insertcols!(df::AbstractDataFrame, col::ColumnIndex, name_cols::Pair{Sy
             dfp[!, name] = item_new
         else
             if hasproperty(dfp, name)
-                @assert makeunique
-                k = 1
-                while true
-                    nn = Symbol("$(name)_$k")
-                    if !hasproperty(dfp, nn)
-                        name = nn
-                        break
+                if dupcol == :makeunique
+                    k = 1
+                    while true
+                        nn = Symbol("$(name)_$k")
+                        if !hasproperty(dfp, nn)
+                            name = nn
+                            break
+                        end
+                        k += 1
                     end
-                    k += 1
+                    insert!(index(dfp), col_ind, name)
+                    insert!(_columns(dfp), col_ind, item_new)
+                else
+                    @assert dupcol == :update
+                    # Just update without adding to index
+                    dfp[!, name] = _update_missing.(dfp[!, name], item_new)
+                    col_ind -= 1
                 end
+            else
+                insert!(index(dfp), col_ind, name)
+                insert!(_columns(dfp), col_ind, item_new)
             end
-            insert!(index(dfp), col_ind, name)
-            insert!(_columns(dfp), col_ind, item_new)
         end
         col_ind += 1
     end
@@ -3134,22 +3157,22 @@ function insertcols!(df::AbstractDataFrame, col::ColumnIndex, name_cols::Pair{Sy
 end
 
 insertcols!(df::AbstractDataFrame, col::ColumnIndex, name_cols::Pair{<:AbstractString}...;
-            after::Bool=false, makeunique::Bool=false, copycols::Bool=true) =
+            after::Bool=false, makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
     insertcols!(df, col, (Symbol(n) => v for (n, v) in name_cols)...,
-                after=after, makeunique=makeunique, copycols=copycols)
+                after=after, makeunique=makeunique, dupcol=dupcol, copycols=copycols)
 
 insertcols!(df::AbstractDataFrame, name_cols::Pair{Symbol}...;
-            after::Bool=false, makeunique::Bool=false, copycols::Bool=true) =
+            after::Bool=false, makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
     insertcols!(df, ncol(df)+1, name_cols..., after=after,
-                makeunique=makeunique, copycols=copycols)
+                makeunique=makeunique, dupcol=dupcol, copycols=copycols)
 
 insertcols!(df::AbstractDataFrame, name_cols::Pair{<:AbstractString}...;
-            after::Bool=false, makeunique::Bool=false, copycols::Bool=true) =
+            after::Bool=false, makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
     insertcols!(df, (Symbol(n) => v for (n, v) in name_cols)...,
-                after=after, makeunique=makeunique, copycols=copycols)
+                after=after, makeunique=makeunique, dupcol=dupcol, copycols=copycols)
 
 function insertcols!(df::AbstractDataFrame, col::ColumnIndex; after::Bool=false,
-                     makeunique::Bool=false, copycols::Bool=true)
+                     makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
     if col isa SymbolOrString
         col_ind = Int(columnindex(df, col))
         if col_ind == 0
@@ -3173,7 +3196,7 @@ function insertcols!(df::AbstractDataFrame, col::ColumnIndex; after::Bool=false,
 end
 
 function insertcols!(df::AbstractDataFrame; after::Bool=false,
-                     makeunique::Bool=false, copycols::Bool=true)
+                     makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
     _drop_all_nonnote_metadata!(parent(df))
     return df
 end

--- a/src/abstractdataframe/reshape.jl
+++ b/src/abstractdataframe/reshape.jl
@@ -823,7 +823,7 @@ julia> permutedims(df2, 1, "different_name")
 """
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
                           dest_namescol::Union{Symbol, AbstractString};
-                          makeunique::Bool=false, strict::Bool=true)
+                          makeunique::Bool=false, dupcol::Symbol=:error, strict::Bool=true)
 
     if src_namescol isa Integer
         1 <= src_namescol <= ncol(df) || throw(BoundsError(index(df), src_namescol))
@@ -854,18 +854,18 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex,
 
     if ncol(df_notsrc) == 0
         df_tmp = DataFrame(AbstractVector[[] for _ in 1:nrow(df)], new_col_names,
-                           makeunique=makeunique, copycols=false)
+                           makeunique=makeunique, dupcol=dupcol, copycols=false)
     else
         m = permutedims(Matrix(df_notsrc))
-        df_tmp = rename!(DataFrame(Tables.table(m)), new_col_names, makeunique=makeunique)
+        df_tmp = rename!(DataFrame(Tables.table(m)), new_col_names, makeunique=makeunique, dupcol=dupcol)
     end
-    out_df = hcat!(df_permuted, df_tmp, makeunique=makeunique, copycols=false)
+    out_df = hcat!(df_permuted, df_tmp, makeunique=makeunique, dupcol=dupcol, copycols=false)
     _copy_table_note_metadata!(out_df, df)
     return out_df
 end
 
 function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
-                          makeunique::Bool=false, strict::Bool=true)
+                          makeunique::Bool=false, dupcol::Symbol=:error, strict::Bool=true)
     if src_namescol isa Integer
         1 <= src_namescol <= ncol(df) || throw(BoundsError(index(df), src_namescol))
         dest_namescol = _names(df)[src_namescol]
@@ -873,7 +873,7 @@ function Base.permutedims(df::AbstractDataFrame, src_namescol::ColumnIndex;
         dest_namescol = src_namescol
     end
     return permutedims(df, src_namescol, dest_namescol;
-                       makeunique=makeunique, strict=strict)
+                       makeunique=makeunique, dupcol=dupcol, strict=strict)
 end
 
 function Base.permutedims(df::AbstractDataFrame)
@@ -883,8 +883,8 @@ function Base.permutedims(df::AbstractDataFrame)
 end
 
 function Base.permutedims(df::AbstractDataFrame, cnames::AbstractVector;
-                          makeunique::Bool=false)
-    out_df = DataFrame(permutedims(Matrix(df)), cnames, makeunique=makeunique)
+                          makeunique::Bool=false, dupcol::Symbol=:error)
+    out_df = DataFrame(permutedims(Matrix(df)), cnames, makeunique=makeunique, dupcol=dupcol)
     _copy_table_note_metadata!(out_df, df)
     return out_df
 end

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -8,16 +8,16 @@ particularly a `Vector`, `PooledVector` or `CategoricalVector`.
 
 # Constructors
 ```julia
-DataFrame(pairs::Pair...; makeunique::Bool=false, copycols::Bool=true)
-DataFrame(pairs::AbstractVector{<:Pair}; makeunique::Bool=false, copycols::Bool=true)
+DataFrame(pairs::Pair...; makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
+DataFrame(pairs::AbstractVector{<:Pair}; makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
 DataFrame(ds::AbstractDict; copycols::Bool=true)
 DataFrame(; kwargs..., copycols::Bool=true)
 
 DataFrame(table; copycols::Union{Bool, Nothing}=nothing)
 DataFrame(table, names::AbstractVector;
-          makeunique::Bool=false, copycols::Union{Bool, Nothing}=nothing)
+          makeunique::Bool=false, dupcol::Symbol=:error, copycols::Union{Bool, Nothing}=nothing)
 DataFrame(columns::AbstractVecOrMat, names::AbstractVector;
-          makeunique::Bool=false, copycols::Bool=true)
+          makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
 
 DataFrame(::DataFrameRow; copycols::Bool=true)
 DataFrame(::GroupedDataFrame; copycols::Bool=true, keepkeys::Bool=true)
@@ -35,6 +35,7 @@ DataFrame(::GroupedDataFrame; copycols::Bool=true, keepkeys::Bool=true)
   To force a copy in such cases, or to get mutable columns from an immutable
   input table (like `Arrow.Table`), pass `copycols=true` explicitly.
 - `makeunique` : if `false` (the default), an error will be raised
+- `Symbol` : One of :error (the default), :makeunique (same as makeunique=true), or :update
 
 (note that not all constructors support these keyword arguments)
 
@@ -84,9 +85,13 @@ Pass the `copycols=false` keyword argument (where supported) to reuse vectors wi
 copying them.
 
 By default an error will be raised if duplicates in column names are found. Pass
-`makeunique=true` keyword argument (where supported) to accept duplicate names,
+`makeunique=true` keyword argument or `dupcol=:makeunique` (where supported) to accept duplicate names,
 in which case they will be suffixed with `_i` (`i` starting at 1 for the first
 duplicate).
+
+If duplicate column names are found and `dupcol=:update` then the left-hand column is `updated`
+with values from the right-hand column (i.e. non-missing values in the right-hand column will
+overwrite values in the left-hand column)
 
 If an `AbstractRange` is passed to a `DataFrame` constructor as a column it is
 always collected to a `Vector` (even if `copycols=false`). As a general rule
@@ -194,7 +199,7 @@ mutable struct DataFrame <: AbstractDataFrame
                        colindex::Index; copycols::Bool=true)
         if length(columns) == length(colindex) == 0
             return new(AbstractVector[], Index(), nothing, nothing, true)
-        elseif length(columns) != length(colindex)
+        elseif length(columns) != column_length(colindex)
             throw(DimensionMismatch("Number of columns ($(length(columns))) and number of " *
                                     "column names ($(length(colindex))) are not equal"))
         end
@@ -232,6 +237,22 @@ mutable struct DataFrame <: AbstractDataFrame
             firstindex(col) != 1 && _onebased_check_error(i, col)
         end
 
+        # process updates if they exist
+        if !isempty(colindex.updates)
+            updated = Vector{Any}(nothing, length(colindex.names))
+            for src in eachindex(colindex.updates)
+                name = colindex.updates[src]
+                dst = colindex.lookup[name]
+                if isnothing(updated[dst])
+                    updated[dst] = columns[src]
+                else
+                    updated[dst] = _update_missing.(updated[dst], columns[src])
+                end
+            end
+            columns = updated
+            colindex = Index(colindex.lookup, colindex.names)
+        end
+
         return new(convert(Vector{AbstractVector}, columns), colindex, nothing, nothing, true)
     end
 end
@@ -254,24 +275,27 @@ end
 
 DataFrame(df::DataFrame; copycols::Bool=true) = copy(df, copycols=copycols)
 
-function DataFrame(pairs::Pair{Symbol, <:Any}...; makeunique::Bool=false,
+function DataFrame(pairs::Pair{Symbol, <:Any}...; 
+                   makeunique::Bool=false, dupcol::Symbol=:error,
                    copycols::Bool=true)::DataFrame
     colnames = [Symbol(k) for (k, v) in pairs]
     columns = Any[v for (k, v) in pairs]
-    return DataFrame(columns, Index(colnames, makeunique=makeunique),
+    return DataFrame(columns, Index(colnames, dupcol=_dupcol(dupcol, makeunique)),
                      copycols=copycols)
 end
 
-function DataFrame(pairs::Pair{<:AbstractString, <:Any}...; makeunique::Bool=false,
+function DataFrame(pairs::Pair{<:AbstractString, <:Any}...; 
+                   makeunique::Bool=false, dupcol::Symbol=:error,
                    copycols::Bool=true)::DataFrame
     colnames = [Symbol(k) for (k, v) in pairs]
     columns = Any[v for (k, v) in pairs]
-    return DataFrame(columns, Index(colnames, makeunique=makeunique),
+    return DataFrame(columns, Index(colnames, dupcol=_dupcol(dupcol, makeunique)),
                      copycols=copycols)
 end
 
 # this is needed as a workaround for Tables.jl dispatch
-function DataFrame(pairs::AbstractVector{<:Pair}; makeunique::Bool=false,
+function DataFrame(pairs::AbstractVector{<:Pair}; 
+                   makeunique::Bool=false, dupcol::Symbol=:error,
                    copycols::Bool=true)
     if isempty(pairs)
         return DataFrame()
@@ -281,7 +305,7 @@ function DataFrame(pairs::AbstractVector{<:Pair}; makeunique::Bool=false,
         end
         colnames = [Symbol(k) for (k, v) in pairs]
         columns = Any[v for (k, v) in pairs]
-        return DataFrame(columns, Index(colnames, makeunique=makeunique),
+        return DataFrame(columns, Index(colnames, dupcol=_dupcol(dupcol, makeunique)),
                          copycols=copycols)
     end
 end
@@ -334,12 +358,13 @@ function DataFrame(; kwargs...)
 end
 
 function DataFrame(columns::AbstractVector, cnames::AbstractVector{Symbol};
-                   makeunique::Bool=false, copycols::Bool=true)::DataFrame
+                   makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)::DataFrame
+    dupcol = _dupcol(dupcol, makeunique)
     if !(eltype(columns) <: AbstractVector) && !all(col -> isa(col, AbstractVector), columns)
-        return rename!(DataFrame(columns, copycols=copycols), cnames, makeunique=makeunique)
+        return rename!(DataFrame(columns, copycols=copycols), cnames, dupcol=dupcol)
     end
     return DataFrame(collect(AbstractVector, columns),
-                     Index(convert(Vector{Symbol}, cnames), makeunique=makeunique),
+                     Index(convert(Vector{Symbol}, cnames), dupcol=dupcol),
                      copycols=copycols)
 end
 
@@ -351,18 +376,18 @@ function _name2symbol(str::AbstractVector)
 end
 
 DataFrame(columns::AbstractVector, cnames::AbstractVector;
-          makeunique::Bool=false, copycols::Bool=true) =
-    DataFrame(columns, _name2symbol(cnames), makeunique=makeunique, copycols=copycols)
+          makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
+    DataFrame(columns, _name2symbol(cnames), dupcol=_dupcol(dupcol, makeunique), copycols=copycols)
 
 DataFrame(columns::AbstractVector{<:AbstractVector}, cnames::AbstractVector{Symbol};
-          makeunique::Bool=false, copycols::Bool=true)::DataFrame =
+          makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)::DataFrame =
     DataFrame(collect(AbstractVector, columns),
-              Index(convert(Vector{Symbol}, cnames), makeunique=makeunique),
+              Index(convert(Vector{Symbol}, cnames), dupcol=_dupcol(dupcol, makeunique)),
               copycols=copycols)
 
 DataFrame(columns::AbstractVector{<:AbstractVector}, cnames::AbstractVector;
-          makeunique::Bool=false, copycols::Bool=true) =
-    DataFrame(columns, _name2symbol(cnames); makeunique=makeunique, copycols=copycols)
+          makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
+    DataFrame(columns, _name2symbol(cnames); dupcol=_dupcol(dupcol, makeunique), copycols=copycols)
 
 function DataFrame(columns::AbstractVector, cnames::Symbol; copycols::Bool=true)
     if cnames !== :auto
@@ -375,15 +400,15 @@ function DataFrame(columns::AbstractVector, cnames::Symbol; copycols::Bool=true)
 end
 
 function DataFrame(columns::AbstractMatrix, cnames::AbstractVector{Symbol};
-                   makeunique::Bool=false, copycols::Bool=true)
+                   makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
     getter = copycols ? getindex : view
     return DataFrame(AbstractVector[getter(columns, :, i) for i in 1:size(columns, 2)],
-                     cnames, makeunique=makeunique, copycols=false)
+                     cnames, dupcol=_dupcol(dupcol, makeunique), copycols=false)
 end
 
 DataFrame(columns::AbstractMatrix, cnames::AbstractVector;
-          makeunique::Bool=false, copycols::Bool=true) =
-    DataFrame(columns, _name2symbol(cnames); makeunique=makeunique, copycols=copycols)
+          makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
+    DataFrame(columns, _name2symbol(cnames); dupcol=_dupcol(dupcol, makeunique), copycols=copycols)
 
 function DataFrame(columns::AbstractMatrix, cnames::Symbol; copycols::Bool=true)
     if cnames !== :auto
@@ -392,7 +417,7 @@ function DataFrame(columns::AbstractMatrix, cnames::Symbol; copycols::Bool=true)
                             "positional argument is passed then the second " *
                             "argument must be a vector of column names or :auto"))
     end
-    return DataFrame(columns, gennames(size(columns, 2)), makeunique=false, copycols=copycols)
+    return DataFrame(columns, gennames(size(columns, 2)), dupcol=:error, copycols=copycols)
 end
 
 # Discontinued constructors
@@ -1202,8 +1227,8 @@ end
 
 # hcat! for 2 arguments, only a vector or a data frame is allowed
 function hcat!(df1::DataFrame, df2::AbstractDataFrame;
-               makeunique::Bool=false, copycols::Bool=true)
-    u = add_names(index(df1), index(df2), makeunique=makeunique)
+               makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
+    u = add_names(index(df1), index(df2), dupcol=_dupcol(dupcol, makeunique))
 
     _drop_all_nonnote_metadata!(df1)
     _keep_matching_table_note_metadata!(df1, df2)
@@ -1217,31 +1242,31 @@ end
 
 # TODO: after deprecation remove AbstractVector methods
 
-function hcat!(df::DataFrame, x::AbstractVector; makeunique::Bool=false, copycols::Bool=true)
+function hcat!(df::DataFrame, x::AbstractVector; makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
     Base.depwarn("horizontal concatenation of data frame with a vector is deprecated. " *
                  "Pass DataFrame(x1=x) instead.", :hcat!)
     return hcat!(df, DataFrame(AbstractVector[x], [:x1], copycols=false),
-                 makeunique=makeunique, copycols=copycols)
+                 dupcol=_dupcol(dupcol, makeunique), copycols=copycols)
 end
 
-function hcat!(x::AbstractVector, df::DataFrame; makeunique::Bool=false, copycols::Bool=true)
+function hcat!(x::AbstractVector, df::DataFrame; makeunique::Bool=false, dupcol::Symbol=:error,copycols::Bool=true)
     Base.depwarn("horizontal concatenation of data frame with a vector is deprecated. " *
                  "Pass DataFrame(x1=x) instead.", :hcat!)
     return hcat!(DataFrame(AbstractVector[x], [:x1], copycols=copycols), df,
-                 makeunique=makeunique, copycols=copycols)
+                 dupcol=_dupcol(dupcol, makeunique), copycols=copycols)
 end
 
 # hcat! for 1-n arguments
-function hcat!(df::DataFrame; makeunique::Bool=false, copycols::Bool=true)
+function hcat!(df::DataFrame; makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true)
     _drop_all_nonnote_metadata!(df)
     return df
 end
 
 hcat!(a::DataFrame, b::Union{AbstractDataFrame, AbstractVector},
       c::Union{AbstractDataFrame, AbstractVector}...;
-      makeunique::Bool=false, copycols::Bool=true) =
-    hcat!(hcat!(a, b, makeunique=makeunique, copycols=copycols),
-          c..., makeunique=makeunique, copycols=copycols)
+      makeunique::Bool=false, dupcol::Symbol=:error, copycols::Bool=true) =
+    hcat!(hcat!(a, b, dupcol=_dupcol(dupcol, makeunique), copycols=copycols),
+          c..., dupcol=_dupcol(dupcol, makeunique), copycols=copycols)
 
 ##############################################################################
 ##

--- a/src/join/composer.jl
+++ b/src/join/composer.jl
@@ -118,7 +118,8 @@ _rename_cols(old_names::AbstractVector{Symbol},
            for n in old_names]
 
 function _propagate_join_metadata!(joiner::DataFrameJoiner, dfr_noon::AbstractDataFrame,
-                                   res::DataFrame, kind::Symbol)
+                                   res::DataFrame, kind::Symbol;
+                                   dupcol::Symbol=:error, names=nothing)
     @assert kind == :left || kind == :right || kind == :outer || kind == :inner
 
     # The steps taken in this function are (all applies only to :note-style metadata):
@@ -174,8 +175,17 @@ function _propagate_join_metadata!(joiner::DataFrameJoiner, dfr_noon::AbstractDa
         end
     end
 
-    for i in 1:ncol(dfr_noon)
-        _copy_col_note_metadata!(res, ncol(joiner.dfl) + i, dfr_noon, i)
+    if dupcol != :update
+        for i in 1:ncol(dfr_noon)
+            _copy_col_note_metadata!(res, ncol(joiner.dfl) + i, dfr_noon, i)
+        end
+    else
+        map = Index(names, dupcol=dupcol)
+        for i in 1:ncol(dfr_noon)
+            name = map.updates[ncol(joiner.dfl) + i]
+            dst = map.lookup[name]
+            _merge_col_note_metadata!(res, dst, dfr_noon, i)
+        end
     end
 
     if kind == :outer || kind == :inner
@@ -235,7 +245,7 @@ function _count_sortperm!(input::Vector{Int}, count::Vector,
 end
 
 function compose_inner_table(joiner::DataFrameJoiner,
-                             makeunique::Bool,
+                             dupcol::Symbol,
                              left_rename::Union{Function, AbstractString, Symbol},
                              right_rename::Union{Function, AbstractString, Symbol},
                              order::Symbol)
@@ -278,9 +288,9 @@ function compose_inner_table(joiner::DataFrameJoiner,
 
     new_names = vcat(_rename_cols(_names(joiner.dfl), left_rename, joiner.left_on),
                      _rename_cols(_names(dfr_noon), right_rename))
-    res = DataFrame(cols, new_names, makeunique=makeunique, copycols=false)
+    res = DataFrame(cols, new_names, dupcol=dupcol, copycols=false)
 
-    _propagate_join_metadata!(joiner, dfr_noon, res, :inner)
+    _propagate_join_metadata!(joiner, dfr_noon, res, :inner, dupcol=dupcol, names=new_names)
     return res
 end
 
@@ -292,7 +302,7 @@ function find_missing_idxs(present::Vector{Int}, target_len::Int)
     return _findall(not_seen)
 end
 
-function compose_joined_table(joiner::DataFrameJoiner, kind::Symbol, makeunique::Bool,
+function compose_joined_table(joiner::DataFrameJoiner, kind::Symbol, dupcol::Symbol,
                               left_rename::Union{Function, AbstractString, Symbol},
                               right_rename::Union{Function, AbstractString, Symbol},
                               indicator::Union{Nothing, Symbol, AbstractString},
@@ -314,12 +324,12 @@ function compose_joined_table(joiner::DataFrameJoiner, kind::Symbol, makeunique:
     else
         rightonly_ixs = 1:0
     end
-    return _compose_joined_table(joiner, kind, makeunique, left_rename, right_rename,
+    return _compose_joined_table(joiner, kind, dupcol, left_rename, right_rename,
                                  indicator, left_ixs, right_ixs,
                                  leftonly_ixs, rightonly_ixs, order)
 end
 
-function _compose_joined_table(joiner::DataFrameJoiner, kind::Symbol, makeunique::Bool,
+function _compose_joined_table(joiner::DataFrameJoiner, kind::Symbol, dupcol::Symbol,
                                left_rename::Union{Function, AbstractString, Symbol},
                                right_rename::Union{Function, AbstractString, Symbol},
                                indicator::Union{Nothing, Symbol, AbstractString},
@@ -440,14 +450,14 @@ function _compose_joined_table(joiner::DataFrameJoiner, kind::Symbol, makeunique
 
     new_names = vcat(_rename_cols(_names(joiner.dfl), left_rename, joiner.left_on),
                      _rename_cols(_names(dfr_noon), right_rename))
-    res = DataFrame(cols, new_names, makeunique=makeunique, copycols=false)
+    res = DataFrame(cols, new_names, dupcol=dupcol, copycols=false)
 
     if new_order !== nothing
         isnothing(src_indicator) || permute!(src_indicator, new_order)
         permute!(res, new_order)
     end
 
-    _propagate_join_metadata!(joiner, dfr_noon, res, kind)
+    _propagate_join_metadata!(joiner, dfr_noon, res, kind, dupcol=dupcol, names=new_names)
 
     return res, src_indicator
 end
@@ -484,7 +494,7 @@ function _sort_compose_helper(fillval::Int, # value to use to fill unused indice
 end
 
 function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
-               on::Union{<:OnType, AbstractVector}, kind::Symbol, makeunique::Bool,
+               on::Union{<:OnType, AbstractVector}, kind::Symbol, dupcol::Symbol,
                indicator::Union{Nothing, Symbol, AbstractString},
                validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}},
                left_rename::Union{Function, AbstractString, Symbol},
@@ -579,16 +589,16 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
 
     src_indicator = nothing
     if kind == :inner
-        joined = compose_inner_table(joiner, makeunique, left_rename, right_rename, order)
+        joined = compose_inner_table(joiner, dupcol, left_rename, right_rename, order)
     elseif kind == :left
         joined, src_indicator =
-            compose_joined_table(joiner, kind, makeunique, left_rename, right_rename, indicator, order)
+            compose_joined_table(joiner, kind, dupcol, left_rename, right_rename, indicator, order)
     elseif kind == :right
         joined, src_indicator =
-            compose_joined_table(joiner, kind, makeunique, left_rename, right_rename, indicator, order)
+            compose_joined_table(joiner, kind, dupcol, left_rename, right_rename, indicator, order)
     elseif kind == :outer
         joined, src_indicator =
-            compose_joined_table(joiner, kind, makeunique, left_rename, right_rename, indicator, order)
+            compose_joined_table(joiner, kind, dupcol, left_rename, right_rename, indicator, order)
     elseif kind == :semi
         joined = joiner.dfl[find_semi_rows(joiner), :]
     elseif kind == :anti
@@ -606,7 +616,7 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
                                    invpool, pool)
 
         unique_indicator = indicator
-        if makeunique
+        if dupcol == :makeunique
             try_idx = 0
             while hasproperty(joined, unique_indicator)
                 try_idx += 1
@@ -614,12 +624,16 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
             end
         end
 
-        if hasproperty(joined, unique_indicator)
-            throw(ArgumentError("joined data frame already has column " *
-                                ":$unique_indicator. Pass makeunique=true to " *
-                                "make it unique using a suffix automatically."))
+        if unique_indicator == indicator && dupcol == :update
+            joined[!, indicator] = _update_missing.(joined[!, indicator], indicatorcol)
+        else
+            if hasproperty(joined, unique_indicator)
+                throw(ArgumentError("joined data frame already has column " *
+                                    ":$unique_indicator. Pass dupcol=:makeunique to " *
+                                    "make it unique using a suffix automatically."))
+            end
+            joined[!, unique_indicator] = indicatorcol
         end
-        joined[!, unique_indicator] = indicatorcol
     else
         @assert isnothing(src_indicator)
     end
@@ -628,10 +642,10 @@ function _join(df1::AbstractDataFrame, df2::AbstractDataFrame;
 end
 
 """
-    innerjoin(df1, df2; on, makeunique=false, validate=(false, false),
+    innerjoin(df1, df2; on, makeunique=false, dupcol=:error, validate=(false, false),
               renamecols=(identity => identity), matchmissing=:error,
               order=:undefined)
-    innerjoin(df1, df2, dfs...; on, makeunique=false,
+    innerjoin(df1, df2, dfs...; on, makeunique=false, dupcol=:error,
               validate=(false, false), matchmissing=:error,
               order=:undefined)
 
@@ -755,7 +769,7 @@ julia> innerjoin(name, job2, on = [:ID => :identifier], renamecols = uppercase =
 """
 function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
                    on::Union{<:OnType, AbstractVector} = Symbol[],
-                   makeunique::Bool=false,
+                   makeunique::Bool=false, dupcol::Symbol=:error,
                    validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
                    renamecols::Pair=identity => identity,
                    matchmissing::Symbol=:error,
@@ -764,7 +778,7 @@ function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
         throw(ArgumentError("renamecols keyword argument must be a `Pair` " *
                             "containing functions, strings, or `Symbol`s"))
     end
-    return _join(df1, df2, on=on, kind=:inner, makeunique=makeunique,
+    return _join(df1, df2, on=on, kind=:inner, dupcol=_dupcol(dupcol, makeunique),
                  indicator=nothing, validate=validate,
                  left_rename=first(renamecols), right_rename=last(renamecols),
                  matchmissing=matchmissing, order=order)
@@ -772,16 +786,17 @@ end
 
 function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame...;
                    on::Union{<:OnType, AbstractVector} = Symbol[],
-                   makeunique::Bool=false,
+                   makeunique::Bool=false, dupcol::Symbol=:error,
                    validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
                    matchmissing::Symbol=:error,
                    order::Symbol=:undefined)
     @assert !isempty(dfs)
-    res = innerjoin(df1, df2, on=on, makeunique=makeunique, validate=validate,
+    dupcol = _dupcol(dupcol, makeunique)
+    res = innerjoin(df1, df2, on=on, dupcol=dupcol, validate=validate,
                     matchmissing=matchmissing,
                     order=order === :right ? :undefined : order)
     for (i, dfn) in enumerate(dfs)
-        res = innerjoin(res, dfn, on=on, makeunique=makeunique, validate=validate,
+        res = innerjoin(res, dfn, on=on, dupcol=dupcol, validate=validate,
                         matchmissing=matchmissing,
                         order= order === :right ?
                                (i == length(dfs) ? :right : :undefined) :
@@ -791,7 +806,7 @@ function innerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::Abstract
 end
 
 """
-    leftjoin(df1, df2; on, makeunique=false, source=nothing, validate=(false, false),
+    leftjoin(df1, df2; on, makeunique=false, dupcol=:error, source=nothing, validate=(false, false),
              renamecols=(identity => identity), matchmissing=:error, order=:undefined)
 
 Perform a left join of two data frame objects and return a `DataFrame` containing
@@ -813,8 +828,13 @@ change in future releases.
   `isequal`. `on` is a required argument.
 - `makeunique` : if `false` (the default), an error will be raised
   if duplicate names are found in columns not joined on;
-  if `true`, duplicate names will be suffixed with `_i`
+  if `true`, duplicate names will be suffixed with `_i` (deprecated)
   (`i` starting at 1 for the first duplicate).
+- `dupcol` : if `dupcol=:error` (the default) then columns names of passed objects must be unique.
+  If `dupcol=:makeunique` then duplicate column names will be suffixed
+  with `_i` (`i` starting at 1 for the first duplicate).
+  If `dupcol=:update` then duplicate columns names will be combined with the left-hand
+  column overwritten by non-missing values from the right hand column(s)
 - `source` : Default: `nothing`. If a `Symbol` or string, adds indicator
   column with the given name, for whether a row appeared in only `df1` (`"left_only"`)
   or in both (`"both"`). If the name is already in use,
@@ -915,12 +935,14 @@ julia> leftjoin(name, job2, on = [:ID => :identifier], renamecols = uppercase =>
 ```
 """
 function leftjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
-                  on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false,
+                  on::Union{<:OnType, AbstractVector} = Symbol[], 
+                  makeunique::Bool=false, dupcol::Symbol=:error,
                   source::Union{Nothing, Symbol, AbstractString}=nothing,
                   indicator::Union{Nothing, Symbol, AbstractString}=nothing,
                   validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
                   renamecols::Pair=identity => identity, matchmissing::Symbol=:error,
                   order::Symbol=:undefined)
+
     if !all(x -> x isa Union{Function, AbstractString, Symbol}, renamecols)
         throw(ArgumentError("renamecols keyword argument must be a `Pair` " *
                             "containing functions, strings, or `Symbol`s"))
@@ -937,14 +959,14 @@ function leftjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
                             "It is not allowed to pass both `indicator` and `source` " *
                             "keyword arguments at the same time."))
     end
-    return _join(df1, df2, on=on, kind=:left, makeunique=makeunique,
+    return _join(df1, df2, on=on, kind=:left, dupcol=_dupcol(dupcol, makeunique),
                  indicator=source, validate=validate,
                  left_rename=first(renamecols), right_rename=last(renamecols),
                  matchmissing=matchmissing, order=order)
 end
 
 """
-    rightjoin(df1, df2; on, makeunique=false, source=nothing,
+    rightjoin(df1, df2; on, makeunique=false, dupcol=:error, source=nothing,
               validate=(false, false), renamecols=(identity => identity),
               matchmissing=:error, order=:undefined)
 
@@ -970,7 +992,12 @@ change in future releases.
 - `makeunique` : if `false` (the default), an error will be raised
   if duplicate names are found in columns not joined on;
   if `true`, duplicate names will be suffixed with `_i`
-  (`i` starting at 1 for the first duplicate).
+  (`i` starting at 1 for the first duplicate). (deprecated)
+- `dupcol` : if `dupcol=:error` (the default) then columns names of passed objects must be unique.
+  If `dupcol=:makeunique` then duplicate column names will be suffixed
+  with `_i` (`i` starting at 1 for the first duplicate).
+  If `dupcol=:update` then duplicate columns names will be combined with the left-hand
+  column overwritten by non-missing values from the right hand column(s)
 - `source` : Default: `nothing`. If a `Symbol` or string, adds indicator
   column with the given name for whether a row appeared in only `df2` (`"right_only"`)
   or in both (`"both"`). If the name is already in use,
@@ -1071,7 +1098,8 @@ julia> rightjoin(name, job2, on = [:ID => :identifier], renamecols = uppercase =
 ```
 """
 function rightjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
-                   on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false,
+                   on::Union{<:OnType, AbstractVector} = Symbol[], 
+                   makeunique::Bool=false, dupcol::Symbol=:error,
                    source::Union{Nothing, Symbol, AbstractString}=nothing,
                    indicator::Union{Nothing, Symbol, AbstractString}=nothing,
                    validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
@@ -1093,16 +1121,16 @@ function rightjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
                             "It is not allowed to pass both `indicator` and `source` " *
                             "keyword arguments at the same time."))
     end
-    return _join(df1, df2, on=on, kind=:right, makeunique=makeunique,
+    return _join(df1, df2, on=on, kind=:right, dupcol=_dupcol(dupcol, makeunique),
                  indicator=source, validate=validate,
                  left_rename=first(renamecols), right_rename=last(renamecols),
                  matchmissing=matchmissing, order=order)
 end
 
 """
-    outerjoin(df1, df2; on, makeunique=false, source=nothing, validate=(false, false),
+    outerjoin(df1, df2; on, makeunique=false, dupcol::Symbol=:error, source=nothing, validate=(false, false),
               renamecols=(identity => identity), matchmissing=:error, order=:undefined)
-    outerjoin(df1, df2, dfs...; on, makeunique = false,
+    outerjoin(df1, df2, dfs...; on, makeunique=false, dupcol::Symbol=:error, 
               validate = (false, false), matchmissing=:error, order=:undefined)
 
 Perform an outer join of two or more data frame objects and return a `DataFrame`
@@ -1128,7 +1156,12 @@ This behavior may change in future releases.
 - `makeunique` : if `false` (the default), an error will be raised
   if duplicate names are found in columns not joined on;
   if `true`, duplicate names will be suffixed with `_i`
-  (`i` starting at 1 for the first duplicate).
+  (`i` starting at 1 for the first duplicate). (deprecated)
+  - `dupcol` : if `dupcol=:error` (the default) then columns names of passed objects must be unique.
+  If `dupcol=:makeunique` then duplicate column names will be suffixed
+  with `_i` (`i` starting at 1 for the first duplicate).
+  If `dupcol=:update` then duplicate columns names will be combined with the left-hand
+  column overwritten by non-missing values from the right hand column(s)
 - `source` : Default: `nothing`. If a `Symbol` or string, adds indicator
   column with the given name for whether a row appeared in only `df1` (`"left_only"`),
   only `df2` (`"right_only"`) or in both (`"both"`). If the name is already in use,
@@ -1240,7 +1273,8 @@ julia> outerjoin(name, job2, on = [:ID => :identifier], renamecols = uppercase =
 ```
 """
 function outerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
-                   on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false,
+                   on::Union{<:OnType, AbstractVector} = Symbol[], 
+                   makeunique::Bool=false, dupcol::Symbol=:error,
                    source::Union{Nothing, Symbol, AbstractString}=nothing,
                    indicator::Union{Nothing, Symbol, AbstractString}=nothing,
                    validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
@@ -1262,27 +1296,29 @@ function outerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
                             "It is not allowed to pass both `indicator` and `source` " *
                             "keyword arguments at the same time."))
     end
-    return _join(df1, df2, on=on, kind=:outer, makeunique=makeunique,
+    return _join(df1, df2, on=on, kind=:outer, dupcol=_dupcol(dupcol, makeunique),
                  indicator=source, validate=validate,
                  left_rename=first(renamecols), right_rename=last(renamecols),
                  matchmissing=matchmissing, order=order)
 end
 
 function outerjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame...;
-                   on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false,
+                   on::Union{<:OnType, AbstractVector} = Symbol[], 
+                   makeunique::Bool=false, dupcol::Symbol=:error,
                    validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
                    matchmissing::Symbol=:error, order::Symbol=:undefined)
-    res = outerjoin(df1, df2, on=on, makeunique=makeunique, validate=validate,
+    dupcol = _dupcol(dupcol, makeunique)
+    res = outerjoin(df1, df2, on=on, dupcol=dupcol, validate=validate,
                         matchmissing=matchmissing, order=order)
     for dfn in dfs
-        res = outerjoin(res, dfn, on=on, makeunique=makeunique, validate=validate,
+        res = outerjoin(res, dfn, on=on, dupcol=dupcol, validate=validate,
                         matchmissing=matchmissing, order=order)
     end
     return res
 end
 
 """
-    semijoin(df1, df2; on, makeunique=false, validate=(false, false), matchmissing=:error)
+    semijoin(df1, df2; on, makeunique=false, dupcol=:error, validate=(false, false), matchmissing=:error)
 
 Perform a semi join of two data frame objects and return a `DataFrame`
 containing the result. A semi join returns the subset of rows of `df1` that
@@ -1384,16 +1420,16 @@ julia> semijoin(name, job2, on = [:ID => :identifier])
 ```
 """
 semijoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
-         on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false,
+         on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false, dupcol::Symbol=:error,
          validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
          matchmissing::Symbol=:error) =
-    _join(df1, df2, on=on, kind=:semi, makeunique=makeunique,
+    _join(df1, df2, on=on, kind=:semi, dupcol=_dupcol(dupcol, makeunique),
           indicator=nothing, validate=validate,
           left_rename=identity, right_rename=identity, matchmissing=matchmissing,
           order=:left)
 
 """
-    antijoin(df1, df2; on, makeunique=false, validate=(false, false), matchmissing=:error)
+    antijoin(df1, df2; on, makeunique=false, dupcol=:error, validate=(false, false), matchmissing=:error)
 
 Perform an anti join of two data frame objects and return a `DataFrame`
 containing the result. An anti join returns the subset of rows of `df1` that do
@@ -1488,10 +1524,10 @@ julia> antijoin(name, job2, on = [:ID => :identifier])
 ```
 """
 antijoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
-         on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false,
+         on::Union{<:OnType, AbstractVector} = Symbol[], makeunique::Bool=false, dupcol::Symbol=:error,
          validate::Union{Pair{Bool, Bool}, Tuple{Bool, Bool}}=(false, false),
          matchmissing::Symbol=:error) =
-    _join(df1, df2, on=on, kind=:anti, makeunique=makeunique,
+    _join(df1, df2, on=on, kind=:anti, dupcol=_dupcol(dupcol, makeunique),
           indicator=nothing, validate=validate,
           left_rename=identity, right_rename=identity,
           matchmissing=matchmissing,
@@ -1499,7 +1535,7 @@ antijoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
 
 """
     crossjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
-              makeunique::Bool=false, renamecols=identity => identity)
+              makeunique::Bool=false, dupcol::Symbol=:error, renamecols=identity => identity)
     crossjoin(df1, df2, dfs...; makeunique = false)
 
 Perform a cross join of two or more data frame objects and return a `DataFrame`
@@ -1565,22 +1601,25 @@ julia> crossjoin(df1, df2)
 ```
 """
 function crossjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
-                   makeunique::Bool=false, renamecols::Pair=identity => identity)
+                   makeunique::Bool=false, dupcol::Symbol=:error, renamecols::Pair=identity => identity)
     _check_consistency(df1)
     _check_consistency(df2)
+    dupcol = _dupcol(dupcol, makeunique)
     r1, r2 = size(df1, 1), size(df2, 1)
 
     new_names = vcat(_rename_cols(_names(df1), first(renamecols)),
                      _rename_cols(_names(df2), last(renamecols)))
     cols = Any[[repeat(c, inner=r2) for c in eachcol(df1)];
                [repeat(c, outer=r1) for c in eachcol(df2)]]
-    res = DataFrame(cols, new_names, copycols=false, makeunique=makeunique)
+    res = DataFrame(cols, new_names, copycols=false, dupcol=dupcol)
 
     for i in 1:ncol(df1)
         _copy_col_note_metadata!(res, i, df1, i)
     end
-    for i in 1:ncol(df2)
-        _copy_col_note_metadata!(res, ncol(df1) + i, df2, i)
+    if dupcol != :update
+        for i in 1:ncol(df2)
+            _copy_col_note_metadata!(res, ncol(df1) + i, df2, i)
+        end
     end
 
     _merge_matching_table_note_metadata!(res, (df1, df2))
@@ -1589,8 +1628,8 @@ function crossjoin(df1::AbstractDataFrame, df2::AbstractDataFrame;
 end
 
 crossjoin(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame...;
-          makeunique::Bool=false) =
-    crossjoin(crossjoin(df1, df2, makeunique=makeunique), dfs..., makeunique=makeunique)
+          makeunique::Bool=false, dupcol::Symbol=:error) =
+    crossjoin(crossjoin(df1, df2, dupcol=_dupcol(dupcol, makeunique)), dfs..., dupcol=_dupcol(dupcol, makeunique))
 
 # an explicit error is thrown as join was supported in the past
 Base.join(df1::AbstractDataFrame, df2::AbstractDataFrame, dfs::AbstractDataFrame...;

--- a/src/other/metadata.jl
+++ b/src/other/metadata.jl
@@ -705,6 +705,24 @@ function _copy_col_note_metadata!(dst::DataFrame, dst_col, src, src_col)
     return nothing
 end
 
+# copy column-level :note-style metadata from Tables.jl table src to dst
+# from column src_col to dst_col
+# discarding previous metadata contents of dst
+function _merge_col_note_metadata!(dst::DataFrame, dst_col, src, src_col)
+    #emptycolmetadata!(dst, dst_col)
+    metadata = colmetadata(dst, dst_col)
+    if DataAPI.colmetadatasupport(typeof(src)).read
+        for key in colmetadatakeys(src, src_col)
+            val, style = colmetadata(src, src_col, key, style=true)
+            # TODO write only if does not overwrite
+            if style === :note && !haskey(metadata, key)
+                colmetadata!(dst, dst_col, key, val, style=:note)
+            end
+        end
+    end
+    return nothing
+end
+
 # this is a function used to copy table-level and column-level :note-style metadata
 # from Tables.jl table src to dst, discarding previous metadata contents of dst
 function _copy_all_note_metadata!(dst::DataFrame, src)

--- a/src/other/tables.jl
+++ b/src/other/tables.jl
@@ -64,11 +64,11 @@ end
 
 # the logic here relies on the fact that Tables.CopiedColumns
 # is the only exception for default copycols value 
-DataFrame(x, cnames::AbstractVector; makeunique::Bool=false,
+DataFrame(x, cnames::AbstractVector; makeunique::Bool=false, dupcol::Symbol=:error,
           copycols::Union{Nothing, Bool}=nothing) =
     rename!(DataFrame(x, copycols=something(copycols, !(x isa Tables.CopiedColumns))),
             _name2symbol(cnames),
-            makeunique=makeunique)
+            makeunique=makeunique, dupcol=dupcol)
 
 function Base.append!(df::DataFrame, table; cols::Symbol=:setequal,
                       promote::Bool=(cols in [:union, :subset]))

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -152,6 +152,8 @@ end
 
     @test names(rename(df, [:f, :g])) == ["f", "g"]
     @test names(rename(df, [:f, :f], makeunique=true)) == ["f", "f_1"]
+    @test names(rename(df, [:f, :f], dupcol=:makeunique)) == ["f", "f_1"]
+    @test names(rename(df, [:f, :f], dupcol=:update)) == ["f", "f"]
     @test names(df) == ["a", "b"]
 
     rename!(df, [:f, :g])
@@ -208,7 +210,7 @@ end
     @test df.newcol == ["a", "b"]
 
     @test_throws ArgumentError insertcols!(df, 1, :newcol => ["a1", "b1"])
-    @test insertcols!(df, 1, :newcol => ["a1", "b1"], makeunique=true) == df
+    @test insertcols!(df, 1, :newcol => ["a1", "b1"], dupcol=:makeunique) == df
     @test propertynames(df) == [:newcol_1, :newcol, :a, :b]
     @test df.a == [1, 2]
     @test df.b == [3.0, 4.0]
@@ -235,7 +237,7 @@ end
     @test df.newcol == ["a", "b"]
 
     @test_throws ArgumentError insertcols!(df, 1, "newcol" => ["a1", "b1"])
-    @test insertcols!(df, 1, "newcol" => ["a1", "b1"], makeunique=true) == df
+    @test insertcols!(df, 1, "newcol" => ["a1", "b1"], dupcol=:makeunique) == df
     @test propertynames(df) == [:newcol_1, :newcol, :a, :b]
     @test df.a == [1, 2]
     @test df.b == [3.0, 4.0]
@@ -254,10 +256,23 @@ end
     df = DataFrame(a=[1, 2], a_1=[3, 4])
     @test_throws ArgumentError insertcols!(df, 1, :a => [11, 12])
     @test df == DataFrame(a=[1, 2], a_1=[3, 4])
+    insertcols!(df, 1, :a => [11, 12], dupcol=:makeunique)
+    @test propertynames(df) == [:a_2, :a, :a_1]
+    insertcols!(df, 4, :a => [11, 12], dupcol=:makeunique)
+    @test propertynames(df) == [:a_2, :a, :a_1, :a_3]
+
+    df = DataFrame(a=[1, 2], a_1=[3, 4])
     insertcols!(df, 1, :a => [11, 12], makeunique=true)
     @test propertynames(df) == [:a_2, :a, :a_1]
     insertcols!(df, 4, :a => [11, 12], makeunique=true)
     @test propertynames(df) == [:a_2, :a, :a_1, :a_3]
+
+    df = DataFrame(a=[1, 2], a_1=[3, 4])
+    insertcols!(df, 1, :a => [11, 12], dupcol=:update)
+    @test propertynames(df) == [:a, :a_1]
+    @test df == DataFrame(a=[11, 12], a_1=[3, 4])
+
+    @test_throws ArgumentError insertcols!(df, 10, :a => [11, 12], dupcol=:makeunique)
     @test_throws ArgumentError insertcols!(df, 10, :a => [11, 12], makeunique=true)
 
     dfc = copy(df)
@@ -303,6 +318,11 @@ end
     @test df.a_1 === v2
     @test df.a_2 === v3
 
+    df = DataFrame()
+    @test insertcols!(df, 1, :a=>v1, :a=>v2, :a=>v3, dupcol=:update, copycols=false) ==
+          DataFrame(a=v3)
+    @test df.a isa Vector{Int}
+
     df = DataFrame(p='a':'b', q='r':'s')
     @test insertcols!(df, 2, :a=>v1, :b=>v2, :c=>v3) ==
           DataFrame(p='a':'b', a=v1, b=v2, c=v3, q='r':'s')
@@ -313,11 +333,20 @@ end
 
     df = DataFrame(p='a':'b', q='r':'s')
     @test_throws ArgumentError insertcols!(df, 2, :p=>v1, :q=>v2, :p=>v3)
-    @test insertcols!(df, 2, :p=>v1, :q=>v2, :p=>v3, makeunique=true, copycols=true) ==
+    @test insertcols!(df, 2, :p=>v1, :q=>v2, :p=>v3, dupcol=:makeunique, copycols=true) ==
           DataFrame(p='a':'b', p_1=v1, q_1=v2, p_2=v3, q='r':'s')
     @test df.p_1 isa Vector{Int}
     @test df.q_1 !== v2
     @test df.p_2 !== v3
+
+    df = DataFrame(p='a':'b', q='r':'s')
+    @test insertcols!(df, 2, :p=>v1, :q=>v2, :p=>v3, makeunique=true, copycols=true) ==
+          DataFrame(p='a':'b', p_1=v1, q_1=v2, p_2=v3, q='r':'s')
+
+    df = DataFrame(p='a':'b', q='r':'s')
+    @test_throws ArgumentError insertcols!(df, 2, :p=>v1, :q=>v2, :p=>v3)
+    @test insertcols!(df, 2, :p=>v1, :q=>v2, :p=>v3, dupcol=:update, copycols=true) ==
+          DataFrame(p=v3, q=v2)
 
     df = DataFrame(a=1:3, b=4:6)
     @test insertcols!(copy(df), :c=>7:9) == insertcols!(copy(df), 3, :c=>7:9)

--- a/test/join.jl
+++ b/test/join.jl
@@ -182,12 +182,12 @@ end
     @test typeof.(eachcol(crossjoin(df1, df2, makeunique=true))) ==
         [Vector{Int}, Vector{Float64}, Vector{Int}, Vector{Float64}]
 
-    i(on) = innerjoin(df1, df2, on=on, makeunique=true)
-    l(on) = leftjoin(df1, df2, on=on, makeunique=true)
-    r(on) = rightjoin(df1, df2, on=on, makeunique=true)
-    o(on) = outerjoin(df1, df2, on=on, makeunique=true)
-    s(on) = semijoin(df1, df2, on=on, makeunique=true)
-    a(on) = antijoin(df1, df2, on=on, makeunique=true)
+    i(on,makeunique=true) = innerjoin(df1, df2, on=on, makeunique=makeunique)
+    l(on,makeunique=true) = leftjoin(df1, df2, on=on, makeunique=makeunique)
+    r(on,makeunique=true) = rightjoin(df1, df2, on=on, makeunique=makeunique)
+    o(on,makeunique=true) = outerjoin(df1, df2, on=on, makeunique=makeunique)
+    s(on,makeunique=true) = semijoin(df1, df2, on=on, makeunique=makeunique)
+    a(on,makeunique=true) = antijoin(df1, df2, on=on, makeunique=makeunique)
 
     @test s(:id) ==
           s(:fid) ==
@@ -241,6 +241,71 @@ end
                                      Vector{Union{Int, Missing}}]
 
     on = [:id, :fid]
+    @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
+    @test typeof.(eachcol(i(on))) == [Vector{Int}, Vector{Float64}]
+    @test l(on) == DataFrame(id=[1, 3, 5], fid=[1, 3, 5])
+    @test typeof.(eachcol(l(on))) == [Vector{Int}, Vector{Float64}]
+    @test r(on) == DataFrame(id=[1, 3, 0, 2, 4], fid=[1, 3, 0, 2, 4])
+    @test typeof.(eachcol(r(on))) == [Vector{Int}, Vector{Float64}]
+    @test o(on) == DataFrame(id=[1, 3, 5, 0, 2, 4], fid=[1, 3, 5, 0, 2, 4])
+    @test typeof.(eachcol(o(on))) == [Vector{Int}, Vector{Float64}]
+end
+
+@testset "update joins" begin
+    df1 = DataFrame(Any[[1, 3, 5], [1.0, 3.0, 5.0]], [:id, :fid])
+    df2 = DataFrame(Any[[0, 1, 2, 3, 4], [0.0, 1.0, 2.0, 3.0, 4.0]], [:id, :fid])
+
+    @test crossjoin(df1, df2, dupcol=:update) ==
+        DataFrame(Any[repeat([0, 1, 2, 3, 4], outer=3),
+                      repeat([0.0, 1.0, 2.0, 3.0, 4.0], outer=3)],
+                  [:id, :fid])
+
+    i(on,dupcol=:update) = innerjoin(df1, df2, on=on, dupcol=dupcol)
+    l(on,dupcol=:update) = leftjoin(df1, df2, on=on, dupcol=dupcol)
+    r(on,dupcol=:update) = rightjoin(df1, df2, on=on, dupcol=dupcol)
+    o(on,dupcol=:update) = outerjoin(df1, df2, on=on, dupcol=dupcol)
+    s(on,dupcol=:update) = semijoin(df1, df2, on=on, dupcol=dupcol)
+    a(on,dupcol=:update) = antijoin(df1, df2, on=on, dupcol=dupcol)
+
+    @test s(:id) ==
+          s(:fid) ==
+          s([:id, :fid]) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
+    @test typeof.(eachcol(s(:id))) ==
+          typeof.(eachcol(s(:fid))) ==
+          typeof.(eachcol(s([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
+    @test a(:id) ==
+          a(:fid) ==
+          a([:id, :fid]) == DataFrame([[5], [5]], [:id, :fid])
+    @test typeof.(eachcol(a(:id))) ==
+          typeof.(eachcol(a(:fid))) ==
+          typeof.(eachcol(a([:id, :fid]))) == [Vector{Int}, Vector{Float64}]
+
+    on = :id
+    @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
+    @test typeof.(eachcol(i(on))) == [Vector{Int}, Vector{Float64}]
+    @test l(on) ≅ DataFrame(id=[1, 3, 5], fid=[1, 3, 5])
+    @test typeof.(eachcol(l(on))) == [Vector{Int}, Vector{Float64}]
+    @test r(on) ≅ DataFrame(id=[1, 3, 0, 2, 4], fid=[1, 3, 0, 2, 4])
+    @test typeof.(eachcol(r(on))) == [Vector{Int}, Vector{Float64}]
+    @test o(on) ≅ DataFrame(id=[1, 3, 5, 0, 2, 4],
+                            fid=[1, 3, 5, 0, 2, 4])
+    @test typeof.(eachcol(o(on))) == [Vector{Int}, Vector{Float64}]
+
+    on = :fid
+    df1.id = [1, missing, 5]
+    @test i(on) == DataFrame([[1, 3], [1.0, 3.0]], [:id, :fid])
+    @test typeof.(eachcol(i(on))) == [Vector{Int}, Vector{Float64}]
+    @test l(on) ≅ DataFrame(id=[1, 3, 5], fid=[1, 3, 5])
+    @test typeof.(eachcol(l(on))) == [Vector{Int}, Vector{Float64}]
+    @test r(on) ≅ DataFrame(id=[1, 3, 0, 2, 4],
+                            fid=[1, 3, 0, 2, 4])
+    @test typeof.(eachcol(r(on))) == [Vector{Int}, Vector{Float64}]
+    @test o(on) ≅ DataFrame(id=[1, 3, 5, 0, 2, 4],
+                            fid=[1, 3, 5, 0, 2, 4])
+    @test typeof.(eachcol(o(on))) == [Vector{Int}, Vector{Float64}]
+
+    on = [:id, :fid]
+    df1.id = [1, 3, 5]
     @test i(on) == DataFrame([[1, 3], [1, 3]], [:id, :fid])
     @test typeof.(eachcol(i(on))) == [Vector{Int}, Vector{Float64}]
     @test l(on) == DataFrame(id=[1, 3, 5], fid=[1, 3, 5])


### PR DESCRIPTION
Add the `dupcol` keyword In all constructors and joins that allow `makeunique=true` to generate new column names when there are duplicates among the constructed or joined columns. Allows for extensible actions to be taken when these duplicate columns are detected:

- `:error` throws an error when duplicate column names are given or created (equivalent to `makeunique=false`, the default),
- `:makeunique` creates new column names for the duplicate columns using the same approach as `makeunique=true`), and
- `:update` which coalesces values by updating the values from the first duplicate column with non-missing values from each subsequent duplicate column name.

N.B. This approach is extensible to other possible actions such as `:ignore` or `:overwrite` if so desired.

Also warns that `makeunique=true` as deprecated but maintains its functionality.