### PR TITLE
Convert the one and two argument show methods to MIME"text/plain" methods

### DIFF
--- a/docs/src/man/basics.md
+++ b/docs/src/man/basics.md
@@ -647,7 +647,7 @@ You can adjust how data frame is displayed by calling the `show` function manual
 `show(german, allcols=true)` does the same for columns, e.g.:
 
 ```jldoctest dataframe
-julia> show(german, allcols=true)
+julia> show(MIME("text/plain"), german, allcols=true)
 1000×10 DataFrame
   Row │ id     Age    Sex      Job    Housing  Saving accounts  Checking account  Credit amount  Duration  Purpose
       │ Int64  Int64  String7  Int64  String7  String15         String15          Int64          Int64     String31

--- a/docs/src/man/customizing_output.md
+++ b/docs/src/man/customizing_output.md
@@ -53,7 +53,7 @@ julia> df
 
 julia> # Using this option, no cell will be truncated if there is room to display it.
 
-julia> show(df; truncate = 0)
+julia> show(MIME("text/plain"), df; truncate = 0)
 3×3 DataFrame
  Row │ a      b        c
      │ Int64  Float64  String
@@ -64,7 +64,7 @@ julia> show(df; truncate = 0)
 
 julia> # Hide row numbers.
 
-julia> show(df; show_row_number = false)
+julia> show(MIME("text/plain"), df; show_row_number = false)
 3×3 DataFrame
  a      b        c
  Int64  Float64  String
@@ -75,7 +75,7 @@ julia> show(df; show_row_number = false)
 
 julia> # Hide the column element types in text output.
 
-julia> show(df; eltypes = false)
+julia> show(MIME("text/plain"), df; eltypes = false)
 3×3 DataFrame
  Row │ a  b      c
 ─────┼─────────────────────────────────────────────
@@ -140,7 +140,7 @@ julia> function parentheses_fmt(v, i, j)
            return v
        end;
 
-julia> show(df; formatters = [parentheses_fmt])
+julia> show(MIME("text/plain"), df; formatters = [parentheses_fmt])
 7×5 DataFrame
  Row │ A        B        C        D        E
      │ Float64  Float64  Float64  Float64  Float64
@@ -190,6 +190,7 @@ julia> profit = DataFrame(
        );
 
 julia> show(
+           MIME("text/plain"),
            profit;
            # We use this option to align the summary rows with the data rows at the decimal
            # point.

--- a/docs/src/man/split_apply_combine.md
+++ b/docs/src/man/split_apply_combine.md
@@ -635,71 +635,7 @@ data frame and get a vector of results either use a comprehension or `collect`
 `GroupedDataFrame` into a vector first. Here are examples of both approaches:
 
 ```jldoctest sac
-julia> sdf_vec = collect(iris_gdf)
-3-element Vector{Any}:
- 50×5 SubDataFrame
- Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
-     │ Float64      Float64     Float64      Float64     String15
-─────┼───────────────────────────────────────────────────────────────
-   1 │         5.1         3.5          1.4         0.2  Iris-setosa
-   2 │         4.9         3.0          1.4         0.2  Iris-setosa
-   3 │         4.7         3.2          1.3         0.2  Iris-setosa
-   4 │         4.6         3.1          1.5         0.2  Iris-setosa
-   5 │         5.0         3.6          1.4         0.2  Iris-setosa
-   6 │         5.4         3.9          1.7         0.4  Iris-setosa
-   7 │         4.6         3.4          1.4         0.3  Iris-setosa
-   8 │         5.0         3.4          1.5         0.2  Iris-setosa
-  ⋮  │      ⋮           ⋮            ⋮           ⋮            ⋮
-  44 │         5.0         3.5          1.6         0.6  Iris-setosa
-  45 │         5.1         3.8          1.9         0.4  Iris-setosa
-  46 │         4.8         3.0          1.4         0.3  Iris-setosa
-  47 │         5.1         3.8          1.6         0.2  Iris-setosa
-  48 │         4.6         3.2          1.4         0.2  Iris-setosa
-  49 │         5.3         3.7          1.5         0.2  Iris-setosa
-  50 │         5.0         3.3          1.4         0.2  Iris-setosa
-                                                      35 rows omitted
- 50×5 SubDataFrame
- Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
-     │ Float64      Float64     Float64      Float64     String15
-─────┼───────────────────────────────────────────────────────────────────
-   1 │         7.0         3.2          4.7         1.4  Iris-versicolor
-   2 │         6.4         3.2          4.5         1.5  Iris-versicolor
-   3 │         6.9         3.1          4.9         1.5  Iris-versicolor
-   4 │         5.5         2.3          4.0         1.3  Iris-versicolor
-   5 │         6.5         2.8          4.6         1.5  Iris-versicolor
-   6 │         5.7         2.8          4.5         1.3  Iris-versicolor
-   7 │         6.3         3.3          4.7         1.6  Iris-versicolor
-   8 │         4.9         2.4          3.3         1.0  Iris-versicolor
-  ⋮  │      ⋮           ⋮            ⋮           ⋮              ⋮
-  44 │         5.0         2.3          3.3         1.0  Iris-versicolor
-  45 │         5.6         2.7          4.2         1.3  Iris-versicolor
-  46 │         5.7         3.0          4.2         1.2  Iris-versicolor
-  47 │         5.7         2.9          4.2         1.3  Iris-versicolor
-  48 │         6.2         2.9          4.3         1.3  Iris-versicolor
-  49 │         5.1         2.5          3.0         1.1  Iris-versicolor
-  50 │         5.7         2.8          4.1         1.3  Iris-versicolor
-                                                          35 rows omitted
- 50×5 SubDataFrame
- Row │ SepalLength  SepalWidth  PetalLength  PetalWidth  Species
-     │ Float64      Float64     Float64      Float64     String15
-─────┼──────────────────────────────────────────────────────────────────
-   1 │         6.3         3.3          6.0         2.5  Iris-virginica
-   2 │         5.8         2.7          5.1         1.9  Iris-virginica
-   3 │         7.1         3.0          5.9         2.1  Iris-virginica
-   4 │         6.3         2.9          5.6         1.8  Iris-virginica
-   5 │         6.5         3.0          5.8         2.2  Iris-virginica
-   6 │         7.6         3.0          6.6         2.1  Iris-virginica
-   7 │         4.9         2.5          4.5         1.7  Iris-virginica
-   8 │         7.3         2.9          6.3         1.8  Iris-virginica
-  ⋮  │      ⋮           ⋮            ⋮           ⋮             ⋮
-  44 │         6.8         3.2          5.9         2.3  Iris-virginica
-  45 │         6.7         3.3          5.7         2.5  Iris-virginica
-  46 │         6.7         3.0          5.2         2.3  Iris-virginica
-  47 │         6.3         2.5          5.0         1.9  Iris-virginica
-  48 │         6.5         3.0          5.2         2.0  Iris-virginica
-  49 │         6.2         3.4          5.4         2.3  Iris-virginica
-  50 │         5.9         3.0          5.1         1.8  Iris-virginica
-                                                         35 rows omitted
+julia> sdf_vec = collect(iris_gdf);
 
 julia> map(nrow, sdf_vec)
 3-element Vector{Int64}:
@@ -942,7 +878,7 @@ julia> df = DataFrame(customer_id=["a", "b", "b", "b", "c", "c"],
 
 julia> gdf = groupby(df, :customer_id, sort=true);
 
-julia> show(gdf, allgroups=true)
+julia> show(MIME("text/plain"), gdf, allgroups=true)
 GroupedDataFrame with 3 groups based on key: customer_id
 Group 1 (1 row): customer_id = "a"
  Row │ customer_id  transaction_id  volume

--- a/src/abstractdataframe/abstractdataframe.jl
+++ b/src/abstractdataframe/abstractdataframe.jl
@@ -2947,23 +2947,9 @@ as a `SubDataFrame`.
 ```jldoctest
 julia> collect(Iterators.partition(DataFrame(x=1:5), 2))
 3-element Vector{SubDataFrame{DataFrame, DataFrames.Index, UnitRange{Int64}}}:
- 2×1 SubDataFrame
- Row │ x
-     │ Int64
-─────┼───────
-   1 │     1
-   2 │     2
- 2×1 SubDataFrame
- Row │ x
-     │ Int64
-─────┼───────
-   1 │     3
-   2 │     4
- 1×1 SubDataFrame
- Row │ x
-     │ Int64
-─────┼───────
-   1 │     5
+ SubDataFrame{DataFrame, DataFrames.Index, UnitRange{Int64}}(DataFrame(AbstractVector[[1, 2, 3, 4, 5]], DataFrames.Index(Dict(:x => 1), [:x]), nothing, nothing, true), DataFrames.Index(Dict(:x => 1), [:x]), 1:2)
+ SubDataFrame{DataFrame, DataFrames.Index, UnitRange{Int64}}(DataFrame(AbstractVector[[1, 2, 3, 4, 5]], DataFrames.Index(Dict(:x => 1), [:x]), nothing, nothing, true), DataFrames.Index(Dict(:x => 1), [:x]), 3:4)
+ SubDataFrame{DataFrame, DataFrames.Index, UnitRange{Int64}}(DataFrame(AbstractVector[[1, 2, 3, 4, 5]], DataFrames.Index(Dict(:x => 1), [:x]), nothing, nothing, true), DataFrames.Index(Dict(:x => 1), [:x]), 5:5)
 ```
 """
 function Iterators.partition(df::AbstractDataFrame, n::Integer)

--- a/src/abstractdataframe/io.jl
+++ b/src/abstractdataframe/io.jl
@@ -147,8 +147,6 @@ Base.show(io::IO, mime::MIME"text/csv", df::AbstractDataFrame) =
     printtable(io, df, header = true, separator = ',')
 Base.show(io::IO, mime::MIME"text/tab-separated-values", df::AbstractDataFrame) =
     printtable(io, df, header = true, separator = '\t')
-Base.show(io::IO, mime::MIME"text/plain", df::AbstractDataFrame; kwargs...) =
-    show(io, df; kwargs...)
 
 ##############################################################################
 #

--- a/src/abstractdataframe/show.jl
+++ b/src/abstractdataframe/show.jl
@@ -409,7 +409,9 @@ else
 end
 
 """
-    show([io::IO, ]df::AbstractDataFrame;
+    show([io::IO, ],
+         ::MIME"text/plain",
+         df::AbstractDataFrame;
          allrows::Bool = !get(io, :limit, false),
          allcols::Bool = !get(io, :limit, false),
          allgroups::Bool = !get(io, :limit, false),
@@ -453,7 +455,7 @@ julia> using DataFrames
 
 julia> df = DataFrame(A=1:3, B=["x", "y", "z"]);
 
-julia> show(df, row_labels=nothing)
+julia> show(MIME("text/plain"), df, row_labels=nothing)
 3×2 DataFrame
  A      B
  Int64  String
@@ -464,6 +466,7 @@ julia> show(df, row_labels=nothing)
 ```
 """
 function Base.show(io::IO,
+                   ::MIME"text/plain",
                    df::AbstractDataFrame;
                    allrows::Bool = !get(io, :limit, false),
                    allcols::Bool = !get(io, :limit, false),
@@ -480,7 +483,8 @@ function Base.show(io::IO,
           summary=summary, eltypes=eltypes, truncate=truncate, kwargs...)
 end
 
-Base.show(df::AbstractDataFrame;
+Base.show(::MIME"text/plain",
+          df::AbstractDataFrame;
           allrows::Bool = !get(stdout, :limit, true),
           allcols::Bool = !get(stdout, :limit, true),
           rowlabel::Symbol = :Row,
@@ -488,7 +492,7 @@ Base.show(df::AbstractDataFrame;
           eltypes::Bool = true,
           truncate::Int = 32,
           kwargs...) =
-    show(stdout, df;
+    show(stdout, MIME("text/plain"), df;
          allrows=allrows, allcols=allcols, rowlabel=rowlabel, summary=summary,
          eltypes=eltypes, truncate=truncate, kwargs...)
 

--- a/src/groupeddataframe/groupeddataframe.jl
+++ b/src/groupeddataframe/groupeddataframe.jl
@@ -187,7 +187,8 @@ julia> gd[k]
    2 │     1      2      5
 
 julia> for g in gd
-           println(g)
+           show(MIME("text/plain"), g)
+           println()
        end
 2×3 SubDataFrame
  Row │ a      b      c

--- a/src/groupeddataframe/show.jl
+++ b/src/groupeddataframe/show.jl
@@ -6,7 +6,7 @@ function Base.summary(io::IO, gd::GroupedDataFrame)
     join(io, groupcols(gd), ", ")
 end
 
-function Base.show(io::IO, gd::GroupedDataFrame;
+function Base.show(io::IO, ::MIME"text/plain", gd::GroupedDataFrame;
                    allgroups::Bool = !get(io, :limit, false),
                    allrows::Bool = !get(io, :limit, false),
                    allcols::Bool = !get(io, :limit, false),
@@ -33,7 +33,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
             join(io, identified_groups, ", ")
             println(io)
 
-            show(io, gd[i]; summary=false,
+            show(io, MIME("text/plain"), gd[i]; summary=false,
                  allrows=allrows, allcols=allcols, rowlabel=rowlabel,
                  truncate=truncate, kwargs...)
         end
@@ -90,7 +90,7 @@ function Base.show(io::IO, gd::GroupedDataFrame;
         join(io, identified_groups, ", ")
         println(io)
 
-        show(io, gd[1]; summary=false,
+        show(io, MIME("text/plain"), gd[1]; summary=false,
              allrows=allrows, allcols=allcols, rowlabel=rowlabel,
              truncate=truncate, display_size=(h1, w), kwargs...)
 
@@ -106,13 +106,14 @@ function Base.show(io::IO, gd::GroupedDataFrame;
         join(io, identified_groups, ", ")
         println(io)
 
-        show(io, gd[N]; summary=false,
+        show(io, MIME("text/plain"), gd[N]; summary=false,
              allrows=allrows, allcols=allcols, rowlabel=rowlabel,
              truncate=truncate, display_size=(h2, w), kwargs...)
     end
 end
 
-function Base.show(df::GroupedDataFrame;
+function Base.show(::MIME"text/plain",
+                   df::GroupedDataFrame;
                    allrows::Bool = !get(stdout, :limit, true),
                    allcols::Bool = !get(stdout, :limit, true),
                    allgroups::Bool = !get(stdout, :limit, true),
@@ -120,7 +121,7 @@ function Base.show(df::GroupedDataFrame;
                    summary::Bool = true,
                    truncate::Int = 32,
                    kwargs...) # -> Nothing
-    return show(stdout, df;
+    return show(stdout, MIME("text/plain"), df;
                 allrows=allrows, allcols=allcols, allgroups=allgroups,
                 rowlabel=rowlabel, summary=summary, truncate=truncate,
                 kwargs...)

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -1434,7 +1434,7 @@ end
                    C=Float32[1.0, 2.0, 3.0, 4.0])
     gd = groupby_checked(df, :A)
     io = IOContext(IOBuffer(), :limit=>true)
-    show(io, gd)
+    show(io, MIME("text/plain"), gd)
     str = String(take!(io.io))
     summary_str = summary(gd)
     @test summary_str == "GroupedDataFrame with 4 groups based on key: A"
@@ -1451,7 +1451,7 @@ end
              │ Int64  String  Float32
         ─────┼────────────────────────
            1 │     4  A\\nC        4.0"""
-    show(io, gd, allgroups=true)
+    show(io, MIME("text/plain"), gd, allgroups=true)
     str = String(take!(io.io))
     @test str == """
         $summary_str
@@ -1476,17 +1476,17 @@ end
         ─────┼────────────────────────
            1 │     4  A\\nC        4.0"""
 
-    # Test two-argument show
+    # Test three-argument show
     str1, dsize = capture_stdout() do
-        show(gd)
+        show(MIME("text/plain"), gd)
     end
     io = IOContext(IOBuffer(), :limit=>true, :displaysize=>dsize)
-    show(io, gd)
+    show(io, MIME("text/plain"), gd)
     str2 = String(take!(io.io))
     @test str1 == str2
 
     # Test error when invalid keyword arguments are passed in text backend.
-    @test_throws ArgumentError show(stdout, gd, max_column_width="100px")
+    @test_throws ArgumentError show(stdout, MIME("text/plain"), gd, max_column_width="100px")
 
     str = sprint(show, "text/html", gd)
     @test str == "<p>" *
@@ -1591,7 +1591,7 @@ end
     gd = groupby_checked(DataFrame(a=[Symbol("&")], b=["&"]), [1, 2])
     summary_str = summary(gd)
     @test summary_str == "GroupedDataFrame with 1 group based on keys: a, b"
-    @test sprint(show, gd) === """
+    @test sprint(show, MIME("text/plain"), gd) === """
         $summary_str
         Group 1 (1 row): a = :&, b = "&"
          Row │ a       b
@@ -1782,7 +1782,7 @@ end
     @test isequal_typed(DataFrame(gdf), df)
 
     # work around automatic trimming of trailing whitespace in most editors
-    @test sprint(show, groupby_checked(df, [])) ==
+    @test sprint(show, MIME("text/plain"), groupby_checked(df, [])) ==
         "GroupedDataFrame with 1 group based on key: \n" *
         "Group 1 (3 rows): \n" *
         """ Row │ x1     x2     y

--- a/test/io.jl
+++ b/test/io.jl
@@ -1467,7 +1467,7 @@ end
                  nothing]
 
     io = IOBuffer()
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io))
 
     @test str == """
@@ -1488,7 +1488,7 @@ end
     # TODO: update when https://github.com/KristofferC/Crayons.jl/issues/47 is resolved
     if Base.get_have_color()
         io = IOBuffer()
-        show(IOContext(io, :color => true), df)
+        show(IOContext(io, :color => true), MIME("text/plain"), df)
         str = String(take!(io))
         @test str == """
         \e[1m9×2 DataFrame\e[0m
@@ -1755,19 +1755,9 @@ end
         ─────┼───────────────────────────────────
            1 │ 01234567890123456789012345678901…"""
 
-    io = IOBuffer()
-    show(io, df)
-    str = String(take!(io))
-    @test str == """
-        1×1 DataFrame
-         Row │ x
-             │ String
-        ─────┼───────────────────────────────────
-           1 │ 01234567890123456789012345678901…"""
-
     # no truncation
     io = IOBuffer()
-    show(io, df, truncate=0)
+    show(io, MIME("text/plain"), df, truncate=0)
     str = String(take!(io))
     @test str == """
         1×1 DataFrame
@@ -1778,7 +1768,7 @@ end
 
     # custom truncation
     io = IOBuffer()
-    show(io, df, truncate=1)
+    show(io, MIME("text/plain"), df, truncate=1)
     str = String(take!(io))
     @test str == """
         1×1 DataFrame
@@ -1790,7 +1780,7 @@ end
 
     df = DataFrame(x12345678901234567890="0123456789"^10)
     io = IOBuffer()
-    show(io, df, truncate=1, rowlabel=:r12345678901234567890)
+    show(io, MIME("text/plain"), df, truncate=1, rowlabel=:r12345678901234567890)
     str = String(take!(io))
     @test str == """
         1×1 DataFrame

--- a/test/show.jl
+++ b/test/show.jl
@@ -44,17 +44,13 @@ end
 
     for allrows in [true, false], allcols in [true, false]
         io = IOBuffer()
-        show(io, df, allcols=allcols, allrows=allrows)
-        str = String(take!(io))
-        @test str == refstr
-        io = IOBuffer()
         show(io, MIME("text/plain"), df, allcols=allcols, allrows=allrows)
         str = String(take!(io))
         @test str == refstr
     end
 
     df = DataFrame(A=Vector{String}(undef, 3))
-    @test sprint(show, df) == """
+    @test sprint(show, MIME("text/plain"), df) == """
         3×1 DataFrame
          Row │ A
              │ String
@@ -69,7 +65,7 @@ end
                        :auto)
 
     io = IOContext(IOBuffer(), :displaysize=>(11, 40), :limit=>true)
-    show(io, df_big)
+    show(io, MIME("text/plain"), df_big)
     str = String(take!(io.io))
     @test str == """
         25×5 DataFrame
@@ -82,7 +78,7 @@ end
                    2 columns and 23 rows omitted"""
 
     io = IOContext(IOBuffer(), :displaysize=>(11, 40), :limit=>true)
-    show(io, df_big, allcols=true)
+    show(io, MIME("text/plain"), df_big, allcols=true)
     str = String(take!(io.io))
     @test str == """
         25×5 DataFrame
@@ -95,7 +91,7 @@ end
                                                  23 rows omitted"""
 
     io = IOContext(IOBuffer(), :displaysize=>(11, 40), :limit=>true)
-    show(io, df_big, allrows=true, allcols=true)
+    show(io, MIME("text/plain"), df_big, allrows=true, allcols=true)
     str = String(take!(io.io))
     @test str == """
         25×5 DataFrame
@@ -129,7 +125,7 @@ end
           25 │ 10000025  10000050  10000075  10000100  10000125"""
 
     io = IOContext(IOBuffer(), :displaysize=>(11, 40), :limit=>true)
-    show(io, df_big, allrows=true, allcols=false)
+    show(io, MIME("text/plain"), df_big, allrows=true, allcols=false)
     str = String(take!(io.io))
     @test str == """
         25×5 DataFrame
@@ -168,7 +164,7 @@ end
     df = DataFrame(x = (1:50) .> 5, y = (1:50) .> 25, z = (1:50) .> 45)
     io = IOContext(IOBuffer(), :displaysize=>(30, 40), :limit=>true)
 
-    show(io, groupby(df, :x), allcols=true)
+    show(io, MIME("text/plain"), groupby(df, :x), allcols=true)
     str = String(take!(io.io))
     @test str == """
         GroupedDataFrame with 2 groups based on key: x
@@ -199,7 +195,7 @@ end
           45 │ true   true   true
                    35 rows omitted"""
 
-    show(io, groupby(df, :y), allcols=true)
+    show(io, MIME("text/plain"), groupby(df, :y), allcols=true)
     str = String(take!(io.io))
     @test str == """
         GroupedDataFrame with 2 groups based on key: y
@@ -230,7 +226,7 @@ end
           25 │ true  true   true
                   19 rows omitted"""
 
-    show(io, groupby(df, :z), allcols=true)
+    show(io, MIME("text/plain"), groupby(df, :z), allcols=true)
     str = String(take!(io.io))
     @test str == """
         GroupedDataFrame with 2 groups based on key: z
@@ -261,7 +257,7 @@ end
            4 │ true  true  true
            5 │ true  true  true"""
 
-    show(io, groupby(df, :x), allcols=true, allrows=true)
+    show(io, MIME("text/plain"), groupby(df, :x), allcols=true, allrows=true)
     str = String(take!(io.io))
     @test str == """
         GroupedDataFrame with 2 groups based on key: x
@@ -328,9 +324,9 @@ end
     # height is zero or invalid -> print all rows
     for h in -1:0
         io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
-        show(io, groupby(df, :x), allcols=true)
+        show(io, MIME("text/plain"), groupby(df, :x), allcols=true)
         str_hrows = String(take!(io.io))
-        show(io, groupby(df, :x), allcols=true, allrows=true)
+        show(io, MIME("text/plain"), groupby(df, :x), allcols=true, allrows=true)
         str_allrows = String(take!(io.io))
         @test str_hrows == str_allrows
     end
@@ -339,7 +335,7 @@ end
     for a in 1:50, b in 1:50, h in 17:40
         df = DataFrame(x = [fill(1, a); fill(2, b)])
         io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
-        show(io, groupby(df, :x), allcols=true)
+        show(io, MIME("text/plain"), groupby(df, :x), allcols=true)
         str = String(take!(io.io))
         nlines = length(split(str, '\n'))
         # leave one line for last REPL prompt at top, two for new prompt
@@ -351,7 +347,7 @@ end
     for a in 1:50, h in 17:40
         df = DataFrame(x = fill(1, a))
         io = IOContext(IOBuffer(), :displaysize=>(h, 40), :limit=>true)
-        show(io, groupby(df, :x), allcols=true)
+        show(io, MIME("text/plain"), groupby(df, :x), allcols=true)
         str = String(take!(io.io))
         nlines = length(split(str, '\n'))
         # leave one line for last REPL prompt at top, two for new prompt
@@ -363,7 +359,7 @@ end
     # one group
     io = IOContext(IOBuffer(), :displaysize=>(15, 40), :limit=>true)
     df = DataFrame(x = Int64.(1:15), y = Int64(1))
-    show(io, groupby(df, :y))
+    show(io, MIME("text/plain"), groupby(df, :y))
     str = String(take!(io.io))
     @test str == """
         GroupedDataFrame with 1 group based on key: y
@@ -382,7 +378,7 @@ end
     # zero groups
     io = IOContext(IOBuffer())
     df = DataFrame(x=[], y=Int[])
-    show(io, groupby(df, :x))
+    show(io, MIME("text/plain"), groupby(df, :x))
     str = String(take!(io.io))
     @test str == "GroupedDataFrame with 0 groups based on key: x"
 end
@@ -391,20 +387,20 @@ end
     df = DataFrame(A=Int64[1:4;], B=["x\"", "∀ε>0: x+ε>x", "z\$", "A\nC"],
                    C=Float32[1.0, 2.0, 3.0, 4.0])
     str1, size = capture_stdout() do
-        show(df)
+        show(MIME("text/plain"), df)
     end
     io = IOContext(IOBuffer(), :limit=>true, :displaysize=>size)
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str2 = String(take!(io.io))
     @test str1 == str2
 
     Random.seed!(1)
     df_big = DataFrame(rand(25, 5), :auto)
     str1, size = capture_stdout() do
-        show(df_big)
+        show(MIME("text/plain"), df_big)
     end
     io = IOContext(IOBuffer(), :limit=>true, :displaysize=>size)
-    show(io, df_big)
+    show(io, MIME("text/plain"), df_big)
     str2 = String(take!(io.io))
     @test str1 == str2
 end
@@ -414,7 +410,7 @@ end
                    C=Float32[1.0, 2.0, 3.0, 4.0])
     subdf = view(df, [2, 3], :)
     io = IOBuffer()
-    show(io, subdf, allrows=true, allcols=false)
+    show(io, MIME("text/plain"), subdf, allrows=true, allcols=false)
     str = String(take!(io))
     @test str == """
         2×3 SubDataFrame
@@ -423,9 +419,9 @@ end
         ─────┼─────────────────────────────
            1 │     2  ∀ε>0: x+ε>x      2.0
            2 │     3  z\$               3.0"""
-    show(io, subdf, allrows=true)
-    show(io, subdf, allcols=true)
-    show(io, subdf, allcols=true, allrows=true)
+    show(io, MIME("text/plain"), subdf, allrows=true)
+    show(io, MIME("text/plain"), subdf, allcols=true)
+    show(io, MIME("text/plain"), subdf, allcols=true, allrows=true)
 end
 
 @testset "Test showing StackedVector and RepeatedVector" begin
@@ -441,7 +437,7 @@ end
     # TODO: update when https://github.com/KristofferC/Crayons.jl/issues/47 is resolved
     if Base.get_have_color()
         df = DataFrame(Fish=["Suzy", "Amir"], Mass=[1.5, missing])
-        @test sprint(show, df, context=:color=>true) == """
+        @test sprint(show, MIME("text/plain"), df, context=:color=>true) == """
             \e[1m2×2 DataFrame\e[0m
             \e[1m Row \e[0m│\e[1m Fish   \e[0m\e[1m Mass      \e[0m
             \e[1m     \e[0m│\e[90m String \e[0m\e[90m Float64?  \e[0m
@@ -452,7 +448,7 @@ end
         df = DataFrame(A=[:Symbol, missing, :missing],
                        B=[missing, "String", "missing"],
                        C=[:missing, "missing", missing])
-        @test sprint(show, df, context=:color=>true) == """
+        @test sprint(show, MIME("text/plain"), df, context=:color=>true) == """
             \e[1m3×3 DataFrame\e[0m
             \e[1m Row \e[0m│\e[1m A       \e[0m\e[1m B       \e[0m\e[1m C       \e[0m
             \e[1m     \e[0m│\e[90m Symbol? \e[0m\e[90m String? \e[0m\e[90m Any     \e[0m
@@ -463,7 +459,7 @@ end
     end
 
     df_nothing = DataFrame(A=[1.0, 2.0, 3.0], B=["g", "g", nothing])
-    @test sprint(show, df_nothing) == """
+    @test sprint(show, MIME("text/plain"), df_nothing) == """
         3×2 DataFrame
          Row │ A        B
              │ Float64  Union…
@@ -475,7 +471,7 @@ end
 
 @testset "Test correct width computation" begin
     df = DataFrame([["a"]], [:x])
-    @test sprint(show, df) == """
+    @test sprint(show, MIME("text/plain"), df) == """
         1×1 DataFrame
          Row │ x
              │ String
@@ -486,7 +482,7 @@ end
 @testset "Test showing special types" begin
     # strings with escapes
     df = DataFrame(a=["1\n1", "2\t2", "3\r3", "4\$4", "5\"5", "6\\6"])
-    @test sprint(show, df) == """
+    @test sprint(show, MIME("text/plain"), df) == """
         6×1 DataFrame
          Row │ a
              │ String
@@ -500,7 +496,7 @@ end
 
     # categorical
     df = DataFrame(a=categorical([1, 2, 3]), b=categorical(["a", "b", missing]))
-    @test sprint(show, df) == """
+    @test sprint(show, MIME("text/plain"), df) == """
         3×2 DataFrame
          Row │ a     b
              │ Cat…  Cat…?
@@ -511,7 +507,7 @@ end
 
     # BigFloat
     df = DataFrame(a=[big(1.0), missing])
-    @test sprint(show, df) == """
+    @test sprint(show, MIME("text/plain"), df) == """
         2×1 DataFrame
          Row │ a
              │ BigFloat?
@@ -521,7 +517,7 @@ end
 
     # date types
     df = DataFrame(a=Date(2020, 2, 11), b=DateTime(2020, 2, 11, 15), c=Day(1))
-    @test sprint(show, df) == """
+    @test sprint(show, MIME("text/plain"), df) == """
         1×3 DataFrame
          Row │ a           b                    c
              │ Date        DateTime             Day
@@ -530,7 +526,7 @@ end
 
     # Irrational
     df = DataFrame(a=π)
-    @test sprint(show, df) == """
+    @test sprint(show, MIME("text/plain"), df) == """
         1×1 DataFrame
          Row │ a
              │ Irration…
@@ -540,14 +536,14 @@ end
 
 @testset "Test using :compact parameter of IOContext" begin
     df = DataFrame(x=[float(pi)])
-    @test sprint(show, df) == """
+    @test sprint(show, MIME("text/plain"), df) == """
         1×1 DataFrame
          Row │ x
              │ Float64
         ─────┼─────────
            1 │ 3.14159"""
 
-    @test sprint(show, df, context=:compact=>false) == """
+    @test sprint(show, MIME("text/plain"), df, context=:compact=>false) == """
         1×1 DataFrame
          Row │ x
              │ Float64
@@ -557,27 +553,27 @@ end
 
 @testset "Test of DataFrameRows and DataFrameColumns" begin
     df = DataFrame(x=[float(pi)])
-    @test sprint(show, eachrow(df)) == """
+    @test sprint(show, MIME("text/plain"), eachrow(df)) == """
         1×1 DataFrameRows
          Row │ x
              │ Float64
         ─────┼─────────
            1 │ 3.14159"""
 
-    @test sprint((io, x) -> show(io, x, summary=false), eachrow(df)) == """
+    @test sprint((io, x) -> show(io, MIME("text/plain"), x, summary=false), eachrow(df)) == """
          Row │ x
              │ Float64
         ─────┼─────────
            1 │ 3.14159"""
 
-    @test sprint(show, eachcol(df)) == """
+    @test sprint(show, MIME("text/plain"), eachcol(df)) == """
         1×1 DataFrameColumns
          Row │ x
              │ Float64
         ─────┼─────────
            1 │ 3.14159"""
 
-    @test sprint((io, x) -> show(io, x, summary=false), eachcol(df)) == """
+    @test sprint((io, x) -> show(io, MIME("text/plain"), x, summary=false), eachcol(df)) == """
          Row │ x
              │ Float64
         ─────┼─────────
@@ -586,58 +582,58 @@ end
 
 @testset "Test empty data frame and DataFrameRow" begin
     df = DataFrame(x=[float(pi)])
-    @test sprint(show, df[:, 2:1]) == "0×0 DataFrame"
-    @test sprint(show, @view df[:, 2:1]) == "0×0 SubDataFrame"
-    @test sprint(show, df[1, 2:1]) == "DataFrameRow"
+    @test sprint(show, MIME("text/plain"), df[:, 2:1]) == "0×0 DataFrame"
+    @test sprint(show, MIME("text/plain"), @view df[:, 2:1]) == "0×0 SubDataFrame"
+    @test sprint(show, MIME("text/plain"), df[1, 2:1]) == "DataFrameRow"
 end
 
 @testset "consistency" begin
     df = DataFrame(a=[1, 1, 2, 2], b=[5, 6, 7, 8], c=1:4)
     push!(df.c, 5)
-    @test_throws AssertionError sprint(show, df)
+    @test_throws AssertionError sprint(show, MIME("text/plain"), df)
 
     df = DataFrame(a=[1, 1, 2, 2], b=[5, 6, 7, 8], c=1:4)
     push!(DataFrames._columns(df), df[:, :a])
-    @test_throws AssertionError sprint(show, df)
+    @test_throws AssertionError sprint(show, MIME("text/plain"), df)
 end
 
 @testset "wide type name" begin
-    @test sprint(show, DataFrame(a=⛵⛵⛵⛵⛵())) == """
+    @test sprint(show, MIME("text/plain"), DataFrame(a=⛵⛵⛵⛵⛵())) == """
         1×1 DataFrame
          Row │ a
              │ ⛵⛵⛵⛵…
         ─────┼───────────
            1 │ "⛵\""""
 
-    @test sprint(show, DataFrame(a=categorical([Int64(2)^54]))) == """
+    @test sprint(show, MIME("text/plain"), DataFrame(a=categorical([Int64(2)^54]))) == """
         1×1 DataFrame
          Row │ a
              │ Cat…
         ─────┼───────────────────
            1 │ 18014398509481984"""
 
-    @test sprint(show, DataFrame(a=categorical([Int64(2)^53]))) == """
+    @test sprint(show, MIME("text/plain"), DataFrame(a=categorical([Int64(2)^53]))) == """
         1×1 DataFrame
          Row │ a
              │ Cat…
         ─────┼──────────────────
            1 │ 9007199254740992"""
 
-    @test sprint(show, DataFrame(a=categorical([Int64(2)^37]))) == """
+    @test sprint(show, MIME("text/plain"), DataFrame(a=categorical([Int64(2)^37]))) == """
         1×1 DataFrame
          Row │ a
              │ Cat…
         ─────┼──────────────
            1 │ 137438953472"""
 
-    @test sprint(show, DataFrame(a=categorical([Int64(2)^36]))) == """
+    @test sprint(show, MIME("text/plain"), DataFrame(a=categorical([Int64(2)^36]))) == """
         1×1 DataFrame
          Row │ a
              │ Cat…
         ─────┼─────────────
            1 │ 68719476736"""
 
-    @test sprint(show, DataFrame(a=Union{Function, Missing}[missing])) == """
+    @test sprint(show, MIME("text/plain"), DataFrame(a=Union{Function, Missing}[missing])) == """
         1×1 DataFrame
          Row │ a
              │ Function?
@@ -649,7 +645,7 @@ end
     df = DataFrame(A=Int32.(1:3), B=["x", "y", "z"])
 
     io = IOBuffer()
-    show(io, df, eltypes=true)
+    show(io, MIME("text/plain"), df, eltypes=true)
     str = String(take!(io))
     @test str == """
         3×2 DataFrame
@@ -661,7 +657,7 @@ end
            3 │     3  z"""
 
     io = IOBuffer()
-    show(io, df, eltypes=false)
+    show(io, MIME("text/plain"), df, eltypes=false)
     str = String(take!(io))
     @test str == """
         3×2 DataFrame
@@ -676,7 +672,7 @@ end
     df = DataFrame(x=AbstractVector[1:2])
 
     io = IOBuffer()
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io))
     @test str == """
         1×1 DataFrame
@@ -689,7 +685,7 @@ end
 @testset "wide output and column trimming" begin
     df = DataFrame(x="0123456789"^4)
     io = IOBuffer()
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io))
     @test str == """
         1×1 DataFrame
@@ -699,7 +695,7 @@ end
            1 │ 01234567890123456789012345678901…"""
 
     io = IOContext(IOBuffer(), :displaysize=>(10, 10), :limit=>true)
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io.io))
     @test str === """
         1×1 Data ⋯
@@ -711,7 +707,7 @@ end
 
     df = DataFrame(x="😄"^20)
     io = IOBuffer()
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io))
     @test str === """
         1×1 DataFrame
@@ -729,7 +725,7 @@ end
                    e=[i == 2 ? -0.0 : i == 3 ? +0.0 : 10^i for i = -7:1.0:7])
 
     io = IOBuffer()
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io))
     @test str == """
         15×5 DataFrame
@@ -754,7 +750,7 @@ end
 
 
     io = IOBuffer()
-    show(io, df, eltypes = false)
+    show(io, MIME("text/plain"), df, eltypes = false)
     str = String(take!(io))
     @test str == """
         15×5 DataFrame
@@ -779,7 +775,7 @@ end
     df = DataFrame(This_is_a_very_big_name=1.0, b=2.0, c=3.0)
 
     io = IOBuffer()
-    show(io, df, eltypes = false)
+    show(io, MIME("text/plain"), df, eltypes = false)
     str = String(take!(io))
     @test str == """
         1×3 DataFrame
@@ -792,7 +788,7 @@ end
                    T=100001:1.0:100011)
 
     io = IOBuffer()
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io))
     @test str == """
         11×3 DataFrame
@@ -815,7 +811,7 @@ end
                    🚀🚀🚀🚀🚀=1.0:2:22)
 
     io = IOBuffer()
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io))
     @test str == """
         11×2 DataFrame
@@ -838,7 +834,7 @@ end
                    🚀🚀🚀🚀🚀🚀🚀=collect(1.0:2:22) .+ pi)
 
     io = IOBuffer()
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io))
     @test str == """
         11×2 DataFrame
@@ -858,7 +854,7 @@ end
           11 │          1.00003e5        24.1416"""
 
     io = IOContext(IOBuffer(), :compact => false)
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io.io))
     @test str == """
         11×2 DataFrame
@@ -881,7 +877,7 @@ end
                    Union{F, Float64, Missing}[i == 6 ? F(1234567) : i == 4 ? missing : 10.0^i for i = -6:1:6])
 
     io = IOContext(IOBuffer())
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io.io))
     @test str == """
         13×1 DataFrame
@@ -928,7 +924,7 @@ end
                    very_big_column_name_4=d)
 
     io = IOContext(IOBuffer())
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io.io))
 
     @test str == """
@@ -952,7 +948,7 @@ end
 
 @testset "Invalid keywords in text mode" begin
     df = DataFrame(a=[1, 1, 2, 2], b=[5, 6, 7, 8], c=1:4)
-    @test_throws ArgumentError show(stdout, df, max_column_width="100px")
+    @test_throws MethodError show(stdout, df, max_column_width="100px")
     @test_throws ArgumentError show(stdout, MIME("text/plain"), df, max_column_width="100px")
 end
 
@@ -960,7 +956,7 @@ end
     df = DataFrame(a=Int64[10, 20], b=Int64[30, 40], c=Int64[50, 60])
 
     io = IOContext(IOBuffer())
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io.io))
     @test str == """
         2×3 DataFrame
@@ -972,7 +968,7 @@ end
 
 
     io = IOContext(IOBuffer())
-    show(io, df, show_row_number=false)
+    show(io, MIME("text/plain"), df, show_row_number=false)
     str = String(take!(io.io))
     @test str == """
         2×3 DataFrame
@@ -983,7 +979,7 @@ end
             20     40     60"""
 
     io = IOContext(IOBuffer())
-    show(io, df[2, :])
+    show(io, MIME("text/plain"), df[2, :])
     str = String(take!(io.io))
     @test str == """
         DataFrameRow
@@ -994,7 +990,7 @@ end
 
 
     io = IOContext(IOBuffer())
-    show(io, df[2, :], show_row_number=false)
+    show(io, MIME("text/plain"), df[2, :], show_row_number=false)
     str = String(take!(io.io))
     @test str == """
         DataFrameRow
@@ -1012,7 +1008,7 @@ end
         float   = [10.0^n for n in 1:10], string = ["A"^100 for _ in 1:10]
     )
     io = IOContext(IOBuffer())
-    show(io, df)
+    show(io, MIME("text/plain"), df)
     str = String(take!(io.io))
 
     @test str == """
@@ -1034,7 +1030,7 @@ end
 
 @testset "cover all corner cases of compacttype" begin
     df = DataFrame(x2345678901234567=categorical(["1"]))
-    @test sprint(show, df) === """
+    @test sprint(show, MIME("text/plain"), df) === """
         1×1 DataFrame
          Row │ x2345678901234567
              │ CategoricalValue…
@@ -1046,22 +1042,6 @@ end
     df = DataFrame(id=inlinestrings(["a", "b", "c"]), value=collect(Int64, 1:3))
 
     io = IOContext(IOBuffer(), :limit=>true)
-    show(io, groupby(df, :id))
-    @test String(take!(io.io)) === """
-        GroupedDataFrame with 3 groups based on key: id
-        First Group (1 row): id = "a"
-         Row │ id       value
-             │ String1  Int64
-        ─────┼────────────────
-           1 │ a            1
-        ⋮
-        Last Group (1 row): id = "c"
-         Row │ id       value
-             │ String1  Int64
-        ─────┼────────────────
-           1 │ c            3"""
-
-    io = IOContext(IOBuffer(), :limit=>true)
     show(io, MIME("text/plain"), groupby(df, :id))
     @test String(take!(io.io)) === """
         GroupedDataFrame with 3 groups based on key: id
@@ -1076,27 +1056,6 @@ end
              │ String1  Int64
         ─────┼────────────────
            1 │ c            3"""
-
-    io = IOContext(IOBuffer(), :limit=>false)
-    show(io, groupby(df, :id))
-    @test String(take!(io.io)) === """
-        GroupedDataFrame with 3 groups based on key: id
-        Group 1 (1 row): id = "a"
-         Row │ id       value
-             │ String1  Int64
-        ─────┼────────────────
-           1 │ a            1
-        Group 2 (1 row): id = "b"
-         Row │ id       value
-             │ String1  Int64
-        ─────┼────────────────
-           1 │ b            2
-        Group 3 (1 row): id = "c"
-         Row │ id       value
-             │ String1  Int64
-        ─────┼────────────────
-           1 │ c            3"""
-
 
     io = IOContext(IOBuffer(), :limit=>false)
     show(io, MIME("text/plain"), groupby(df, :id))
@@ -1117,26 +1076,6 @@ end
              │ String1  Int64
         ─────┼────────────────
            1 │ c            3"""
-
-    io = IOContext(IOBuffer(), :limit=>true)
-    show(io, groupby(df[1:1, :], :id))
-    @test String(take!(io.io)) === """
-        GroupedDataFrame with 1 group based on key: id
-        First Group (1 row): id = "a"
-         Row │ id       value
-             │ String1  Int64
-        ─────┼────────────────
-           1 │ a            1"""
-
-    io = IOContext(IOBuffer(), :limit=>false)
-    show(io, groupby(df[1:1, :], :id))
-    @test String(take!(io.io)) === """
-        GroupedDataFrame with 1 group based on key: id
-        Group 1 (1 row): id = "a"
-         Row │ id       value
-             │ String1  Int64
-        ─────┼────────────────
-           1 │ a            1"""
 
     io = IOContext(IOBuffer(), :limit=>true)
     show(io, MIME("text/plain"), groupby(df[1:1, :], :id))


### PR DESCRIPTION
Strictly speaking, I consider this a bugfix. "Decorated" multiline output should be handled by a show method for `MIME"text/plain"` and not the two-argument show method. However, the show method here is very useful and probably used by many downstream packages, so it might cause a temporary ecosystem imbalance if this is released as a non-breaking release. We saw that when fixing the show method for StatsBase's `CoefTable`. Are there other changes waiting for a breaking release?