### PR TITLE
add sortrows and sortcols to unstack

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
   columns only to a subset of the columns specified by the `cols`
   keyword argument
   ([#3386](https://github.com/JuliaData/DataFrames.jl/pull/3386))
+* Add `sortrows` and `sortcols` keyword arguments to `unstack`
+  ([#3395](https://github.com/JuliaData/DataFrames.jl/pull/3395))
 
 ## Bug fixes
 


### PR DESCRIPTION
Fixes https://github.com/JuliaData/DataFrames.jl/issues/3334

Tests are missing, but I would like to get feedback if we like the design before I move forward.

This is useful as the order of appearance is often not wanted. And it is impossible to ensure wanted sort order of rows and columns in the source. Finally, especially for columns - it is especially useful if you have ordered categorical values to present (so you can sort data e.g. by day of week, which is lost after you created the output since column names are `Symbol` then)