### PR TITLE
disambiguate allunique signature

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,12 @@
   release are now removed.
   ([#3422](https://github.com/JuliaData/DataFrames.jl/issues/3422))
 
+## Julia compatibility change
+
+* Ensure that `allunique(::AbstractDataFrame, ::Any)` always gets
+  interpreted as test for uniqueness of rows in the first positional argument
+  ([#3434](https://github.com/JuliaData/DataFrames.jl/issues/3434))
+
 # DataFrames.jl v1.6.1 Release Notes
 
 ## Bug fixes

--- a/src/abstractdataframe/unique.jl
+++ b/src/abstractdataframe/unique.jl
@@ -207,6 +207,11 @@ function Base.allunique(df::AbstractDataFrame, cols=:)
                             Val(false), nothing, false, nothing, true)[1] == nrow(df)
 end
 
+# avoid invoking Base.allunique(f, iterator) introduced in Julia 1.11
+
+Base.allunique(df::AbstractDataFrame, cols::Tuple) =
+    invoke(Base.allunique, Tuple{AbstractDataFrame, Any}, df, cols)
+
 """
     unique(df::AbstractDataFrame; view::Bool=false, keep::Symbol=:first)
     unique(df::AbstractDataFrame, cols; view::Bool=false, keep::Symbol=:first)

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -2331,6 +2331,7 @@ end
         @test allunique(df, [])
         @test allunique(df, x -> 1:4)
         @test allunique(df, [:a, :b] => ByRow(string))
+        @test_throws ArgumentError allunique(df, ())
     end
 end
 


### PR DESCRIPTION
This resolves dispatch ambiguity introduced in Julia 1.11.