### PR TITLE
dcast instead of SDcols

### DIFF
--- a/docs/src/man/comparisons.md
+++ b/docs/src/man/comparisons.md
@@ -285,7 +285,7 @@ df2 <- data.table(grp=c(1,3), w = c(10,11))
 | Transform several columns         | `df[, .(max(x), min(y)) ]`                                                                 | `combine(df, :x => maximum, :y => minimum)`                                 |
 |                                   | `df[, lapply(.SD, mean), .SDcols = c("x", "y") ]`                                          | `combine(df, [:x, :y] .=> mean)`                                            |
 |                                   | `df[, lapply(.SD, mean), .SDcols = patterns("*x") ]`                                       | `combine(df, names(df, r"^x") .=> mean)`                                    |
-|                                   | `df[, unlist(lapply(.SD, function(x) c(max=max(x), min=min(x)))), .SDcols = c("x", "y") ]` | `combine(df, ([:x, :y] .=> [maximum minimum])...)`                          |
+|                                   | `dcast(df, . ~ ., list(max,min), value.var = c("x","y"))`                                  | `combine(df, ([:x, :y] .=> [maximum minimum])...)`                          |
 | Multivariate function             | `df[, .(cor(x,y)) ]`                                                                       | `transform(df, [:x, :y] => cor)`                                            |
 | Row-wise                          | `df[, min_xy := min(x, y), by = 1:nrow(df)]`                                               | `transform!(df, [:x, :y] => ByRow(min))`                                    |
 |                                   | `df[, argmax_xy := which.max(.SD) , .SDcols = patterns("*x"), by = 1:nrow(df) ]`           | `transform!(df, AsTable(r"^x") => ByRow(argmax))`                           |


### PR DESCRIPTION
using dcast is simpler so you may consider mentioning that, for example below
```r
> data.table(iris)[, unlist(lapply(.SD, function(x) c(max=max(x), min=min(x)))), .SDcols = c("Petal.Length", "Petal.Width") ]
Petal.Length.max Petal.Length.min  Petal.Width.max  Petal.Width.min 
             6.9              1.0              2.5              0.1 
> dcast(data.table(iris), . ~ ., list(max,min), value.var = c("Petal.Length", "Petal.Width"))
Key: <.>
        . Petal.Length_max Petal.Width_max Petal.Length_min Petal.Width_min
   <char>            <num>           <num>            <num>           <num>
1:      .              6.9             2.5                1             0.1
```