### PR TITLE
Fix `@spawn_or_run_task` with interactive threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          JULIA_NUM_THREADS: 4
+          JULIA_NUM_THREADS: 4,1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,13 @@
   keyword argument
   ([#3380](https://github.com/JuliaData/DataFrames.jl/pull/3380))
 
+## Bug fixes
+
+* Always use the default thread pool for multithreaded operations,
+  instead of using the interactive thread pool when Julia was started
+  with `-tM,N` with N > 0
+  ([#3385](https://github.com/JuliaData/DataFrames.jl/pull/3385))
+
 # DataFrames.jl v1.6.1 Release Notes
 
 ## Bug fixes

--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -7,7 +7,8 @@ CurrentModule = DataFrames
 ## Multithreading support
 
 By default, selected operations in DataFrames.jl automatically use multiple threads
-when available. It is task-based and implemented using the `@spawn` macro from Julia Base.
+when available. Multi-threading is task-based and implemented using the `@spawn`
+macro from Julia Base. Tasks are therefore scheduled on the `:default` threadpool.
 Functions that take user-defined functions and may run it in parallel
 accept a `threads` keyword argument which allows disabling multithreading
 when the provided function requires serial execution or is not thread-safe.

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -229,14 +229,15 @@ macro spawn_or_run_task(threads, ex)
         Base.replace_linenums!(thunk, __source__)
     end
     var = esc(Base.sync_varname)
+    spawn_set_thrpool = VERSION >= v"1.9.0" ?
+        :(Base.Threads._spawn_set_thrpool(task, :default)) :
+        :()
     quote
         let $(letargs...)
             if $(esc(threads))
                 local task = Task($thunk)
                 task.sticky = false
-                if VERSION >= v"1.9.0"
-                    Base.Threads._spawn_set_thrpool(task, :default)
-                end
+                $(spawn_set_thrpool)
             else
                 # Run expr immediately
                 res = $thunk()
@@ -259,16 +260,23 @@ end
 Equivalent to `Threads.@spawn` if `threads === true`,
 otherwise run `expr`.
 """
-macro spawn_or_run(threads, expr)
-    letargs = Base._lift_one_interp!(expr)
+macro spawn_or_run(threads, ex)
+    letargs = Base._lift_one_interp!(ex)
 
-    thunk = esc(:(()->($expr)))
+    thunk = :(()->($(esc(ex))))
+    if VERSION >= v"1.10.0-DEV"
+        Base.replace_linenums!(thunk, __source__)
+    end
     var = esc(Base.sync_varname)
+    spawn_set_thrpool = VERSION >= v"1.9.0" ?
+        :(Base.Threads._spawn_set_thrpool(task, :default)) :
+        :()
     quote
         let $(letargs...)
             if $(esc(threads))
                 local task = Task($thunk)
                 task.sticky = false
+                $(spawn_set_thrpool)
                 if $(Expr(:islocal, var))
                     put!($var, task)
                 end


### PR DESCRIPTION
When Julia ≥ 1.9 is started with `-tX,Y`, by default tasks use the pool of interactive threads instead of the default pool. Fix this by updating `spawn_or_run_task` to match the code used by `@spawn` in Julia master.

Fixes #3383.