### PR TITLE
do not pass empty vector to Tables.columntable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,9 @@
 * Ensure that `allunique(::AbstractDataFrame, ::Any)` always gets
   interpreted as test for uniqueness of rows in the first positional argument
   ([#3434](https://github.com/JuliaData/DataFrames.jl/issues/3434))
+* Make sure that an empty vector of `Any` or of `AbstractVector` is treated as having
+  no columns when a data frame is being processed with `combine`/`select`/`transform`.
+  ([#3435](https://github.com/JuliaData/DataFrames.jl/issues/3435))
 
 # DataFrames.jl v1.6.1 Release Notes
 

--- a/src/abstractdataframe/selection.jl
+++ b/src/abstractdataframe/selection.jl
@@ -805,21 +805,25 @@ function select_transform!((nc,)::Ref{Any}, df::AbstractDataFrame, newdf::DataFr
     res = _transformation_helper(df, col_idx, Ref{Any}(fun))
 
     if newname === AsTable || newname isa AbstractVector{Symbol}
-        if res isa AbstractVector && !isempty(res)
-            kp1 = keys(res[1])
-            prepend = all(x -> x isa Integer, kp1)
-            if !(prepend || all(x -> x isa Symbol, kp1) || all(x -> x isa AbstractString, kp1))
-                throw(ArgumentError("keys of the returned elements must be " *
-                                    "`Symbol`s, strings or integers"))
+        if res isa AbstractVector
+            if isempty(res)
+                res = NamedTuple()
+            else
+                kp1 = keys(res[1])
+                prepend = all(x -> x isa Integer, kp1)
+                if !(prepend || all(x -> x isa Symbol, kp1) || all(x -> x isa AbstractString, kp1))
+                    throw(ArgumentError("keys of the returned elements must be " *
+                                        "`Symbol`s, strings or integers"))
+                end
+                if any(x -> !isequal(keys(x), kp1), res)
+                    throw(ArgumentError("keys of the returned elements must be identical"))
+                end
+                newres = DataFrame()
+                for n in kp1
+                    newres[!, prepend ? Symbol("x", n) : Symbol(n)] = [x[n] for x in res]
+                end
+                res = newres
             end
-            if any(x -> !isequal(keys(x), kp1), res)
-                throw(ArgumentError("keys of the returned elements must be identical"))
-            end
-            newres = DataFrame()
-            for n in kp1
-                newres[!, prepend ? Symbol("x", n) : Symbol(n)] = [x[n] for x in res]
-            end
-            res = newres
         elseif !(res isa Union{AbstractDataFrame, NamedTuple, DataFrameRow, AbstractMatrix,
                                Tables.AbstractRow})
             res = Tables.columntable(res)

--- a/test/select.jl
+++ b/test/select.jl
@@ -3024,4 +3024,22 @@ end
     @test_throws ArgumentError combine(gdf, :x => (x -> x[1] == 2 ? "x" : cr) => AsTable)
 end
 
+@testset "empty vector" begin
+    df = DataFrame(a=1:3)
+
+    @test_throws ArgumentError select(df, :a => (x -> Vector{Any}[]))
+
+    for T in (Vector{Any}, Any, NamedTuple{(:x,),Tuple{Int64}})
+        v = combine(df, :a => (x -> T[])).a_function
+        @test isempty(v)
+        @test eltype(v) === T
+    end
+
+    @test size(combine(df, :a => (x -> Vector{Any}[]) => AsTable)) == (0, 0)
+    @test size(combine(df, :a => (x -> Any[]) => AsTable)) == (0, 0)
+    df2 = combine(df, :a => (x -> NamedTuple{(:x,),Tuple{Int64}}[]) => AsTable)
+    @test size(df2) == (0, 1)
+    @test eltype(df2.x) === Int
+end
+
 end # module


### PR DESCRIPTION
@nalimilan - following your comment on Slack this is a DataFrames.jl fix. In it I propose even more extreme approach - do not generate any columns if the returned vector is empty. This will make consistent behavior of `DataFrame`, and `GroupedDataFrame`, as it is now a corner case when they differ.

The behavior before this PR is:

```
julia> df = DataFrame(a=[1,2,3])
3×1 DataFrame
 Row │ a
     │ Int64
─────┼───────
   1 │     1
   2 │     2
   3 │     3

julia> gdf = groupby(df, :a)
GroupedDataFrame with 3 groups based on key: a
First Group (1 row): a = 1
 Row │ a
     │ Int64
─────┼───────
   1 │     1
⋮
Last Group (1 row): a = 3
 Row │ a
     │ Int64
─────┼───────
   1 │     3

julia> combine(df, :a => (a -> [(b=1,c=2)][1:0]) => AsTable) # we try to identify columns
0×2 DataFrame
 Row │ b      c
     │ Int64  Int64
─────┴──────────────

julia> combine(gdf, :a => (a -> [(b=1,c=2)][1:0]) => AsTable) # we just ignore empty groups
0×1 DataFrame
 Row │ a
     │ Int64
─────┴───────
```

TODO: tests/news - after we decide what we want