### PR TITLE
Typo fix

### DIFF
--- a/docs/src/man/querying_frameworks.md
+++ b/docs/src/man/querying_frameworks.md
@@ -30,7 +30,7 @@ pipe the output of one transformation as an input to another, as with
 Below we present several selected examples of usage of the package.
 
 First we subset rows of the source data frame using a logical condition
-and select its two columns, renaming one of them:
+and select two of its columns, renaming one of them:
 
 ```jldoctest dataframesmeta
 julia> using DataFramesMeta


### PR DESCRIPTION
"its two" implies that there are only two columns, but there are three. It is selecting two of the three.

This is a small thing, but it took me longer than I would like to admit to understand what was happening in the example.

```julia
julia> @chain df begin
           @rsubset :age > 40 
           @select(:number_of_children = :children, :name)
       end
2×2 DataFrame
 Row │ number_of_children  name
     │ Int64               String
─────┼────────────────────────────
   1 │                  0  John
   2 │                  4  Roger
```