### PR TITLE
Add TidierData to frameworks docs page

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -9,6 +9,7 @@ Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 Query = "1a8c2f83-1ff3-5112-b086-8aa67b057ba1"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+TidierData = "fe2206b3-d496-4ee9-a338-6a095c4ece80"
 
 [compat]
 Documenter = "1"

--- a/docs/src/man/querying_frameworks.md
+++ b/docs/src/man/querying_frameworks.md
@@ -11,7 +11,7 @@ and to allow advanced users to write more compact code.
 ## TidierData.jl
 [TidierData.jl](https://tidierorg.github.io/TidierData.jl/latest/), part of 
 the [Tidier](https://tidierorg.github.io/Tidier.jl/dev/) ecosystem, is a macro-based 
-data analysis interface that wraps `DataFrames`.  The instructions below are for version 
+data analysis interface that wraps DataFrames.jl.  The instructions below are for version 
 0.16.0 of TidierData.jl.
 
 First, install the TidierData.jl package:
@@ -27,7 +27,7 @@ functions including
 [pivoting](https://tidierorg.github.io/TidierData.jl/latest/examples/generated/UserGuide/pivots/), 
 [nesting](https://tidierorg.github.io/TidierData.jl/latest/examples/generated/UserGuide/nesting/), 
 and [joining](https://tidierorg.github.io/TidierData.jl/latest/examples/generated/UserGuide/joins/) 
-data frames. TidierData re-exports `DataFrame()` from DataFrames.jl, `@chain` from Chain.jl, and 
+data frames. TidierData re-exports `DataFrame` from DataFrames.jl, `@chain` from Chain.jl, and 
 Statistics.jl to streamline data operations. 
 
 TidierData.jl is heavily inspired by the `dplyr` and `tidyr` R packages (part of the R 

--- a/docs/src/man/querying_frameworks.md
+++ b/docs/src/man/querying_frameworks.md
@@ -50,7 +50,7 @@ julia> @chain df begin
    2 │ Roger              4
 ```
 
-Below are examples showcasing `@group_by` with `@summarize` or `@mutate` - analagous to the split, apply combine pattern.
+Below are examples showcasing `@group_by` with `@summarize` or `@mutate` - analagous to the split, apply, combine pattern.
 
 ```jldoctest tidierdata
 julia> df = DataFrame(groups = repeat('a':'e', inner = 2), b_col = 1:10, c_col = 11:20,  d_col = 111:120)
@@ -86,13 +86,12 @@ julia> @chain df begin
 julia> @chain df begin
          @filter(b_col > 4 && c_col <= 18)
          @group_by(groups)
-         @mutate begin
-            new_col = b_col + maximum(d_col)
-            new_col2 = c_col - maximum(d_col)
+         @mutate(
+            new_col = b_col + maximum(d_col),
+            new_col2 = c_col - maximum(d_col),
             new_col3 = case_when(c_col >= 18 => "high",
                                  c_col > 15 => "medium",
-                                 true => "low")
-         end
+                                 true => "low"))
          @select(starts_with("new"))
          @ungroup
       end


### PR DESCRIPTION
This PR adds TidierData to the frameworks manipulations docs page. 

I tried to keep it brief and similar to the other framework examples. 

I am happy to make any changes. 

@kdpsingh @bkamins 

Thank you