### PR TITLE
add `?` suffix to show on all return paths

### DIFF
--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -129,7 +129,7 @@ function compacttype(T::Type, maxwidth::Int)
 
     # handle the case when the type printed is not parametric but string(T)
     # prefixed it with the module name which caused it to be overlong
-    textwidth(sT) ≤ maxwidth + 1 && endswith(sTfull, sT) && return sT
+    textwidth(sT) ≤ maxwidth + 1 && endswith(sTfull, sT) && return sT * suffix
 
     cumwidth = 0
     stop = 0


### PR DESCRIPTION
noticed after https://github.com/apache/arrow-julia/pull/512 was displaying `Union{Missing, Base.CodeUnits}`  as just `CodeUnits` without the `?`