### PR TITLE
Adjust codebase to the fact that we require at least Julia 1.10

### DIFF
--- a/docs/src/lib/functions.md
+++ b/docs/src/lib/functions.md
@@ -29,9 +29,8 @@ This is a list of operations that currently make use of multi-threading:
 - `dropmissing` when the provided data frame has more than 1 column and `view=false` 
   (subsetting of individual columns is spawned in separate tasks).
 
-In general at least Julia 1.4 is required to ensure that multi-threading is used
-and the Julia process must be started with more than one thread. Some operations
-turn on multi-threading only if enough rows in the processed data frame are present
+In general to ensure that multi-threading is used Julia process must be started with more than one thread.
+Some operations turn on multi-threading only if enough rows in the processed data frame are present
 (the exact threshold when multi-threading is enabled is considered to be undefined
 and might change in the future).
 

--- a/docs/src/lib/indexing.md
+++ b/docs/src/lib/indexing.md
@@ -71,10 +71,7 @@ In the descriptions below `df` represents a `DataFrame`, `sdf` is a
 `:` always expands to `axes(df, 1)` or `axes(sdf, 1)`.
 
 `df.col` works like `df[!, col]` and `sdf.col` works like `sdf[!, col]` in all
-cases. An exception is that under Julia 1.6 or earlier
-`df.col .= v` and `sdf.col .= v` performs in-place broadcasting
-if `col` is present in `df`/`sdf` and is a valid identifier (this inconsistency
-is not present under Julia 1.7 and later).
+cases.
 
 ## `getindex` and `view`
 
@@ -288,7 +285,7 @@ Additional rules:
   `df` with freshly allocated vectors;
 * `df.col .= v` syntax currently performs in-place assignment to an existing
   vector `df.col`; this behavior is deprecated and a new column will be
-  allocated in the future. Starting from Julia 1.7 if `:col` is not present in
+  allocated in the future. If `:col` is not present in
   `df` then a new column will be created in `df`.
 * in the `sdf[CartesianIndex(row, col)] .= v`, `sdf[row, col] .= v` and
   `sdf[row, cols] .= v` syntaxes the assignment to `sdf` is performed in-place;
@@ -308,7 +305,7 @@ Additional rules:
   values already present in `cols`;
 * `sdf.col .= v` syntax currently performs in-place assignment to an existing
   vector `sdf.col`; this behavior is deprecated and a new column will be
-  allocated in the future. Starting from Julia 1.7 if `:col` is not present in
+  allocated in the future. If `:col` is not present in
   `sdf` then a new column will be created in `sdf` if `sdf` was created with `:`
   as a column selector.
 * `dfr.col .= v` syntax is allowed and performs in-place assignment to a value

--- a/docs/src/lib/metadata.md
+++ b/docs/src/lib/metadata.md
@@ -263,10 +263,8 @@ metadata is always dropped). These are:
   for row keys columns.
 * [`permutedims`](@ref): propagates table-level metadata and drops column-level
    metadata.
-* broadcasted assignment does not change target metadata;
-  under Julia earlier than 1.7 operation of kind `df.a .= s` does not drop non-`:note`-style
-  metadata; under Julia 1.7 or later this operation preserves only `:note`-style
-  metadata
+* broadcasted assignment does not change target metadata:
+  operation preserves only `:note`-style metadata
 * broadcasting propagates table-level metadata if some key is present
   in all passed data frames and value associated with it is identical in all
   passed data frames; column-level metadata is propagated for columns if some

--- a/docs/src/man/basics.md
+++ b/docs/src/man/basics.md
@@ -36,8 +36,8 @@ you have installed with the `status` command.
 julia> ]
 
 (@v1.9) pkg> status DataFrames
-      Status `~\v1.6\Project.toml`
-  [a93c6f00] DataFrames v1.5.0
+      Status `~\v1.13\Project.toml`
+  [a93c6f00] DataFrames v1.8.0
 ```
 
 Throughout the rest of the tutorial we will assume that you have installed the

--- a/src/DataFrames.jl
+++ b/src/DataFrames.jl
@@ -115,19 +115,8 @@ export AbstractDataFrame,
 using Base.Threads: @spawn
 using Base: ComposedFunction
 
-if isdefined(Base, :keepat!)  # Introduced in 1.7.0
-    import Base.keepat!
-else
-    import Compat.keepat!
-    export keepat!
-end
-
-if VERSION >= v"1.9.0-DEV.1163"
-    import Base: stack
-else
-    import Compat: stack
-    export stack
-end
+import Base.keepat!
+import Base: stack
 
 const METADATA_FIXED =
     """

--- a/src/dataframe/dataframe.jl
+++ b/src/dataframe/dataframe.jl
@@ -877,11 +877,6 @@ function Base.deleteat!(df::DataFrame, inds::AbstractVector)
         throw(ArgumentError("unsupported index $inds"))
     end
 
-    # workaround https://github.com/JuliaLang/julia/pull/41646
-    if VERSION <= v"1.6.2" && inds isa UnitRange{<:Integer}
-        inds = collect(inds)
-    end
-
     if !issorted(inds, lt=<=)
         throw(ArgumentError("Indices passed to deleteat! must be unique and sorted"))
     end
@@ -892,10 +887,6 @@ end
 function Base.deleteat!(df::DataFrame, inds::AbstractVector{Bool})
     if length(inds) != size(df, 1)
         throw(BoundsError(df, (inds, :)))
-    end
-    # workaround https://github.com/JuliaLang/julia/pull/41646
-    if VERSION <= v"1.6.2" && drop isa UnitRange{<:Integer}
-        inds = collect(inds)
     end
     return _deleteat!_helper(df, inds)
 end

--- a/src/other/broadcasting.jl
+++ b/src/other/broadcasting.jl
@@ -183,14 +183,12 @@ function Base.dotview(df::AbstractDataFrame, ::typeof(!), cols)
     return LazyNewColDataFrame(df, cols isa AbstractString ? Symbol(cols) : cols)
 end
 
-if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-    function Base.dotgetproperty(df::AbstractDataFrame, col::SymbolOrString)
-        if columnindex(df, col) == 0 && !is_column_insertion_allowed(df)
-            throw(ArgumentError("creating new columns in a SubDataFrame that subsets " *
-                                "columns of its parent data frame is disallowed"))
-        end
-        return LazyNewColDataFrame(df, Symbol(col))
+function Base.dotgetproperty(df::AbstractDataFrame, col::SymbolOrString)
+    if columnindex(df, col) == 0 && !is_column_insertion_allowed(df)
+        throw(ArgumentError("creating new columns in a SubDataFrame that subsets " *
+                            "columns of its parent data frame is disallowed"))
     end
+    return LazyNewColDataFrame(df, Symbol(col))
 end
 
 function Base.copyto!(lazydf::LazyNewColDataFrame, bc::Base.Broadcast.Broadcasted{T}) where T

--- a/src/other/utils.jl
+++ b/src/other/utils.jl
@@ -225,13 +225,9 @@ macro spawn_or_run_task(threads, ex)
     letargs = Base._lift_one_interp!(ex)
 
     thunk = :(()->($(esc(ex))))
-    @static if VERSION >= v"1.10.0-DEV"
-        Base.replace_linenums!(thunk, __source__)
-    end
+    Base.replace_linenums!(thunk, __source__)
     var = esc(Base.sync_varname)
-    spawn_set_thrpool = VERSION >= v"1.9.0" ?
-        :(Base.Threads._spawn_set_thrpool(task, :default)) :
-        :()
+    spawn_set_thrpool = :(Base.Threads._spawn_set_thrpool(task, :default))
     quote
         let $(letargs...)
             if $(esc(threads))
@@ -264,13 +260,9 @@ macro spawn_or_run(threads, ex)
     letargs = Base._lift_one_interp!(ex)
 
     thunk = :(()->($(esc(ex))))
-    if VERSION >= v"1.10.0-DEV"
-        Base.replace_linenums!(thunk, __source__)
-    end
+    Base.replace_linenums!(thunk, __source__)
     var = esc(Base.sync_varname)
-    spawn_set_thrpool = VERSION >= v"1.9.0" ?
-        :(Base.Threads._spawn_set_thrpool(task, :default)) :
-        :()
+    spawn_set_thrpool = :(Base.Threads._spawn_set_thrpool(task, :default))
     quote
         let $(letargs...)
             if $(esc(threads))

--- a/test/broadcasting.jl
+++ b/test/broadcasting.jl
@@ -1463,50 +1463,25 @@ end
 
     df = copy(refdf)
     v1 = df[!, 1]
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        df.x1 .= 'd'
-        @test df.x1 == ['d', 'd', 'd']
-        @test eltype(df.x1) === Char
-        @test_throws MethodError df[:, 1] .= "d"
-        @test_throws DimensionMismatch df[:, 1] .= [1 2 3]
-        @test v1 == [1.5, 2.5, 3.5]
-    else
-        df.x1 .= 'd'
-        @test v1 == [100.0, 100.0, 100.0]
-        @test_throws MethodError df[:, 1] .= "d"
-        @test v1 == [100.0, 100.0, 100.0]
-        @test_throws DimensionMismatch df[:, 1] .= [1 2 3]
-        @test v1 == [100.0, 100.0, 100.0]
-    end
+    df.x1 .= 'd'
+    @test df.x1 == ['d', 'd', 'd']
+    @test eltype(df.x1) === Char
+    @test_throws MethodError df[:, 1] .= "d"
+    @test_throws DimensionMismatch df[:, 1] .= [1 2 3]
+    @test v1 == [1.5, 2.5, 3.5]
 
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        df = DataFrame(a=1:4, b=1, c=2)
-        df.a .= 'a':'d'
-        @test df == DataFrame(a='a':'d', b=1, c=2)
-        dfv = view(df, 2:3, 2:3)
-        x = df.b
-        dfv.b .= 0
-        @test df.b == [1, 0, 0, 1]
-        @test x == [1, 1, 1, 1]
-    else
-        df = DataFrame(a=1:4, b=1, c=2)
-        df.a .= 'a':'d'
-        @test df == DataFrame(a=97:100, b=1, c=2)
-        dfv = view(df, 2:3, 2:3)
-        x = df.b
-        dfv.b .= 0
-        @test df.b == [1, 0, 0, 1]
-        @test x === df.b
-    end
+    df = DataFrame(a=1:4, b=1, c=2)
+    df.a .= 'a':'d'
+    @test df == DataFrame(a='a':'d', b=1, c=2)
+    dfv = view(df, 2:3, 2:3)
+    x = df.b
+    dfv.b .= 0
+    @test df.b == [1, 0, 0, 1]
+    @test x == [1, 1, 1, 1]
 
     df = copy(refdf)
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        df.newcol .= 'd'
-        @test df == [refdf DataFrame(newcol=fill('d', 3))]
-    else
-        @test_throws ArgumentError df.newcol .= 'd'
-        @test df == refdf
-    end
+    df.newcol .= 'd'
+    @test df == [refdf DataFrame(newcol=fill('d', 3))]
 
     df = view(copy(refdf), :, :)
     v1 = df[!, 1]
@@ -1637,31 +1612,17 @@ end
 
     df = view(copy(refdf), :, :)
     v1 = df[!, 1]
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        df.x1 .= 'd'
-        @test df.x1 == ['d', 'd', 'd']
-        @test eltype(df.x1) === Any
-        df[:, 1] .= "d"
-        @test df.x1 == ["d", "d", "d"]
-        @test_throws DimensionMismatch df[:, 1] .= [1 2 3]
-        @test v1 == [1.5, 2.5, 3.5]
-    else
-        df.x1 .= 'd'
-        @test v1 == [100.0, 100.0, 100.0]
-        @test_throws MethodError df[:, 1] .= "d"
-        @test v1 == [100.0, 100.0, 100.0]
-        @test_throws DimensionMismatch df[:, 1] .= [1 2 3]
-        @test v1 == [100.0, 100.0, 100.0]
-    end
+    df.x1 .= 'd'
+    @test df.x1 == ['d', 'd', 'd']
+    @test eltype(df.x1) === Any
+    df[:, 1] .= "d"
+    @test df.x1 == ["d", "d", "d"]
+    @test_throws DimensionMismatch df[:, 1] .= [1 2 3]
+    @test v1 == [1.5, 2.5, 3.5]
 
     df = view(copy(refdf), :, :)
-    if VERSION >= v"1.7"
-        df.newcol .= 'd'
-        @test df.newcol == fill('d', 3)
-    else
-        @test_throws ArgumentError df.newcol .= 'd'
-        @test df == refdf
-    end
+    df.newcol .= 'd'
+    @test df.newcol == fill('d', 3)
 end
 
 @testset "DataFrameRow getproperty broadcasted assignment" begin
@@ -1910,47 +1871,28 @@ end
 
 @testset "broadcasting of getproperty" begin
     df = DataFrame(a=1:4)
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        df.b .= 1
-        x = df.b
-        df.c .= 4:-1:1
-        df.a .= 'a':'d'
-        @test df.a isa Vector{Char}
-        @test df == DataFrame(a='a':'d', b=1, c=4:-1:1)
+    df.b .= 1
+    x = df.b
+    df.c .= 4:-1:1
+    df.a .= 'a':'d'
+    @test df.a isa Vector{Char}
+    @test df == DataFrame(a='a':'d', b=1, c=4:-1:1)
 
-        # in views also column replacement is performed
-        dfv = view(df, 2:3, 2:3)
-        dfv.b .= 0
-        @test x == [1, 1, 1, 1]
-        @test df.b !== x
-        @test df == DataFrame(a='a':'d', b=[1, 0, 0, 1], c=4:-1:1)
-        dfv.c .= ["p", "q"]
-        @test df == DataFrame(a='a':'d', b=[1, 0, 0, 1], c=[4, "p", "q", 1])
-    else
-        # Julia older than 1.7
-        df[!, :b] .= 1
-        x = df.b
-        df[!, :c] .= 4:-1:1
-        df.a .= 'a':'d'
-        dfv = view(df, 2:3, 2:3)
-        dfv.b .= 0
-        @test x == [1, 0, 0, 1]
-        @test df.b === x
-        @test df == DataFrame(a=97:100, b=[1, 0, 0, 1], c=4:-1:1)
-        @test_throws MethodError dfv.c .= ["p", "q"]
-        @test df == DataFrame(a=97:100, b=[1, 0, 0, 1], c=[4, 3, 2, 1])
-    end
+    # in views also column replacement is performed
+    dfv = view(df, 2:3, 2:3)
+    dfv.b .= 0
+    @test x == [1, 1, 1, 1]
+    @test df.b !== x
+    @test df == DataFrame(a='a':'d', b=[1, 0, 0, 1], c=4:-1:1)
+    dfv.c .= ["p", "q"]
+    @test df == DataFrame(a='a':'d', b=[1, 0, 0, 1], c=[4, "p", "q", 1])
 end
 
 @testset "dotgetproperty on SubDataFrame" begin
     df = DataFrame(a=1:3, b=4:6)
     dfv = @view df[[3, 1], :]
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        dfv.c .= [1, 2]
-        @test df ≅ DataFrame(a=1:3, b=4:6, c=[2, missing, 1])
-    else
-        @test_throws ArgumentError dfv.c .= [1, 2]
-    end
+    dfv.c .= [1, 2]
+    @test df ≅ DataFrame(a=1:3, b=4:6, c=[2, missing, 1])
 
     df = DataFrame(a=1:3, b=4:6)
     dfv = @view df[[3, 1], 1:2]

--- a/test/dataframe.jl
+++ b/test/dataframe.jl
@@ -557,7 +557,7 @@ end
                                        nothing, nothing, nothing],
                                 min=[1.0, 1.0, "a", "a", Date(2000), 1],
                                 q25=[1.75, 1.5, nothing, nothing, nothing, nothing],
-                                median=[2.5, 2.0, nothing, nothing, VERSION >= v"1.7.0-beta1.2" ? Date(2002) : nothing, nothing],
+                                median=[2.5, 2.0, nothing, nothing, Date(2002), nothing],
                                 q75=[3.25, 2.5, nothing, nothing, nothing, nothing],
                                 max=[4.0, 3.0, "d", "c", Date(2004), 2],
                                 sum=[10, 6, nothing, nothing, nothing, nothing],
@@ -1652,11 +1652,7 @@ end
     @test x == 1:10
     df.y .= 1
     @test df.y == [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        @test y == 1.0:10.0
-    else
-        @test df.y === y
-    end
+    @test y == 1.0:10.0
     df.z = z
     @test df.z === z
     df[!, :zz] .= 1
@@ -1980,8 +1976,7 @@ end
         @test names(x, :) == names(x)
         @test names(x, <("a2")) == ["a1"]
 
-        # before Julia 1.8 it is TypeError; the change is caused by the redesign of ifelse
-        @test_throws Union{MethodError, TypeError} names(x, x -> 1)
+        @test_throws MethodError names(x, x -> 1)
     end
 end
 

--- a/test/indexing_offset.jl
+++ b/test/indexing_offset.jl
@@ -22,13 +22,7 @@ using Test, DataFrames, OffsetArrays
     @test_throws ArgumentError insertcols!(df, :b => ov1)
     @test_throws DimensionMismatch df[!, :b] .= ov1
 
-    # this is consequence of the fact that OffsetArrays wrap AbstractRange in this case
-    # Base.CanonicalIndexError is not available in Julia 1.7 or earlier
-    if VERSION >= v"1.8-DEV"
-        @test_throws Base.CanonicalIndexError df[:, :a] = ov1
-    else
-        @test_throws ErrorException df[:, :a] = ov1
-    end
+    @test_throws Base.CanonicalIndexError df[:, :a] = ov1
 
     # this inconsistency is the consequence how setindex! for vector is defined in Base
     df = DataFrame(a=5:-1:1)

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -1071,37 +1071,34 @@ end
         @test isempty(collect(colmetadatakeys(df, :b)))
     end
 
-    # special case due to changes in handling of broadcasting in Julia 1.7
-    if VERSION >= v"1.7.0"
-        for fun in (x -> (x.a .= 11:13), x -> (x.a .= 1))
-            df = DataFrame(a=1:3, b=["x", "y", "z"])
-            metadata!(df, "name", "empty", style=:note)
-            metadata!(df, "name2", "empty2", style=:default)
-            colmetadata!(df, :a, "name", "a", style=:note)
-            colmetadata!(df, :a, "name2", "a2", style=:default)
-            @test check_allnotemetadata(df)
-            fun(df)
-            @test check_allnotemetadata(df)
-            @test collect(metadatakeys(df)) == ["name"]
-            @test metadata(df, "name") == "empty"
-            @test collect(colmetadatakeys(df, :a)) == ["name"]
-            @test colmetadata(df, :a, "name") == "a"
-            @test isempty(collect(colmetadatakeys(df, :b)))
+    for fun in (x -> (x.a .= 11:13), x -> (x.a .= 1))
+        df = DataFrame(a=1:3, b=["x", "y", "z"])
+        metadata!(df, "name", "empty", style=:note)
+        metadata!(df, "name2", "empty2", style=:default)
+        colmetadata!(df, :a, "name", "a", style=:note)
+        colmetadata!(df, :a, "name2", "a2", style=:default)
+        @test check_allnotemetadata(df)
+        fun(df)
+        @test check_allnotemetadata(df)
+        @test collect(metadatakeys(df)) == ["name"]
+        @test metadata(df, "name") == "empty"
+        @test collect(colmetadatakeys(df, :a)) == ["name"]
+        @test colmetadata(df, :a, "name") == "a"
+        @test isempty(collect(colmetadatakeys(df, :b)))
 
-            df = view(DataFrame(a=1:3, b=["x", "y", "z"]), :, :)
-            metadata!(df, "name", "empty", style=:note)
-            metadata!(parent(df), "name2", "empty2", style=:default)
-            colmetadata!(df, :a, "name", "a", style=:note)
-            colmetadata!(parent(df), :a, "name2", "a2", style=:default)
-            @test check_allnotemetadata(df)
-            fun(df)
-            @test check_allnotemetadata(df)
-            @test collect(metadatakeys(df)) == ["name"]
-            @test metadata(df, "name") == "empty"
-            @test collect(colmetadatakeys(df, :a)) == ["name"]
-            @test colmetadata(df, :a, "name") == "a"
-            @test isempty(collect(colmetadatakeys(df, :b)))
-        end
+        df = view(DataFrame(a=1:3, b=["x", "y", "z"]), :, :)
+        metadata!(df, "name", "empty", style=:note)
+        metadata!(parent(df), "name2", "empty2", style=:default)
+        colmetadata!(df, :a, "name", "a", style=:note)
+        colmetadata!(parent(df), :a, "name2", "a2", style=:default)
+        @test check_allnotemetadata(df)
+        fun(df)
+        @test check_allnotemetadata(df)
+        @test collect(metadatakeys(df)) == ["name"]
+        @test metadata(df, "name") == "empty"
+        @test collect(colmetadatakeys(df, :a)) == ["name"]
+        @test colmetadata(df, :a, "name") == "a"
+        @test isempty(collect(colmetadatakeys(df, :b)))
     end
 end
 

--- a/test/subdataframe.jl
+++ b/test/subdataframe.jl
@@ -292,13 +292,7 @@ end
     @test_throws ArgumentError SubDataFrame(sdf, true, 1)
     @test_throws ArgumentError SubDataFrame(sdf, true, :)
     @test_throws ArgumentError SubDataFrame(sdf, Integer[true], 1)
-
-    if VERSION >= v"1.7.0-DEV"
-        @test_throws ArgumentError SubDataFrame(sdf, Integer[true, true, true], :)
-    else
-        @test SubDataFrame(sdf, Integer[true, true, true], :) ==
-              SubDataFrame(sdf, [1, 1, 1], :)
-    end
+    @test_throws ArgumentError SubDataFrame(sdf, Integer[true, true, true], :)
 end
 
 @testset "disallowed use of SubDataFrame constructor" begin

--- a/test/subdataframe_mutation.jl
+++ b/test/subdataframe_mutation.jl
@@ -1365,29 +1365,17 @@ end
     df = DataFrame(a=1:3)
     sdf = @view df[[3, 2], :]
     sdf.a .= 12.0
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        @test eltype(sdf.a) === Float64
-    else
-        @test eltype(sdf.a) === Int
-    end
+    @test eltype(sdf.a) === Float64
     @test df ≅ DataFrame(a=[1, 12, 12])
 
-    if VERSION >= v"1.7"
-        sdf.c .= 100
-        @test df ≅ DataFrame(a=[1, 12, 12], c=[missing, 100, 100])
-    else
-        @test_throws ArgumentError sdf.c .= 100
-    end
+    sdf.c .= 100
+    @test df ≅ DataFrame(a=[1, 12, 12], c=[missing, 100, 100])
 
     df = DataFrame(a=1:3)
     sdf = @view df[[3, 2], 1:1]
     @test_throws ArgumentError sdf.c = [5, 6]
     sdf.a .= 12.0
-    if isdefined(Base, :dotgetproperty) # Introduced in Julia 1.7
-        @test eltype(sdf.a) === Float64
-    else
-        @test eltype(sdf.a) === Int
-    end
+    @test eltype(sdf.a) === Float64
     @test df ≅ DataFrame(a=[1, 12, 12])
 end
 


### PR DESCRIPTION
In this PR I clean-up all things that when we require Julia 1.10 or newer are consistent. No functionality change is expected